### PR TITLE
[bugfix] fixes the model agent daemonset deployment volume

### DIFF
--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         - name: host-models
           hostPath:
             path: {{ .Values.modelAgent.hostPath }}
-            type: Directory
+            type: DirectoryOrCreate
       containers:
       - name: model-agent
         image: "{{ .Values.modelAgent.image.repository }}:{{ .Values.modelAgent.image.tag }}"

--- a/config/model-agent/daemonset.yaml
+++ b/config/model-agent/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       - name: host-models
         hostPath:
           path: /raid/models
-          type: Directory
+          type: DirectoryOrCreate
       containers:
       - name: model-agent
         image: ghcr.io/moirai-internal/model-agent:v0.1.0


### PR DESCRIPTION
## What type of PR is this?

  /kind bug

  ## What this PR does / why we need it:

  This PR fixes the model agent daemonset deployment failure that occurs when the volume mount directory doesn't exist on the node. Previously, the hostPath volume type
   was set to `Directory`, which requires the directory to pre-exist on the node, forcing users to manually SSH into nodes to create the directory.

  By changing the hostPath volume type from `Directory` to `DirectoryOrCreate`, Kubernetes will automatically create the directory if it doesn't exist, eliminating the
  need for manual intervention.

  ## Which issue(s) this PR fixes:

  Fixes #

  ## Special notes for your reviewer:

  The change was applied to both daemonset configurations:
  - Helm chart template: `/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml`
  - Config manifest: `/config/model-agent/daemonset.yaml`

  This is a minimal change that improves deployment reliability without any breaking changes.

  ## Does this PR introduce a user-facing change?

  ```release-note
  Fixed model agent daemonset deployment failure when the host directory doesn't exist by using DirectoryOrCreate volume type instead of Directory