### PR TITLE
[bugfix] fix hf token fetch and deletion logic

### DIFF
--- a/pkg/hfutil/hub/constants.go
+++ b/pkg/hfutil/hub/constants.go
@@ -48,10 +48,10 @@ const (
 	DownloadTimeout       = 10 * time.Minute
 
 	// Download configuration
-	DefaultMaxWorkers    = 8
+	DefaultMaxWorkers    = 4                // Reduced to minimize concurrent API calls
 	DefaultChunkSize     = 10 * 1024 * 1024 // 10MB
-	DefaultMaxRetries    = 5
-	DefaultRetryInterval = 10 * time.Second
+	DefaultMaxRetries    = 10               // Increased for better 429 handling
+	DefaultRetryInterval = 15 * time.Second // Increased base interval
 
 	// File size thresholds
 	LfsFileSizeThreshold = 10 * 1024 * 1024 // 10MB

--- a/pkg/hfutil/hub/constants_test.go
+++ b/pkg/hfutil/hub/constants_test.go
@@ -194,9 +194,9 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "https://huggingface.co", DefaultEndpoint)
 	assert.Equal(t, "main", DefaultRevision)
 	assert.Equal(t, ".cache/huggingface/hub", DefaultCacheDir)
-	assert.Equal(t, 8, DefaultMaxWorkers)
+	assert.Equal(t, 4, DefaultMaxWorkers) // Updated to reduce concurrent API calls
 	assert.Equal(t, 10*1024*1024, DefaultChunkSize)
-	assert.Equal(t, 5, DefaultMaxRetries)
+	assert.Equal(t, 10, DefaultMaxRetries) // Increased for better 429 handling
 
 	// Test repository types
 	assert.Equal(t, "model", RepoTypeModel)
@@ -257,7 +257,7 @@ func TestTimeoutConstants(t *testing.T) {
 	assert.Equal(t, "10s", DefaultRequestTimeout.String())
 	assert.Equal(t, "10s", DefaultEtagTimeout.String())
 	assert.Equal(t, "10m0s", DownloadTimeout.String())
-	assert.Equal(t, "10s", DefaultRetryInterval.String())
+	assert.Equal(t, "15s", DefaultRetryInterval.String())
 }
 
 func TestFileSizeThresholds(t *testing.T) {

--- a/pkg/hfutil/hub/module.go
+++ b/pkg/hfutil/hub/module.go
@@ -185,6 +185,14 @@ func WithPatterns(allowPatterns, ignorePatterns []string) DownloadOption {
 	}
 }
 
+// WithDownloadToken sets the authentication token for the download
+func WithDownloadToken(token string) DownloadOption {
+	return func(config *DownloadConfig) error {
+		config.Token = token
+		return nil
+	}
+}
+
 // Module provides the fx module for dependency injection
 var Module = fx.Provide(
 	func(v *viper.Viper, params HubClientParams) (*HubClient, error) {

--- a/site/content/en/docs/concepts/base_model.md
+++ b/site/content/en/docs/concepts/base_model.md
@@ -332,6 +332,38 @@ data:
   token: <base64-encoded-token>
 ```
 
+#### Using Custom Secret Key Names
+
+By default, the Model Agent looks for a key named "token" in your secret. However, you can specify a custom key name using the `secretKey` parameter:
+
+```yaml
+# Create a secret with a custom key name
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-credentials
+data:
+  access-token: <base64-encoded-token>
+  
+---
+# Reference it in your BaseModel
+apiVersion: ome.io/v1beta1
+kind: BaseModel
+metadata:
+  name: private-model
+spec:
+  storage:
+    storageUri: "hf://my-org/private-model"
+    storageKey: "hf-credentials"
+    parameters:
+      secretKey: "access-token"  # Specify the custom key name
+```
+
+This is useful when:
+- You have existing secrets with different key names
+- You're following specific naming conventions in your organization
+- You need to store multiple tokens in the same secret
+
 ## Complete Configuration Example
 
 Here's a comprehensive BaseModel configuration showing all available options:


### PR DESCRIPTION
## What type of PR is this?

  /kind bug

  ## What this PR does / why we need it:

  This PR fixes multiple critical issues in the model-agent that were preventing proper model downloads and management in production environments:

  ### 1. **RBAC Permissions Issue**
  - Added permission for model-agent to access secrets at cluster scope
  - Previously failing with "secrets is forbidden" errors

  ### 2. **HTTP 429 Rate Limiting**
  - Implemented proper rate limit handling with exponential backoff and jitter
  - Added Retry-After header parsing for server-suggested delays
  - Prevents thundering herd problem in large clusters with many agents

  ### 3. **Nil Pointer Dereference**
  - Fixed crashes in progress logging when progressManager.logger was nil
  - Added proper nil checks throughout the codebase

  ### 4. **Model Deletion Path Mismatch**
  - Fixed incorrect path construction during model deletion
  - Now uses consistent `getDestPath()` for both download and delete operations

  ### 5. **Flexible Secret Key Configuration**
  - Made secret key name configurable via model parameters
  - Previously hardcoded to "token", now supports custom keys
  - Updated documentation with examples

  ### 6. **Download Cancellation Support**
  - Added context cancellation for in-progress downloads
  - Prevents stuck downloads when resources are deleted
  - Tracks active downloads and cancels them appropriately

  ### 7. **HuggingFace Token Authentication**
  - Fixed critical bug where tokens were retrieved but not passed to downloads
  - Added `WithDownloadToken` option to pass tokens per download
  - Resolves HTTP 401 errors for gated models

  ## Which issue(s) this PR fixes:

  Fixes #

  ## Special notes for your reviewer:

  - The HF token fix is the most critical - it was causing authentication failures for all gated models
  - The rate limiting improvements are essential for large-scale deployments
  - All changes maintain backward compatibility
  - Tests have been updated and are passing

  ## Does this PR introduce a user-facing change?

  ```release-note
  - Fixed model-agent authentication failures for gated HuggingFace models
  - Added configurable secret key names for authentication tokens (defaults to "token")
  - Improved reliability with better rate limit handling and download cancellation
  - Fixed model deletion not properly cleaning up downloaded files