### PR TITLE
[core] feat: add multi-cloud storage support for benchmark results

### DIFF
--- a/pkg/controller/v1beta1/benchmark/controller.go
+++ b/pkg/controller/v1beta1/benchmark/controller.go
@@ -501,20 +501,20 @@ func (r *BenchmarkJobReconciler) updateStatus(ctx context.Context, benchmarkJob 
 
 		// Map job conditions to benchmark job states
 		switch {
-		case isComplete:
-			// Completed
-			if benchmarkStatus.State != "Completed" {
-				benchmarkStatus.State = "Completed"
+		case isFailed:
+			// Failed - check this first as a job can be both complete and failed
+			if benchmarkStatus.State != "Failed" {
+				benchmarkStatus.State = "Failed"
 				if benchmarkStatus.StartTime == nil && job.Status.StartTime != nil {
 					benchmarkStatus.StartTime = job.Status.StartTime
 				}
 				benchmarkStatus.CompletionTime = completionTime
 				benchmarkStatus.LastReconcileTime = &now
 			}
-		case isFailed:
-			// Failed
-			if benchmarkStatus.State != "Failed" {
-				benchmarkStatus.State = "Failed"
+		case isComplete:
+			// Completed - only if not failed
+			if benchmarkStatus.State != "Completed" {
+				benchmarkStatus.State = "Completed"
 				if benchmarkStatus.StartTime == nil && job.Status.StartTime != nil {
 					benchmarkStatus.StartTime = job.Status.StartTime
 				}

--- a/pkg/controller/v1beta1/benchmark/utils/utils_test.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils_test.go
@@ -213,9 +213,95 @@ func TestBuildStorageArgs(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "unsupported storage scheme",
+			name: "s3 storage scheme",
 			storageSpec: &v1beta1.StorageSpec{
 				StorageUri: strPtr("s3://my-bucket/path"),
+			},
+			want: []string{
+				"--upload-results",
+				"--storage-provider", "aws",
+				"--storage-bucket", "my-bucket",
+				"--storage-prefix", "path",
+			},
+			wantErr: false,
+		},
+		{
+			name: "s3 storage with credentials",
+			storageSpec: &v1beta1.StorageSpec{
+				StorageUri: strPtr("s3://my-bucket@us-west-2/path/to/data"),
+				Parameters: &map[string]string{
+					"aws_access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+					"aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG",
+					"aws_profile":           "production",
+				},
+			},
+			want: []string{
+				"--upload-results",
+				"--storage-provider", "aws",
+				"--storage-bucket", "my-bucket",
+				"--storage-prefix", "path/to/data",
+				"--storage-aws-access-key-id", "AKIAIOSFODNN7EXAMPLE",
+				"--storage-aws-secret-access-key", "wJalrXUtnFEMI/K7MDENG",
+				"--storage-aws-profile", "production",
+				"--storage-aws-region", "us-west-2",
+			},
+			wantErr: false,
+		},
+		{
+			name: "azure storage scheme",
+			storageSpec: &v1beta1.StorageSpec{
+				StorageUri: strPtr("az://myaccount/mycontainer/path/to/blob"),
+			},
+			want: []string{
+				"--upload-results",
+				"--storage-provider", "azure",
+				"--storage-bucket", "mycontainer",
+				"--storage-prefix", "path/to/blob",
+				"--storage-azure-account-name", "myaccount",
+			},
+			wantErr: false,
+		},
+		{
+			name: "gcs storage scheme",
+			storageSpec: &v1beta1.StorageSpec{
+				StorageUri: strPtr("gs://my-bucket/path/to/object"),
+				Parameters: &map[string]string{
+					"gcp_project_id":       "my-project",
+					"gcp_credentials_path": "/path/to/creds.json",
+				},
+			},
+			want: []string{
+				"--upload-results",
+				"--storage-provider", "gcp",
+				"--storage-bucket", "my-bucket",
+				"--storage-prefix", "path/to/object",
+				"--storage-gcp-project-id", "my-project",
+				"--storage-gcp-credentials-path", "/path/to/creds.json",
+			},
+			wantErr: false,
+		},
+		{
+			name: "github storage scheme",
+			storageSpec: &v1beta1.StorageSpec{
+				StorageUri: strPtr("github://myorg/myrepo@v1.0.0"),
+				Parameters: &map[string]string{
+					"github_token": "ghp_xxxxxxxxxxxx",
+				},
+			},
+			want: []string{
+				"--upload-results",
+				"--storage-provider", "github",
+				"--github-owner", "myorg",
+				"--github-repo", "myrepo",
+				"--github-tag", "v1.0.0",
+				"--github-token", "ghp_xxxxxxxxxxxx",
+			},
+			wantErr: false,
+		},
+		{
+			name: "unsupported storage scheme",
+			storageSpec: &v1beta1.StorageSpec{
+				StorageUri: strPtr("ftp://my-server/path"),
 			},
 			want:    nil,
 			wantErr: true,


### PR DESCRIPTION
## What type of PR is this?

  /kind feature

  ## What this PR does / why we need it:

  This PR adds multi-cloud storage support to BenchmarkJob, enabling users to store benchmark results in their preferred cloud storage provider.
  Previously, only OCI Object Storage was supported.

  The implementation extends the storage package to support:
  - **AWS S3** (`s3://bucket/prefix`)
  - **Azure Blob Storage** (`az://account/container/blob`)
  - **Google Cloud Storage** (`gs://bucket/object`)
  - **GitHub Releases** (`github://owner/repo@tag`)

  This aligns with genai-bench's new multi-cloud capabilities and allows users to integrate benchmark results storage with their existing cloud
  infrastructure.

  ### Changes:
  1. **Storage Package** (`pkg/utils/storage/`):
     - Added parse functions for S3, Azure, GCS, and GitHub storage URIs
     - Added validation functions for each storage type
     - Updated `GetStorageType()` and `ValidateStorageURI()` to handle new types

  2. **Benchmark Utils** (`pkg/controller/v1beta1/benchmark/utils/`):
     - Extended `BuildStorageArgs()` to generate correct CLI arguments for genai-bench
     - Added support for provider-specific authentication parameters

  3. **Documentation** (`site/content/en/docs/concepts/benchmark.md`):
     - Added examples for each storage provider
     - Documented URI formats and authentication options
     - Added best practices for multi-cloud storage
     - Added link to official genai-bench documentation

  4. **Tests**:
     - Added comprehensive test coverage for all new storage types
     - Updated existing tests to reflect new functionality

  ## Which issue(s) this PR fixes:

  Fixes #

  ## Special notes for your reviewer:

  - The implementation follows the URI patterns and CLI arguments documented in genai-bench's multi-cloud documentation
  - All existing OCI storage functionality remains unchanged for backward compatibility
  - The PR includes extensive test coverage with all tests passing
  - Documentation has been updated with clear examples for each storage provider

  ## Does this PR introduce a user-facing change?

  ```release-note
  Add multi-cloud storage support for BenchmarkJob results. Users can now store benchmark results in AWS S3, Azure Blob Storage, Google Cloud Storage,
   and GitHub Releases in addition to OCI Object Storage.