### PR TITLE
feat(helm): Add imagePullSecrets support to ome-resources chart

### DIFF
--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -25,6 +25,11 @@ spec:
         {{- toYaml .Values.modelAgent.affinity | nindent 8 }}
       nodeSelector:
         {{- toYaml .Values.modelAgent.nodeSelector | nindent 8 }}
+      {{- $imagePullSecrets := .Values.modelAgent.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      {{- if $imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml $imagePullSecrets | nindent 8 }}
+      {{- end }}
       volumes:
         - name: host-models
           hostPath:

--- a/charts/ome-resources/templates/ome-controller/deployment.yaml
+++ b/charts/ome-resources/templates/ome-controller/deployment.yaml
@@ -44,6 +44,11 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- $imagePullSecrets := .Values.ome.controller.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      {{- if $imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml $imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - command:
         - /manager

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -1,3 +1,11 @@
+# Global settings that apply to all resources
+global:
+  # Image pull secrets for all containers in the chart
+  # Example:
+  # imagePullSecrets:
+  #   - name: my-registry-secret
+  imagePullSecrets: []
+
 ome:
   version: &defaultVersion v0.1.2
   metricsaggregator:


### PR DESCRIPTION
## Summary
- Adds global imagePullSecrets configuration to the ome-resources Helm chart
- Enables deployment to environments with private container registries

## Changes
- Added `global.imagePullSecrets` configuration option to `values.yaml` with example usage
- Updated model-agent daemonset template to use global imagePullSecrets
- Updated ome-controller deployment template to use global imagePullSecrets

## Test plan
- [ ] Deploy the chart with imagePullSecrets configured
- [ ] Verify pods can pull images from private registries
- [ ] Verify deployment works without imagePullSecrets (backward compatibility)