### PR TITLE
fix: use non-deprecated node instance type label

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -488,10 +488,11 @@ const (
 
 // Model Agent & Model Controller
 var (
-	NodeInstanceShapeLabel    = "node.kubernetes.io/instance-type"
-	ModelsLabelPrefix         = "models.ome/"
-	TargetInstanceShapes      = "models.ome.io/target-instance-shapes"
-	ModelStatusConfigMapLabel = "models.ome/basemodel-status"
+	NodeInstanceShapeLabel           = "node.kubernetes.io/instance-type"
+	DeprecatedNodeInstanceShapeLabel = "beta.kubernetes.io/instance-type"
+	ModelsLabelPrefix                = "models.ome/"
+	TargetInstanceShapes             = "models.ome.io/target-instance-shapes"
+	ModelStatusConfigMapLabel        = "models.ome/basemodel-status"
 
 	ModelLabelDomain          = "models.ome.io"
 	ClusterBaseModelLabelType = "clusterbasemodel"

--- a/pkg/modelagent/scout.go
+++ b/pkg/modelagent/scout.go
@@ -58,7 +58,12 @@ func NewScout(ctx context.Context, nodeName string,
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node info for node %s: %w", nodeName, err)
 	}
-	nodeShapeAlias, err := utils.GetOCINodeShortVersionShape(nodeInfo.Labels["beta.kubernetes.io/instance-type"])
+	// Try the newer label first, then fallback to the deprecated beta label
+	instanceType, ok := nodeInfo.Labels[constants.NodeInstanceShapeLabel]
+	if !ok {
+		instanceType = nodeInfo.Labels[constants.DeprecatedNodeInstanceShapeLabel]
+	}
+	nodeShapeAlias, err := utils.GetOCINodeShortVersionShape(instanceType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/modelagent/scout_test.go
+++ b/pkg/modelagent/scout_test.go
@@ -24,11 +24,11 @@ func TestShouldDownloadModel(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
 			Labels: map[string]string{
-				constants.NodeInstanceShapeLabel:   "GPU.A10.2",
-				"node.kubernetes.io/instance-type": "GPU.A10.2",
-				"accelerator":                      "nvidia",
-				"gpu-model":                        "a10",
-				"region":                           "us-west-2",
+				constants.NodeInstanceShapeLabel:           "GPU.A10.2",
+				constants.DeprecatedNodeInstanceShapeLabel: "GPU.A10.2",
+				"accelerator": "nvidia",
+				"gpu-model":   "a10",
+				"region":      "us-west-2",
 			},
 			Annotations: map[string]string{
 				constants.TargetInstanceShapes: "GPU.A10.2,GPU.A100.8",


### PR DESCRIPTION
Replace deprecated beta.kubernetes.io/instance-type label with the GA
node.kubernetes.io/instance-type label for node instance type detection.

The code now tries the newer label first using the ok value from map
lookup and falls back to the deprecated beta label for backward
compatibility. This ensures the code works with both old and new
Kubernetes versions while preferring the non-deprecated label when
available.

The deprecated label constant has been moved to pkg/constants for
better maintainability.