### PR TITLE
Fix YAML syntax error in helm workflow

### DIFF
--- a/.github/workflows/helm-gh-pages.yaml
+++ b/.github/workflows/helm-gh-pages.yaml
@@ -49,12 +49,12 @@ jobs:
       - name: Prepare charts directory
         run: |
           mkdir -p .charts-repo
-          
+
           # If this is a release, update versions
           if [[ "${{ github.event_name }}" == "release" ]]; then
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"  # Remove 'v' prefix
-            
+
             for chart in charts/*/; do
               yq eval -i ".version = \"${VERSION}\"" "${chart}Chart.yaml"
               yq eval -i ".appVersion = \"${VERSION}\"" "${chart}Chart.yaml"
@@ -77,10 +77,10 @@ jobs:
         run: |
           git fetch origin gh-pages || true
           git checkout gh-pages || git checkout --orphan gh-pages
-          
+
           # Clean everything except charts directory
           find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.charts-repo' -exec rm -rf {} +
-          
+
           # Create charts directory if it doesn't exist
           mkdir -p charts
 
@@ -88,10 +88,10 @@ jobs:
         run: |
           # Copy new charts
           cp .charts-repo/*.tgz charts/ || true
-          
+
           # Generate index.yaml
           helm repo index charts --url https://sgl-project.github.io/ome/charts
-          
+
           # Also create an index at root for backward compatibility
           cp charts/index.yaml .
 
@@ -113,35 +113,35 @@ jobs:
           <body>
               <h1>OME Helm Charts Repository</h1>
               <p>This is the official Helm charts repository for OME (Oracle Machine Learning Engine).</p>
-              
+
               <div class="instructions">
                   <h2>Installation Instructions</h2>
-                  
+
                   <h3>Option 1: OCI Registry (Recommended)</h3>
                   <pre>
-# Install directly from OCI registry
-helm install ome-crd oci://ghcr.io/moirai-internal/charts/ome-crd --namespace ome --create-namespace
-helm install ome oci://ghcr.io/moirai-internal/charts/ome-resources --namespace ome</pre>
+          # Install directly from OCI registry
+          helm install ome-crd oci://ghcr.io/moirai-internal/charts/ome-crd --namespace ome --create-namespace
+          helm install ome oci://ghcr.io/moirai-internal/charts/ome-resources --namespace ome</pre>
 
                   <h3>Option 2: Helm Repository</h3>
                   <pre>
-# Add the OME Helm repository
-helm repo add ome https://sgl-project.github.io/ome
-helm repo update
+          # Add the OME Helm repository
+          helm repo add ome https://sgl-project.github.io/ome
+          helm repo update
 
-# Install OME CRDs
-helm install ome-crd ome/ome-crd --namespace ome --create-namespace
+          # Install OME CRDs
+          helm install ome-crd ome/ome-crd --namespace ome --create-namespace
 
-# Install OME resources
-helm install ome ome/ome-resources --namespace ome</pre>
+          # Install OME resources
+          helm install ome ome/ome-resources --namespace ome</pre>
               </div>
-              
+
               <h2>Available Charts</h2>
               <ul>
                   <li><a href="charts/">Browse all charts</a></li>
                   <li><a href="charts/index.yaml">Helm repository index</a></li>
               </ul>
-              
+
               <h2>Documentation</h2>
               <p>For more information, visit the <a href="https://sgl-project.github.io/ome/docs/">OME documentation</a>.</p>
           </body>


### PR DESCRIPTION
## Summary
- Fixed indentation in heredoc content that was causing YAML syntax error on line 123

## Test plan
- [ ] GitHub Actions validates YAML syntax
- [ ] Workflow runs successfully