### PR TITLE
Fix model-agent health check timing to account for startup jitter

### DIFF
--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -61,13 +61,13 @@ spec:
           httpGet:
             path: /livez
             port: {{ .Values.modelAgent.health.port }}
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
           periodSeconds: 5
         readinessProbe:
           httpGet:
             path: /healthz
             port: {{ .Values.modelAgent.health.port }}
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
         {{- if .Values.modelAgent.resources }}
         resources:
           {{- toYaml .Values.modelAgent.resources | nindent 10 }}

--- a/config/model-agent/daemonset.yaml
+++ b/config/model-agent/daemonset.yaml
@@ -64,14 +64,14 @@ spec:
           httpGet:
             path: /livez
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
           periodSeconds: 30
           timeoutSeconds: 20
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
           periodSeconds: 30
           timeoutSeconds: 20
         resources:


### PR DESCRIPTION
Increase initialDelaySeconds for health checks from 5 to 60 seconds to prevent
restart loops caused by the interaction between node-specific startup jitter
and insufficient health check delays.

## Problem

The model-agent implements startup jitter to prevent thundering herd problems
when multiple agents start simultaneously (see cmd/model-agent/main.go:227-237).
This jitter creates a deterministic but distributed delay of 0-30 seconds per
node based on a hash of the node name:

```go
// cmd/model-agent/main.go:233-234
// Create delay between 0-30 seconds based on node name
jitterDelay := time.Duration(hash%30) * time.Second
```

However, health checks were configured with only 5 seconds initialDelaySeconds,
causing them to start checking before the application finished initializing.
This created a race condition where:

1. Pod starts with 5s health check delay
2. Node-specific jitter delay (0-30s) begins
3. Health checks fail because app isn't ready yet
4. Kubelet kills and restarts the pod
5. Cycle repeats indefinitely

## Solution

Set initialDelaySeconds to 60 seconds, providing sufficient buffer for:
- Maximum jitter delay (30s)
- Additional startup time for cache sync and health server initialization
- Safety margin for system load variations

## Files Changed

- charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
- config/model-agent/daemonset.yaml

Both liveness and readiness probes now use initialDelaySeconds: 60.

## References

- Jitter implementation: cmd/model-agent/main.go:227-237
- Hash calculation: cmd/model-agent/main.go:229-231
- Delay calculation: cmd/model-agent/main.go:234
