### PR TITLE
Add LWS worker-index 0 to sample DS manifest

### DIFF
--- a/config/runtimes/srt/deepseek-rdma-pd-rt.yaml
+++ b/config/runtimes/srt/deepseek-rdma-pd-rt.yaml
@@ -80,7 +80,7 @@ spec:
             --deepep-mode normal
             --disaggregation-mode prefill
             --mem-fraction-static 0.849
-            --context-length 32768 
+            --context-length 32768
             --tp-size ${PARALLELISM_SIZE}
             --dist-init-addr $(LWS_LEADER_ADDRESS):5000
             --nnodes ${LWS_GROUP_SIZE}
@@ -349,8 +349,8 @@ spec:
           --service-discovery
           --service-discovery-namespace "${NAMESPACE}"
           --service-discovery-port 8080
-          --prefill-selector component=engine ome.io/inferenceservice=${INFERENCESERVICE_NAME}
-          --decode-selector component=decoder ome.io/inferenceservice=${INFERENCESERVICE_NAME}
+          --prefill-selector component=engine leaderworkerset.sigs.k8s.io/worker-index=0 ome.io/inferenceservice=${INFERENCESERVICE_NAME}
+          --decode-selector component=decoder leaderworkerset.sigs.k8s.io/worker-index=0 ome.io/inferenceservice=${INFERENCESERVICE_NAME}
       env:
         - name: NAMESPACE
           valueFrom:


### PR DESCRIPTION
If you don't set `leaderworkerset.sigs.k8s.io/worker-index=0` for the
router selector like this, then the behavior of the router will
potentially match against one of the non-head pods which is invalid. The
non-head pod will return a 404 and your generations will stall.

Actually, other example manifests have this already. It was just this
one that seems to be missing this label expression.
