### PR TITLE
[bugfix] fix nodeshape for unknown vendors

### DIFF
--- a/pkg/utils/instance_type_util.go
+++ b/pkg/utils/instance_type_util.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"fmt"
-
 	"github.com/sgl-project/ome/pkg/imds"
 	"github.com/sgl-project/ome/pkg/logging"
 )
@@ -45,5 +43,6 @@ func GetInstanceTypeShortName(currentInstanceType string) (string, error) {
 	if shortName, ok := instanceTypeMap[currentInstanceType]; ok {
 		return shortName, nil
 	}
-	return "", fmt.Errorf("couldn't find instance type %s in the mapping", currentInstanceType)
+	// Return the original instance type as a fallback for unknown shapes
+	return currentInstanceType, nil
 }

--- a/pkg/utils/instance_type_util_test.go
+++ b/pkg/utils/instance_type_util_test.go
@@ -67,18 +67,18 @@ func TestGetInstanceTypeShortName(t *testing.T) {
 			expected:     "L40",
 			expectError:  false,
 		},
-		// Error cases
+		// Fallback cases
 		{
 			name:         "Unknown instance type",
 			instanceType: "unknown-instance-type",
-			expected:     "",
-			expectError:  true,
+			expected:     "unknown-instance-type",
+			expectError:  false,
 		},
 		{
 			name:         "Empty instance type",
 			instanceType: "",
 			expected:     "",
-			expectError:  true,
+			expectError:  false,
 		},
 	}
 


### PR DESCRIPTION
 ## What type of PR is this?

  /kind bug

  ## What this PR does / why we need it:

  This PR fixes the ome-model-agent-daemonset startup failure by
  modifying the `GetInstanceTypeShortName` function to gracefully
  handle unknown instance types.

  Previously, the function would return an error when encountering an
  instance type that wasn't in the predefined mapping, causing the pod
   initialization to fail with "couldn't find shape in the shape
  mapping".

  The fix changes the behavior to return the original instance type as
   a fallback instead of returning an error. This ensures that the
  system can continue operating even when encountering new or custom
  instance types that haven't been added to the mapping yet.

  ## Which issue(s) this PR fixes:

  Fixes #140

  ## Special notes for your reviewer:

  The change removes the error return for unknown instance types and
  instead returns the original instance type string. This approach:
  - Maintains backward compatibility for known instance types
  - Allows the system to work with new instance types without
  requiring immediate code updates
  - Prevents pod startup failures due to missing mappings

  ## Does this PR introduce a user-facing change?

  ```release-note
  Fix ome-model-agent-daemonset startup failure when encountering
  unknown instance types by returning the original instance type as a
  fallback instead of an error