### PR TITLE
[core] adds model node selector to components

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -325,8 +325,8 @@ const (
 
 // Labels to put on kservice
 const (
-	KServiceComponentLabel = "component"
-	KServiceEndpointLabel  = "endpoint"
+	OMEComponentLabel = "component"
+	OMEEndpointLabel  = "endpoint"
 )
 
 // Labels for TrainedModel
@@ -388,14 +388,6 @@ const (
 
 // DefaultModelLocalMountPath is where models will be mounted by the storage-initializer
 const DefaultModelLocalMountPath = "/mnt/models"
-
-// Multi-model InferenceService
-const (
-	ModelConfigVolumeName = "model-config"
-	ModelDirVolumeName    = "model-dir"
-	ModelConfigDir        = "/mnt/configs"
-	ModelDir              = DefaultModelLocalMountPath
-)
 
 var (
 	ServiceAnnotationDisallowedList = []string{

--- a/pkg/controller/v1beta1/inferenceservice/components/base_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base_test.go
@@ -1,0 +1,193 @@
+package components
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/gomega"
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/constants"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestUpdatePodSpecNodeSelector(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tests := []struct {
+		name                              string
+		baseModel                         *v1beta1.BaseModelSpec
+		baseModelMeta                     *metav1.ObjectMeta
+		fineTunedServingWithMergedWeights bool
+		existingNodeSelector              map[string]string
+		expectedNodeSelector              map[string]string
+	}{
+		{
+			name: "BaseModel with namespace",
+			baseModel: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{
+					Name: "safetensors",
+				},
+			},
+			baseModelMeta: &metav1.ObjectMeta{
+				Name:      "llama-3-8b",
+				Namespace: "default",
+			},
+			expectedNodeSelector: map[string]string{
+				"models.ome.io/default.basemodel.llama-3-8b": "Ready",
+			},
+		},
+		{
+			name: "ClusterBaseModel without namespace",
+			baseModel: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{
+					Name: "safetensors",
+				},
+			},
+			baseModelMeta: &metav1.ObjectMeta{
+				Name: "mixtral-8x7b",
+				// No namespace for ClusterBaseModel
+			},
+			expectedNodeSelector: map[string]string{
+				"models.ome.io/clusterbasemodel.mixtral-8x7b": "Ready",
+			},
+		},
+		{
+			name: "Existing node selector should be preserved",
+			baseModel: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{
+					Name: "safetensors",
+				},
+			},
+			baseModelMeta: &metav1.ObjectMeta{
+				Name:      "model-1",
+				Namespace: "test-ns",
+			},
+			existingNodeSelector: map[string]string{
+				"custom-label": "custom-value",
+			},
+			expectedNodeSelector: map[string]string{
+				"custom-label": "custom-value",
+				"models.ome.io/test-ns.basemodel.model-1": "Ready",
+			},
+		},
+		{
+			name: "Skip node selector for merged fine-tuned weights",
+			baseModel: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{
+					Name: "safetensors",
+				},
+			},
+			baseModelMeta: &metav1.ObjectMeta{
+				Name:      "base-model",
+				Namespace: "default",
+			},
+			fineTunedServingWithMergedWeights: true,
+			expectedNodeSelector:              nil, // No node selector should be added
+		},
+		{
+			name:                 "No base model",
+			baseModel:            nil,
+			baseModelMeta:        nil,
+			expectedNodeSelector: nil,
+		},
+		{
+			name: "Long model names should be handled",
+			baseModel: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{
+					Name: "safetensors",
+				},
+			},
+			baseModelMeta: &metav1.ObjectMeta{
+				Name:      "very-long-model-name-that-exceeds-normal-length-limits-and-should-be-truncated",
+				Namespace: "long-namespace-name",
+			},
+			expectedNodeSelector: map[string]string{
+				constants.GetBaseModelLabel("long-namespace-name", "very-long-model-name-that-exceeds-normal-length-limits-and-should-be-truncated"): "Ready",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create BaseComponentFields
+			b := &BaseComponentFields{
+				BaseModel:                         tt.baseModel,
+				BaseModelMeta:                     tt.baseModelMeta,
+				FineTunedServingWithMergedWeights: tt.fineTunedServingWithMergedWeights,
+				Log:                               ctrl.Log.WithName("test"),
+			}
+
+			// Create pod spec with existing node selector if provided
+			podSpec := &v1.PodSpec{}
+			if tt.existingNodeSelector != nil {
+				podSpec.NodeSelector = make(map[string]string)
+				for k, v := range tt.existingNodeSelector {
+					podSpec.NodeSelector[k] = v
+				}
+			}
+
+			// Create inference service
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-isvc",
+					Namespace: "default",
+				},
+			}
+
+			// Call the function
+			UpdatePodSpecNodeSelector(b, isvc, podSpec)
+
+			// Verify the result
+			g.Expect(podSpec.NodeSelector).To(gomega.Equal(tt.expectedNodeSelector))
+		})
+	}
+}
+
+func TestProcessBaseLabels(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Test that ProcessBaseLabels adds the correct labels
+	b := &BaseComponentFields{
+		BaseModel: &v1beta1.BaseModelSpec{
+			ModelExtensionSpec: v1beta1.ModelExtensionSpec{
+				Vendor: stringPtr("meta"),
+			},
+		},
+		BaseModelMeta: &metav1.ObjectMeta{
+			Name:      "test-model",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.ModelCategoryAnnotation: "LARGE",
+			},
+		},
+		RuntimeName:      "test-runtime",
+		FineTunedServing: true,
+		Log:              logr.Discard(),
+	}
+
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-isvc",
+			Namespace: "default",
+		},
+	}
+
+	existingLabels := map[string]string{
+		"custom-label": "custom-value",
+	}
+
+	labels := ProcessBaseLabels(b, isvc, v1beta1.EngineComponent, existingLabels)
+
+	// Check expected labels
+	g.Expect(labels).To(gomega.HaveKeyWithValue("custom-label", "custom-value"))
+	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.InferenceServicePodLabelKey, "test-isvc"))
+	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.OMEComponentLabel, "engine"))
+	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.ServingRuntimeLabelKey, "test-runtime"))
+	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.FTServingLabelKey, "true"))
+	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.InferenceServiceBaseModelNameLabelKey, "test-model"))
+	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.InferenceServiceBaseModelSizeLabelKey, "LARGE"))
+	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.BaseModelTypeLabelKey, string(constants.ServingBaseModel)))
+	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.BaseModelVendorLabelKey, "meta"))
+}

--- a/pkg/controller/v1beta1/inferenceservice/components/decoder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder.go
@@ -281,6 +281,7 @@ func (d *Decoder) reconcilePodSpec(isvc *v1beta1.InferenceService, objectMeta *m
 	}
 
 	UpdatePodSpecVolumes(&d.BaseComponentFields, isvc, podSpec, objectMeta)
+	UpdatePodSpecNodeSelector(&d.BaseComponentFields, isvc, podSpec)
 
 	d.Log.Info("Decoder PodSpec updated", "inference service", isvc.Name, "namespace", isvc.Namespace)
 	return podSpec, nil
@@ -310,6 +311,7 @@ func (d *Decoder) reconcileWorkerPodSpec(isvc *v1beta1.InferenceService, objectM
 		return nil, err
 	}
 	UpdatePodSpecVolumes(&d.BaseComponentFields, isvc, workerPodSpec, objectMeta)
+	UpdatePodSpecNodeSelector(&d.BaseComponentFields, isvc, workerPodSpec)
 
 	d.Log.Info("Decoder Worker PodSpec updated", "inference service", isvc.Name, "namespace", isvc.Namespace)
 	return workerPodSpec, nil

--- a/pkg/controller/v1beta1/inferenceservice/components/engine.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine.go
@@ -285,6 +285,7 @@ func (e *Engine) reconcilePodSpec(isvc *v1beta1.InferenceService, objectMeta *me
 		return nil, err
 	}
 	UpdatePodSpecVolumes(&e.BaseComponentFields, isvc, podSpec, objectMeta)
+	UpdatePodSpecNodeSelector(&e.BaseComponentFields, isvc, podSpec)
 
 	e.Log.Info("Engine PodSpec updated", "inference service", isvc.Name, "namespace", isvc.Namespace)
 	return podSpec, nil
@@ -314,6 +315,7 @@ func (e *Engine) reconcileWorkerPodSpec(isvc *v1beta1.InferenceService, objectMe
 		return nil, err
 	}
 	UpdatePodSpecVolumes(&e.BaseComponentFields, isvc, workerPodSpec, objectMeta)
+	UpdatePodSpecNodeSelector(&e.BaseComponentFields, isvc, workerPodSpec)
 	e.Log.Info("Engine Worker PodSpec updated", "inference service", isvc.Name, "namespace", isvc.Namespace)
 	return workerPodSpec, nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/engine_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine_test.go
@@ -85,7 +85,8 @@ func TestEngineReconcile(t *testing.T) {
 				},
 			},
 			baseModelMeta: &metav1.ObjectMeta{
-				Name: "base-model-1",
+				Name:      "base-model-1",
+				Namespace: "default",
 				Annotations: map[string]string{
 					constants.ModelCategoryAnnotation: "LARGE",
 				},
@@ -167,6 +168,12 @@ func TestEngineReconcile(t *testing.T) {
 				// since environment variables are only applied to the runner container
 				g.Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(gomega.BeEmpty())
 
+				// Check node selector was added for the base model
+				expectedNodeSelector := map[string]string{
+					"models.ome.io/default.basemodel.base-model-1": "Ready",
+				}
+				g.Expect(deployment.Spec.Template.Spec.NodeSelector).To(gomega.Equal(expectedNodeSelector))
+
 				// Check service was created
 				service := &v1.Service{}
 				err = c.Get(context.TODO(), types.NamespacedName{
@@ -188,7 +195,8 @@ func TestEngineReconcile(t *testing.T) {
 				},
 			},
 			baseModelMeta: &metav1.ObjectMeta{
-				Name: "base-model-2",
+				Name:      "base-model-2",
+				Namespace: "default",
 			},
 			engineSpec: &v1beta1.EngineSpec{
 				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
@@ -270,6 +278,13 @@ func TestEngineReconcile(t *testing.T) {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(lwsList.Items).To(gomega.HaveLen(1))
 				g.Expect(lwsList.Items[0].Spec.Replicas).To(gomega.Equal(int32Ptr(2)))
+
+				// Check node selector was added for both leader and worker pods
+				expectedNodeSelector := map[string]string{
+					"models.ome.io/default.basemodel.base-model-2": "Ready",
+				}
+				g.Expect(lwsList.Items[0].Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.NodeSelector).To(gomega.Equal(expectedNodeSelector))
+				g.Expect(lwsList.Items[0].Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.NodeSelector).To(gomega.Equal(expectedNodeSelector))
 			},
 		},
 		{
@@ -432,6 +447,81 @@ func TestEngineReconcile(t *testing.T) {
 			},
 		},
 		{
+			name:           "ClusterBaseModel with node selector",
+			deploymentMode: constants.RawDeployment,
+			baseModel: &v1beta1.BaseModelSpec{
+				ModelFormat: v1beta1.ModelFormat{
+					Name: "safetensors",
+				},
+				Storage: &v1beta1.StorageSpec{
+					Path: stringPtr("/mnt/models/cluster-model"),
+				},
+			},
+			baseModelMeta: &metav1.ObjectMeta{
+				Name: "cluster-base-model",
+				// No namespace for ClusterBaseModel
+			},
+			engineSpec: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					MinReplicas: intPtr(1),
+					MaxReplicas: 3,
+				},
+				PodSpec: v1beta1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "engine",
+							Image: "engine:latest",
+						},
+					},
+				},
+			},
+			runtime:     &v1beta1.ServingRuntimeSpec{},
+			runtimeName: "test-runtime",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Model: &v1beta1.ModelRef{},
+				},
+			},
+			setupMocks: func(c client.Client, cs kubernetes.Interface) {
+				// Create inferenceservice config
+				cm := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "inferenceservice-config",
+						Namespace: "ome",
+					},
+					Data: map[string]string{
+						"config": "{}",
+					},
+				}
+				err := c.Create(context.TODO(), cm)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = cs.CoreV1().ConfigMaps("ome").Create(context.TODO(), cm, metav1.CreateOptions{})
+				if err != nil && !strings.Contains(err.Error(), "already exists") {
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			},
+			validate: func(t *testing.T, c client.Client, isvc *v1beta1.InferenceService) {
+				// Check deployment was created
+				deployment := &appsv1.Deployment{}
+				err := c.Get(context.TODO(), types.NamespacedName{
+					Name:      "test-cluster-isvc-engine",
+					Namespace: "default",
+				}, deployment)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Check node selector for ClusterBaseModel (no namespace in label)
+				expectedNodeSelector := map[string]string{
+					"models.ome.io/clusterbasemodel.cluster-base-model": "Ready",
+				}
+				g.Expect(deployment.Spec.Template.Spec.NodeSelector).To(gomega.Equal(expectedNodeSelector))
+			},
+		},
+		{
 			name:           "Engine with nil spec should error",
 			deploymentMode: constants.RawDeployment,
 			engineSpec:     nil,
@@ -588,7 +678,7 @@ func TestEngineReconcileObjectMeta(t *testing.T) {
 				"custom-label":                                  "value",
 				"engine-label":                                  "engine-value",
 				constants.InferenceServicePodLabelKey:           "test-isvc",
-				constants.KServiceComponentLabel:                "engine",
+				constants.OMEComponentLabel:                     "engine",
 				constants.ServingRuntimeLabelKey:                "test-runtime",
 				constants.InferenceServiceBaseModelNameLabelKey: "base-model",
 				constants.InferenceServiceBaseModelSizeLabelKey: "LARGE",
@@ -640,7 +730,7 @@ func TestEngineReconcileObjectMeta(t *testing.T) {
 			},
 			expectedLabels: map[string]string{
 				constants.InferenceServicePodLabelKey:           "ft-isvc",
-				constants.KServiceComponentLabel:                "engine",
+				constants.OMEComponentLabel:                     "engine",
 				constants.FTServingLabelKey:                     "true",
 				constants.FineTunedWeightFTStrategyLabelKey:     "lora",
 				constants.FTServingWithMergedWeightsLabelKey:    "false",

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/external_service/external_service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/external_service/external_service_reconciler.go
@@ -116,17 +116,17 @@ func (r *ExternalServiceReconciler) determineTargetSelector(isvc *v1beta1.Infere
 
 	// Priority: Router > Engine > Predictor
 	if isvc.Spec.Router != nil {
-		baseSelector[constants.KServiceComponentLabel] = string(v1beta1.RouterComponent)
+		baseSelector[constants.OMEComponentLabel] = string(v1beta1.RouterComponent)
 		return baseSelector
 	}
 
 	if isvc.Spec.Engine != nil {
-		baseSelector[constants.KServiceComponentLabel] = string(v1beta1.EngineComponent)
+		baseSelector[constants.OMEComponentLabel] = string(v1beta1.EngineComponent)
 		return baseSelector
 	}
 
 	// Fallback to predictor
-	baseSelector[constants.KServiceComponentLabel] = string(constants.Predictor)
+	baseSelector[constants.OMEComponentLabel] = string(constants.Predictor)
 	return baseSelector
 }
 
@@ -140,7 +140,7 @@ func (r *ExternalServiceReconciler) buildExternalService(isvc *v1beta1.Inference
 			Namespace: isvc.Namespace,
 			Labels: map[string]string{
 				constants.InferenceServicePodLabelKey: isvc.Name,
-				constants.KServiceComponentLabel:      "external-service",
+				constants.OMEComponentLabel:           "external-service",
 			},
 			Annotations: r.getServiceAnnotations(isvc),
 		},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/external_service/external_service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/external_service/external_service_reconciler_test.go
@@ -210,7 +210,7 @@ func TestExternalServiceReconciler_determineTargetSelector(t *testing.T) {
 			},
 			expectedSelector: map[string]string{
 				constants.InferenceServicePodLabelKey: "test-service",
-				constants.KServiceComponentLabel:      string(v1beta1.RouterComponent),
+				constants.OMEComponentLabel:           string(v1beta1.RouterComponent),
 			},
 			description: "router component should be selected when multiple components exist",
 		},
@@ -232,7 +232,7 @@ func TestExternalServiceReconciler_determineTargetSelector(t *testing.T) {
 			},
 			expectedSelector: map[string]string{
 				constants.InferenceServicePodLabelKey: "test-service",
-				constants.KServiceComponentLabel:      string(v1beta1.EngineComponent),
+				constants.OMEComponentLabel:           string(v1beta1.EngineComponent),
 			},
 			description: "engine component should be selected when router doesn't exist",
 		},
@@ -253,7 +253,7 @@ func TestExternalServiceReconciler_determineTargetSelector(t *testing.T) {
 			},
 			expectedSelector: map[string]string{
 				constants.InferenceServicePodLabelKey: "test-service",
-				constants.KServiceComponentLabel:      string(constants.Predictor),
+				constants.OMEComponentLabel:           string(constants.Predictor),
 			},
 			description: "predictor component should be selected as fallback",
 		},
@@ -411,7 +411,7 @@ func TestExternalServiceReconciler_Reconcile(t *testing.T) {
 					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						constants.InferenceServicePodLabelKey: "test-service",
-						constants.KServiceComponentLabel:      string(v1beta1.EngineComponent),
+						constants.OMEComponentLabel:           string(v1beta1.EngineComponent),
 					},
 					Ports: []corev1.ServicePort{
 						{
@@ -450,7 +450,7 @@ func TestExternalServiceReconciler_Reconcile(t *testing.T) {
 					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
 						constants.InferenceServicePodLabelKey: "test-service",
-						constants.KServiceComponentLabel:      string(v1beta1.EngineComponent),
+						constants.OMEComponentLabel:           string(v1beta1.EngineComponent),
 					},
 					Ports: []corev1.ServicePort{
 						{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/builders/ingress_builder.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/builders/ingress_builder.go
@@ -240,7 +240,7 @@ func (b *IngressBuilder) generateMetadata(isvc *v1beta1.InferenceService,
 		Namespace: isvc.Namespace,
 		Labels: utils.Union(isvc.Labels, map[string]string{
 			constants.InferenceServicePodLabelKey: isvc.Name,
-			constants.KServiceComponentLabel:      string(componentType),
+			constants.OMEComponentLabel:           string(componentType),
 		}),
 		Annotations: annotations,
 	}


### PR DESCRIPTION
## What type of PR is this?

  /kind feature

  ## What this PR does / why we need it:

  This PR adds node selector functionality to InferenceService components (engine and decoder) to ensure they are scheduled only on nodes where the
  required model has been successfully downloaded by the model agent.

  **Background:**
  The model agent downloads models to nodes and labels them with their availability status:
  - For BaseModel: `models.ome.io/{namespace}.basemodel.{model_name}=Ready`
  - For ClusterBaseModel: `models.ome.io/clusterbasemodel.{model_name}=Ready`

  **Changes:**
  1. Added `UpdatePodSpecNodeSelector` function in the base component that:
     - Adds appropriate node selectors based on the model type (BaseModel vs ClusterBaseModel)
     - Handles long model names with proper truncation
     - Skips node selector for fine-tuned serving with merged weights (as they don't need the base model on the node)
     - Preserves existing node selectors

  2. Updated engine and decoder components to call `UpdatePodSpecNodeSelector` for both leader and worker pods in multi-node deployments

  3. Added comprehensive unit tests to verify the node selector functionality

  **Benefits:**
  - Prevents pods from being scheduled on nodes without the required model
  - Avoids runtime errors when pods try to access models that aren't available
  - Ensures proper scheduling for both namespace-scoped BaseModel and cluster-scoped ClusterBaseModel resources

  ## Which issue(s) this PR fixes:

  Fixes #

  ## Special notes for your reviewer:

  1. The router component was intentionally not updated as it doesn't require direct model access
  2. The implementation uses the existing label format from the model agent's `node_label_reconciler.go`
  3. Tests have been added for:
     - BaseModel with namespace
     - ClusterBaseModel without namespace
     - Long model names that require truncation
     - Fine-tuned serving with merged weights (should skip node selector)
     - Preservation of existing node selectors

  ## Does this PR introduce a user-facing change?

  ```release-note
  InferenceService pods (engine and decoder) now include node selectors to ensure they are scheduled only on nodes where the required model is
  available. This prevents scheduling failures and runtime errors when models are not present on the target node.