### PR TITLE
[bugfix] Separate OCI Object Storage clients for ome agent

### DIFF
--- a/cmd/ome-agent/replica_agent.go
+++ b/cmd/ome-agent/replica_agent.go
@@ -44,7 +44,7 @@ func (r *ReplicaAgent) FxModules() []fx.Option {
 		afero.Module,
 		logging.Module,
 		logging.ModuleNamed("another_log"),
-		ociobjectstore.OCIOSDataStoreModule,
+		ociobjectstore.OCIOSDataStoreListProvider,
 		replica.Module,
 		fx.Populate(&r.agent),
 	}

--- a/internal/ome-agent/replica/module.go
+++ b/internal/ome-agent/replica/module.go
@@ -13,7 +13,7 @@ type replicaParams struct {
 	fx.In
 
 	AnotherLogger           logging.Interface `name:"another_log"`
-	ObjectStorageDataStores *ociobjectstore.OCIOSDataStore
+	ObjectStorageDataStores []*ociobjectstore.OCIOSDataStore
 }
 
 var Module = fx.Provide(

--- a/internal/ome-agent/replica/replica.go
+++ b/internal/ome-agent/replica/replica.go
@@ -69,8 +69,8 @@ func (r *ReplicaAgent) Start() error {
 }
 
 func (r *ReplicaAgent) listSourceObjects() ([]objectstorage.ObjectSummary, error) {
-	r.Config.ObjectStorageDataStore.SetRegion(r.Config.SourceObjectStoreURI.Region)
-	sourceObjs, err := r.Config.ObjectStorageDataStore.ListObjects(r.Config.SourceObjectStoreURI)
+	r.Config.SourceObjectStorageDataStore.SetRegion(r.Config.SourceObjectStoreURI.Region)
+	sourceObjs, err := r.Config.SourceObjectStorageDataStore.ListObjects(r.Config.SourceObjectStoreURI)
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +140,8 @@ func (r *ReplicaAgent) processObjectReplication(objects <-chan objectstorage.Obj
 }
 
 func (r *ReplicaAgent) downloadObject(srcObj ociobjectstore.ObjectURI, obj *objectstorage.ObjectSummary) error {
-	r.Config.ObjectStorageDataStore.SetRegion(r.Config.SourceObjectStoreURI.Region)
-	err := r.Config.ObjectStorageDataStore.MultipartDownload(srcObj, r.Config.LocalPath,
+	r.Config.SourceObjectStorageDataStore.SetRegion(r.Config.SourceObjectStoreURI.Region)
+	err := r.Config.SourceObjectStorageDataStore.MultipartDownload(srcObj, r.Config.LocalPath,
 		ociobjectstore.WithChunkSize(DefaultDownloadChunkSizeInMB),
 		ociobjectstore.WithThreads(DefaultDownloadThreads))
 	if err != nil {
@@ -152,10 +152,10 @@ func (r *ReplicaAgent) downloadObject(srcObj ociobjectstore.ObjectURI, obj *obje
 }
 
 func (r *ReplicaAgent) uploadObject(targetObj ociobjectstore.ObjectURI, objName string) error {
-	r.Config.ObjectStorageDataStore.SetRegion(r.Config.TargetObjectStoreURI.Region)
+	r.Config.TargetObjectStorageDataStore.SetRegion(r.Config.TargetObjectStoreURI.Region)
 	curFilePath := filepath.Join(r.Config.LocalPath, objName)
 
-	err := r.Config.ObjectStorageDataStore.MultipartFileUpload(curFilePath, targetObj, DefaultUploadChunkSizeInMB, DefaultUploadThreads)
+	err := r.Config.TargetObjectStorageDataStore.MultipartFileUpload(curFilePath, targetObj, DefaultUploadChunkSizeInMB, DefaultUploadThreads)
 	if err != nil {
 		r.logger.Errorf("Failed to upload object %s: %+v", targetObj.ObjectName, err)
 		return err

--- a/internal/ome-agent/replica/replica_test.go
+++ b/internal/ome-agent/replica/replica_test.go
@@ -43,14 +43,15 @@ func TestNewReplicaAgent(t *testing.T) {
 	mockDataStore := &ociobjectstore.OCIOSDataStore{}
 
 	config := &Config{
-		AnotherLogger:          mockLogger,
-		LocalPath:              "/test/path",
-		SourceObjectStoreURI:   ociobjectstore.ObjectURI{Namespace: "src-ns", BucketName: "src-bucket"},
-		TargetObjectStoreURI:   ociobjectstore.ObjectURI{Namespace: "tgt-ns", BucketName: "tgt-bucket"},
-		ObjectStorageDataStore: mockDataStore,
-		NumConnections:         5,
-		DownloadSizeLimitGB:    100,
-		EnableSizeLimitCheck:   true,
+		AnotherLogger:                mockLogger,
+		LocalPath:                    "/test/path",
+		SourceObjectStoreURI:         ociobjectstore.ObjectURI{Namespace: "src-ns", BucketName: "src-bucket"},
+		TargetObjectStoreURI:         ociobjectstore.ObjectURI{Namespace: "tgt-ns", BucketName: "tgt-bucket"},
+		SourceObjectStorageDataStore: mockDataStore,
+		TargetObjectStorageDataStore: mockDataStore,
+		NumConnections:               5,
+		DownloadSizeLimitGB:          100,
+		EnableSizeLimitCheck:         true,
 	}
 
 	agent, err := NewReplicaAgent(config)
@@ -305,14 +306,14 @@ func TestReplicaAgent_Start(t *testing.T) {
 	agent := &ReplicaAgent{
 		logger: mockLogger,
 		Config: Config{
-			AnotherLogger:          mockLogger,
-			LocalPath:              "/test/path",
-			SourceObjectStoreURI:   sourceURI,
-			TargetObjectStoreURI:   targetURI,
-			ObjectStorageDataStore: mockDataStore.OCIOSDataStore,
-			NumConnections:         1,
-			DownloadSizeLimitGB:    100,
-			EnableSizeLimitCheck:   true,
+			AnotherLogger:                mockLogger,
+			LocalPath:                    "/test/path",
+			SourceObjectStoreURI:         sourceURI,
+			TargetObjectStoreURI:         targetURI,
+			SourceObjectStorageDataStore: mockDataStore.OCIOSDataStore,
+			NumConnections:               1,
+			DownloadSizeLimitGB:          100,
+			EnableSizeLimitCheck:         true,
 		},
 	}
 

--- a/pkg/ociobjectstore/config.go
+++ b/pkg/ociobjectstore/config.go
@@ -19,6 +19,8 @@ const (
 	RegionViperKeyName         = "region_override"
 	EnableOboTokenViperKeyName = "enable_obo_token"
 	OboTokenViperKeyName       = "obo_token"
+	SourceOsConfigName         = "source"
+	TargetOsConfigName         = "target"
 )
 
 // Config holds the configuration parameters required to initialize a OCIOSDataStore.
@@ -85,6 +87,23 @@ func WithAnotherLog(logger logging.Interface) Option {
 			return errors.New("nil another logger")
 		}
 		c.AnotherLogger = logger
+		return nil
+	}
+}
+
+func WithName(name string) Option {
+	return func(cfg *Config) error {
+		if name == "" {
+			return errors.New("name cannot be empty")
+		}
+		cfg.Name = name
+		return nil
+	}
+}
+
+func WithOboTokenEnabled(enabled bool) Option {
+	return func(cfg *Config) error {
+		cfg.EnableOboToken = enabled
 		return nil
 	}
 }

--- a/pkg/ociobjectstore/config_test.go
+++ b/pkg/ociobjectstore/config_test.go
@@ -408,6 +408,46 @@ func TestWithAnotherLog(t *testing.T) {
 	}
 }
 
+// TestWithName tests the WithName option
+func TestWithName(t *testing.T) {
+	tests := []struct {
+		testName      string
+		name          string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			testName:      "empty name",
+			name:          "",
+			expectError:   true,
+			errorContains: "name cannot be empty",
+		},
+		{
+			testName:    "valid name",
+			name:        "Valid name",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			c := &Config{}
+			option := WithName(tt.name)
+			err := option(c)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.name, c.Name)
+			}
+		})
+	}
+}
+
 // TestConfig_Validate tests the Validate method
 func TestConfig_Validate(t *testing.T) {
 	tests := []struct {

--- a/pkg/ociobjectstore/module.go
+++ b/pkg/ociobjectstore/module.go
@@ -28,6 +28,68 @@ var OCIOSDataStoreModule = fx.Provide(
 	ProvideOCIOSDataStore,
 )
 
+type OSDataStoreConfigWrapper struct {
+	fx.Out
+
+	OSDataStoreConfig *Config `group:"casperConfigs"`
+}
+
+// ProvideSourceOCIOSDataStoreConfig ProvideSourceOCIOSDataStore constructs a Config instance for the source OCI Object Storage
+// location using Viper configuration, environment context, and a logger.
+// This function is intended to be used as an fx provider. The resulting Config is wrapped in
+// OSDataStoreConfigWrapper and added to the "oSDataStoreConfig" value group for collective injection.
+//
+// Returns:
+//   - OSDataStoreConfigWrapper containing the initialized Config if successful
+//   - An error if configuration loading or initialization fails
+func ProvideSourceOCIOSDataStoreConfig(v *viper.Viper, logger logging.Interface) (OSDataStoreConfigWrapper, error) {
+	config, err := NewConfig(WithViper(v), WithAnotherLog(logger), WithName(SourceOsConfigName))
+	if err != nil {
+		return OSDataStoreConfigWrapper{}, fmt.Errorf("error creating source object store config: %w", err)
+	}
+	if err = config.Validate(); err != nil {
+		return OSDataStoreConfigWrapper{}, fmt.Errorf("ociobjectstore config is invalid: %w", err)
+	}
+	return OSDataStoreConfigWrapper{
+		OSDataStoreConfig: config,
+	}, nil
+}
+
+// ProvideTargetOCIOSDataStoreConfig constructs a Config instance for the destination (target) OCI Object Storage
+// location using Viper configuration, environment context, and a logger. This function is intended to be
+// used as an fx provider. The resulting Config is wrapped in OSDataStoreConfigWrapper and added to the
+// "oSDataStoreConfig" value group for collective injection.
+//
+// Note: Destination object storage locations are currently expected to reside under service tenancies
+// where customer OBO tokens are not permitted.
+//
+// TODO: Refactor to separate source and target configuration in OME agent config, and read specifically
+// from the target config.
+//
+// Returns:
+//   - OSDataStoreConfigWrapper containing the initialized Config if successful
+//   - An error if configuration loading or initialization fails
+func ProvideTargetOCIOSDataStoreConfig(v *viper.Viper, logger logging.Interface) (OSDataStoreConfigWrapper, error) {
+	config, err := NewConfig(WithViper(v), WithAnotherLog(logger), WithName(TargetOsConfigName), WithOboTokenEnabled(false))
+	if err != nil {
+		return OSDataStoreConfigWrapper{}, fmt.Errorf("error creating target object store config: %w", err)
+	}
+	if err = config.Validate(); err != nil {
+		return OSDataStoreConfigWrapper{}, fmt.Errorf("ociobjectstore config is invalid: %w", err)
+	}
+	return OSDataStoreConfigWrapper{
+		OSDataStoreConfig: config,
+	}, nil
+}
+
+// OCIOSDataStoreListProvider is an fx module that provides a singleton OCIOSDataStore.
+// It wires ProvideSourceOCIOSDataStore and ProvideTargetOCIOSDataStore into the fx dependency graph.
+var OCIOSDataStoreListProvider = fx.Provide(
+	ProvideSourceOCIOSDataStoreConfig,
+	ProvideTargetOCIOSDataStoreConfig,
+	ProvideListOfOCIOSDataStoreWithAppParams,
+)
+
 // appParams defines the fx input struct for dependency injection.
 // It demonstrates two advanced fx features:
 //   - Named logger injection using `name:"another_log"`

--- a/pkg/ociobjectstore/module_test.go
+++ b/pkg/ociobjectstore/module_test.go
@@ -121,6 +121,48 @@ func TestOCIOSDataStoreModule(t *testing.T) {
 	})
 }
 
+func TestOCIOSDataStoreListProvider(t *testing.T) {
+	t.Run("ListProvider structure validation", func(t *testing.T) {
+		// Test that OCIOSDataStoreModule is a valid fx.Option
+		assert.NotNil(t, OCIOSDataStoreListProvider)
+
+		// Test that we can create the module without panicking
+		assert.NotPanics(t, func() {
+			_ = OCIOSDataStoreListProvider
+		})
+	})
+
+	t.Run("ListProvider function with invalid config", func(t *testing.T) {
+		v := viper.New()
+		// Don't set auth_type to test error handling
+
+		logger := testingPkg.SetupMockLogger()
+
+		_, err := ProvideSourceOCIOSDataStoreConfig(v, logger)
+		assert.Error(t, err)
+		// The actual error message is about config validation, not "error reading agent config"
+		assert.Contains(t, err.Error(), "ociobjectstore config is invalid")
+
+		_, err = ProvideTargetOCIOSDataStoreConfig(v, logger)
+		assert.Error(t, err)
+		// The actual error message is about config validation, not "error reading agent config"
+		assert.Contains(t, err.Error(), "ociobjectstore config is invalid")
+	})
+
+	t.Run("ListProvider function with nil logger", func(t *testing.T) {
+		v := viper.New()
+		v.Set(AuthTypeViperKeyName, "InstancePrincipal")
+
+		_, err := ProvideSourceOCIOSDataStoreConfig(v, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "nil another logger")
+
+		_, err = ProvideTargetOCIOSDataStoreConfig(v, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "nil another logger")
+	})
+}
+
 func TestAppParams(t *testing.T) {
 	t.Run("AppParams structure", func(t *testing.T) {
 		// Test that appParams can be created


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

This PR updates the object replication workflow to use separate Object Storage clients for downloading and uploading objects, improving both security and maintainability.

**Background:** 

We want to ensure that customers do not have direct write access to the customer model store bucket. Granting write permissions would allow users operating with OBO (On-Behalf-Of) tokens to directly overwrite or modify data in the model store, which introduces significant security and data integrity risks. By clearly separating client responsibilities - one for downloading with customer-level credentials and one for uploading with service-level credentials - we prevent unauthorized or accidental data modifications by customers. This approach also provides stronger isolation of permissions and aligns with the principle of least privilege.

**Changes:**

1. Refactored the replica job to use two distinct Object Storage clients:
   * The download client, authenticated with the customer's OBO token, can only retrieve (read) objects from buckets within the customer’s tenancy.
   *  The upload client, authenticated with a service instance principal, exclusively writes (uploads) objects to the customer model store bucket within the service tenancy.
2. Updated internal logic to handle and manage multiple clients for enhanced security.
3. Prepared the client structure for future scalability, such as cross-region replication and fan-out scenarios.

## Which issue(s) this PR fixes:
Fixes #

## Does this PR introduce a user-facing change?

```release-note
None
```