### PR TITLE
[Bugfix] Fix models yaml file no such file or directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ install: kustomize ## 🚀 Deploy controller in the configured Kubernetes cluste
 	@echo "## 💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥 ##"
 	@echo "Are you really sure you want to completely re-install in [$(value KUBECONFIG)] environment ?"
 	@echo "## 💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥 ##"
-	@read -p "Press enter to continue"
+	@read -p "Press enter to continue" var
 	
 	@echo "\n🔧 Step 1: Configuring certificates..."
 	@cd config/default && if [ ${OME_ENABLE_SELF_SIGNED_CA} != false ]; then \
@@ -452,7 +452,7 @@ uninstall: kustomize ## 🧹 Uninstall controller from the configured Kubernetes
 	@echo "## 💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥 ##"
 	@echo "Are you really sure you want to completely destroy [$(value KUBECONFIG)] environment ?"
 	@echo "## 💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥 ##"
-	@read -p "Press enter to continue"
+	@read -p "Press enter to continue" var
 	kubectl delete --ignore-not-found=$(ignore-not-found) -k config/default
 	kubectl delete --ignore-not-found=$(ignore-not-found) -k config/clusterresources
 	@echo "✅ Controller uninstalled"

--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ install: kustomize ## 🚀 Deploy controller in the configured Kubernetes cluste
 	@echo "## 💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥 ##"
 	@echo "Are you really sure you want to completely re-install in [$(value KUBECONFIG)] environment ?"
 	@echo "## 💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥 ##"
-	@read -p "Press enter to continue"
+	@read -p "Press enter to continue" var
 	
 	@echo "\n🔧 Step 1: Configuring certificates..."
 	@cd config/default && if [ ${OME_ENABLE_SELF_SIGNED_CA} != false ]; then \
@@ -452,7 +452,8 @@ uninstall: kustomize ## 🧹 Uninstall controller from the configured Kubernetes
 	@echo "## 💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥 ##"
 	@echo "Are you really sure you want to completely destroy [$(value KUBECONFIG)] environment ?"
 	@echo "## 💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥💥 ##"
-	@read -p "Press enter to continue"
+	@read -p "Press enter to continue" var
+
 	kubectl delete --ignore-not-found=$(ignore-not-found) -k config/default
 	kubectl delete --ignore-not-found=$(ignore-not-found) -k config/clusterresources
 	@echo "✅ Controller uninstalled"

--- a/config/models/kustomization.yaml
+++ b/config/models/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 
 resources:
   - meta/Llama-3.3-70B-instruct.yaml
-  - meta/llama-4-maverick-17b-128e-instruct-fp8.yaml
-  - meta/llama-4-scout-17b-16e-instruct.yaml
+  - meta/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+  - meta/Llama-4-Scout-17B-16E-Instruct.yaml
   - intfloat/e5-mistral-7b-instruct.yaml
   - microsoft/Phi-3-vision-128k-instruct.yaml
   - deepseek-ai/DeepSeek-V3.yaml


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:

When I exec `make install`:
```shell
🔄 Step 4: Applying cluster resources...
kubectl apply --server-side --force-conflicts -k config/clusterresources
error: accumulating resources: accumulation err='accumulating resources from '../models': '/root/OME/ome/config/models' must resolve to a file': recursed accumulation of path '/root/OME/ome/config/models': accumulating resources: accumulation err='accumulating resources from 'meta/llama-4-maverick-17b-128e-instruct-fp8.yaml': evalsymlink failure on '/root/OME/ome/config/models/meta/llama-4-maverick-17b-128e-instruct-fp8.yaml' : lstat /root/OME/ome/config/models/meta/llama-4-maverick-17b-128e-instruct-fp8.yaml: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on '/root/OME/ome/config/models/meta/llama-4-maverick-17b-128e-instruct-fp8.yaml' : lstat /root/OME/ome/config/models/meta/llama-4-maverick-17b-128e-instruct-fp8.yaml: no such file or directory
make: *** [Makefile:429: install] Error 1
``` 

## Which issue(s) this PR fixes:
Fixes #151 