### PR TITLE
[Misc] replica ome-agent: minor improvements + cleanup

### DIFF
--- a/cmd/ome-agent/replica_agent.go
+++ b/cmd/ome-agent/replica_agent.go
@@ -80,37 +80,35 @@ func OCIOSDataStoreListProvider() fx.Option {
 	)
 }
 
-func provideSourceOCIOSDataSourceConfig(logger logging.Interface, v *viper.Viper) OCIOSDataStoreConfigWrapper {
+func provideSourceOCIOSDataSourceConfig(
+	logger logging.Interface,
+	v *viper.Viper) (OCIOSDataStoreConfigWrapper, error) {
 	sourceOCIEnabled := v.GetBool("source.oci.enabled")
 	if !sourceOCIEnabled {
-		return OCIOSDataStoreConfigWrapper{
-			OCIOSDataStoreConfig: nil,
-		}
+		return OCIOSDataStoreConfigWrapper{}, nil
 	}
 
 	sourceOCIOSDataStoreConfig := &ociobjectstore.Config{}
 	if err := v.UnmarshalKey("source.oci", sourceOCIOSDataStoreConfig); err != nil {
-		panic(fmt.Errorf("error occurred when unmarshalling key source: %+v", err))
+		return OCIOSDataStoreConfigWrapper{}, fmt.Errorf("error occurred when unmarshalling key source: %+v", err)
 	}
 	sourceOCIOSDataStoreConfig.AnotherLogger = logger
 	sourceOCIOSDataStoreConfig.Name = replica.SourceStorageConfigKeyName
 
 	return OCIOSDataStoreConfigWrapper{
 		OCIOSDataStoreConfig: sourceOCIOSDataStoreConfig,
-	}
+	}, nil
 }
 
-func provideTargetOCIOSDataStoreConfig(logger logging.Interface, v *viper.Viper) OCIOSDataStoreConfigWrapper {
+func provideTargetOCIOSDataStoreConfig(logger logging.Interface, v *viper.Viper) (OCIOSDataStoreConfigWrapper, error) {
 	targetOCIEnabled := v.GetBool("target.oci.enabled")
 	if !targetOCIEnabled {
-		return OCIOSDataStoreConfigWrapper{
-			OCIOSDataStoreConfig: nil,
-		}
+		return OCIOSDataStoreConfigWrapper{}, nil
 	}
 
 	targetOCIOSDataStoreConfig := &ociobjectstore.Config{}
 	if err := v.UnmarshalKey("target.oci", targetOCIOSDataStoreConfig); err != nil {
-		panic(fmt.Errorf("error occurred when unmarshalling key source: %+v", err))
+		return OCIOSDataStoreConfigWrapper{}, fmt.Errorf("error occurred when unmarshalling key target: %+v", err)
 	}
 
 	targetOCIOSDataStoreConfig.AnotherLogger = logger
@@ -118,5 +116,5 @@ func provideTargetOCIOSDataStoreConfig(logger logging.Interface, v *viper.Viper)
 
 	return OCIOSDataStoreConfigWrapper{
 		OCIOSDataStoreConfig: targetOCIOSDataStoreConfig,
-	}
+	}, nil
 }

--- a/cmd/ome-agent/replica_agent_test.go
+++ b/cmd/ome-agent/replica_agent_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	testingPkg "github.com/sgl-project/ome/pkg/testing"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOCIOSDataStoreListProvider(t *testing.T) {
+	t.Run("Source/Target disabled returns empty wrapper and no error", func(t *testing.T) {
+		logger := testingPkg.SetupMockLogger()
+		v := viper.New()
+		v.Set("source.oci.enabled", false)
+		v.Set("target.oci.enabled", false)
+
+		w, err := provideSourceOCIOSDataSourceConfig(logger, v)
+		assert.NoError(t, err)
+		assert.Nil(t, w.OCIOSDataStoreConfig)
+
+		w, err = provideTargetOCIOSDataStoreConfig(logger, v)
+		assert.NoError(t, err)
+		assert.Nil(t, w.OCIOSDataStoreConfig)
+	})
+
+	t.Run("Source/Target enabled with minimal config sets Name and logger", func(t *testing.T) {
+		logger := testingPkg.SetupMockLogger()
+		v := viper.New()
+		v.Set("source.oci.enabled", true)
+		v.Set("target.oci.enabled", true)
+		// Minimal config: no other fields set
+
+		w, err := provideSourceOCIOSDataSourceConfig(logger, v)
+		assert.NoError(t, err)
+		if assert.NotNil(t, w.OCIOSDataStoreConfig) {
+			assert.Equal(t, "source", w.OCIOSDataStoreConfig.Name)
+			assert.Equal(t, logger, w.OCIOSDataStoreConfig.AnotherLogger)
+		}
+
+		w, err = provideTargetOCIOSDataStoreConfig(logger, v)
+		assert.NoError(t, err)
+		if assert.NotNil(t, w.OCIOSDataStoreConfig) {
+			assert.Equal(t, "target", w.OCIOSDataStoreConfig.Name)
+			assert.Equal(t, logger, w.OCIOSDataStoreConfig.AnotherLogger)
+		}
+	})
+
+	t.Run("Source/Target enabled with invalid config key returns error", func(t *testing.T) {
+		logger := testingPkg.SetupMockLogger()
+		v := viper.New()
+		v.Set("source.oci.enabled", true)
+		v.Set("target.oci.enabled", true)
+		// Set a value that will cause UnmarshalKey to fail
+		v.Set("source.oci.enable_obo_token", "invalid_value")
+		v.Set("target.oci.auth_type", []int{1, 2, 3})
+
+		_, err := provideSourceOCIOSDataSourceConfig(logger, v)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unmarshalling key source")
+
+		_, err = provideTargetOCIOSDataStoreConfig(logger, v)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unmarshalling key target")
+	})
+}

--- a/internal/ome-agent/replica/oci_to_oci.go
+++ b/internal/ome-agent/replica/oci_to_oci.go
@@ -1,6 +1,7 @@
 package replica
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -56,6 +57,9 @@ func (r *OCIToOCIReplicator) Replicate(objects []ReplicationObject) error {
 	}
 
 	r.logger.Infof("Replication completed with %d successes and %d errors in %v", successCount, errorCount, time.Since(startTime))
+	if errorCount > 0 {
+		return fmt.Errorf("%d/%d replications failed", errorCount, len(objects))
+	}
 	return nil
 }
 

--- a/pkg/ociobjectstore/module.go
+++ b/pkg/ociobjectstore/module.go
@@ -28,65 +28,6 @@ var OCIOSDataStoreModule = fx.Provide(
 	ProvideOCIOSDataStore,
 )
 
-type OSDataStoreConfigWrapper struct {
-	fx.Out
-
-	OSDataStoreConfig *Config `group:"casperConfigs"`
-}
-
-// ProvideSourceOCIOSDataStoreConfig ProvideSourceOCIOSDataStore constructs a Config instance for the source OCI Object Storage
-// location using Viper configuration, environment context, and a logger.
-// This function is intended to be used as an fx provider. The resulting Config is wrapped in
-// OSDataStoreConfigWrapper and added to the "oSDataStoreConfig" value group for collective injection.
-//
-// Returns:
-//   - OSDataStoreConfigWrapper containing the initialized Config if successful
-//   - An error if configuration loading or initialization fails
-func ProvideSourceOCIOSDataStoreConfig(v *viper.Viper, logger logging.Interface) (OSDataStoreConfigWrapper, error) {
-	config, err := NewConfig(WithViper(v), WithAnotherLog(logger), WithName(SourceOsConfigName))
-	if err != nil {
-		return OSDataStoreConfigWrapper{}, fmt.Errorf("error creating source object store config: %w", err)
-	}
-	if err = config.Validate(); err != nil {
-		return OSDataStoreConfigWrapper{}, fmt.Errorf("ociobjectstore config is invalid: %w", err)
-	}
-	return OSDataStoreConfigWrapper{
-		OSDataStoreConfig: config,
-	}, nil
-}
-
-// ProvideTargetOCIOSDataStoreConfig constructs a Config instance for the destination (target) OCI Object Storage
-// location using Viper configuration, environment context, and a logger. This function is intended to be
-// used as an fx provider. The resulting Config is wrapped in OSDataStoreConfigWrapper and added to the
-// "OCIOSDataStoreConfigs" value group for collective injection.
-//
-// Note: Destination object storage locations are currently expected to reside under service tenancies
-// where customer OBO tokens are not permitted.
-//
-// Returns:
-//   - OSDataStoreConfigWrapper containing the initialized Config if successful
-//   - An error if configuration loading or initialization fails
-func ProvideTargetOCIOSDataStoreConfig(v *viper.Viper, logger logging.Interface) (OSDataStoreConfigWrapper, error) {
-	config, err := NewConfig(WithViper(v), WithAnotherLog(logger), WithName(TargetOsConfigName), WithOboTokenEnabled(false))
-	if err != nil {
-		return OSDataStoreConfigWrapper{}, fmt.Errorf("error creating target object store config: %w", err)
-	}
-	if err = config.Validate(); err != nil {
-		return OSDataStoreConfigWrapper{}, fmt.Errorf("ociobjectstore config is invalid: %w", err)
-	}
-	return OSDataStoreConfigWrapper{
-		OSDataStoreConfig: config,
-	}, nil
-}
-
-// OCIOSDataStoreListProvider is an fx module that provides a singleton OCIOSDataStore.
-// It wires ProvideSourceOCIOSDataStore and ProvideTargetOCIOSDataStore into the fx dependency graph.
-var OCIOSDataStoreListProvider = fx.Provide(
-	ProvideSourceOCIOSDataStoreConfig,
-	ProvideTargetOCIOSDataStoreConfig,
-	ProvideListOfOCIOSDataStoreWithAppParams,
-)
-
 // appParams defines the fx input struct for dependency injection.
 // It demonstrates two advanced fx features:
 //   - Named logger injection using `name:"another_log"`

--- a/pkg/ociobjectstore/module_test.go
+++ b/pkg/ociobjectstore/module_test.go
@@ -121,48 +121,6 @@ func TestOCIOSDataStoreModule(t *testing.T) {
 	})
 }
 
-func TestOCIOSDataStoreListProvider(t *testing.T) {
-	t.Run("ListProvider structure validation", func(t *testing.T) {
-		// Test that OCIOSDataStoreModule is a valid fx.Option
-		assert.NotNil(t, OCIOSDataStoreListProvider)
-
-		// Test that we can create the module without panicking
-		assert.NotPanics(t, func() {
-			_ = OCIOSDataStoreListProvider
-		})
-	})
-
-	t.Run("ListProvider function with invalid config", func(t *testing.T) {
-		v := viper.New()
-		// Don't set auth_type to test error handling
-
-		logger := testingPkg.SetupMockLogger()
-
-		_, err := ProvideSourceOCIOSDataStoreConfig(v, logger)
-		assert.Error(t, err)
-		// The actual error message is about config validation, not "error reading agent config"
-		assert.Contains(t, err.Error(), "ociobjectstore config is invalid")
-
-		_, err = ProvideTargetOCIOSDataStoreConfig(v, logger)
-		assert.Error(t, err)
-		// The actual error message is about config validation, not "error reading agent config"
-		assert.Contains(t, err.Error(), "ociobjectstore config is invalid")
-	})
-
-	t.Run("ListProvider function with nil logger", func(t *testing.T) {
-		v := viper.New()
-		v.Set(AuthTypeViperKeyName, "InstancePrincipal")
-
-		_, err := ProvideSourceOCIOSDataStoreConfig(v, nil)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "nil another logger")
-
-		_, err = ProvideTargetOCIOSDataStoreConfig(v, nil)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "nil another logger")
-	})
-}
-
 func TestAppParams(t *testing.T) {
 	t.Run("AppParams structure", func(t *testing.T) {
 		// Test that appParams can be created


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup + minor_updates

## What this PR does / why we need it:
Making some improvements (suggested by genmini-code-assist in #157) and cleanup to replica ome-agent

## Which changes this PR include?
1. Removed the usage of `panic` in replica_agent.go to avoid the application from crashing unexpectedly;
2. Let an error return when it is not a complete successful replication in oci_to_oci.go, i.e., failed the application when a partial or total failure during replication tasks;
3. Cleaned up unused/duplicate code in ociobjectstore module;
4. Added unit tests for functions in replica_agent.go.

## Special notes for your reviewer:
Tested in local.
For the above change #2, tested after the change, a partial failure will let the application fail with exit code 1.
