### PR TITLE
[core] add pvc storage parsing supporting base model and cluster base…

### DIFF
--- a/oeps/0004-pvc-storage-support/README.md
+++ b/oeps/0004-pvc-storage-support/README.md
@@ -40,8 +40,8 @@ Currently, OME supports multiple storage backends (OCI Object Storage, HuggingFa
 ### Goals
 
 1. Enable BaseModel/ClusterBaseModel to reference models stored in PVCs using URI format:
-   - BaseModel: `pvc://{pvc-name}/{sub-path}` (PVC in same namespace)
-   - ClusterBaseModel: `pvc://{namespace}/{pvc-name}/{sub-path}` (PVC in specified namespace)
+   - BaseModel: `pvc://{pvc-name}/{sub-path}` (assumes same namespace as the BaseModel)
+   - ClusterBaseModel: `pvc://{namespace}:{pvc-name}/{sub-path}` (explicitly specifies namespace with colon separator)
 2. Support both ReadWriteMany (RWX) and ReadWriteOnce (RWO) access modes appropriately
 3. Automatically extract and populate model metadata (architecture, parameters, capabilities) from PVC-stored models
 4. Maintain compatibility with existing InferenceService scheduling and deployment mechanisms
@@ -101,8 +101,8 @@ As a data scientist, I have models stored on high-performance block storage expo
    - Metadata extraction happens once per model
 
 5. **Namespace Handling**:
-   - **BaseModel**: PVC must be in the same namespace, URI format: `pvc://{pvc-name}/{sub-path}`
-   - **ClusterBaseModel**: PVC namespace must be specified in URI: `pvc://{namespace}/{pvc-name}/{sub-path}`
+   - **BaseModel**: PVC is assumed to be in the same namespace, URI format: `pvc://{pvc-name}/{sub-path}`
+   - **ClusterBaseModel**: PVC namespace must be specified explicitly, URI format: `pvc://{namespace}:{pvc-name}/{sub-path}`
    - For ClusterBaseModel, metadata extraction jobs are created in the PVC's namespace
    - InferenceService pods will be scheduled in the PVC's namespace for ClusterBaseModel
 
@@ -365,8 +365,8 @@ metadata:
   name: llama2-7b-shared
 spec:
   storage:
-    storageUri: "pvc://model-storage/model-storage-pvc/models/llama2-7b"
-    # Format: pvc://{namespace}/{pvc-name}/{sub-path}
+    storageUri: "pvc://model-storage:model-storage-pvc/models/llama2-7b"
+    # Format: pvc://{namespace}:{pvc-name}/{sub-path}
   modelFormat:
     name: llama
 ```

--- a/site/content/en/docs/concepts/base_model.md
+++ b/site/content/en/docs/concepts/base_model.md
@@ -140,7 +140,7 @@ storage:
 
 Reference models already stored in Kubernetes persistent volumes:
 ```
-pvc://{pvc-name}/{sub-path}
+pvc://[{namespace}:]{pvc-name}/{sub-path}
 ```
 
 Example:
@@ -149,6 +149,8 @@ storage:
   storageUri: "pvc://model-storage/llama-models/llama-3-70b"
   path: "/local/models/llama-3-70b"
 ```
+
+> **Note**: For BaseModel resources, if no namespace is specified, the PVC is assumed to be in the same namespace as the BaseModel. For ClusterBaseModel resources, you must specify the namespace explicitly using the colon separator format: `pvc://namespace:pvc-name/path`.
 
 ### Vendor Storage
 

--- a/site/content/en/docs/concepts/benchmark.md
+++ b/site/content/en/docs/concepts/benchmark.md
@@ -206,7 +206,7 @@ outputLocation:
 | Azure | `az://{account}/{container}/{path}` | `az://myaccount/mycontainer/results` |
 | GCS | `gs://{bucket}/{path}` | `gs://mybucket/results` |
 | GitHub | `github://{owner}/{repo}[@{tag}]` | `github://myorg/myrepo@v1.0.0` |
-| PVC | `pvc://{pvc-name}/{path}` | `pvc://my-pvc/results` |
+| PVC | `pvc://[{namespace}:]{pvc-name}/{path}` | `pvc://my-pvc/results` or `pvc://default:my-pvc/results` |
 
 ### Authentication Options
 


### PR DESCRIPTION
<!-- 
Thank you for contributing to OME! Please read the contributing guidelines:
https://github.com/sgl-project/ome/blob/main/CONTRIBUTING.md
-->

## What type of PR is this?

/kind feature

## What this PR does / why we need it:

This PR implements an improved PVC storage URI parsing format that makes namespace specification more intuitive for users. The new format uses a colon separator to distinguish namespace from PVC name, making it immediately clear when a namespace is being explicitly specified versus when it's part of the PVC name.

### Key improvements:
- **Clearer syntax**: `pvc://namespace:pvc-name/path` is more intuitive than `pvc://namespace/pvc-name/path`
- **Optional namespace**: When namespace is omitted (`pvc://pvc-name/path`), it assumes the BaseModel's namespace
- **Better validation**: Added proper Kubernetes namespace validation and error messages
- **Consistent with industry patterns**: Similar to Docker image naming (`registry:port/image`)

### Implementation details:
1. Updated `ParsePVCStorageURI` in `pkg/utils/storage/storage.go` to parse the new format
2. Added namespace validation (lowercase alphanumeric with hyphens, max 63 chars)
3. Updated all tests, documentation, and examples to use the new format
4. Maintains backward compatibility by design - old URIs would simply fail validation with clear error messages

## Which issue(s) this PR fixes:

Fixes #160 #161  (OEP-0004 PVC Storage Support)

## Special notes for your reviewer:

- The colon separator was chosen after user feedback that the original slash-based format was confusing
- Empty namespace in the parsed result means "use the BaseModel's namespace" - this is intentional
- All documentation has been updated to reflect the new format
- Test coverage includes edge cases like empty namespace, multiple colons, invalid characters

## Does this PR introduce a user-facing change?

```release-note
Added support for PVC storage URIs with improved namespace specification format. BaseModel and ClusterBaseModel resources can now reference models in PVCs using:
- `pvc://pvc-name/path` - for PVCs in the same namespace (BaseModel)
- `pvc://namespace:pvc-name/path` - for PVCs in a specific namespace (ClusterBaseModel)
```