### PR TITLE
[core] add model metadata parser to ome agent

### DIFF
--- a/cmd/ome-agent/k8sclient.go
+++ b/cmd/ome-agent/k8sclient.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	omev1beta1 "github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+)
+
+// NewK8sClient creates a new Kubernetes client using controller-runtime
+// This follows the pattern used by other ome-agent components
+func NewK8sClient() (client.Client, error) {
+	// Create a new scheme with all required API types
+	scheme := runtime.NewScheme()
+
+	// Add standard Kubernetes types
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add client-go scheme: %w", err)
+	}
+
+	// Add OME custom resource types
+	if err := omev1beta1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add OME v1beta1 scheme: %w", err)
+	}
+
+	// Get the Kubernetes config (in-cluster or from kubeconfig)
+	config := ctrl.GetConfigOrDie()
+
+	// Create the client with the scheme
+	k8sClient, err := client.New(config, client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	return k8sClient, nil
+}

--- a/cmd/ome-agent/main.go
+++ b/cmd/ome-agent/main.go
@@ -27,4 +27,5 @@ func init() {
 	rootCmd.AddCommand(CreateAgentCommand(NewReplicaAgent()))
 	rootCmd.AddCommand(CreateAgentCommand(NewServingAgent()))
 	rootCmd.AddCommand(CreateAgentCommand(NewFineTunedAdapterAgent()))
+	rootCmd.AddCommand(CreateAgentCommand(NewModelMetadataAgent()))
 }

--- a/cmd/ome-agent/model_metadata_agent.go
+++ b/cmd/ome-agent/model_metadata_agent.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/fx"
+
+	modelmetadata "github.com/sgl-project/ome/internal/ome-agent/model-metadata"
+	aferoModule "github.com/sgl-project/ome/pkg/afero"
+	"github.com/sgl-project/ome/pkg/logging"
+)
+
+// ModelMetadataAgent implements the AgentModule interface for model metadata extraction
+type ModelMetadataAgent struct {
+	extractor *modelmetadata.MetadataExtractor
+}
+
+// Name returns the name of the agent
+func (m *ModelMetadataAgent) Name() string {
+	return "model-metadata"
+}
+
+// ShortDescription returns a short description of the agent
+func (m *ModelMetadataAgent) ShortDescription() string {
+	return "Extract model metadata from PVC-mounted models"
+}
+
+// LongDescription returns a detailed description of the agent
+func (m *ModelMetadataAgent) LongDescription() string {
+	return "Model metadata agent mounts PVCs and extracts model metadata to update BaseModel/ClusterBaseModel CRs"
+}
+
+// ConfigureCommand configures the agent command
+func (m *ModelMetadataAgent) ConfigureCommand(cmd *cobra.Command) {
+	// Add flags for the model metadata agent
+	// These will be provided by the BaseModel controller when running as a Job
+	cmd.Flags().String("model-path", "", "Path to the model directory")
+	cmd.Flags().String("basemodel-name", "", "Name of the BaseModel CR")
+	cmd.Flags().String("basemodel-namespace", "", "Namespace of the BaseModel CR")
+	cmd.Flags().Bool("cluster-scoped", false, "Whether this is a ClusterBaseModel")
+
+	_ = cmd.MarkFlagRequired("model-path")
+	_ = cmd.MarkFlagRequired("basemodel-name")
+
+	// Bind flags to viper with underscore keys to match mapstructure tags
+	_ = viper.BindPFlag("model_path", cmd.Flags().Lookup("model-path"))
+	_ = viper.BindPFlag("basemodel_name", cmd.Flags().Lookup("basemodel-name"))
+	_ = viper.BindPFlag("basemodel_namespace", cmd.Flags().Lookup("basemodel-namespace"))
+	_ = viper.BindPFlag("cluster_scoped", cmd.Flags().Lookup("cluster-scoped"))
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		runAgentCommand(cmd, m, m.Start)
+	}
+}
+
+// FxModules returns the fx modules needed by this agent
+func (m *ModelMetadataAgent) FxModules() []fx.Option {
+	return []fx.Option{
+		aferoModule.Module,
+		logging.Module,
+		fx.Provide(NewK8sClient),
+		modelmetadata.Module,
+		fx.Populate(&m.extractor),
+	}
+}
+
+// Start runs the agent
+func (m *ModelMetadataAgent) Start() error {
+	return m.extractor.Start()
+}
+
+// NewModelMetadataAgent creates a new model metadata agent
+func NewModelMetadataAgent() *ModelMetadataAgent {
+	return &ModelMetadataAgent{}
+}

--- a/cmd/ome-agent/model_metadata_agent_test.go
+++ b/cmd/ome-agent/model_metadata_agent_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelMetadataAgent_ConfigureCommand(t *testing.T) {
+	// Test that required flags are properly configured
+	agent := NewModelMetadataAgent()
+	cmd := &cobra.Command{}
+
+	agent.ConfigureCommand(cmd)
+
+	// Check required flags
+	modelPathFlag := cmd.Flags().Lookup("model-path")
+	assert.NotNil(t, modelPathFlag)
+	assert.Equal(t, "model-path", modelPathFlag.Name)
+
+	baseModelNameFlag := cmd.Flags().Lookup("basemodel-name")
+	assert.NotNil(t, baseModelNameFlag)
+	assert.Equal(t, "basemodel-name", baseModelNameFlag.Name)
+
+	baseModelNamespaceFlag := cmd.Flags().Lookup("basemodel-namespace")
+	assert.NotNil(t, baseModelNamespaceFlag)
+	assert.Equal(t, "basemodel-namespace", baseModelNamespaceFlag.Name)
+
+	clusterScopedFlag := cmd.Flags().Lookup("cluster-scoped")
+	assert.NotNil(t, clusterScopedFlag)
+	assert.Equal(t, "cluster-scoped", clusterScopedFlag.Name)
+}
+
+func TestModelMetadataAgent_Name(t *testing.T) {
+	agent := NewModelMetadataAgent()
+	assert.Equal(t, "model-metadata", agent.Name())
+}
+
+func TestModelMetadataAgent_ShortDescription(t *testing.T) {
+	agent := NewModelMetadataAgent()
+	assert.Equal(t, "Extract model metadata from PVC-mounted models", agent.ShortDescription())
+}
+
+func TestModelMetadataAgent_LongDescription(t *testing.T) {
+	agent := NewModelMetadataAgent()
+	expected := "Model metadata agent mounts PVCs and extracts model metadata to update BaseModel/ClusterBaseModel CRs"
+	assert.Equal(t, expected, agent.LongDescription())
+}

--- a/config/ome-agent/model-metadata.yaml
+++ b/config/ome-agent/model-metadata.yaml
@@ -1,0 +1,9 @@
+# Minimal configuration for model-metadata agent
+# This agent is designed to be run as a Kubernetes Job with command-line arguments
+# The actual values will be provided via command-line flags by the BaseModel controller
+
+# Placeholder values - will be overridden by command-line flags
+model_path: ""
+basemodel_name: ""
+basemodel_namespace: ""
+cluster_scoped: false

--- a/hack/test-model-metadata-agent.sh
+++ b/hack/test-model-metadata-agent.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Example of how the BaseModel controller would invoke the model-metadata agent
+
+# This would be run as a Kubernetes Job with the model PVC mounted at /model
+ome-agent model-metadata \
+  --config /etc/ome-agent/model-metadata.yaml \
+  --model-path /model \
+  --basemodel-name llama-7b \
+  --basemodel-namespace model-serving \
+  --cluster-scoped false

--- a/internal/ome-agent/model-metadata/config.go
+++ b/internal/ome-agent/model-metadata/config.go
@@ -1,0 +1,107 @@
+package modelmetadata
+
+import (
+	"fmt"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+
+	"github.com/sgl-project/ome/pkg/configutils"
+	"github.com/sgl-project/ome/pkg/logging"
+)
+
+// Config defines the configuration for the model metadata extractor
+type Config struct {
+	Logger logging.Interface
+
+	ModelPath          string `mapstructure:"model_path" validate:"required"`
+	BaseModelName      string `mapstructure:"basemodel_name" validate:"required"`
+	BaseModelNamespace string `mapstructure:"basemodel_namespace"`
+	ClusterScoped      bool   `mapstructure:"cluster_scoped"`
+}
+
+// Option defines a function that applies configuration options
+type Option func(*Config) error
+
+// Apply applies the given options to the configuration
+func (c *Config) Apply(opts ...Option) error {
+	for _, o := range opts {
+		if o != nil {
+			if err := o(c); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// defaultConfig returns a new configuration with default values
+func defaultConfig() *Config {
+	return &Config{
+		ClusterScoped: false,
+	}
+}
+
+// NewConfig builds and returns a new configuration from the given options
+func NewConfig(opts ...Option) (*Config, error) {
+	c := defaultConfig()
+	if err := c.Apply(opts...); err != nil {
+		return nil, fmt.Errorf("failed to apply config options: %w", err)
+	}
+	return c, nil
+}
+
+// WithLogger sets the logger for the configuration
+func WithLogger(logger logging.Interface) Option {
+	return func(c *Config) error {
+		if logger == nil {
+			return errors.New("logger cannot be nil")
+		}
+		c.Logger = logger
+		return nil
+	}
+}
+
+// WithViper loads configuration using Viper
+func WithViper(v *viper.Viper) Option {
+	return func(c *Config) error {
+		*c = *defaultConfig()
+
+		// Bind environment variables
+		if err := configutils.BindEnvsRecursive(v, c, ""); err != nil {
+			return fmt.Errorf("error binding envs: %w", err)
+		}
+
+		// Unmarshal configuration
+		if err := v.Unmarshal(c); err != nil {
+			return fmt.Errorf("error unmarshalling config: %w", err)
+		}
+
+		return nil
+	}
+}
+
+// WithAppParams applies configuration parameters from model-metadata-specific params
+func WithAppParams(params metadataParams) Option {
+	return func(c *Config) error {
+		// Currently no app params needed, but kept for consistency
+		return nil
+	}
+}
+
+// Validate checks if the configuration is valid
+func (c *Config) Validate() error {
+	// Use struct validation
+	validate := validator.New()
+	if err := validate.Struct(c); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+
+	// Custom validation
+	if !c.ClusterScoped && c.BaseModelNamespace == "" {
+		return errors.New("basemodel_namespace is required for namespace-scoped BaseModel")
+	}
+
+	return nil
+}

--- a/internal/ome-agent/model-metadata/metadata.go
+++ b/internal/ome-agent/model-metadata/metadata.go
@@ -1,0 +1,249 @@
+// Package modelmetadata provides functionality to extract metadata from model files
+// stored in PVCs and update BaseModel/ClusterBaseModel CRs.
+//
+// This agent is designed to be run as a Kubernetes Job by the BaseModel controller.
+// The controller will:
+// 1. Create a Job with the model PVC mounted
+// 2. Pass the model path and BaseModel details via command-line flags
+// 3. The agent will extract metadata and update the CR
+//
+// Example invocation:
+//
+//	ome-agent model-metadata \
+//	  --config /etc/ome-agent/model-metadata.yaml \
+//	  --model-path /model \
+//	  --basemodel-name llama-7b \
+//	  --basemodel-namespace model-serving
+package modelmetadata
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/hfutil/modelconfig"
+	"github.com/sgl-project/ome/pkg/logging"
+)
+
+type MetadataExtractor struct {
+	config *Config
+	fs     afero.Fs
+	client client.Client
+	logger logging.Interface
+}
+
+func NewMetadataExtractor(config *Config, fs afero.Fs, client client.Client) (*MetadataExtractor, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid configuration")
+	}
+
+	return &MetadataExtractor{
+		config: config,
+		fs:     fs,
+		client: client,
+		logger: config.Logger,
+	}, nil
+}
+
+func (m *MetadataExtractor) Start() error {
+	m.logger.Infof("Starting model metadata extraction for model at %s", m.config.ModelPath)
+
+	// Try different config file names
+	configFiles := []string{"config.json", "model_config.json", "configuration.json"}
+
+	var configPath string
+	for _, configFile := range configFiles {
+		path := filepath.Join(m.config.ModelPath, configFile)
+		exists, err := afero.Exists(m.fs, path)
+		if err != nil {
+			m.logger.Warnf("Error checking for %s: %v", path, err)
+			continue
+		}
+		if exists {
+			configPath = path
+			break
+		}
+	}
+
+	if configPath == "" {
+		return errors.New("no model config file found (tried: config.json, model_config.json, configuration.json)")
+	}
+
+	m.logger.Infof("Found model config at %s", configPath)
+
+	// Use hfutil/modelconfig to load the model
+	model, err := modelconfig.LoadModelConfig(configPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load model config from %s", configPath)
+	}
+
+	// Update the CR
+	if m.config.ClusterScoped {
+		return m.updateClusterBaseModel(model)
+	}
+	return m.updateBaseModel(model)
+}
+
+func (m *MetadataExtractor) updateBaseModel(model modelconfig.HuggingFaceModel) error {
+	ctx := context.Background()
+
+	// Fetch the BaseModel
+	baseModel := &v1beta1.BaseModel{}
+	err := m.client.Get(ctx, types.NamespacedName{
+		Name:      m.config.BaseModelName,
+		Namespace: m.config.BaseModelNamespace,
+	}, baseModel)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get BaseModel %s/%s", m.config.BaseModelNamespace, m.config.BaseModelName)
+	}
+
+	// Update spec with extracted metadata
+	updated := m.updateSpec(&baseModel.Spec, model)
+	if !updated {
+		m.logger.Info("No updates needed for BaseModel spec")
+		return nil
+	}
+
+	// Update the BaseModel
+	err = m.client.Update(ctx, baseModel)
+	if err != nil {
+		return errors.Wrapf(err, "failed to update BaseModel %s/%s", m.config.BaseModelNamespace, m.config.BaseModelName)
+	}
+
+	m.logger.Infof("Successfully updated BaseModel %s/%s", m.config.BaseModelNamespace, m.config.BaseModelName)
+	return nil
+}
+
+func (m *MetadataExtractor) updateClusterBaseModel(model modelconfig.HuggingFaceModel) error {
+	ctx := context.Background()
+
+	// Fetch the ClusterBaseModel
+	clusterBaseModel := &v1beta1.ClusterBaseModel{}
+	err := m.client.Get(ctx, types.NamespacedName{Name: m.config.BaseModelName}, clusterBaseModel)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get ClusterBaseModel %s", m.config.BaseModelName)
+	}
+
+	// Update spec with extracted metadata
+	updated := m.updateSpec(&clusterBaseModel.Spec, model)
+	if !updated {
+		m.logger.Info("No updates needed for ClusterBaseModel spec")
+		return nil
+	}
+
+	// Update the ClusterBaseModel
+	err = m.client.Update(ctx, clusterBaseModel)
+	if err != nil {
+		return errors.Wrapf(err, "failed to update ClusterBaseModel %s", m.config.BaseModelName)
+	}
+
+	m.logger.Infof("Successfully updated ClusterBaseModel %s", m.config.BaseModelName)
+	return nil
+}
+
+func (m *MetadataExtractor) updateSpec(spec *v1beta1.BaseModelSpec, model modelconfig.HuggingFaceModel) bool {
+	if spec == nil || model == nil {
+		return false
+	}
+
+	updated := false
+
+	// Model type
+	modelType := model.GetModelType()
+	if spec.ModelType == nil && modelType != "" {
+		spec.ModelType = &modelType
+		updated = true
+	}
+
+	// Architecture
+	arch := model.GetArchitecture()
+	if spec.ModelArchitecture == nil && arch != "" {
+		spec.ModelArchitecture = &arch
+		updated = true
+	}
+
+	// Parameter count
+	paramCount := model.GetParameterCount()
+	if spec.ModelParameterSize == nil && paramCount > 0 {
+		paramStr := modelconfig.FormatParamCount(paramCount)
+		spec.ModelParameterSize = &paramStr
+		updated = true
+	}
+
+	// Max tokens
+	contextLength := int32(model.GetContextLength())
+	if spec.MaxTokens == nil && contextLength > 0 {
+		spec.MaxTokens = &contextLength
+		updated = true
+	}
+
+	// Capabilities
+	if len(spec.ModelCapabilities) == 0 {
+		capabilities := m.inferCapabilities(model)
+		if len(capabilities) > 0 {
+			spec.ModelCapabilities = capabilities
+			updated = true
+		}
+	}
+
+	// Framework (default to pytorch for HF models)
+	if spec.ModelFramework == nil {
+		spec.ModelFramework = &v1beta1.ModelFrameworkSpec{
+			Name: "transformers",
+		}
+		updated = true
+	}
+
+	// Torch dtype as model format
+	torchDtype := model.GetTorchDtype()
+	if spec.ModelFormat.Name == "" && torchDtype != "" {
+		spec.ModelFormat = v1beta1.ModelFormat{
+			Name: torchDtype,
+		}
+		updated = true
+	}
+
+	return updated
+}
+
+func (m *MetadataExtractor) inferCapabilities(model modelconfig.HuggingFaceModel) []string {
+	var capabilities []string
+
+	// Check for vision capability
+	if model.HasVision() {
+		capabilities = append(capabilities, "vision")
+	}
+
+	// Infer from architecture and model type
+	arch := strings.ToLower(model.GetArchitecture())
+	modelType := strings.ToLower(model.GetModelType())
+
+	// Text generation models
+	if strings.Contains(arch, "causallm") || strings.Contains(modelType, "gpt") ||
+		strings.Contains(modelType, "llama") || strings.Contains(modelType, "llava") ||
+		strings.Contains(modelType, "mistral") || strings.Contains(modelType, "falcon") ||
+		strings.Contains(modelType, "opt") || strings.Contains(modelType, "bloom") ||
+		strings.Contains(modelType, "qwen") {
+		capabilities = append(capabilities, "text-generation")
+	}
+
+	// Embedding models
+	if strings.Contains(arch, "embedding") || strings.Contains(modelType, "bert") ||
+		strings.Contains(modelType, "sentence") || strings.Contains(modelType, "e5") ||
+		strings.Contains(modelType, "bge") {
+		capabilities = append(capabilities, "text-embeddings")
+	}
+
+	// Default to text-generation if no capabilities detected
+	if len(capabilities) == 0 {
+		capabilities = append(capabilities, "text-generation")
+	}
+
+	return capabilities
+}

--- a/internal/ome-agent/model-metadata/metadata_test.go
+++ b/internal/ome-agent/model-metadata/metadata_test.go
@@ -1,0 +1,210 @@
+package modelmetadata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/hfutil/modelconfig"
+	"github.com/sgl-project/ome/pkg/logging"
+)
+
+// mockHuggingFaceModel implements the HuggingFaceModel interface for testing
+type mockHuggingFaceModel struct {
+	modelType          string
+	architecture       string
+	parameterCount     int64
+	contextLength      int
+	transformerVersion string
+	quantizationType   string
+	torchDtype         string
+	modelSizeBytes     int64
+	hasVision          bool
+}
+
+func (m *mockHuggingFaceModel) GetModelType() string          { return m.modelType }
+func (m *mockHuggingFaceModel) GetArchitecture() string       { return m.architecture }
+func (m *mockHuggingFaceModel) GetParameterCount() int64      { return m.parameterCount }
+func (m *mockHuggingFaceModel) GetContextLength() int         { return m.contextLength }
+func (m *mockHuggingFaceModel) GetTransformerVersion() string { return m.transformerVersion }
+func (m *mockHuggingFaceModel) GetQuantizationType() string   { return m.quantizationType }
+func (m *mockHuggingFaceModel) GetTorchDtype() string         { return m.torchDtype }
+func (m *mockHuggingFaceModel) GetModelSizeBytes() int64      { return m.modelSizeBytes }
+func (m *mockHuggingFaceModel) HasVision() bool               { return m.hasVision }
+
+func TestMetadataExtractor_updateSpec(t *testing.T) {
+	zapLogger, _ := zap.NewDevelopment()
+	logger := zapLogger.Sugar()
+	defer func() { _ = logger.Sync() }()
+
+	tests := []struct {
+		name           string
+		initialSpec    *v1beta1.BaseModelSpec
+		model          modelconfig.HuggingFaceModel
+		expectedUpdate bool
+		validate       func(*testing.T, *v1beta1.BaseModelSpec)
+	}{
+		{
+			name:        "update empty spec",
+			initialSpec: &v1beta1.BaseModelSpec{},
+			model: &mockHuggingFaceModel{
+				modelType:          "llama",
+				architecture:       "LlamaForCausalLM",
+				parameterCount:     7000000000, // 7B
+				contextLength:      4096,
+				torchDtype:         "float16",
+				transformerVersion: "4.33.2",
+				modelSizeBytes:     14000000000, // 14GB
+			},
+			expectedUpdate: true,
+			validate: func(t *testing.T, spec *v1beta1.BaseModelSpec) {
+				assert.Equal(t, "llama", *spec.ModelType)
+				assert.Equal(t, "LlamaForCausalLM", *spec.ModelArchitecture)
+				assert.Equal(t, "7B", *spec.ModelParameterSize)
+				assert.Equal(t, int32(4096), *spec.MaxTokens)
+				assert.Equal(t, "transformers", spec.ModelFramework.Name)
+				assert.Equal(t, "float16", spec.ModelFormat.Name)
+				assert.Contains(t, spec.ModelCapabilities, "text-generation")
+			},
+		},
+		{
+			name: "preserve existing values",
+			initialSpec: &v1beta1.BaseModelSpec{
+				ModelType:         stringPtr("custom-llama"),
+				ModelArchitecture: stringPtr("CustomLlama"),
+			},
+			model: &mockHuggingFaceModel{
+				modelType:          "llama",
+				architecture:       "LlamaForCausalLM",
+				parameterCount:     7000000000,
+				transformerVersion: "4.33.2",
+				modelSizeBytes:     14000000000,
+			},
+			expectedUpdate: true,
+			validate: func(t *testing.T, spec *v1beta1.BaseModelSpec) {
+				// Existing values should be preserved
+				assert.Equal(t, "custom-llama", *spec.ModelType)
+				assert.Equal(t, "CustomLlama", *spec.ModelArchitecture)
+				// New values should be added
+				assert.Equal(t, "7B", *spec.ModelParameterSize)
+			},
+		},
+		{
+			name:        "vision model capabilities",
+			initialSpec: &v1beta1.BaseModelSpec{},
+			model: &mockHuggingFaceModel{
+				modelType:          "llava",
+				architecture:       "LlavaForConditionalGeneration",
+				hasVision:          true,
+				transformerVersion: "4.33.2",
+				modelSizeBytes:     14000000000,
+			},
+			expectedUpdate: true,
+			validate: func(t *testing.T, spec *v1beta1.BaseModelSpec) {
+				assert.Contains(t, spec.ModelCapabilities, "vision")
+				assert.Contains(t, spec.ModelCapabilities, "text-generation")
+			},
+		},
+		{
+			name:        "embedding model capabilities",
+			initialSpec: &v1beta1.BaseModelSpec{},
+			model: &mockHuggingFaceModel{
+				modelType:          "bge-base",
+				architecture:       "BertModel",
+				transformerVersion: "4.33.2",
+				modelSizeBytes:     400000000,
+			},
+			expectedUpdate: true,
+			validate: func(t *testing.T, spec *v1beta1.BaseModelSpec) {
+				assert.Contains(t, spec.ModelCapabilities, "text-embeddings")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{Logger: logging.Discard()}
+			extractor := &MetadataExtractor{
+				config: config,
+				logger: config.Logger,
+			}
+
+			updated := extractor.updateSpec(tt.initialSpec, tt.model)
+			assert.Equal(t, tt.expectedUpdate, updated)
+
+			if tt.validate != nil {
+				tt.validate(t, tt.initialSpec)
+			}
+		})
+	}
+}
+
+func TestMetadataExtractor_updateBaseModel(t *testing.T) {
+	// Setup
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+
+	baseModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model",
+			Namespace: "default",
+		},
+		Spec: v1beta1.BaseModelSpec{},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(baseModel).
+		Build()
+
+	logger := logging.Discard()
+	config := &Config{
+		BaseModelName:      "test-model",
+		BaseModelNamespace: "default",
+		Logger:             logger,
+	}
+
+	extractor := &MetadataExtractor{
+		config: config,
+		client: fakeClient,
+		logger: logger,
+	}
+
+	model := &mockHuggingFaceModel{
+		modelType:          "llama",
+		architecture:       "LlamaForCausalLM",
+		parameterCount:     7000000000,
+		contextLength:      4096,
+		transformerVersion: "4.33.2",
+		modelSizeBytes:     14000000000,
+	}
+
+	// Execute
+	err := extractor.updateBaseModel(model)
+	require.NoError(t, err)
+
+	// Verify
+	updatedModel := &v1beta1.BaseModel{}
+	err = fakeClient.Get(context.Background(), client.ObjectKey{
+		Name:      "test-model",
+		Namespace: "default",
+	}, updatedModel)
+	require.NoError(t, err)
+
+	assert.Equal(t, "llama", *updatedModel.Spec.ModelType)
+	assert.Equal(t, "LlamaForCausalLM", *updatedModel.Spec.ModelArchitecture)
+	assert.Equal(t, "7B", *updatedModel.Spec.ModelParameterSize)
+	assert.Equal(t, int32(4096), *updatedModel.Spec.MaxTokens)
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/internal/ome-agent/model-metadata/module.go
+++ b/internal/ome-agent/model-metadata/module.go
@@ -1,0 +1,41 @@
+package modelmetadata
+
+import (
+	"fmt"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"go.uber.org/fx"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sgl-project/ome/pkg/logging"
+)
+
+type metadataParams struct {
+	fx.In
+
+	Logger logging.Interface
+	Fs     afero.Fs
+	Client client.Client
+	Viper  *viper.Viper
+}
+
+// Module provides the model metadata extractor via fx
+var Module = fx.Provide(
+	func(params metadataParams) (*MetadataExtractor, error) {
+		config, err := NewConfig(
+			WithViper(params.Viper),
+			WithLogger(params.Logger),
+			WithAppParams(params),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error creating model metadata config: %w", err)
+		}
+
+		// Validate configuration
+		if err := config.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid model metadata config: %w", err)
+		}
+
+		return NewMetadataExtractor(config, params.Fs, params.Client)
+	})


### PR DESCRIPTION
## What type of PR is this?

  /kind feature

  ## What this PR does / why we need it:

  This PR implements the model metadata extraction agent as part of OEP-0004 (PVC Storage Support). The new `model-metadata` agent enables OME to
  extract metadata from models stored in Kubernetes PVCs without requiring the model to be downloaded or accessible via object storage.

  **Key changes:**
  - Added new `model-metadata` agent to the ome-agent framework that can be run as a Kubernetes Job
  - Implemented metadata extraction using the existing `hfutil/modelconfig` parser for robust support of 20+ model types
  - Created internal business logic module following established ome-agent patterns
  - Added support for both BaseModel and ClusterBaseModel CRs with proper namespace handling
  - Implemented automatic capability inference (text-generation, vision, embeddings) based on model architecture

  **Architecture decisions:**
  - The agent is designed to be invoked by the BaseModel controller as a Job with the PVC mounted
  - Uses command-line flags for parameters since it runs as a Job (not a long-running service)
  - Leverages existing model config parsing infrastructure for consistency and maintainability
  - Only updates CR fields that are not already set, preserving user-specified values

  ## Which issue(s) this PR fixes:

  Related to OEP-0004: PVC Storage Support implementation

  ## Special notes for your reviewer:

  1. **Configuration approach**: Unlike other agents that read from static YAML config, this agent uses command-line flags because it's designed to be
   run as a Kubernetes Job with dynamic parameters from the BaseModel controller.

  2. **Code organization**: Following reviewer feedback, the implementation:
     - Uses `pkg/hfutil/modelconfig` instead of custom parsing logic
     - Follows the internal module pattern used by other agents (enigma, replica)
     - Maintains k8sclient.go in cmd/ome-agent as a shared utility

  3. **Testing**: Comprehensive unit tests cover config extraction, metadata parsing, and CR updates for both BaseModel and ClusterBaseModel
  scenarios.

  4. **Files structure**:
     - Agent wrapper: `cmd/ome-agent/model_metadata_agent.go`
     - Business logic: `internal/ome-agent/model-metadata/`
     - Config template: `config/ome-agent/model-metadata.yaml`

### address
#163 #160 

  ## Does this PR introduce a user-facing change?

  ```release-note
  Add model-metadata agent to extract metadata from PVC-stored models for BaseModel and ClusterBaseModel CRs