### PR TITLE
[utils] Add CoreWeave H200 shape configuration

### DIFF
--- a/pkg/utils/instance_type_util.go
+++ b/pkg/utils/instance_type_util.go
@@ -24,6 +24,7 @@ var instanceTypeMap = map[string]string{
 
 	// CoreWeave instance types
 	"gd-8xh100ib-i128": "H100",
+	"gd-8xh200ib-i128": "H200",
 	"gd-8xl40-i128":    "L40",
 }
 


### PR DESCRIPTION
Added the gd-8xh200ib-i128 shape mapping for H200 GPUs to support
CoreWeave's H200 instance types.
