### PR TITLE
[core] add kimi k2 model support

### DIFF
--- a/pkg/hfutil/modelconfig/kimi_k2.go
+++ b/pkg/hfutil/modelconfig/kimi_k2.go
@@ -1,0 +1,190 @@
+package modelconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+)
+
+// KimiK2Config defines the configuration for Kimi-K2 models
+// This model uses the DeepseekV3ForCausalLM architecture
+type KimiK2Config struct {
+	BaseModelConfig
+
+	// Model dimensions
+	HiddenSize            int `json:"hidden_size"`
+	IntermediateSize      int `json:"intermediate_size"`
+	NumHiddenLayers       int `json:"num_hidden_layers"`
+	NumAttentionHeads     int `json:"num_attention_heads"`
+	NumKeyValueHeads      int `json:"num_key_value_heads"`
+	MaxPositionEmbeddings int `json:"max_position_embeddings"`
+	VocabSize             int `json:"vocab_size"`
+
+	// MoE specific parameters
+	NumRoutedExperts    int `json:"n_routed_experts"`
+	NumSharedExperts    int `json:"n_shared_experts"`
+	NumExpertsPerTok    int `json:"num_experts_per_tok"`
+	MoeIntermediateSize int `json:"moe_intermediate_size"`
+	MoeLayerFreq        int `json:"moe_layer_freq"`
+	FirstKDenseReplace  int `json:"first_k_dense_replace"`
+
+	// Special tokens
+	BosTokenId int `json:"bos_token_id"`
+	EosTokenId int `json:"eos_token_id"`
+
+	// Attention related
+	HiddenAct        string  `json:"hidden_act"`
+	RmsNormEps       float64 `json:"rms_norm_eps"`
+	RopeTheta        float64 `json:"rope_theta"`
+	AttentionDropout float64 `json:"attention_dropout"`
+	AttentionBias    bool    `json:"attention_bias"`
+
+	// Kimi-K2 specific parameters
+	AuxLossAlpha          float64 `json:"aux_loss_alpha"`
+	KvLoraRank            int     `json:"kv_lora_rank"`
+	NGroup                int     `json:"n_group"`
+	NormTopkProb          bool    `json:"norm_topk_prob"`
+	NumNextnPredictLayers int     `json:"num_nextn_predict_layers"`
+	PretrainingTP         int     `json:"pretraining_tp"`
+	QLoraRank             int     `json:"q_lora_rank"`
+	QkNopeHeadDim         int     `json:"qk_nope_head_dim"`
+	QkRopeHeadDim         int     `json:"qk_rope_head_dim"`
+	RoutedScalingFactor   float64 `json:"routed_scaling_factor"`
+	ScoringFunc           string  `json:"scoring_func"`
+	SeqAux                bool    `json:"seq_aux"`
+	TopkGroup             int     `json:"topk_group"`
+	TopkMethod            string  `json:"topk_method"`
+	VHeadDim              int     `json:"v_head_dim"`
+
+	// RoPE scaling (YARN type for Kimi-K2)
+	RopeScaling RopeScalingConfig `json:"rope_scaling"`
+
+	// Quantization settings
+	QuantizationConfig *QuantizationConfig `json:"quantization_config,omitempty"`
+
+	// Misc options
+	TieWordEmbeddings bool    `json:"tie_word_embeddings"`
+	UseCache          bool    `json:"use_cache"`
+	InitializerRange  float64 `json:"initializer_range"`
+}
+
+// LoadKimiK2Config loads a Kimi-K2 configuration from a JSON file
+func LoadKimiK2Config(path string) (*KimiK2Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Kimi-K2 config file '%s': %w", path, err)
+	}
+
+	var cfg KimiK2Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse Kimi-K2 config JSON from '%s': %w", path, err)
+	}
+
+	cfg.ConfigPath = path
+
+	// Validate the configuration
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid Kimi-K2 configuration in '%s': %w", path, err)
+	}
+
+	return &cfg, nil
+}
+
+// Validate checks if the Kimi-K2 configuration is valid
+func (c *KimiK2Config) Validate() error {
+	if c.HiddenSize <= 0 {
+		return fmt.Errorf("hidden_size must be positive, got %d", c.HiddenSize)
+	}
+	if c.NumHiddenLayers <= 0 {
+		return fmt.Errorf("num_hidden_layers must be positive, got %d", c.NumHiddenLayers)
+	}
+	if c.NumAttentionHeads <= 0 {
+		return fmt.Errorf("num_attention_heads must be positive, got %d", c.NumAttentionHeads)
+	}
+	if c.NumKeyValueHeads <= 0 {
+		return fmt.Errorf("num_key_value_heads must be positive, got %d", c.NumKeyValueHeads)
+	}
+	if c.VocabSize <= 0 {
+		return fmt.Errorf("vocab_size must be positive, got %d", c.VocabSize)
+	}
+	if c.MaxPositionEmbeddings <= 0 {
+		return fmt.Errorf("max_position_embeddings must be positive, got %d", c.MaxPositionEmbeddings)
+	}
+	if c.NumRoutedExperts <= 0 {
+		return fmt.Errorf("n_routed_experts must be positive, got %d", c.NumRoutedExperts)
+	}
+	if c.NumExpertsPerTok <= 0 {
+		return fmt.Errorf("num_experts_per_tok must be positive, got %d", c.NumExpertsPerTok)
+	}
+	return nil
+}
+
+// GetParameterCount returns the total number of parameters in the model
+func (c *KimiK2Config) GetParameterCount() int64 {
+	// First try to get parameter count from safetensors files
+	count, err := FindAndParseSafetensors(c.ConfigPath)
+	if err == nil {
+		return count
+	}
+
+	// Log the error but continue with estimated parameter count
+	log.Printf("Warning: failed to get parameter count from safetensors for %s: %v", c.ConfigPath, err)
+
+	// Kimi-K2 is based on DeepSeek V3 architecture but with more experts (384 vs 256)
+	// This model has approximately 1.5T parameters according to the model documentation
+	return 1_500_000_000_000 // 1.5T parameters
+}
+
+// GetTransformerVersion returns the transformers library version
+func (c *KimiK2Config) GetTransformerVersion() string {
+	return c.BaseModelConfig.TransformerVersion
+}
+
+// GetQuantizationType returns the quantization method used (if any)
+func (c *KimiK2Config) GetQuantizationType() string {
+	if c.QuantizationConfig != nil && c.QuantizationConfig.QuantMethod != "" {
+		return c.QuantizationConfig.QuantMethod
+	}
+	return ""
+}
+
+// GetArchitecture returns the model architecture
+func (c *KimiK2Config) GetArchitecture() string {
+	if len(c.Architectures) > 0 {
+		return c.Architectures[0]
+	}
+	return ""
+}
+
+// GetModelType returns the model type
+func (c *KimiK2Config) GetModelType() string {
+	return c.ModelType
+}
+
+// GetContextLength returns the maximum context length
+func (c *KimiK2Config) GetContextLength() int {
+	return c.MaxPositionEmbeddings
+}
+
+// GetModelSizeBytes returns the estimated size of the model in bytes
+func (c *KimiK2Config) GetModelSizeBytes() int64 {
+	return EstimateModelSizeBytes(c.GetParameterCount(), c.GetTorchDtype())
+}
+
+// GetTorchDtype returns the torch data type used by the model
+func (c *KimiK2Config) GetTorchDtype() string {
+	return c.TorchDtype
+}
+
+// HasVision returns false since this is not a multimodal vision model
+func (c *KimiK2Config) HasVision() bool {
+	return false
+}
+
+// Register the Kimi-K2 model handler
+func init() {
+	RegisterModelLoader("kimi_k2", func(configPath string) (HuggingFaceModel, error) {
+		return LoadKimiK2Config(configPath)
+	})
+}

--- a/pkg/hfutil/modelconfig/kimi_k2_test.go
+++ b/pkg/hfutil/modelconfig/kimi_k2_test.go
@@ -1,0 +1,150 @@
+package modelconfig
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadKimiK2Config(t *testing.T) {
+	configPath := filepath.Join("testdata", "kimi_k2_instruct.json")
+
+	// Load the config
+	config, err := LoadKimiK2Config(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load Kimi-K2 config: %v", err)
+	}
+
+	// Verify fields were parsed correctly
+	if config.ModelType != "kimi_k2" {
+		t.Errorf("Incorrect model type, expected 'kimi_k2', got %s", config.ModelType)
+	}
+
+	if config.HiddenSize != 7168 {
+		t.Errorf("Incorrect hidden size, expected 7168, got %d", config.HiddenSize)
+	}
+
+	if config.NumHiddenLayers != 61 {
+		t.Errorf("Incorrect number of layers, expected 61, got %d", config.NumHiddenLayers)
+	}
+
+	if config.NumRoutedExperts != 384 {
+		t.Errorf("Incorrect number of experts, expected 384, got %d", config.NumRoutedExperts)
+	}
+
+	if config.VocabSize != 163840 {
+		t.Errorf("Incorrect vocabulary size, expected 163840, got %d", config.VocabSize)
+	}
+
+	// Verify interface methods
+	if config.GetModelType() != "kimi_k2" {
+		t.Errorf("GetModelType() returned incorrect value: %s", config.GetModelType())
+	}
+
+	if config.GetArchitecture() != "DeepseekV3ForCausalLM" {
+		t.Errorf("GetArchitecture() returned incorrect value: %s", config.GetArchitecture())
+	}
+
+	if config.GetContextLength() != 131072 {
+		t.Errorf("GetContextLength() returned incorrect value: %d", config.GetContextLength())
+	}
+
+	// Check if parameter count is reasonable (should be around 1.5T)
+	paramCount := config.GetParameterCount()
+	if paramCount == 0 {
+		t.Error("Parameter count should not be zero")
+	}
+	expectedParamCount := int64(1_500_000_000_000)
+	if paramCount != expectedParamCount {
+		t.Errorf("Incorrect parameter count, expected %d, got %d", expectedParamCount, paramCount)
+	}
+}
+
+func TestKimiK2LoadModelConfig(t *testing.T) {
+	configPath := filepath.Join("testdata", "kimi_k2_instruct.json")
+
+	// Load the config using the generic loader
+	config, err := LoadModelConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load model config: %v", err)
+	}
+
+	// Verify the right type was loaded
+	if config.GetModelType() != "kimi_k2" {
+		t.Errorf("Incorrect model type, expected 'kimi_k2', got %s", config.GetModelType())
+	}
+
+	// Verify it implements the interface correctly
+	_, ok := config.(*KimiK2Config)
+	if !ok {
+		t.Error("LoadModelConfig should return a *KimiK2Config for kimi_k2 model type")
+	}
+}
+
+func TestKimiK2ModelMetadata(t *testing.T) {
+	configPath := filepath.Join("testdata", "kimi_k2_instruct.json")
+
+	// Load the config
+	config, err := LoadKimiK2Config(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load Kimi-K2 config: %v", err)
+	}
+
+	// Test model metadata
+	transformerVersion := config.GetTransformerVersion()
+	if transformerVersion != "4.48.3" {
+		t.Errorf("Incorrect transformer version, expected '4.48.3', got '%s'", transformerVersion)
+	}
+
+	// Check quantization type (should be fp8 based on the config)
+	quantizationType := config.GetQuantizationType()
+	if quantizationType != "fp8" {
+		t.Errorf("Expected 'fp8' quantization type, got '%s'", quantizationType)
+	}
+
+	// Check data type
+	torchDtype := config.GetTorchDtype()
+	if torchDtype != "bfloat16" {
+		t.Errorf("Incorrect torch dtype, expected 'bfloat16', got '%s'", torchDtype)
+	}
+
+	// Check architecture
+	architecture := config.GetArchitecture()
+	if architecture != "DeepseekV3ForCausalLM" {
+		t.Errorf("Incorrect architecture, expected 'DeepseekV3ForCausalLM', got '%s'", architecture)
+	}
+
+	// Check model type
+	modelType := config.GetModelType()
+	if modelType != "kimi_k2" {
+		t.Errorf("Incorrect model type, expected 'kimi_k2', got '%s'", modelType)
+	}
+
+	// Check context length
+	contextLength := config.GetContextLength()
+	if contextLength != 131072 {
+		t.Errorf("Incorrect context length, expected 131072, got %d", contextLength)
+	}
+
+	// Verify RoPE scaling configuration
+	if config.RopeScaling.Type != "yarn" {
+		t.Errorf("Incorrect RoPE scaling type, expected 'yarn', got '%s'", config.RopeScaling.Type)
+	}
+
+	if config.RopeScaling.Factor != 32.0 {
+		t.Errorf("Incorrect RoPE scaling factor, expected 32.0, got %f", config.RopeScaling.Factor)
+	}
+
+	// Verify MoE configuration
+	if config.NumExpertsPerTok != 8 {
+		t.Errorf("Incorrect num_experts_per_tok, expected 8, got %d", config.NumExpertsPerTok)
+	}
+
+	if config.MoeLayerFreq != 1 {
+		t.Errorf("Incorrect moe_layer_freq, expected 1, got %d", config.MoeLayerFreq)
+	}
+
+	// Verify vision capability (should be false)
+	if config.HasVision() {
+		t.Error("HasVision() should return false for Kimi-K2")
+	}
+}

--- a/pkg/hfutil/modelconfig/testdata/kimi_k2_instruct.json
+++ b/pkg/hfutil/modelconfig/testdata/kimi_k2_instruct.json
@@ -1,0 +1,69 @@
+{
+  "architectures": [
+    "DeepseekV3ForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "auto_map": {
+    "AutoConfig": "configuration_deepseek.DeepseekV3Config",
+    "AutoModel": "modeling_deepseek.DeepseekV3Model",
+    "AutoModelForCausalLM": "modeling_deepseek.DeepseekV3ForCausalLM"
+  },
+  "aux_loss_alpha": 0.001,
+  "bos_token_id": 163584,
+  "eos_token_id": 163585,
+  "first_k_dense_replace": 1,
+  "hidden_act": "silu",
+  "hidden_size": 7168,
+  "initializer_range": 0.02,
+  "intermediate_size": 18432,
+  "kv_lora_rank": 512,
+  "max_position_embeddings": 131072,
+  "model_type": "kimi_k2",
+  "moe_intermediate_size": 2048,
+  "moe_layer_freq": 1,
+  "n_group": 1,
+  "n_routed_experts": 384,
+  "n_shared_experts": 1,
+  "norm_topk_prob": true,
+  "num_attention_heads": 64,
+  "num_experts_per_tok": 8,
+  "num_hidden_layers": 61,
+  "num_key_value_heads": 64,
+  "num_nextn_predict_layers": 0,
+  "pretraining_tp": 1,
+  "q_lora_rank": 1536,
+  "qk_nope_head_dim": 128,
+  "qk_rope_head_dim": 64,
+  "quantization_config": {
+    "activation_scheme": "dynamic",
+    "fmt": "e4m3",
+    "quant_method": "fp8",
+    "weight_block_size": [
+      128,
+      128
+    ]
+  },
+  "rms_norm_eps": 1e-06,
+  "rope_theta": 50000.0,
+  "routed_scaling_factor": 2.827,
+  "rope_scaling": {
+    "beta_fast": 1.0,
+    "beta_slow": 1.0,
+    "factor": 32.0,
+    "mscale": 1.0,
+    "mscale_all_dim": 1.0,
+    "original_max_position_embeddings": 4096,
+    "type": "yarn"
+  },
+  "scoring_func": "sigmoid",
+  "seq_aux": true,
+  "tie_word_embeddings": false,
+  "topk_group": 1,
+  "topk_method": "noaux_tc",
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.48.3",
+  "use_cache": true,
+  "v_head_dim": 128,
+  "vocab_size": 163840
+}

--- a/pkg/modelagent/gopher.go
+++ b/pkg/modelagent/gopher.go
@@ -353,7 +353,9 @@ func (s *Gopher) processTask(task *GopherTask) error {
 				s.logger.Warnf("No model object found in task, skipping config parsing")
 			}
 
-			_ = s.safeParseAndUpdateModelConfig(destPath, baseModel, clusterBaseModel)
+			if err := s.safeParseAndUpdateModelConfig(destPath, baseModel, clusterBaseModel); err != nil {
+				s.logger.Errorf("Failed to parse and update model config: %v", err)
+			}
 		case storage.StorageTypeVendor:
 			s.logger.Infof("Skipping download for model %s", modelInfo)
 		case storage.StorageTypeHuggingFace:
@@ -915,6 +917,8 @@ func (s *Gopher) processHuggingFaceModel(ctx context.Context, task *GopherTask, 
 		s.logger.Debugf("Using ClusterBaseModel %s for config parsing", clusterBaseModel.Name)
 	}
 
-	_ = s.safeParseAndUpdateModelConfig(destPath, baseModel, clusterBaseModel)
+	if err := s.safeParseAndUpdateModelConfig(destPath, baseModel, clusterBaseModel); err != nil {
+		s.logger.Errorf("Failed to parse and update model config: %v", err)
+	}
 	return nil
 }


### PR DESCRIPTION
## What type of PR is this?

  /kind feature

  ## What this PR does / why we need it:

  This PR adds support for the Kimi-K2-Instruct model from Moonshot AI to the OME model configuration parser.


  ### Changes made:
  1. **Added Kimi-K2 model configuration support** (`pkg/hfutil/modelconfig/kimi_k2.go`):
  2. **Added comprehensive tests** (`pkg/hfutil/modelconfig/kimi_k2_test.go`):
  3. **Added test data** (`pkg/hfutil/modelconfig/testdata/kimi_k2_instruct.json`):
  4. **Improved error handling** in `pkg/modelagent/gopher.go`:

  ## Which issue(s) this PR fixes:

  Fixes #

  ## Special notes for your reviewer:

  - The Kimi-K2 model uses `model_type: "kimi_k2"` but architectures `["DeepseekV3ForCausalLM"]`, which is why it shares many configuration fields with DeepSeek V3
  - The parameter count is set to 1.5T based on the model documentation and the increased expert count (384 vs 256 in DeepSeek V3)
  - This change enables the model agent to properly parse Kimi-K2 model configurations and populate ConfigMaps with detailed metadata instead of just basic status information

  ## Does this PR introduce a user-facing change?

  ```release-note
  Add support for Kimi-K2 models in the model configuration parser, enabling automatic metadata extraction for Kimi-K2-Instruct and similar models