### PR TITLE
fix: benchmark container volume mounts update when base model exists

### DIFF
--- a/pkg/controller/v1beta1/benchmark/controller.go
+++ b/pkg/controller/v1beta1/benchmark/controller.go
@@ -260,7 +260,7 @@ func (r *BenchmarkJobReconciler) createPodSpec(benchmarkJob *v1beta1.BenchmarkJo
 		if err != nil {
 			return nil, err
 		}
-		benchmarkutils.UpdateVolumeMounts(inferenceService, &defaultContainer, baseModel)
+		benchmarkutils.UpdateVolumeMounts(&defaultContainer, baseModelName, baseModel)
 
 		volumes = append(volumes, v1.Volume{
 			Name: baseModelName,

--- a/pkg/controller/v1beta1/benchmark/utils/utils.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils.go
@@ -128,12 +128,10 @@ func buildArgsFromEndpoint(endpoint *v1beta1.Endpoint) map[string]string {
 }
 
 // UpdateVolumeMounts updates the volume mounts for the benchmark container if a base model is defined.
-func UpdateVolumeMounts(isvc *v1beta1.InferenceService, container *v1.Container, baseModel *v1beta1.BaseModelSpec) {
-	if isvc.Spec.Predictor.Model == nil || isvc.Spec.Predictor.Model.BaseModel == nil || baseModel == nil {
+func UpdateVolumeMounts(container *v1.Container, baseModelName string, baseModel *v1beta1.BaseModelSpec) {
+	if baseModelName == "" || baseModel == nil {
 		return
 	}
-
-	baseModelName := *isvc.Spec.Predictor.Model.BaseModel
 
 	// Define the volume mount
 	volumeMount := v1.VolumeMount{

--- a/pkg/controller/v1beta1/benchmark/utils/utils_test.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils_test.go
@@ -468,23 +468,16 @@ func TestBuildInferenceServiceArgs(t *testing.T) {
 func TestUpdateVolumeMounts(t *testing.T) {
 	tests := []struct {
 		name      string
-		isvc      *v1beta1.InferenceService
 		model     *v1beta1.ClusterBaseModel
 		container *v1.Container
 		want      *v1.Container
 	}{
 		{
 			name: "with base model",
-			isvc: &v1beta1.InferenceService{
-				Spec: v1beta1.InferenceServiceSpec{
-					Predictor: v1beta1.PredictorSpec{
-						Model: &v1beta1.ModelSpec{
-							BaseModel: strPtr("test-model"),
-						},
-					},
-				},
-			},
 			model: &v1beta1.ClusterBaseModel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-model",
+				},
 				Spec: v1beta1.BaseModelSpec{
 					Storage: &v1beta1.StorageSpec{
 						Path: strPtr("/model/test-model"),
@@ -509,12 +502,7 @@ func TestUpdateVolumeMounts(t *testing.T) {
 			},
 		},
 		{
-			name: "without base model",
-			isvc: &v1beta1.InferenceService{
-				Spec: v1beta1.InferenceServiceSpec{
-					Predictor: v1beta1.PredictorSpec{},
-				},
-			},
+			name:      "without base model",
 			container: &v1.Container{},
 			want:      &v1.Container{},
 		},
@@ -523,9 +511,9 @@ func TestUpdateVolumeMounts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.model != nil {
-				UpdateVolumeMounts(tt.isvc, tt.container, &tt.model.Spec)
+				UpdateVolumeMounts(tt.container, tt.model.Name, &tt.model.Spec)
 			} else {
-				UpdateVolumeMounts(tt.isvc, tt.container, nil)
+				UpdateVolumeMounts(tt.container, "", nil)
 			}
 			if !reflect.DeepEqual(tt.container, tt.want) {
 				t.Errorf("UpdateVolumeMounts() = %v, want %v", tt.container, tt.want)


### PR DESCRIPTION
<!-- 
Thank you for contributing to OME! Please read the contributing guidelines:
https://github.com/sgl-project/ome/blob/main/CONTRIBUTING.md
-->

## What type of PR is this?

/kind bug

## What this PR does / why we need it:

<!-- 
Please include a summary of the changes and which issue is fixed. 
Include relevant motivation and context.
-->

when base model can be obtained from `isvc.Spec.Model` and `isvc.Spec.Predictor.Model` is nil, the model path won't be mounted. it is not correct.

## Which issue(s) this PR fixes:

<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->
Fixes #

## Special notes for your reviewer:

<!-- 
Any specific areas you'd like reviewed? Any concerns?
-->

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Fix benchmark container don't  mount model path when base model exists
```