### PR TITLE
[Bugfix] Wait for the OME controller Pod to become ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ $(shell perl -pi -e 's/cpu:.*/cpu: $(OME_CONTROLLER_CPU_LIMIT)/' config/default/
 $(shell perl -pi -e 's/memory:.*/memory: $(OME_CONTROLLER_MEMORY_LIMIT)/' config/default/manager_resources_patch.yaml)
 
 
-# Default to not waiting for controller
-WAIT_FOR_CONTROLLER ?= false
+# By default, wait for the OME controller pod to become ready
+WAIT_FOR_CONTROLLER ?= true
 
 .PHONY: all
 all: test ## 🎯 Run all tests


### PR DESCRIPTION
<!-- 
Thank you for contributing to OME! Please read the contributing guidelines:
https://github.com/sgl-project/ome/blob/main/CONTRIBUTING.md
-->

## What type of PR is this?

/kind bug

## What this PR does / why we need it:

We set `WAIT_FOR_CONTROLLER` to `true` by default to ensure the OME controller Pod is ready before `ome-webhook-server-service` is invoked. This helps prevent connection errors during installation.

## Which issue(s) this PR fixes:

<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->
Fixes https://github.com/sgl-project/ome/issues/225

## Special notes for your reviewer:

<!-- 
Any specific areas you'd like reviewed? Any concerns?
-->

N/A

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```