### PR TITLE
[BUG]Fix BenchmarkJob Deprecated Storage Command

### DIFF
--- a/pkg/controller/v1beta1/benchmark/utils/utils.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils.go
@@ -174,8 +174,8 @@ func BuildStorageArgs(storageSpec *v1beta1.StorageSpec) ([]string, error) {
 		args = append(args, "--upload-results")
 		args = append(args,
 			"--namespace", components.Namespace,
-			"--bucket", components.Bucket,
-			"--prefix", components.Prefix,
+			"--storage-bucket", components.Bucket,
+			"--storage-prefix", components.Prefix,
 		)
 
 		// Handle storage parameters

--- a/pkg/controller/v1beta1/benchmark/utils/utils_test.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils_test.go
@@ -104,8 +104,8 @@ func TestBuildStorageArgs(t *testing.T) {
 			want: []string{
 				"--upload-results",
 				"--namespace", "my-namespace",
-				"--bucket", "my-bucket",
-				"--prefix", "results",
+				"--storage-bucket", "my-bucket",
+				"--storage-prefix", "results",
 				"--auth", "instance_principal",
 				"--config-file", "/path/to/config",
 				"--profile", "DEFAULT",
@@ -125,8 +125,8 @@ func TestBuildStorageArgs(t *testing.T) {
 			want: []string{
 				"--upload-results",
 				"--namespace", "my-namespace",
-				"--bucket", "my-bucket",
-				"--prefix", "results",
+				"--storage-bucket", "my-bucket",
+				"--storage-prefix", "results",
 				"--auth", "instance_principal",
 			},
 			wantErr: false,
@@ -139,8 +139,8 @@ func TestBuildStorageArgs(t *testing.T) {
 			want: []string{
 				"--upload-results",
 				"--namespace", "my-namespace",
-				"--bucket", "my-bucket",
-				"--prefix", "results",
+				"--storage-bucket", "my-bucket",
+				"--storage-prefix", "results",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
<!-- 
Thank you for contributing to OME! Please read the contributing guidelines:
https://github.com/sgl-project/ome/blob/main/CONTRIBUTING.md
-->

## What type of PR is this?
/kind bug
<!-- 
Add one of the following:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

## What this PR does / why we need it:
Storage is required by BenchmarkJob but command line arguments was changed. 
<!-- 
Please include a summary of the changes and which issue is fixed. 
Include relevant motivation and context.
-->

## Which issue(s) this PR fixes:
https://github.com/sgl-project/ome/issues/238
<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->
Fixes #

## Special notes for your reviewer:

<!-- 
Any specific areas you'd like reviewed? Any concerns?
-->

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```