### PR TITLE
[BUG]Fix api-backend default value for benchmark job

### DIFF
--- a/pkg/controller/v1beta1/benchmark/utils/utils.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils.go
@@ -95,9 +95,8 @@ func BuildInferenceServiceArgs(c client.Client, endpointSpec v1beta1.EndpointSpe
 		if protocolVersion != "" {
 			args["--api-backend"] = string(protocolVersion)
 		} else {
-			// Default or error if protocol is mandatory?
-			// For now, let's assume a default or leave it empty if not critical
-			args["--api-backend"] = "vllm" // Assuming default if nil
+			// Default to openai for inference service
+			args["--api-backend"] = "openai"
 		}
 
 		// Extract the URL from the InferenceService's status if available


### PR DESCRIPTION
<!-- 
Thank you for contributing to OME! Please read the contributing guidelines:
https://github.com/sgl-project/ome/blob/main/CONTRIBUTING.md
-->

## What type of PR is this?
/kind bug
<!-- 
Add one of the following:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

## What this PR does / why we need it:
The default value is used when an inference service is provided to benchmark job. 

api-backend is not a field for inference service. Assuming openai is the default for inference service. 

Also "vllm" is not a valid api-backend
<!-- 
Please include a summary of the changes and which issue is fixed. 
Include relevant motivation and context.
-->

## Which issue(s) this PR fixes:

<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->
Fixes #

## Special notes for your reviewer:

<!-- 
Any specific areas you'd like reviewed? Any concerns?
-->

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```