### PR TITLE
[docs] Update Bootstrap utility classes following Bootstrap 5 breaking changes

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -6,10 +6,10 @@ description = "OME is a Kubernetes operator for enterprise-grade management and 
 
 {{< blocks/cover title="Welcome to OME" image_anchor="top" height="full" color="orange" >}}
 <div class="mx-auto">
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="docs/">
+	<a class="btn btn-lg btn-primary me-3 mb-4" href="docs/">
 		Read the docs <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/sgl-project/ome">
+	<a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/sgl-project/ome">
 		GitHub <i class="fab fa-github ml-2 "></i>
 	</a>
 	<p class="lead mt-5">Open Model Engine</p>

--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -10,7 +10,7 @@
 		<ul class="navbar-nav ml-auto pt-4 pt-md-0 my-2 my-md-1">
 			{{ $p := . }}
 			{{ range .Site.Menus.main }}
-			<li class="nav-item mr-2 mr-lg-4 mt-1 mt-lg-0">
+			<li class="nav-item me-2 me-lg-4 mt-1 mt-lg-0">
 				{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
 				{{ with .Page }}
 				{{ $active = or $active ( $.IsDescendant .)  }}
@@ -23,7 +23,7 @@
 			</li>
 			{{ end }}
 			{{ if  .Site.Params.versions }}
-			<li class="nav-item dropdown mt-1 mt-lg-0 mr-2">
+			<li class="nav-item dropdown mt-1 mt-lg-0 me-2">
 				{{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

## What this PR does / why we need it:

The spacing between the two buttons on the official website is too narrow.

<img width="1508" height="456" alt="image" src="https://github.com/user-attachments/assets/2a8c0e19-538c-44f7-8fc4-11491ddbc2fc" />

After research, I found that this is due to some breaking changes in the Bootstrap 5 upgrade, where .ml-* and .mr-* were renamed to .ms-* and .me-*. Reference: https://getbootstrap.com/docs/5.1/migration/#utilities

So this PR updates Bootstrap utility classes in the site codebase to use logical property names, following Bootstrap 5 breaking changes for RTL support.

The modified version looks better.

<img width="1620" height="560" alt="image" src="https://github.com/user-attachments/assets/aa730657-2d59-4f38-bd98-ac800cda736b" />


## Which issue(s) this PR fixes:

<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->
Fixes #

## Special notes for your reviewer:

<!-- 
Any specific areas you'd like reviewed? Any concerns?
-->

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
[docs] Update Bootstrap utility classes following Bootstrap 5 breaking changes
```