### PR TITLE
Support extra volumes and mounts in model-agent

### DIFF
--- a/charts/ome-resources/README.md
+++ b/charts/ome-resources/README.md
@@ -16,6 +16,8 @@ OME Resources and Controller
 | modelAgent.image.repository | string | `"model-agent"` |  |
 | modelAgent.image.tag | string | `"v0.1.2"` |  |
 | modelAgent.nodeSelector | object | `{}` |  |
+| modelAgent.extraVolumeMounts | list | `[]` |  |
+| modelAgent.extraVolumes | list | `[]` |  |
 | modelAgent.priorityClassName | string | `"system-node-critical"` |  |
 | modelAgent.resources.limits.cpu | string | `"10"` |  |
 | modelAgent.resources.limits.memory | string | `"100Gi"` |  |
@@ -88,4 +90,3 @@ OME Resources and Controller
 | ome.omeAgent.tag | string | `"v0.1.2"` |  |
 | ome.omeAgent.vaultId | string | `"ocid1.vault.oc1.ap-osaka-1.dummy.dummy-vault"` |  |
 | ome.version | string | `"v0.1.2"` |  |
-

--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -7,7 +7,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
   selector:
-    matchLabels: 
+    matchLabels:
       app.kubernetes.io/component: "ome-model-agent-daemonset"
   template:
     metadata:
@@ -35,6 +35,9 @@ spec:
           hostPath:
             path: {{ .Values.modelAgent.hostPath }}
             type: DirectoryOrCreate
+        {{- with .Values.modelAgent.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
       - name: model-agent
         image: {{ include "ome.imageWithHub" (dict "values" .Values "repository" .Values.modelAgent.image.repository "tag" .Values.modelAgent.image.tag) }}
@@ -57,6 +60,9 @@ spec:
         - name: host-models
           readOnly: false
           mountPath: {{ .Values.modelAgent.hostPath }}
+        {{- with .Values.modelAgent.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /livez

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -98,6 +98,26 @@ modelAgent:
 
   nodeSelector: {}
 
+  # Additional volumes to mount into the model-agent DaemonSet pods
+  # Examples:
+  # extraVolumes:
+  #   - name: shared-tmp
+  #     emptyDir: {}
+  #   - name: config
+  #     configMap:
+  #       name: my-config
+  extraVolumes: []
+
+  # Additional volumeMounts for the model-agent container
+  # Examples:
+  # extraVolumeMounts:
+  #   - name: shared-tmp
+  #     mountPath: /tmp/shared
+  #   - name: config
+  #     mountPath: /etc/model-agent/config
+  #     readOnly: true
+  extraVolumeMounts: []
+
   tolerations:
     - key: nvidia.com/gpu
       operator: Exists


### PR DESCRIPTION
Users may need to mount additional config, scratch space, or secrets into the model-agent DaemonSet pods. This change exposes `modelAgent.extraVolumes` and `modelAgent.extraVolumeMounts` in the Helm values so integrators can supply arbitrary volumes/mounts without forking the chart.

Changes:
- Template `extraVolumes` under `spec.template.spec.volumes`.
- Template `extraVolumeMounts` under container `volumeMounts`.
- Add values with docs and examples in `values.yaml`.
- Document new values in README.
- Minor whitespace cleanup in daemonset template.

No breaking changes; defaults keep behavior unchanged.
