### PR TITLE
[core] implement storage interface for multi cloud support

### DIFF
--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -1,0 +1,136 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Common storage errors
+var (
+	// ErrNotFound indicates the requested object was not found
+	ErrNotFound = errors.New("storage: object not found")
+
+	// ErrAlreadyExists indicates the object already exists
+	ErrAlreadyExists = errors.New("storage: object already exists")
+
+	// ErrAccessDenied indicates access was denied
+	ErrAccessDenied = errors.New("storage: access denied")
+
+	// ErrInvalidPath indicates an invalid path was provided
+	ErrInvalidPath = errors.New("storage: invalid path")
+
+	// ErrInvalidConfig indicates invalid configuration
+	ErrInvalidConfig = errors.New("storage: invalid configuration")
+
+	// ErrNotSupported indicates the operation is not supported
+	ErrNotSupported = errors.New("storage: operation not supported")
+
+	// ErrTimeout indicates the operation timed out
+	ErrTimeout = errors.New("storage: operation timed out")
+
+	// ErrQuotaExceeded indicates storage quota was exceeded
+	ErrQuotaExceeded = errors.New("storage: quota exceeded")
+
+	// ErrChecksumMismatch indicates checksum verification failed
+	ErrChecksumMismatch = errors.New("storage: checksum mismatch")
+
+	// ErrPartialContent indicates only partial content was retrieved
+	ErrPartialContent = errors.New("storage: partial content")
+)
+
+// Error represents a storage error with additional context
+type Error struct {
+	Op       string // Operation that failed
+	Path     string // Path involved in the operation
+	Provider string // Storage provider type
+	Err      error  // Underlying error
+}
+
+// Error returns the string representation of the error
+func (e *Error) Error() string {
+	if e.Path != "" {
+		return fmt.Sprintf("storage %s: %s failed for %s: %v", e.Provider, e.Op, e.Path, e.Err)
+	}
+	return fmt.Sprintf("storage %s: %s failed: %v", e.Provider, e.Op, e.Err)
+}
+
+// Unwrap returns the underlying error
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+// Is checks if the error matches the target error
+func (e *Error) Is(target error) bool {
+	return errors.Is(e.Err, target)
+}
+
+// NewError creates a new storage error
+func NewError(op string, path string, provider string, err error) error {
+	return &Error{
+		Op:       op,
+		Path:     path,
+		Provider: provider,
+		Err:      err,
+	}
+}
+
+// IsNotFound checks if an error is a not found error
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrNotFound)
+}
+
+// IsAlreadyExists checks if an error is an already exists error
+func IsAlreadyExists(err error) bool {
+	return errors.Is(err, ErrAlreadyExists)
+}
+
+// IsAccessDenied checks if an error is an access denied error
+func IsAccessDenied(err error) bool {
+	return errors.Is(err, ErrAccessDenied)
+}
+
+// IsInvalidPath checks if an error is an invalid path error
+func IsInvalidPath(err error) bool {
+	return errors.Is(err, ErrInvalidPath)
+}
+
+// IsNotSupported checks if an error is a not supported error
+func IsNotSupported(err error) bool {
+	return errors.Is(err, ErrNotSupported)
+}
+
+// IsTimeout checks if an error is a timeout error
+func IsTimeout(err error) bool {
+	return errors.Is(err, ErrTimeout)
+}
+
+// IsChecksumMismatch checks if an error is a checksum mismatch error
+func IsChecksumMismatch(err error) bool {
+	return errors.Is(err, ErrChecksumMismatch)
+}
+
+// RetryableError wraps an error to indicate it can be retried
+type RetryableError struct {
+	Err error
+}
+
+// Error returns the string representation of the retryable error
+func (e *RetryableError) Error() string {
+	return fmt.Sprintf("retryable error: %v", e.Err)
+}
+
+// Unwrap returns the underlying error
+func (e *RetryableError) Unwrap() error {
+	return e.Err
+}
+
+// IsRetryable checks if an error is retryable
+func IsRetryable(err error) bool {
+	var retryable *RetryableError
+	return errors.As(err, &retryable)
+}
+
+// NewRetryableError creates a new retryable error
+func NewRetryableError(err error) error {
+	return &RetryableError{Err: err}
+}

--- a/pkg/storage/errors_test.go
+++ b/pkg/storage/errors_test.go
@@ -1,0 +1,148 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError(t *testing.T) {
+	t.Run("error with path", func(t *testing.T) {
+		err := NewError("upload", "/path/to/file", "s3", ErrAccessDenied)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "storage s3")
+		assert.Contains(t, err.Error(), "upload failed")
+		assert.Contains(t, err.Error(), "/path/to/file")
+		assert.Contains(t, err.Error(), "access denied")
+	})
+
+	t.Run("error without path", func(t *testing.T) {
+		err := NewError("list", "", "azure", ErrTimeout)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "storage azure")
+		assert.Contains(t, err.Error(), "list failed")
+		assert.Contains(t, err.Error(), "operation timed out")
+		assert.NotContains(t, err.Error(), "for ")
+	})
+
+	t.Run("error unwrap", func(t *testing.T) {
+		baseErr := errors.New("base error")
+		err := &Error{
+			Op:       "test",
+			Path:     "/test",
+			Provider: "gcs",
+			Err:      baseErr,
+		}
+		assert.Equal(t, baseErr, err.Unwrap())
+	})
+
+	t.Run("error is", func(t *testing.T) {
+		err := NewError("delete", "/file", "oci", ErrNotFound)
+		assert.True(t, errors.Is(err, ErrNotFound))
+		assert.False(t, errors.Is(err, ErrAlreadyExists))
+	})
+}
+
+func TestErrorCheckers(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		checker func(error) bool
+		want    bool
+	}{
+		{
+			name:    "IsNotFound with ErrNotFound",
+			err:     ErrNotFound,
+			checker: IsNotFound,
+			want:    true,
+		},
+		{
+			name:    "IsNotFound with wrapped ErrNotFound",
+			err:     NewError("get", "/file", "s3", ErrNotFound),
+			checker: IsNotFound,
+			want:    true,
+		},
+		{
+			name:    "IsNotFound with different error",
+			err:     ErrAccessDenied,
+			checker: IsNotFound,
+			want:    false,
+		},
+		{
+			name:    "IsAlreadyExists",
+			err:     NewError("create", "/file", "azure", ErrAlreadyExists),
+			checker: IsAlreadyExists,
+			want:    true,
+		},
+		{
+			name:    "IsAccessDenied",
+			err:     NewError("upload", "/file", "gcs", ErrAccessDenied),
+			checker: IsAccessDenied,
+			want:    true,
+		},
+		{
+			name:    "IsInvalidPath",
+			err:     ErrInvalidPath,
+			checker: IsInvalidPath,
+			want:    true,
+		},
+		{
+			name:    "IsNotSupported",
+			err:     ErrNotSupported,
+			checker: IsNotSupported,
+			want:    true,
+		},
+		{
+			name:    "IsTimeout",
+			err:     ErrTimeout,
+			checker: IsTimeout,
+			want:    true,
+		},
+		{
+			name:    "IsChecksumMismatch",
+			err:     ErrChecksumMismatch,
+			checker: IsChecksumMismatch,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.checker(tt.err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestRetryableError(t *testing.T) {
+	t.Run("create and check retryable", func(t *testing.T) {
+		baseErr := errors.New("temporary error")
+		err := NewRetryableError(baseErr)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "retryable error")
+		assert.Contains(t, err.Error(), "temporary error")
+		assert.True(t, IsRetryable(err))
+	})
+
+	t.Run("non-retryable error", func(t *testing.T) {
+		err := errors.New("permanent error")
+		assert.False(t, IsRetryable(err))
+	})
+
+	t.Run("unwrap retryable error", func(t *testing.T) {
+		baseErr := errors.New("base error")
+		retryErr := &RetryableError{Err: baseErr}
+		assert.Equal(t, baseErr, retryErr.Unwrap())
+	})
+
+	t.Run("nested retryable error", func(t *testing.T) {
+		baseErr := ErrTimeout
+		retryErr := NewRetryableError(baseErr)
+		wrappedErr := NewError("operation", "/path", "s3", retryErr)
+
+		assert.True(t, IsRetryable(wrappedErr))
+		assert.True(t, IsTimeout(baseErr))
+	})
+}

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -1,0 +1,150 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/sgl-project/ome/pkg/logging"
+)
+
+// StorageFactory is a factory function that creates a storage provider
+type StorageFactory func(ctx context.Context, config Config, logger logging.Interface) (Storage, error)
+
+// DefaultFactory is the default storage factory implementation
+type DefaultFactory struct {
+	logger    logging.Interface
+	providers map[Provider]StorageFactory
+	mu        sync.RWMutex
+}
+
+// NewFactory creates a new storage factory
+func NewFactory(logger logging.Interface) *DefaultFactory {
+	return &DefaultFactory{
+		logger:    logger,
+		providers: make(map[Provider]StorageFactory),
+	}
+}
+
+// Register registers a storage provider factory
+func (f *DefaultFactory) Register(provider Provider, factory StorageFactory) error {
+	// Check if it's a known storage provider
+	if provider == "" {
+		return fmt.Errorf("invalid storage provider: empty")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if _, exists := f.providers[provider]; exists {
+		return fmt.Errorf("storage provider %s already registered", provider)
+	}
+
+	f.providers[provider] = factory
+	f.logger.WithField("provider", provider).Debug("Registered storage provider")
+	return nil
+}
+
+// CreateStorage creates a storage provider based on configuration
+func (f *DefaultFactory) CreateStorage(ctx context.Context, config Config) (Storage, error) {
+	if config.Provider == "" {
+		return nil, NewError("create", "", string(config.Provider), ErrInvalidConfig)
+	}
+
+	f.mu.RLock()
+	factory, exists := f.providers[config.Provider]
+	f.mu.RUnlock()
+
+	if !exists {
+		return nil, NewError("create", "", string(config.Provider),
+			fmt.Errorf("storage provider %s not registered", config.Provider))
+	}
+
+	// Validate common configuration
+	if err := f.validateConfig(config); err != nil {
+		return nil, NewError("create", "", string(config.Provider), err)
+	}
+
+	// Create the provider
+	storage, err := factory(ctx, config, f.logger)
+	if err != nil {
+		return nil, NewError("create", "", string(config.Provider), err)
+	}
+
+	f.logger.WithField("provider", config.Provider).
+		WithField("region", config.Region).
+		WithField("bucket", config.Bucket).
+		Info("Created storage provider")
+
+	return storage, nil
+}
+
+// SupportedProviders returns the list of supported storage providers
+func (f *DefaultFactory) SupportedProviders() []Provider {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	providers := make([]Provider, 0, len(f.providers))
+	for p := range f.providers {
+		providers = append(providers, p)
+	}
+	return providers
+}
+
+// validateConfig validates common configuration parameters
+func (f *DefaultFactory) validateConfig(config Config) error {
+	// Validate based on storage provider
+	switch config.Provider {
+	case ProviderS3, ProviderAzure, ProviderGCS:
+		// Cloud storage requires bucket
+		if config.Bucket == "" {
+			return fmt.Errorf("bucket is required for %s storage", config.Provider)
+		}
+		// Validate auth config for cloud storage
+		if config.AuthConfig == nil {
+			return fmt.Errorf("auth configuration is required for %s storage", config.Provider)
+		}
+	case ProviderOCI:
+		// OCI requires namespace and bucket
+		if config.Namespace == "" {
+			return fmt.Errorf("namespace is required for OCI storage")
+		}
+		if config.Bucket == "" {
+			return fmt.Errorf("bucket is required for OCI storage")
+		}
+		if config.AuthConfig == nil {
+			return fmt.Errorf("auth configuration is required for OCI storage")
+		}
+	case ProviderPVC:
+		// PVC requires specific configuration in Extra
+		if config.Extra == nil {
+			return fmt.Errorf("PVC configuration is required in Extra field")
+		}
+	case ProviderLocal:
+		// Local storage requires base path in Extra
+		if config.Extra == nil || config.Extra["base_path"] == nil {
+			return fmt.Errorf("base_path is required for local storage")
+		}
+	}
+
+	return nil
+}
+
+// GlobalFactory is the global storage factory instance
+var globalFactory *DefaultFactory
+var globalFactoryOnce sync.Once
+
+// GetGlobalFactory returns the global storage factory instance
+func GetGlobalFactory(logger logging.Interface) *DefaultFactory {
+	globalFactoryOnce.Do(func() {
+		globalFactory = NewFactory(logger)
+	})
+	return globalFactory
+}
+
+// MustRegister registers a storage provider factory and panics on error
+func MustRegister(provider Provider, factory StorageFactory, logger logging.Interface) {
+	if err := GetGlobalFactory(logger).Register(provider, factory); err != nil {
+		panic(fmt.Sprintf("failed to register storage provider %s: %v", provider, err))
+	}
+}

--- a/pkg/storage/factory_test.go
+++ b/pkg/storage/factory_test.go
@@ -1,0 +1,304 @@
+package storage
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sgl-project/ome/pkg/logging"
+)
+
+// mockStorage is a mock storage implementation for testing
+type mockStorage struct {
+	provider Provider
+}
+
+func (m *mockStorage) Provider() Provider {
+	return m.provider
+}
+
+func (m *mockStorage) Download(ctx context.Context, source string, target string, opts ...DownloadOption) error {
+	return nil
+}
+
+func (m *mockStorage) Upload(ctx context.Context, source string, target string, opts ...UploadOption) error {
+	return nil
+}
+
+func (m *mockStorage) Get(ctx context.Context, uri string) (io.ReadCloser, error) {
+	return io.NopCloser(nil), nil
+}
+
+func (m *mockStorage) Put(ctx context.Context, uri string, reader io.Reader, size int64, opts ...UploadOption) error {
+	return nil
+}
+
+func (m *mockStorage) Delete(ctx context.Context, uri string) error {
+	return nil
+}
+
+func (m *mockStorage) Exists(ctx context.Context, uri string) (bool, error) {
+	return true, nil
+}
+
+func (m *mockStorage) List(ctx context.Context, uri string, opts ...ListOption) ([]ObjectInfo, error) {
+	return []ObjectInfo{}, nil
+}
+
+func (m *mockStorage) Stat(ctx context.Context, uri string) (*Metadata, error) {
+	return &Metadata{Name: uri}, nil
+}
+
+func (m *mockStorage) Copy(ctx context.Context, source string, target string) error {
+	return nil
+}
+
+func TestFactory_Register(t *testing.T) {
+	logger := logging.Discard()
+	factory := NewFactory(logger)
+
+	// Test successful registration
+	err := factory.Register(ProviderS3, func(ctx context.Context, config Config, logger logging.Interface) (Storage, error) {
+		return &mockStorage{provider: ProviderS3}, nil
+	})
+	assert.NoError(t, err)
+
+	// Test duplicate registration
+	err = factory.Register(ProviderS3, func(ctx context.Context, config Config, logger logging.Interface) (Storage, error) {
+		return &mockStorage{provider: ProviderS3}, nil
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already registered")
+
+	// Test empty provider registration
+	err = factory.Register("", func(ctx context.Context, config Config, logger logging.Interface) (Storage, error) {
+		return &mockStorage{}, nil
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid storage provider")
+}
+
+func TestFactory_CreateStorage(t *testing.T) {
+	logger := logging.Discard()
+	factory := NewFactory(logger)
+
+	// Register a mock storage
+	factory.Register(ProviderS3, func(ctx context.Context, config Config, logger logging.Interface) (Storage, error) {
+		return &mockStorage{provider: ProviderS3}, nil
+	})
+
+	tests := []struct {
+		name      string
+		config    Config
+		wantErr   bool
+		errString string
+	}{
+		{
+			name: "successful creation",
+			config: Config{
+				Provider: ProviderS3,
+				Bucket:   "test-bucket",
+				AuthConfig: &AuthConfig{
+					Provider: "aws",
+					Type:     "access_key",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing bucket for cloud storage",
+			config: Config{
+				Provider: ProviderS3,
+				AuthConfig: &AuthConfig{
+					Provider: "aws",
+					Type:     "access_key",
+				},
+			},
+			wantErr:   true,
+			errString: "bucket is required",
+		},
+		{
+			name: "missing auth for cloud storage",
+			config: Config{
+				Provider: ProviderS3,
+				Bucket:   "test-bucket",
+			},
+			wantErr:   true,
+			errString: "auth configuration is required",
+		},
+		{
+			name: "unregistered provider",
+			config: Config{
+				Provider: ProviderAzure,
+				Bucket:   "test-container",
+				AuthConfig: &AuthConfig{
+					Provider: "azure",
+					Type:     "client_secret",
+				},
+			},
+			wantErr:   true,
+			errString: "not registered",
+		},
+		{
+			name: "empty storage provider",
+			config: Config{
+				Provider: "",
+			},
+			wantErr:   true,
+			errString: "invalid configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage, err := factory.CreateStorage(context.Background(), tt.config)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errString != "" {
+					assert.Contains(t, err.Error(), tt.errString)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, storage)
+				assert.Equal(t, tt.config.Provider, storage.Provider())
+			}
+		})
+	}
+}
+
+func TestFactory_SupportedProviders(t *testing.T) {
+	logger := logging.Discard()
+	factory := NewFactory(logger)
+
+	// Initially empty
+	providers := factory.SupportedProviders()
+	assert.Empty(t, providers)
+
+	// Register some providers
+	factory.Register(ProviderS3, func(ctx context.Context, config Config, logger logging.Interface) (Storage, error) {
+		return &mockStorage{provider: ProviderS3}, nil
+	})
+	factory.Register(ProviderAzure, func(ctx context.Context, config Config, logger logging.Interface) (Storage, error) {
+		return &mockStorage{provider: ProviderAzure}, nil
+	})
+
+	// Check supported providers
+	providers = factory.SupportedProviders()
+	assert.Len(t, providers, 2)
+	assert.Contains(t, providers, ProviderS3)
+	assert.Contains(t, providers, ProviderAzure)
+}
+
+func TestFactory_ValidateConfig(t *testing.T) {
+	logger := logging.Discard()
+	factory := NewFactory(logger)
+
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name: "valid S3 config",
+			config: Config{
+				Provider: ProviderS3,
+				Bucket:   "test-bucket",
+				AuthConfig: &AuthConfig{
+					Provider: "aws",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "S3 missing bucket",
+			config: Config{
+				Provider: ProviderS3,
+				AuthConfig: &AuthConfig{
+					Provider: "aws",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "S3 missing auth",
+			config: Config{
+				Provider: ProviderS3,
+				Bucket:   "test-bucket",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid PVC config",
+			config: Config{
+				Provider: ProviderPVC,
+				Extra: map[string]interface{}{
+					"pvc_name": "test-pvc",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "PVC missing extra",
+			config: Config{
+				Provider: ProviderPVC,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid local config",
+			config: Config{
+				Provider: ProviderLocal,
+				Extra: map[string]interface{}{
+					"base_path": "/tmp/storage",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "local missing base_path",
+			config: Config{
+				Provider: ProviderLocal,
+				Extra:    map[string]interface{}{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := factory.validateConfig(tt.config)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGlobalFactory(t *testing.T) {
+	logger := logging.Discard()
+
+	// Get global factory multiple times
+	factory1 := GetGlobalFactory(logger)
+	factory2 := GetGlobalFactory(logger)
+
+	// Should be the same instance
+	assert.Same(t, factory1, factory2)
+
+	// Test MustRegister
+	assert.NotPanics(t, func() {
+		MustRegister(ProviderGitHub, func(ctx context.Context, config Config, logger logging.Interface) (Storage, error) {
+			return &mockStorage{provider: ProviderGitHub}, nil
+		}, logger)
+	})
+
+	// Should panic on duplicate registration
+	assert.Panics(t, func() {
+		MustRegister(ProviderGitHub, func(ctx context.Context, config Config, logger logging.Interface) (Storage, error) {
+			return &mockStorage{provider: ProviderGitHub}, nil
+		}, logger)
+	})
+}

--- a/pkg/storage/interfaces.go
+++ b/pkg/storage/interfaces.go
@@ -1,0 +1,164 @@
+package storage
+
+import (
+	"context"
+	"io"
+	"time"
+
+	utilstorage "github.com/sgl-project/ome/pkg/utils/storage"
+)
+
+// Provider represents the storage provider type
+type Provider string
+
+const (
+	ProviderOCI    Provider = "oci"
+	ProviderS3     Provider = "s3"
+	ProviderGCS    Provider = "gcs"
+	ProviderAzure  Provider = "azure"
+	ProviderGitHub Provider = "github"
+	ProviderLocal  Provider = "local"
+	ProviderPVC    Provider = "pvc"
+)
+
+// Storage is the main interface that all storage backends must implement
+type Storage interface {
+	// Provider returns the storage provider type
+	Provider() Provider
+
+	Download(ctx context.Context, source string, target string, opts ...DownloadOption) error
+	Upload(ctx context.Context, source string, target string, opts ...UploadOption) error
+
+	Get(ctx context.Context, uri string) (io.ReadCloser, error)
+	Put(ctx context.Context, uri string, reader io.Reader, size int64, opts ...UploadOption) error
+
+	Delete(ctx context.Context, uri string) error
+	Exists(ctx context.Context, uri string) (bool, error)
+	List(ctx context.Context, uri string, opts ...ListOption) ([]ObjectInfo, error)
+	Stat(ctx context.Context, uri string) (*Metadata, error)
+	Copy(ctx context.Context, source string, target string) error
+}
+
+// MultipartCapable interface for providers that support multipart uploads
+type MultipartCapable interface {
+	InitiateMultipartUpload(ctx context.Context, uri string, opts ...UploadOption) (string, error)
+	UploadPart(ctx context.Context, uri string, uploadID string, partNumber int, reader io.Reader, size int64) (string, error)
+	CompleteMultipartUpload(ctx context.Context, uri string, uploadID string, parts []Part) error
+	AbortMultipartUpload(ctx context.Context, uri string, uploadID string) error
+}
+
+// BulkStorage interface for providers that support bulk operations
+type BulkStorage interface {
+	BulkDownload(ctx context.Context, downloads []BulkDownloadItem, opts ...BulkOption) (*BulkDownloadResult, error)
+	BulkUpload(ctx context.Context, uploads []BulkUploadItem, opts ...BulkOption) (*BulkUploadResult, error)
+}
+
+// ObjectInfo contains information about a storage object
+type ObjectInfo struct {
+	Name         string
+	Size         int64
+	LastModified time.Time
+	ETag         string
+	ContentType  string
+	IsDir        bool
+}
+
+// Metadata contains detailed metadata about a storage object
+type Metadata struct {
+	Name         string
+	Size         int64
+	ContentType  string
+	ETag         string
+	LastModified time.Time
+	Metadata     map[string]string
+	StorageClass string
+}
+
+// Part represents a part in a multipart upload
+type Part struct {
+	PartNumber int
+	ETag       string
+	Size       int64
+}
+
+// BulkDownloadItem represents a single item in a bulk download operation
+type BulkDownloadItem struct {
+	Source string
+	Target string
+}
+
+// BulkUploadItem represents a single item in a bulk upload operation
+type BulkUploadItem struct {
+	Source string
+	Target string
+}
+
+// BulkDownloadResult contains the results of a bulk download operation
+type BulkDownloadResult struct {
+	Successful []string
+	Failed     map[string]error
+	TotalBytes int64
+	Duration   time.Duration
+}
+
+// BulkUploadResult contains the results of a bulk upload operation
+type BulkUploadResult struct {
+	Successful []string
+	Failed     map[string]error
+	TotalBytes int64
+	Duration   time.Duration
+}
+
+// Config provides configuration for storage providers
+type Config struct {
+	Provider   Provider
+	AuthConfig *AuthConfig // Authentication configuration
+	Region     string
+	Endpoint   string // For S3-compatible or custom endpoints
+	Bucket     string // Default bucket/container
+	Namespace  string // For OCI
+	Extra      map[string]interface{}
+}
+
+// AuthConfig wraps authentication configuration for storage providers
+type AuthConfig struct {
+	Provider string // auth provider type (aws, azure, gcp, oci)
+	Type     string // auth type (e.g., access_key, service_account)
+	Region   string
+	Extra    map[string]interface{} // Provider-specific auth config
+}
+
+// Factory creates storage providers based on configuration
+type Factory interface {
+	CreateStorage(ctx context.Context, config Config) (Storage, error)
+	SupportedProviders() []Provider
+}
+
+// ProgressReporter reports operation progress
+type ProgressReporter interface {
+	Update(bytesTransferred, totalBytes int64)
+	Done()
+	Error(err error)
+}
+
+// Range specifies a byte range for partial downloads
+type Range struct {
+	Start int64
+	End   int64
+}
+
+// Type is an alias to the existing StorageType for backward compatibility
+type Type = utilstorage.StorageType
+
+// Re-export storage type constants for convenience
+const (
+	TypeS3          = utilstorage.StorageTypeS3
+	TypeAzure       = utilstorage.StorageTypeAzure
+	TypeGCS         = utilstorage.StorageTypeGCS
+	TypeOCI         = utilstorage.StorageTypeOCI
+	TypePVC         = utilstorage.StorageTypePVC
+	TypeLocal       = utilstorage.StorageTypeLocal
+	TypeGitHub      = utilstorage.StorageTypeGitHub
+	TypeHuggingFace = utilstorage.StorageTypeHuggingFace
+	TypeVendor      = utilstorage.StorageTypeVendor
+)

--- a/pkg/storage/options.go
+++ b/pkg/storage/options.go
@@ -1,0 +1,273 @@
+package storage
+
+import "time"
+
+// UploadOption configures upload operations
+type UploadOption func(*uploadOptions)
+
+// DownloadOption configures download operations
+type DownloadOption func(*downloadOptions)
+
+// ListOption configures list operations
+type ListOption func(*listOptions)
+
+// BulkOption configures bulk operations
+type BulkOption func(*bulkOptions)
+
+// uploadOptions contains configuration for upload operations
+type uploadOptions struct {
+	ContentType  string
+	Metadata     map[string]string
+	Progress     ProgressReporter
+	PartSize     int64  // For multipart uploads
+	Concurrency  int    // Number of parallel parts for multipart
+	StorageClass string // Storage class/tier
+}
+
+// downloadOptions contains configuration for download operations
+type downloadOptions struct {
+	Range       *Range // For partial downloads
+	Progress    ProgressReporter
+	Concurrency int    // Number of parallel chunks
+	VerifyETag  string // Verify ETag after download
+}
+
+// listOptions contains configuration for list operations
+type listOptions struct {
+	MaxResults    int
+	Delimiter     string
+	Recursive     bool
+	IncludeHidden bool
+	StartAfter    string // For pagination
+}
+
+// bulkOptions contains configuration for bulk operations
+type bulkOptions struct {
+	Concurrency     int
+	Progress        ProgressReporter
+	ContinueOnError bool
+	RetryAttempts   int
+	RetryDelay      time.Duration
+}
+
+// DefaultUploadOptions returns default upload options
+func DefaultUploadOptions() uploadOptions {
+	return uploadOptions{
+		ContentType: "application/octet-stream",
+		Metadata:    make(map[string]string),
+		Concurrency: 5,
+		PartSize:    5 * 1024 * 1024, // 5MB default part size
+	}
+}
+
+// DefaultDownloadOptions returns default download options
+func DefaultDownloadOptions() downloadOptions {
+	return downloadOptions{
+		Concurrency: 5,
+	}
+}
+
+// DefaultListOptions returns default list options
+func DefaultListOptions() listOptions {
+	return listOptions{
+		MaxResults: 1000,
+		Recursive:  false,
+	}
+}
+
+// DefaultBulkOptions returns default bulk options
+func DefaultBulkOptions() bulkOptions {
+	return bulkOptions{
+		Concurrency:     5,
+		ContinueOnError: true,
+		RetryAttempts:   3,
+		RetryDelay:      1 * time.Second,
+	}
+}
+
+// Upload Options
+
+// WithContentType sets the content type for upload
+func WithContentType(contentType string) UploadOption {
+	return func(o *uploadOptions) {
+		o.ContentType = contentType
+	}
+}
+
+// WithMetadata sets metadata for upload
+func WithMetadata(metadata map[string]string) UploadOption {
+	return func(o *uploadOptions) {
+		o.Metadata = metadata
+	}
+}
+
+// WithUploadProgress sets the progress reporter for upload
+func WithUploadProgress(progress ProgressReporter) UploadOption {
+	return func(o *uploadOptions) {
+		o.Progress = progress
+	}
+}
+
+// WithPartSize sets the part size for multipart upload
+func WithPartSize(size int64) UploadOption {
+	return func(o *uploadOptions) {
+		o.PartSize = size
+	}
+}
+
+// WithUploadConcurrency sets the concurrency for multipart upload
+func WithUploadConcurrency(concurrency int) UploadOption {
+	return func(o *uploadOptions) {
+		o.Concurrency = concurrency
+	}
+}
+
+// WithStorageClass sets the storage class/tier
+func WithStorageClass(class string) UploadOption {
+	return func(o *uploadOptions) {
+		o.StorageClass = class
+	}
+}
+
+// Download Options
+
+// WithRange sets the byte range for partial download
+func WithRange(start, end int64) DownloadOption {
+	return func(o *downloadOptions) {
+		o.Range = &Range{
+			Start: start,
+			End:   end,
+		}
+	}
+}
+
+// WithDownloadProgress sets the progress reporter for download
+func WithDownloadProgress(progress ProgressReporter) DownloadOption {
+	return func(o *downloadOptions) {
+		o.Progress = progress
+	}
+}
+
+// WithDownloadConcurrency sets the concurrency for parallel download
+func WithDownloadConcurrency(concurrency int) DownloadOption {
+	return func(o *downloadOptions) {
+		o.Concurrency = concurrency
+	}
+}
+
+// WithETagVerification sets the expected ETag for verification
+func WithETagVerification(etag string) DownloadOption {
+	return func(o *downloadOptions) {
+		o.VerifyETag = etag
+	}
+}
+
+// List Options
+
+// WithMaxResults sets the maximum number of results
+func WithMaxResults(max int) ListOption {
+	return func(o *listOptions) {
+		o.MaxResults = max
+	}
+}
+
+// WithDelimiter sets the delimiter for hierarchical listing
+func WithDelimiter(delimiter string) ListOption {
+	return func(o *listOptions) {
+		o.Delimiter = delimiter
+	}
+}
+
+// WithRecursive enables recursive listing
+func WithRecursive(recursive bool) ListOption {
+	return func(o *listOptions) {
+		o.Recursive = recursive
+	}
+}
+
+// WithIncludeHidden includes hidden files in listing
+func WithIncludeHidden(include bool) ListOption {
+	return func(o *listOptions) {
+		o.IncludeHidden = include
+	}
+}
+
+// WithStartAfter sets the start position for pagination
+func WithStartAfter(marker string) ListOption {
+	return func(o *listOptions) {
+		o.StartAfter = marker
+	}
+}
+
+// BuildUploadOptions applies upload options and returns the configuration
+func BuildUploadOptions(opts ...UploadOption) uploadOptions {
+	options := DefaultUploadOptions()
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return options
+}
+
+// BuildDownloadOptions applies download options and returns the configuration
+func BuildDownloadOptions(opts ...DownloadOption) downloadOptions {
+	options := DefaultDownloadOptions()
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return options
+}
+
+// BuildListOptions applies list options and returns the configuration
+func BuildListOptions(opts ...ListOption) listOptions {
+	options := DefaultListOptions()
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return options
+}
+
+// BuildBulkOptions applies bulk options and returns the configuration
+func BuildBulkOptions(opts ...BulkOption) bulkOptions {
+	options := DefaultBulkOptions()
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return options
+}
+
+// Bulk Options
+
+// WithBulkConcurrency sets the concurrency for bulk operations
+func WithBulkConcurrency(concurrency int) BulkOption {
+	return func(o *bulkOptions) {
+		o.Concurrency = concurrency
+	}
+}
+
+// WithBulkProgress sets the progress reporter for bulk operations
+func WithBulkProgress(progress ProgressReporter) BulkOption {
+	return func(o *bulkOptions) {
+		o.Progress = progress
+	}
+}
+
+// WithContinueOnError sets whether to continue on error during bulk operations
+func WithContinueOnError(continueOnError bool) BulkOption {
+	return func(o *bulkOptions) {
+		o.ContinueOnError = continueOnError
+	}
+}
+
+// WithRetryAttempts sets the number of retry attempts for bulk operations
+func WithRetryAttempts(attempts int) BulkOption {
+	return func(o *bulkOptions) {
+		o.RetryAttempts = attempts
+	}
+}
+
+// WithRetryDelay sets the delay between retries for bulk operations
+func WithRetryDelay(delay time.Duration) BulkOption {
+	return func(o *bulkOptions) {
+		o.RetryDelay = delay
+	}
+}

--- a/pkg/storage/options_test.go
+++ b/pkg/storage/options_test.go
@@ -1,0 +1,245 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUploadOptions(t *testing.T) {
+	t.Run("default options", func(t *testing.T) {
+		opts := DefaultUploadOptions()
+		assert.Equal(t, "application/octet-stream", opts.ContentType)
+		assert.NotNil(t, opts.Metadata)
+		assert.Equal(t, 5, opts.Concurrency)
+		assert.Equal(t, int64(5*1024*1024), opts.PartSize)
+	})
+
+	t.Run("with content type", func(t *testing.T) {
+		opts := BuildUploadOptions(WithContentType("text/plain"))
+		assert.Equal(t, "text/plain", opts.ContentType)
+	})
+
+	t.Run("with metadata", func(t *testing.T) {
+		metadata := map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		}
+		opts := BuildUploadOptions(WithMetadata(metadata))
+		assert.Equal(t, metadata, opts.Metadata)
+	})
+
+	t.Run("with progress", func(t *testing.T) {
+		progress := &SimpleProgressReporter{}
+		opts := BuildUploadOptions(WithUploadProgress(progress))
+		assert.Equal(t, progress, opts.Progress)
+	})
+
+	t.Run("with part size", func(t *testing.T) {
+		opts := BuildUploadOptions(WithPartSize(10 * 1024 * 1024))
+		assert.Equal(t, int64(10*1024*1024), opts.PartSize)
+	})
+
+	t.Run("with concurrency", func(t *testing.T) {
+		opts := BuildUploadOptions(WithUploadConcurrency(10))
+		assert.Equal(t, 10, opts.Concurrency)
+	})
+
+	t.Run("with storage class", func(t *testing.T) {
+		opts := BuildUploadOptions(WithStorageClass("GLACIER"))
+		assert.Equal(t, "GLACIER", opts.StorageClass)
+	})
+
+	t.Run("multiple options", func(t *testing.T) {
+		metadata := map[string]string{"tag": "test"}
+		progress := &SimpleProgressReporter{}
+		opts := BuildUploadOptions(
+			WithContentType("image/jpeg"),
+			WithMetadata(metadata),
+			WithUploadProgress(progress),
+			WithPartSize(1024),
+			WithUploadConcurrency(3),
+			WithStorageClass("STANDARD_IA"),
+		)
+		assert.Equal(t, "image/jpeg", opts.ContentType)
+		assert.Equal(t, metadata, opts.Metadata)
+		assert.Equal(t, progress, opts.Progress)
+		assert.Equal(t, int64(1024), opts.PartSize)
+		assert.Equal(t, 3, opts.Concurrency)
+		assert.Equal(t, "STANDARD_IA", opts.StorageClass)
+	})
+}
+
+func TestDownloadOptions(t *testing.T) {
+	t.Run("default options", func(t *testing.T) {
+		opts := DefaultDownloadOptions()
+		assert.Nil(t, opts.Range)
+		assert.Nil(t, opts.Progress)
+		assert.Equal(t, 5, opts.Concurrency)
+		assert.Empty(t, opts.VerifyETag)
+	})
+
+	t.Run("with range", func(t *testing.T) {
+		opts := BuildDownloadOptions(WithRange(100, 200))
+		assert.NotNil(t, opts.Range)
+		assert.Equal(t, int64(100), opts.Range.Start)
+		assert.Equal(t, int64(200), opts.Range.End)
+	})
+
+	t.Run("with progress", func(t *testing.T) {
+		progress := &SimpleProgressReporter{}
+		opts := BuildDownloadOptions(WithDownloadProgress(progress))
+		assert.Equal(t, progress, opts.Progress)
+	})
+
+	t.Run("with concurrency", func(t *testing.T) {
+		opts := BuildDownloadOptions(WithDownloadConcurrency(8))
+		assert.Equal(t, 8, opts.Concurrency)
+	})
+
+	t.Run("with etag verification", func(t *testing.T) {
+		opts := BuildDownloadOptions(WithETagVerification("abc123"))
+		assert.Equal(t, "abc123", opts.VerifyETag)
+	})
+
+	t.Run("multiple options", func(t *testing.T) {
+		progress := &SimpleProgressReporter{}
+		opts := BuildDownloadOptions(
+			WithRange(0, 1024),
+			WithDownloadProgress(progress),
+			WithDownloadConcurrency(2),
+			WithETagVerification("etag123"),
+		)
+		assert.NotNil(t, opts.Range)
+		assert.Equal(t, int64(0), opts.Range.Start)
+		assert.Equal(t, int64(1024), opts.Range.End)
+		assert.Equal(t, progress, opts.Progress)
+		assert.Equal(t, 2, opts.Concurrency)
+		assert.Equal(t, "etag123", opts.VerifyETag)
+	})
+}
+
+func TestListOptions(t *testing.T) {
+	t.Run("default options", func(t *testing.T) {
+		opts := DefaultListOptions()
+		assert.Equal(t, 1000, opts.MaxResults)
+		assert.Empty(t, opts.Delimiter)
+		assert.False(t, opts.Recursive)
+		assert.False(t, opts.IncludeHidden)
+		assert.Empty(t, opts.StartAfter)
+	})
+
+	t.Run("with max results", func(t *testing.T) {
+		opts := BuildListOptions(WithMaxResults(50))
+		assert.Equal(t, 50, opts.MaxResults)
+	})
+
+	t.Run("with delimiter", func(t *testing.T) {
+		opts := BuildListOptions(WithDelimiter("/"))
+		assert.Equal(t, "/", opts.Delimiter)
+	})
+
+	t.Run("with recursive", func(t *testing.T) {
+		opts := BuildListOptions(WithRecursive(true))
+		assert.True(t, opts.Recursive)
+	})
+
+	t.Run("with include hidden", func(t *testing.T) {
+		opts := BuildListOptions(WithIncludeHidden(true))
+		assert.True(t, opts.IncludeHidden)
+	})
+
+	t.Run("with start after", func(t *testing.T) {
+		opts := BuildListOptions(WithStartAfter("marker123"))
+		assert.Equal(t, "marker123", opts.StartAfter)
+	})
+
+	t.Run("multiple options", func(t *testing.T) {
+		opts := BuildListOptions(
+			WithMaxResults(100),
+			WithDelimiter("/"),
+			WithRecursive(true),
+			WithIncludeHidden(true),
+			WithStartAfter("start-marker"),
+		)
+		assert.Equal(t, 100, opts.MaxResults)
+		assert.Equal(t, "/", opts.Delimiter)
+		assert.True(t, opts.Recursive)
+		assert.True(t, opts.IncludeHidden)
+		assert.Equal(t, "start-marker", opts.StartAfter)
+	})
+}
+
+func TestBulkOptions(t *testing.T) {
+	t.Run("default options", func(t *testing.T) {
+		opts := DefaultBulkOptions()
+		assert.Equal(t, 5, opts.Concurrency)
+		assert.True(t, opts.ContinueOnError)
+		assert.Equal(t, 3, opts.RetryAttempts)
+		assert.NotZero(t, opts.RetryDelay)
+	})
+
+	t.Run("with concurrency", func(t *testing.T) {
+		opts := BuildBulkOptions(WithBulkConcurrency(10))
+		assert.Equal(t, 10, opts.Concurrency)
+	})
+
+	t.Run("with progress", func(t *testing.T) {
+		progress := &SimpleProgressReporter{}
+		opts := BuildBulkOptions(WithBulkProgress(progress))
+		assert.Equal(t, progress, opts.Progress)
+	})
+
+	t.Run("with continue on error", func(t *testing.T) {
+		opts := BuildBulkOptions(WithContinueOnError(false))
+		assert.False(t, opts.ContinueOnError)
+	})
+
+	t.Run("with retry attempts", func(t *testing.T) {
+		opts := BuildBulkOptions(WithRetryAttempts(5))
+		assert.Equal(t, 5, opts.RetryAttempts)
+	})
+
+	t.Run("with retry delay", func(t *testing.T) {
+		delay := 5 * time.Second
+		opts := BuildBulkOptions(WithRetryDelay(delay))
+		assert.Equal(t, delay, opts.RetryDelay)
+	})
+
+	t.Run("multiple options", func(t *testing.T) {
+		progress := &SimpleProgressReporter{}
+		delay := 2 * time.Second
+		opts := BuildBulkOptions(
+			WithBulkConcurrency(8),
+			WithBulkProgress(progress),
+			WithContinueOnError(false),
+			WithRetryAttempts(2),
+			WithRetryDelay(delay),
+		)
+		assert.Equal(t, 8, opts.Concurrency)
+		assert.Equal(t, progress, opts.Progress)
+		assert.False(t, opts.ContinueOnError)
+		assert.Equal(t, 2, opts.RetryAttempts)
+		assert.Equal(t, delay, opts.RetryDelay)
+	})
+}
+
+func TestBuildOptionsIdempotent(t *testing.T) {
+	// Test that building options doesn't modify the defaults
+	defaultUpload := DefaultUploadOptions()
+	BuildUploadOptions(WithContentType("custom"))
+	assert.Equal(t, "application/octet-stream", defaultUpload.ContentType)
+
+	defaultDownload := DefaultDownloadOptions()
+	BuildDownloadOptions(WithDownloadConcurrency(10))
+	assert.Equal(t, 5, defaultDownload.Concurrency)
+
+	defaultList := DefaultListOptions()
+	BuildListOptions(WithMaxResults(10))
+	assert.Equal(t, 1000, defaultList.MaxResults)
+
+	defaultBulk := DefaultBulkOptions()
+	BuildBulkOptions(WithBulkConcurrency(20))
+	assert.Equal(t, 5, defaultBulk.Concurrency)
+}

--- a/pkg/storage/utils.go
+++ b/pkg/storage/utils.go
@@ -1,0 +1,230 @@
+package storage
+
+import (
+	"context"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	utilstorage "github.com/sgl-project/ome/pkg/utils/storage"
+)
+
+// NormalizePath normalizes a storage path
+func NormalizePath(p string) string {
+	// Remove leading slash
+	p = strings.TrimPrefix(p, "/")
+	// Clean the path
+	p = path.Clean(p)
+	// Remove trailing slash unless it's root
+	if p != "/" {
+		p = strings.TrimSuffix(p, "/")
+	}
+	return p
+}
+
+// JoinPath joins storage path components
+func JoinPath(parts ...string) string {
+	joined := path.Join(parts...)
+	return NormalizePath(joined)
+}
+
+// SplitPath splits a storage path into bucket and key
+func SplitPath(p string) (bucket, key string) {
+	p = NormalizePath(p)
+	parts := strings.SplitN(p, "/", 2)
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return parts[0], parts[1]
+}
+
+// IsDirectory checks if a path represents a directory (ends with /)
+func IsDirectory(p string) bool {
+	return strings.HasSuffix(p, "/")
+}
+
+// CalculateETag calculates an ETag for data
+func CalculateETag(data []byte) string {
+	hash := md5.Sum(data)
+	return hex.EncodeToString(hash[:])
+}
+
+// CalculateSHA256 calculates SHA256 hash for data
+func CalculateSHA256(data []byte) string {
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:])
+}
+
+// CopyWithProgress copies from source to destination with progress reporting
+func CopyWithProgress(ctx context.Context, dst io.Writer, src io.Reader, size int64, progress ProgressReporter) (int64, error) {
+	if progress != nil {
+		defer progress.Done()
+	}
+
+	buf := make([]byte, 32*1024) // 32KB buffer
+	var written int64
+
+	for {
+		select {
+		case <-ctx.Done():
+			if progress != nil {
+				progress.Error(ctx.Err())
+			}
+			return written, ctx.Err()
+		default:
+		}
+
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			nw, ew := dst.Write(buf[0:nr])
+			if nw > 0 {
+				written += int64(nw)
+				if progress != nil {
+					progress.Update(written, size)
+				}
+			}
+			if ew != nil {
+				if progress != nil {
+					progress.Error(ew)
+				}
+				return written, ew
+			}
+			if nr != nw {
+				err := io.ErrShortWrite
+				if progress != nil {
+					progress.Error(err)
+				}
+				return written, err
+			}
+		}
+		if er != nil {
+			if er != io.EOF {
+				if progress != nil {
+					progress.Error(er)
+				}
+				return written, er
+			}
+			break
+		}
+	}
+
+	return written, nil
+}
+
+// RetryConfig configures retry behavior
+type RetryConfig struct {
+	MaxAttempts int
+	BaseDelay   time.Duration
+	MaxDelay    time.Duration
+	Multiplier  float64
+}
+
+// DefaultRetryConfig returns default retry configuration
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Second,
+		MaxDelay:    30 * time.Second,
+		Multiplier:  2.0,
+	}
+}
+
+// Retry executes a function with exponential backoff retry
+func Retry(ctx context.Context, config RetryConfig, fn func() error) error {
+	var lastErr error
+	delay := config.BaseDelay
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+
+		// Check if error is retryable
+		if !IsRetryable(err) {
+			return err
+		}
+
+		// Don't retry if context is cancelled
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Don't sleep after last attempt
+		if attempt == config.MaxAttempts {
+			break
+		}
+
+		// Sleep with exponential backoff
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		// Calculate next delay
+		delay = time.Duration(float64(delay) * config.Multiplier)
+		if delay > config.MaxDelay {
+			delay = config.MaxDelay
+		}
+	}
+
+	return fmt.Errorf("operation failed after %d attempts: %w", config.MaxAttempts, lastErr)
+}
+
+// GetStorageTypeFromURI determines the storage type from a URI using the existing utils package
+func GetStorageTypeFromURI(uri string) (Type, error) {
+	storageType, err := utilstorage.GetStorageType(uri)
+	if err != nil {
+		return "", err
+	}
+	return Type(storageType), nil
+}
+
+// SimpleProgressReporter is a simple progress reporter implementation
+type SimpleProgressReporter struct {
+	onUpdate func(bytesTransferred, totalBytes int64)
+	onDone   func()
+	onError  func(err error)
+}
+
+// NewSimpleProgressReporter creates a new simple progress reporter
+func NewSimpleProgressReporter(
+	onUpdate func(bytesTransferred, totalBytes int64),
+	onDone func(),
+	onError func(err error),
+) *SimpleProgressReporter {
+	return &SimpleProgressReporter{
+		onUpdate: onUpdate,
+		onDone:   onDone,
+		onError:  onError,
+	}
+}
+
+// Update reports progress update
+func (r *SimpleProgressReporter) Update(bytesTransferred, totalBytes int64) {
+	if r.onUpdate != nil {
+		r.onUpdate(bytesTransferred, totalBytes)
+	}
+}
+
+// Done reports completion
+func (r *SimpleProgressReporter) Done() {
+	if r.onDone != nil {
+		r.onDone()
+	}
+}
+
+// Error reports an error
+func (r *SimpleProgressReporter) Error(err error) {
+	if r.onError != nil {
+		r.onError(err)
+	}
+}

--- a/pkg/storage/utils_test.go
+++ b/pkg/storage/utils_test.go
@@ -1,0 +1,360 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/path/to/file", "path/to/file"},
+		{"path/to/file", "path/to/file"},
+		{"path//to///file", "path/to/file"},
+		{"/path/to/file/", "path/to/file"},
+		{"", "."},
+		{"/", "."},
+		{"./path", "path"},
+		{"../path", "../path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := NormalizePath(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestJoinPath(t *testing.T) {
+	tests := []struct {
+		parts    []string
+		expected string
+	}{
+		{[]string{"path", "to", "file"}, "path/to/file"},
+		{[]string{"/path", "to", "file"}, "path/to/file"},
+		{[]string{"path/", "/to/", "/file"}, "path/to/file"},
+		{[]string{"", "path", "file"}, "path/file"},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			result := JoinPath(tt.parts...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSplitPath(t *testing.T) {
+	tests := []struct {
+		input          string
+		expectedBucket string
+		expectedKey    string
+	}{
+		{"bucket/path/to/file", "bucket", "path/to/file"},
+		{"bucket", "bucket", ""},
+		{"/bucket/path", "bucket", "path"},
+		{"", ".", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			bucket, key := SplitPath(tt.input)
+			assert.Equal(t, tt.expectedBucket, bucket)
+			assert.Equal(t, tt.expectedKey, key)
+		})
+	}
+}
+
+func TestIsDirectory(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"path/to/dir/", true},
+		{"path/to/file", false},
+		{"/", true},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := IsDirectory(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCalculateETag(t *testing.T) {
+	data := []byte("test data")
+	etag := CalculateETag(data)
+	assert.NotEmpty(t, etag)
+	assert.Len(t, etag, 32) // MD5 hex string length
+
+	// Same data should produce same ETag
+	etag2 := CalculateETag(data)
+	assert.Equal(t, etag, etag2)
+
+	// Different data should produce different ETag
+	etag3 := CalculateETag([]byte("different data"))
+	assert.NotEqual(t, etag, etag3)
+}
+
+func TestCalculateSHA256(t *testing.T) {
+	data := []byte("test data")
+	hash := CalculateSHA256(data)
+	assert.NotEmpty(t, hash)
+	assert.Len(t, hash, 64) // SHA256 hex string length
+
+	// Same data should produce same hash
+	hash2 := CalculateSHA256(data)
+	assert.Equal(t, hash, hash2)
+
+	// Different data should produce different hash
+	hash3 := CalculateSHA256([]byte("different data"))
+	assert.NotEqual(t, hash, hash3)
+}
+
+func TestCopyWithProgress(t *testing.T) {
+	t.Run("successful copy", func(t *testing.T) {
+		src := bytes.NewReader([]byte("test data for copying"))
+		dst := &bytes.Buffer{}
+
+		var progressUpdates []int64
+		var doneCalled bool
+		progress := NewSimpleProgressReporter(
+			func(transferred, total int64) {
+				progressUpdates = append(progressUpdates, transferred)
+			},
+			func() {
+				doneCalled = true
+			},
+			nil,
+		)
+
+		n, err := CopyWithProgress(context.Background(), dst, src, 21, progress)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(21), n)
+		assert.Equal(t, "test data for copying", dst.String())
+		assert.True(t, doneCalled)
+		assert.NotEmpty(t, progressUpdates)
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		src := bytes.NewReader([]byte("test data"))
+		dst := &bytes.Buffer{}
+
+		_, err := CopyWithProgress(ctx, dst, src, 9, nil)
+		assert.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("write error", func(t *testing.T) {
+		src := bytes.NewReader([]byte("test"))
+		dst := &errorWriter{err: errors.New("write failed")}
+
+		var errorCalled bool
+		progress := NewSimpleProgressReporter(
+			nil,
+			nil,
+			func(err error) {
+				errorCalled = true
+			},
+		)
+
+		_, err := CopyWithProgress(context.Background(), dst, src, 4, progress)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "write failed")
+		assert.True(t, errorCalled)
+	})
+}
+
+// errorWriter is a writer that always returns an error
+type errorWriter struct {
+	err error
+}
+
+func (w *errorWriter) Write(p []byte) (int, error) {
+	return 0, w.err
+}
+
+func TestRetry(t *testing.T) {
+	t.Run("successful on first attempt", func(t *testing.T) {
+		attempts := 0
+		config := DefaultRetryConfig()
+		err := Retry(context.Background(), config, func() error {
+			attempts++
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("successful after retries", func(t *testing.T) {
+		attempts := 0
+		config := RetryConfig{
+			MaxAttempts: 3,
+			BaseDelay:   1 * time.Millisecond,
+			MaxDelay:    10 * time.Millisecond,
+			Multiplier:  2.0,
+		}
+		err := Retry(context.Background(), config, func() error {
+			attempts++
+			if attempts < 3 {
+				return NewRetryableError(errors.New("temporary error"))
+			}
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, attempts)
+	})
+
+	t.Run("non-retryable error", func(t *testing.T) {
+		attempts := 0
+		config := DefaultRetryConfig()
+		expectedErr := errors.New("permanent error")
+		err := Retry(context.Background(), config, func() error {
+			attempts++
+			return expectedErr
+		})
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("max attempts exceeded", func(t *testing.T) {
+		attempts := 0
+		config := RetryConfig{
+			MaxAttempts: 2,
+			BaseDelay:   1 * time.Millisecond,
+			MaxDelay:    10 * time.Millisecond,
+			Multiplier:  2.0,
+		}
+		err := Retry(context.Background(), config, func() error {
+			attempts++
+			return NewRetryableError(errors.New("always fails"))
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "operation failed after 2 attempts")
+		assert.Equal(t, 2, attempts)
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		attempts := 0
+		config := DefaultRetryConfig()
+		err := Retry(ctx, config, func() error {
+			attempts++
+			return NewRetryableError(errors.New("error"))
+		})
+		assert.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+		assert.Equal(t, 1, attempts)
+	})
+}
+
+func TestGetStorageTypeFromURI(t *testing.T) {
+	tests := []struct {
+		uri          string
+		expectedType Type
+		expectError  bool
+	}{
+		{
+			uri:          "s3://bucket/path/to/object",
+			expectedType: TypeS3,
+		},
+		{
+			uri:          "az://container/blob/path",
+			expectedType: TypeAzure,
+		},
+		{
+			uri:          "gs://bucket/object/path",
+			expectedType: TypeGCS,
+		},
+		{
+			uri:          "oci://namespace/bucket/object",
+			expectedType: TypeOCI,
+		},
+		{
+			uri:          "pvc://my-pvc/path/to/file",
+			expectedType: TypePVC,
+		},
+		{
+			uri:          "local:///absolute/path",
+			expectedType: TypeLocal,
+		},
+		{
+			uri:         "invalid://scheme",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.uri, func(t *testing.T) {
+			storageType, err := GetStorageTypeFromURI(tt.uri)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedType, storageType)
+			}
+		})
+	}
+}
+
+func TestSimpleProgressReporter(t *testing.T) {
+	var updateCalled, doneCalled, errorCalled bool
+	var lastTransferred, lastTotal int64
+	var lastError error
+
+	reporter := NewSimpleProgressReporter(
+		func(transferred, total int64) {
+			updateCalled = true
+			lastTransferred = transferred
+			lastTotal = total
+		},
+		func() {
+			doneCalled = true
+		},
+		func(err error) {
+			errorCalled = true
+			lastError = err
+		},
+	)
+
+	// Test Update
+	reporter.Update(100, 1000)
+	assert.True(t, updateCalled)
+	assert.Equal(t, int64(100), lastTransferred)
+	assert.Equal(t, int64(1000), lastTotal)
+
+	// Test Done
+	reporter.Done()
+	assert.True(t, doneCalled)
+
+	// Test Error
+	expectedErr := errors.New("test error")
+	reporter.Error(expectedErr)
+	assert.True(t, errorCalled)
+	assert.Equal(t, expectedErr, lastError)
+
+	// Test with nil callbacks
+	nilReporter := NewSimpleProgressReporter(nil, nil, nil)
+	assert.NotPanics(t, func() {
+		nilReporter.Update(0, 0)
+		nilReporter.Done()
+		nilReporter.Error(errors.New("error"))
+	})
+}


### PR DESCRIPTION
<!-- 
Thank you for contributing to OME! Please read the contributing guidelines:
https://github.com/sgl-project/ome/blob/main/CONTRIBUTING.md
-->

## What type of PR is this?
/kind feature


## What this PR does / why we need it:

This PR implements Phase 1 of the multi-cloud storage architecture as outlined in [OEP-0002](.claude/multi-cloud-storage.md). It establishes the foundational interfaces, factory pattern, and core utilities needed to support multiple storage backends (S3, Azure, GCS, OCI, PVC) with a unified API that follows the approved specification.

## Changes
1. **pkg/storage/interfaces.go** - Core storage interfaces and type definitions
   - Unified `Storage` interface with all storage operations per OEP-0002
   - `MultipartCapable` interface for chunked upload support
   - `BulkStorage` interface for batch operations
   - Integration with existing `pkg/utils/storage` types
   - Configuration structures for providers

2. **pkg/storage/factory.go** - Factory pattern implementation
   - Dynamic provider registration system
   - Configuration validation
   - Global factory singleton pattern

3. **pkg/storage/options.go** - Functional options for operations
   - Upload, Download, List, and Bulk options
   - Support for progress tracking, concurrency, metadata
   - Default configurations for each operation type
   - Bulk operation configuration with retry and error handling

4. **pkg/storage/errors.go** - Comprehensive error handling
   - Standard error types (NotFound, AccessDenied, etc.)
   - Structured errors with context
   - Retryable error support for automatic retry logic

5. **pkg/storage/utils.go** - Helper utilities
   - Path manipulation functions
   - Hash calculation (ETag, SHA256)
   - Retry logic with exponential backoff
   - Progress-aware copy operations

## Special notes for your reviewer:

<!-- 
Any specific areas you'd like reviewed? Any concerns?
-->

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```