### PR TITLE
[core] add s3 and minio storage provider and download option support

### DIFF
--- a/pkg/storage/options.go
+++ b/pkg/storage/options.go
@@ -26,12 +26,22 @@ type UploadOptions struct {
 
 // DownloadOptions contains configuration for download operations
 type DownloadOptions struct {
-	Range           *Range // For partial downloads
-	Progress        ProgressReporter
-	Concurrency     int    // Number of parallel chunks
-	VerifyETag      string // Verify ETag after download
-	SkipIfValid     bool   // Skip download if valid local copy exists
-	ForceRedownload bool   // Force download even if local copy exists
+	Range                   *Range // For partial downloads
+	Progress                ProgressReporter
+	Concurrency             int    // Number of parallel chunks (>1 enables parallel download for large files)
+	VerifyETag              string // Verify ETag after download
+	SkipIfValid             bool   // Skip download if valid local copy exists (similar to DisableOverride)
+	ForceRedownload         bool   // Force download even if local copy exists
+	DisableParallelDownload bool   // Disable parallel download even for large files
+
+	// Path manipulation options
+	StripPrefix     bool   // If true, remove a specified prefix from the object path
+	PrefixToStrip   string // The prefix to strip when StripPrefix is true
+	UseBaseNameOnly bool   // If true, download using only the object's base name
+
+	// Advanced options
+	ExcludePatterns     []string // Object names to exclude (glob patterns)
+	JoinWithTailOverlap bool     // Join with tail overlap if true (for chunked downloads)
 }
 
 // ListOptions contains configuration for list operations
@@ -175,6 +185,42 @@ func WithSkipIfValid(skip bool) DownloadOption {
 func WithForceRedownload(force bool) DownloadOption {
 	return func(o *DownloadOptions) {
 		o.ForceRedownload = force
+	}
+}
+
+// WithStripPrefix enables prefix stripping from object paths
+func WithStripPrefix(prefix string) DownloadOption {
+	return func(o *DownloadOptions) {
+		o.StripPrefix = true
+		o.PrefixToStrip = prefix
+	}
+}
+
+// WithUseBaseNameOnly downloads using only the object's base name
+func WithUseBaseNameOnly(useBaseName bool) DownloadOption {
+	return func(o *DownloadOptions) {
+		o.UseBaseNameOnly = useBaseName
+	}
+}
+
+// WithExcludePatterns sets patterns for objects to exclude
+func WithExcludePatterns(patterns []string) DownloadOption {
+	return func(o *DownloadOptions) {
+		o.ExcludePatterns = patterns
+	}
+}
+
+// WithJoinWithTailOverlap enables joining with tail overlap for chunked downloads
+func WithJoinWithTailOverlap(join bool) DownloadOption {
+	return func(o *DownloadOptions) {
+		o.JoinWithTailOverlap = join
+	}
+}
+
+// WithDisableParallelDownload disables parallel download for large files
+func WithDisableParallelDownload(disable bool) DownloadOption {
+	return func(o *DownloadOptions) {
+		o.DisableParallelDownload = disable
 	}
 }
 

--- a/pkg/storage/providers/s3/integrity.go
+++ b/pkg/storage/providers/s3/integrity.go
@@ -1,0 +1,152 @@
+package s3
+
+import (
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// validateETag validates a file against an S3 ETag
+func validateETag(filePath string, etag string) error {
+	// Remove quotes from ETag if present
+	etag = strings.Trim(etag, "\"")
+
+	// Check if this is a multipart upload ETag
+	if isMultipartETag(etag) {
+		// For multipart uploads, we can't easily validate without knowing part sizes
+		// S3 multipart ETags are in format: "<md5>-<parts>"
+		// The MD5 is computed from the MD5s of each part, not the whole file
+		return nil // Skip validation for multipart
+	}
+
+	// For simple uploads, ETag is the MD5 of the file
+	fileMD5, err := calculateFileMD5(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to calculate file MD5: %w", err)
+	}
+
+	if fileMD5 != etag {
+		return fmt.Errorf("ETag validation failed: expected %s, got %s", etag, fileMD5)
+	}
+
+	return nil
+}
+
+// calculateFileMD5 calculates the MD5 hash of a file
+func calculateFileMD5(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := md5.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// calculateMD5 calculates the MD5 hash of data
+func calculateMD5(data []byte) string {
+	hash := md5.Sum(data)
+	return hex.EncodeToString(hash[:])
+}
+
+// calculateBase64MD5 calculates the base64-encoded MD5 hash
+func calculateBase64MD5(data []byte) string {
+	hash := md5.Sum(data)
+	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+// parseMultipartETag parses a multipart ETag and returns the MD5 and part count
+func parseMultipartETag(etag string) (md5Hash string, partCount int, err error) {
+	// Remove quotes if present
+	etag = strings.Trim(etag, "\"")
+
+	// Split by hyphen
+	parts := strings.Split(etag, "-")
+	if len(parts) != 2 {
+		return "", 0, fmt.Errorf("invalid multipart ETag format: %s", etag)
+	}
+
+	md5Hash = parts[0]
+	partCount, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid part count in ETag: %s", parts[1])
+	}
+
+	return md5Hash, partCount, nil
+}
+
+// isServerSideEncryptedETag checks if an ETag indicates server-side encryption
+// SSE-S3 and SSE-KMS encrypted objects have ETags that are not MD5 hashes
+func isServerSideEncryptedETag(etag string, metadata map[string]string) bool {
+	// Check for server-side encryption headers
+	if _, ok := metadata["x-amz-server-side-encryption"]; ok {
+		return true
+	}
+
+	// SSE-C (customer-provided keys) also affects ETag
+	if _, ok := metadata["x-amz-server-side-encryption-customer-algorithm"]; ok {
+		return true
+	}
+
+	// Check if ETag doesn't look like an MD5 (32 hex characters)
+	etag = strings.Trim(etag, "\"")
+	if !isMultipartETag(etag) && len(etag) != 32 {
+		return true
+	}
+
+	return false
+}
+
+// validateIntegrity validates the integrity of downloaded data
+func (p *S3Provider) validateIntegrity(filePath string, expectedETag string, metadata map[string]string) error {
+	if expectedETag == "" {
+		// No ETag to validate against
+		return nil
+	}
+
+	// Skip validation for server-side encrypted objects
+	if isServerSideEncryptedETag(expectedETag, metadata) {
+		p.logger.Debug("Skipping ETag validation for SSE object")
+		return nil
+	}
+
+	// Skip validation for multipart uploads
+	if isMultipartETag(expectedETag) {
+		p.logger.Debug("Skipping ETag validation for multipart upload")
+		return nil
+	}
+
+	// Validate ETag
+	return validateETag(filePath, expectedETag)
+}
+
+// validateUploadIntegrity validates the integrity of uploaded data
+func (p *S3Provider) validateUploadIntegrity(data []byte, responseETag string) error {
+	if responseETag == "" {
+		// No ETag returned
+		return nil
+	}
+
+	// Remove quotes from ETag
+	responseETag = strings.Trim(responseETag, "\"")
+
+	// Calculate MD5 of uploaded data
+	calculatedMD5 := calculateMD5(data)
+
+	// For simple uploads, ETag should match MD5
+	if !isMultipartETag(responseETag) && calculatedMD5 != responseETag {
+		return fmt.Errorf("upload integrity check failed: expected ETag %s, got %s", calculatedMD5, responseETag)
+	}
+
+	return nil
+}

--- a/pkg/storage/providers/s3/multipart.go
+++ b/pkg/storage/providers/s3/multipart.go
@@ -1,0 +1,347 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/sgl-project/ome/pkg/storage"
+)
+
+// MultipartUpload represents an active multipart upload
+type MultipartUpload struct {
+	UploadID string
+	Key      string
+	Parts    []types.CompletedPart
+	mu       sync.Mutex
+}
+
+// InitiateMultipartUpload starts a new multipart upload
+func (p *S3Provider) InitiateMultipartUpload(ctx context.Context, key string, contentType string, metadata map[string]string) (*MultipartUpload, error) {
+	input := &s3.CreateMultipartUploadInput{
+		Bucket: aws.String(p.bucket),
+		Key:    aws.String(key),
+	}
+
+	if contentType != "" {
+		input.ContentType = aws.String(contentType)
+	}
+
+	if len(metadata) > 0 {
+		input.Metadata = ConvertMetadataToS3(metadata)
+	}
+
+	result, err := p.client.CreateMultipartUpload(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initiate multipart upload: %w", err)
+	}
+
+	return &MultipartUpload{
+		UploadID: *result.UploadId,
+		Key:      key,
+		Parts:    make([]types.CompletedPart, 0),
+	}, nil
+}
+
+// UploadPart uploads a single part in a multipart upload
+func (p *S3Provider) UploadPart(ctx context.Context, upload *MultipartUpload, partNumber int32, reader io.Reader, size int64) (*types.CompletedPart, error) {
+	// Read the part data
+	data := make([]byte, size)
+	n, err := io.ReadFull(reader, data)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return nil, fmt.Errorf("failed to read part data: %w", err)
+	}
+	data = data[:n]
+
+	input := &s3.UploadPartInput{
+		Bucket:     aws.String(p.bucket),
+		Key:        aws.String(upload.Key),
+		UploadId:   aws.String(upload.UploadID),
+		PartNumber: aws.Int32(partNumber),
+		Body:       bytes.NewReader(data),
+	}
+
+	result, err := p.client.UploadPart(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upload part %d: %w", partNumber, err)
+	}
+
+	completedPart := types.CompletedPart{
+		ETag:       result.ETag,
+		PartNumber: aws.Int32(partNumber),
+	}
+
+	// Add to the parts list (thread-safe)
+	upload.mu.Lock()
+	upload.Parts = append(upload.Parts, completedPart)
+	upload.mu.Unlock()
+
+	return &completedPart, nil
+}
+
+// CompleteMultipartUpload completes a multipart upload
+func (p *S3Provider) CompleteMultipartUpload(ctx context.Context, upload *MultipartUpload) (*s3.CompleteMultipartUploadOutput, error) {
+	// Sort parts by part number
+	sortCompletedParts(upload.Parts)
+
+	input := &s3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(p.bucket),
+		Key:      aws.String(upload.Key),
+		UploadId: aws.String(upload.UploadID),
+		MultipartUpload: &types.CompletedMultipartUpload{
+			Parts: upload.Parts,
+		},
+	}
+
+	result, err := p.client.CompleteMultipartUpload(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to complete multipart upload: %w", err)
+	}
+
+	return result, nil
+}
+
+// AbortMultipartUpload cancels a multipart upload
+func (p *S3Provider) AbortMultipartUpload(ctx context.Context, upload *MultipartUpload) error {
+	input := &s3.AbortMultipartUploadInput{
+		Bucket:   aws.String(p.bucket),
+		Key:      aws.String(upload.Key),
+		UploadId: aws.String(upload.UploadID),
+	}
+
+	_, err := p.client.AbortMultipartUpload(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to abort multipart upload: %w", err)
+	}
+
+	return nil
+}
+
+// ListMultipartUploads lists all active multipart uploads with pagination support
+func (p *S3Provider) ListMultipartUploads(ctx context.Context, prefix string) ([]*MultipartUpload, error) {
+	var uploads []*MultipartUpload
+	var keyMarker *string
+	var uploadIDMarker *string
+
+	for {
+		input := &s3.ListMultipartUploadsInput{
+			Bucket: aws.String(p.bucket),
+		}
+
+		if prefix != "" {
+			input.Prefix = aws.String(prefix)
+		}
+
+		if keyMarker != nil {
+			input.KeyMarker = keyMarker
+		}
+
+		if uploadIDMarker != nil {
+			input.UploadIdMarker = uploadIDMarker
+		}
+
+		result, err := p.client.ListMultipartUploads(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list multipart uploads: %w", err)
+		}
+
+		for _, upload := range result.Uploads {
+			uploads = append(uploads, &MultipartUpload{
+				UploadID: *upload.UploadId,
+				Key:      *upload.Key,
+			})
+		}
+
+		if !aws.ToBool(result.IsTruncated) {
+			break
+		}
+
+		keyMarker = result.NextKeyMarker
+		uploadIDMarker = result.NextUploadIdMarker
+	}
+
+	return uploads, nil
+}
+
+// ListParts lists the parts that have been uploaded for a multipart upload
+func (p *S3Provider) ListParts(ctx context.Context, upload *MultipartUpload) ([]types.Part, error) {
+	var parts []types.Part
+	var nextPartNumberMarker *string
+
+	for {
+		input := &s3.ListPartsInput{
+			Bucket:   aws.String(p.bucket),
+			Key:      aws.String(upload.Key),
+			UploadId: aws.String(upload.UploadID),
+		}
+
+		if nextPartNumberMarker != nil {
+			input.PartNumberMarker = nextPartNumberMarker
+		}
+
+		result, err := p.client.ListParts(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list parts: %w", err)
+		}
+
+		parts = append(parts, result.Parts...)
+
+		if !aws.ToBool(result.IsTruncated) {
+			break
+		}
+
+		nextPartNumberMarker = result.NextPartNumberMarker
+	}
+
+	return parts, nil
+}
+
+// UploadPartCopy copies data from an existing object as a part
+func (p *S3Provider) UploadPartCopy(ctx context.Context, upload *MultipartUpload, partNumber int32, sourceKey string, startByte, endByte int64) (*types.CompletedPart, error) {
+	copySource := fmt.Sprintf("%s/%s", p.bucket, sourceKey)
+	copyRange := fmt.Sprintf("bytes=%d-%d", startByte, endByte)
+
+	input := &s3.UploadPartCopyInput{
+		Bucket:          aws.String(p.bucket),
+		Key:             aws.String(upload.Key),
+		UploadId:        aws.String(upload.UploadID),
+		PartNumber:      aws.Int32(partNumber),
+		CopySource:      aws.String(copySource),
+		CopySourceRange: aws.String(copyRange),
+	}
+
+	result, err := p.client.UploadPartCopy(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upload part copy %d: %w", partNumber, err)
+	}
+
+	completedPart := types.CompletedPart{
+		ETag:       result.CopyPartResult.ETag,
+		PartNumber: aws.Int32(partNumber),
+	}
+
+	// Add to the parts list (thread-safe)
+	upload.mu.Lock()
+	upload.Parts = append(upload.Parts, completedPart)
+	upload.mu.Unlock()
+
+	return &completedPart, nil
+}
+
+// Helper function to sort completed parts by part number
+func sortCompletedParts(parts []types.CompletedPart) {
+	// Use sort.Slice for efficient sorting, as multipart uploads can have up to 10,000 parts
+	sort.Slice(parts, func(i, j int) bool {
+		return *parts[i].PartNumber < *parts[j].PartNumber
+	})
+}
+
+// UploadLargeFile uploads a large file using multipart upload with automatic part management
+// NOTE: This function is currently unused. The S3 provider uses the SDK's manager.Uploader instead.
+// WARNING: This implementation has a critical race condition - multiple goroutines read from a shared io.Reader.
+// If this function is to be used, it should be refactored to either:
+// 1. Use io.ReaderAt for concurrent reads from different offsets
+// 2. Read sequentially into buffers first, then upload in parallel
+// 3. Protect the reader with a mutex for sequential access
+func (p *S3Provider) UploadLargeFile(ctx context.Context, key string, reader io.Reader, size int64, options storage.UploadOptions) error {
+	// Calculate part size and count
+	partSize := options.PartSize
+	if partSize == 0 {
+		partSize = defaultPartSize * 1024 * 1024 // 5MB default
+	}
+
+	partCount := (size + partSize - 1) / partSize
+
+	// Initiate multipart upload
+	upload, err := p.InitiateMultipartUpload(ctx, key, options.ContentType, options.Metadata)
+	if err != nil {
+		return err
+	}
+
+	// Ensure we abort the upload if something goes wrong
+	defer func() {
+		if err != nil {
+			_ = p.AbortMultipartUpload(ctx, upload)
+		}
+	}()
+
+	// Upload parts concurrently
+	concurrency := options.Concurrency
+	if concurrency == 0 {
+		concurrency = defaultConcurrency
+	}
+
+	var wg sync.WaitGroup
+	errChan := make(chan error, partCount)
+	semaphore := make(chan struct{}, concurrency)
+
+	for i := int64(0); i < partCount; i++ {
+		wg.Add(1)
+		go func(partNum int64) {
+			defer wg.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			// Calculate part size
+			start := partNum * partSize
+			end := start + partSize
+			if end > size {
+				end = size
+			}
+			currentPartSize := end - start
+
+			// Read part data
+			partData := make([]byte, currentPartSize)
+			n, err := io.ReadFull(reader, partData)
+			if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+				errChan <- fmt.Errorf("failed to read part %d: %w", partNum+1, err)
+				return
+			}
+			partData = partData[:n]
+
+			// Upload part
+			_, err = p.UploadPart(ctx, upload, int32(partNum+1), bytes.NewReader(partData), int64(n))
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			// Report progress
+			if options.Progress != nil {
+				options.Progress.Update(int64(n), size)
+			}
+		}(i)
+	}
+
+	// Wait for all uploads to complete
+	wg.Wait()
+	close(errChan)
+
+	// Check for errors
+	for uploadErr := range errChan {
+		if uploadErr != nil {
+			err = uploadErr
+			return fmt.Errorf("multipart upload failed: %w", err)
+		}
+	}
+
+	// Complete the multipart upload
+	_, err = p.CompleteMultipartUpload(ctx, upload)
+	if err != nil {
+		return err
+	}
+
+	// Report completion
+	if options.Progress != nil {
+		options.Progress.Done()
+	}
+
+	return nil
+}

--- a/pkg/storage/providers/s3/parallel.go
+++ b/pkg/storage/providers/s3/parallel.go
@@ -1,0 +1,253 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/sgl-project/ome/pkg/storage"
+)
+
+// downloadChunk represents a chunk to be downloaded
+type downloadChunk struct {
+	index      int
+	start      int64
+	end        int64
+	tempFile   string
+	retryCount int
+}
+
+// downloadResult represents the result of a chunk download
+type downloadResult struct {
+	index        int
+	tempFilePath string
+	err          error
+}
+
+// parallelDownload performs a parallel download of a large object
+func (p *S3Provider) parallelDownload(ctx context.Context, key string, targetFile string, size int64, options storage.DownloadOptions) error {
+	// Track total bytes downloaded for progress reporting
+	var totalBytesDownloaded int64
+	var progressMutex sync.Mutex
+	// Determine number of chunks and chunk size
+	concurrency := options.Concurrency
+	if concurrency <= 0 {
+		concurrency = defaultConcurrency
+	}
+
+	// Calculate chunk size (minimum 5MB per chunk)
+	minChunkSize := int64(5 * 1024 * 1024) // 5MB
+	chunkSize := size / int64(concurrency)
+	if chunkSize < minChunkSize {
+		chunkSize = minChunkSize
+		concurrency = int(size / chunkSize)
+		if concurrency == 0 {
+			concurrency = 1
+		}
+	}
+
+	// Create chunks
+	chunks := make([]downloadChunk, 0, concurrency)
+	for i := 0; i < concurrency; i++ {
+		start := int64(i) * chunkSize
+		end := start + chunkSize - 1
+		if i == concurrency-1 {
+			// Last chunk goes to the end of the file
+			end = size - 1
+		}
+
+		chunks = append(chunks, downloadChunk{
+			index: i,
+			start: start,
+			end:   end,
+		})
+	}
+
+	// Create a temporary directory for chunk files
+	tempDir, err := os.MkdirTemp("", "s3_download_*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir) // Clean up temp directory when done
+
+	// Download chunks in parallel
+	var wg sync.WaitGroup
+	resultChan := make(chan downloadResult, len(chunks))
+	semaphore := make(chan struct{}, concurrency)
+
+	for _, chunk := range chunks {
+		wg.Add(1)
+		go func(ch downloadChunk) {
+			defer wg.Done()
+			semaphore <- struct{}{}        // Acquire semaphore
+			defer func() { <-semaphore }() // Release semaphore
+
+			tempFile := filepath.Join(tempDir, fmt.Sprintf("chunk_%d.tmp", ch.index))
+			chunkSize := ch.end - ch.start + 1
+			err := p.downloadChunk(ctx, key, tempFile, ch.start, ch.end, options)
+
+			if err == nil && options.Progress != nil {
+				// Thread-safe progress update
+				newTotal := atomic.AddInt64(&totalBytesDownloaded, chunkSize)
+				progressMutex.Lock()
+				options.Progress.Update(newTotal, size)
+				progressMutex.Unlock()
+			}
+
+			resultChan <- downloadResult{
+				index:        ch.index,
+				tempFilePath: tempFile,
+				err:          err,
+			}
+		}(chunk)
+	}
+
+	// Wait for all downloads to complete
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	// Collect results
+	results := make(map[int]downloadResult)
+	var downloadErrors []error
+	for result := range resultChan {
+		if result.err != nil {
+			downloadErrors = append(downloadErrors, fmt.Errorf("chunk %d failed: %w", result.index, result.err))
+		} else {
+			results[result.index] = result
+		}
+	}
+
+	// Check if any downloads failed
+	if len(downloadErrors) > 0 {
+		return fmt.Errorf("parallel download failed with %d errors: %v", len(downloadErrors), downloadErrors[0])
+	}
+
+	// Assemble the file from chunks
+	if err := p.assembleChunks(targetFile, results, len(chunks)); err != nil {
+		return fmt.Errorf("failed to assemble chunks: %w", err)
+	}
+
+	// Report progress if configured
+	if options.Progress != nil {
+		options.Progress.Done()
+	}
+
+	return nil
+}
+
+// downloadChunk downloads a specific chunk of the object
+func (p *S3Provider) downloadChunk(ctx context.Context, key string, tempFile string, start, end int64, options storage.DownloadOptions) error {
+	// Create the range header
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", start, end)
+
+	// Get the object with range
+	result, err := p.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(p.bucket),
+		Key:    aws.String(key),
+		Range:  aws.String(rangeHeader),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get object range %s: %w", rangeHeader, err)
+	}
+	defer result.Body.Close()
+
+	// Create temp file
+	file, err := os.Create(tempFile)
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer file.Close()
+
+	// Copy the chunk data
+	bytesWritten, err := io.Copy(file, result.Body)
+	if err != nil {
+		return fmt.Errorf("failed to write chunk: %w", err)
+	}
+
+	expectedSize := end - start + 1
+	if bytesWritten != expectedSize {
+		return fmt.Errorf("chunk size mismatch: expected %d, got %d", expectedSize, bytesWritten)
+	}
+
+	// Note: Progress reporting is now handled by parallelDownload to avoid concurrent updates
+
+	return nil
+}
+
+// assembleChunks assembles the downloaded chunks into the final file
+func (p *S3Provider) assembleChunks(targetFile string, results map[int]downloadResult, totalChunks int) error {
+	// Create the target file
+	target, err := os.Create(targetFile)
+	if err != nil {
+		return fmt.Errorf("failed to create target file: %w", err)
+	}
+	defer target.Close()
+
+	// Get a buffer from the pool
+	bufPtr := p.bufferPool.Get().(*[]byte)
+	buf := *bufPtr
+	defer func() {
+		p.bufferPool.Put(bufPtr)
+	}()
+
+	// Write chunks in order
+	for i := 0; i < totalChunks; i++ {
+		result, ok := results[i]
+		if !ok {
+			return fmt.Errorf("missing chunk %d", i)
+		}
+
+		// Open the chunk file
+		chunkFile, err := os.Open(result.tempFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to open chunk %d: %w", i, err)
+		}
+
+		// Copy chunk to target file
+		_, err = io.CopyBuffer(target, chunkFile, buf)
+		chunkFile.Close()
+		if err != nil {
+			return fmt.Errorf("failed to copy chunk %d: %w", i, err)
+		}
+
+		// Remove the temp file immediately after copying
+		os.Remove(result.tempFilePath)
+	}
+
+	return nil
+}
+
+// downloadParallelWithRetry downloads a file with retry logic
+func (p *S3Provider) downloadParallelWithRetry(ctx context.Context, key string, targetFile string, size int64, options storage.DownloadOptions) error {
+	maxRetries := 3
+	var lastErr error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			p.logger.WithField("attempt", attempt+1).
+				WithField("key", key).
+				Info("Retrying parallel download")
+		}
+
+		err := p.parallelDownload(ctx, key, targetFile, size, options)
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+		p.logger.WithError(err).
+			WithField("attempt", attempt+1).
+			WithField("key", key).
+			Warn("Parallel download attempt failed")
+	}
+
+	return fmt.Errorf("parallel download failed after %d attempts: %w", maxRetries, lastErr)
+}

--- a/pkg/storage/providers/s3/presigned.go
+++ b/pkg/storage/providers/s3/presigned.go
@@ -1,0 +1,192 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// GeneratePresignedGetURL generates a presigned URL for downloading an object
+func (p *S3Provider) GeneratePresignedGetURL(ctx context.Context, key string, expiry time.Duration) (string, error) {
+	// Create a presign client
+	presignClient := s3.NewPresignClient(p.client)
+
+	// Create the request
+	request := &s3.GetObjectInput{
+		Bucket: aws.String(p.bucket),
+		Key:    aws.String(key),
+	}
+
+	// Generate the presigned URL
+	presignedReq, err := presignClient.PresignGetObject(ctx, request, func(opts *s3.PresignOptions) {
+		opts.Expires = expiry
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to generate presigned GET URL: %w", err)
+	}
+
+	return presignedReq.URL, nil
+}
+
+// GeneratePresignedPutURL generates a presigned URL for uploading an object
+func (p *S3Provider) GeneratePresignedPutURL(ctx context.Context, key string, expiry time.Duration, contentType string) (string, error) {
+	// Create a presign client
+	presignClient := s3.NewPresignClient(p.client)
+
+	// Create the request
+	request := &s3.PutObjectInput{
+		Bucket: aws.String(p.bucket),
+		Key:    aws.String(key),
+	}
+
+	// Set content type if provided
+	if contentType != "" {
+		request.ContentType = aws.String(contentType)
+	}
+
+	// Generate the presigned URL
+	presignedReq, err := presignClient.PresignPutObject(ctx, request, func(opts *s3.PresignOptions) {
+		opts.Expires = expiry
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to generate presigned PUT URL: %w", err)
+	}
+
+	return presignedReq.URL, nil
+}
+
+// GeneratePresignedDeleteURL generates a presigned URL for deleting an object
+func (p *S3Provider) GeneratePresignedDeleteURL(ctx context.Context, key string, expiry time.Duration) (string, error) {
+	// Create a presign client
+	presignClient := s3.NewPresignClient(p.client)
+
+	// Create the request
+	request := &s3.DeleteObjectInput{
+		Bucket: aws.String(p.bucket),
+		Key:    aws.String(key),
+	}
+
+	// Generate the presigned URL
+	presignedReq, err := presignClient.PresignDeleteObject(ctx, request, func(opts *s3.PresignOptions) {
+		opts.Expires = expiry
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to generate presigned DELETE URL: %w", err)
+	}
+
+	return presignedReq.URL, nil
+}
+
+// GeneratePresignedPostURL generates presigned POST data for browser-based uploads
+// Note: AWS SDK v2 doesn't have direct POST policy support like v1
+// This would need custom implementation or use of v1 SDK for POST policies
+func (p *S3Provider) GeneratePresignedPostURL(ctx context.Context, key string, expiry time.Duration, conditions []interface{}) (map[string]string, error) {
+	// AWS SDK v2 doesn't have direct POST policy support
+	// Return an error for now
+	return nil, fmt.Errorf("presigned POST not yet implemented in AWS SDK v2")
+}
+
+// PresignedURLOptions contains options for presigned URL generation
+type PresignedURLOptions struct {
+	Expiry                     time.Duration
+	ContentType                string
+	Metadata                   map[string]string
+	ResponseContentDisposition string
+	ResponseContentType        string
+}
+
+// GeneratePresignedURL generates a presigned URL with custom options
+func (p *S3Provider) GeneratePresignedURL(ctx context.Context, operation string, key string, options PresignedURLOptions) (string, error) {
+	// Default expiry to 1 hour if not specified
+	if options.Expiry == 0 {
+		options.Expiry = time.Hour
+	}
+
+	switch operation {
+	case "GET", "get":
+		return p.generatePresignedGetWithOptions(ctx, key, options)
+	case "PUT", "put":
+		return p.generatePresignedPutWithOptions(ctx, key, options)
+	case "DELETE", "delete":
+		return p.GeneratePresignedDeleteURL(ctx, key, options.Expiry)
+	default:
+		return "", fmt.Errorf("unsupported operation: %s", operation)
+	}
+}
+
+// generatePresignedGetWithOptions generates a presigned GET URL with custom options
+func (p *S3Provider) generatePresignedGetWithOptions(ctx context.Context, key string, options PresignedURLOptions) (string, error) {
+	// Create a presign client
+	presignClient := s3.NewPresignClient(p.client)
+
+	// Create the request
+	request := &s3.GetObjectInput{
+		Bucket: aws.String(p.bucket),
+		Key:    aws.String(key),
+	}
+
+	// Set response content disposition if provided
+	if options.ResponseContentDisposition != "" {
+		request.ResponseContentDisposition = aws.String(options.ResponseContentDisposition)
+	}
+
+	// Set response content type if provided
+	if options.ResponseContentType != "" {
+		request.ResponseContentType = aws.String(options.ResponseContentType)
+	}
+
+	// Generate the presigned URL
+	presignedReq, err := presignClient.PresignGetObject(ctx, request, func(opts *s3.PresignOptions) {
+		opts.Expires = options.Expiry
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to generate presigned GET URL: %w", err)
+	}
+
+	return presignedReq.URL, nil
+}
+
+// generatePresignedPutWithOptions generates a presigned PUT URL with custom options
+func (p *S3Provider) generatePresignedPutWithOptions(ctx context.Context, key string, options PresignedURLOptions) (string, error) {
+	// Create a presign client
+	presignClient := s3.NewPresignClient(p.client)
+
+	// Create the request
+	request := &s3.PutObjectInput{
+		Bucket: aws.String(p.bucket),
+		Key:    aws.String(key),
+	}
+
+	// Set content type if provided
+	if options.ContentType != "" {
+		request.ContentType = aws.String(options.ContentType)
+	}
+
+	// Set metadata if provided
+	if len(options.Metadata) > 0 {
+		request.Metadata = options.Metadata
+	}
+
+	// Generate the presigned URL
+	presignedReq, err := presignClient.PresignPutObject(ctx, request, func(opts *s3.PresignOptions) {
+		opts.Expires = options.Expiry
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to generate presigned PUT URL: %w", err)
+	}
+
+	return presignedReq.URL, nil
+}
+
+// GetPresignedURLForDownload generates a presigned URL for downloading (convenience method)
+func (p *S3Provider) GetPresignedURLForDownload(ctx context.Context, key string) (string, error) {
+	return p.GeneratePresignedGetURL(ctx, key, time.Hour)
+}
+
+// GetPresignedURLForUpload generates a presigned URL for uploading (convenience method)
+func (p *S3Provider) GetPresignedURLForUpload(ctx context.Context, key string) (string, error) {
+	return p.GeneratePresignedPutURL(ctx, key, time.Hour, "")
+}

--- a/pkg/storage/utils.go
+++ b/pkg/storage/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -227,4 +228,154 @@ func (r *SimpleProgressReporter) Error(err error) {
 	if r.onError != nil {
 		r.onError(err)
 	}
+}
+
+// ComputeTargetFilePath computes the target file path for a given object key and download options.
+// It handles path manipulation based on the options provided.
+func ComputeTargetFilePath(objectKey string, targetDir string, opts DownloadOptions) string {
+	if opts.UseBaseNameOnly {
+		// Use only the base name (file name) of the object
+		return filepath.Join(targetDir, ObjectBaseName(objectKey))
+	}
+
+	if opts.StripPrefix && opts.PrefixToStrip != "" {
+		// Strip the specified prefix from the object key
+		stripped := TrimObjectPrefix(objectKey, opts.PrefixToStrip)
+		return filepath.Join(targetDir, stripped)
+	}
+
+	if opts.JoinWithTailOverlap {
+		// Join with tail overlap
+		return JoinWithTailOverlap(targetDir, objectKey)
+	}
+
+	// Default: join target directory with full object key
+	return filepath.Join(targetDir, objectKey)
+}
+
+// ObjectBaseName returns only the file name from a given object path.
+// For example, given "bucket/folder/file.txt", it returns "file.txt".
+// If the input path does not contain "/", the original string is returned.
+func ObjectBaseName(objectPath string) string {
+	if !strings.Contains(objectPath, "/") {
+		return objectPath
+	}
+
+	values := strings.Split(objectPath, "/")
+	return values[len(values)-1] // Return the last segment (file name)
+}
+
+// TrimObjectPrefix removes a given prefix from the object path if it exists.
+// For example, given objectPath "bucket/folder/file.txt" and prefix "bucket/",
+// it returns "folder/file.txt".
+func TrimObjectPrefix(objectPath string, prefix string) string {
+	if len(prefix) == 0 {
+		return objectPath
+	}
+
+	return strings.TrimPrefix(objectPath, prefix)
+}
+
+// JoinWithTailOverlap combines directoryPath and objectPath with overlap.
+// This function finds the longest overlap between the directory suffix and object prefix,
+// then combines them without duplication.
+func JoinWithTailOverlap(directoryPath, objectPath string) string {
+	// Clean the directory path using OS-specific separators
+	cleanDir := filepath.Clean(directoryPath)
+	// For object paths, always use forward slashes
+	cleanObj := path.Clean(objectPath)
+
+	// Determine if the directory path was absolute
+	isAbsolute := filepath.IsAbs(directoryPath)
+
+	// Split paths for comparison - use OS separator for directory, forward slash for object
+	dirParts := strings.Split(cleanDir, string(filepath.Separator))
+	objParts := strings.Split(cleanObj, "/")
+
+	// Remove empty parts from splitting
+	dirParts = removeEmptyStrings(dirParts)
+	objParts = removeEmptyStrings(objParts)
+
+	// Find the longest overlap between dirParts suffix and objParts prefix
+	for l := minInt(len(dirParts), len(objParts)); l > 0; l-- {
+		if slicesEqual(dirParts[len(dirParts)-l:], objParts[:l]) {
+			combined := append(dirParts, objParts[l:]...)
+			result := filepath.Join(combined...)
+			// Preserve absolute path nature
+			if isAbsolute && !filepath.IsAbs(result) {
+				result = string(filepath.Separator) + result
+			}
+			return result
+		}
+	}
+
+	// No overlap found - just combine the paths
+	result := filepath.Join(append(dirParts, objParts...)...)
+	// Preserve absolute path nature
+	if isAbsolute && !filepath.IsAbs(result) {
+		result = string(filepath.Separator) + result
+	}
+	return result
+}
+
+// ShouldExclude checks if an object key matches any of the exclude patterns.
+// Patterns can use glob syntax (e.g., "*.tmp", "temp/*", "*/backup/*")
+func ShouldExclude(objectKey string, patterns []string) bool {
+	if len(patterns) == 0 {
+		return false
+	}
+
+	for _, pattern := range patterns {
+		matched, err := filepath.Match(pattern, objectKey)
+		if err != nil {
+			// Invalid pattern, skip it
+			continue
+		}
+		if matched {
+			return true
+		}
+
+		// Also check against the base name
+		matched, err = filepath.Match(pattern, ObjectBaseName(objectKey))
+		if err != nil {
+			continue
+		}
+		if matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// slicesEqual checks if two slices are equal.
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// minInt returns the minimum of two integers.
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// removeEmptyStrings removes empty strings from a slice
+func removeEmptyStrings(s []string) []string {
+	var result []string
+	for _, str := range s {
+		if str != "" {
+			result = append(result, str)
+		}
+	}
+	return result
 }


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## Summary
- Added parallel download support for large files (>100MB) to improve performance
- Fixed critical issue where S3 provider incorrectly handled file vs directory targets during downloads
- Implemented all missing download options for feature parity with OCI provider
- Enhanced test suite with comprehensive coverage for all download scenarios

## Features Added

### 1. Parallel Download Support

Implemented s3 provider multi-threaded downloads for large files to significantly improve download performance:
  - Automatically triggers for files >100MB
  - Uses configurable number of workers (default: 4)
  - Downloads file in chunks with concurrent goroutines
  - Properly handles partial content with byte ranges
  - Includes progress reporting for each chunk

```go
  // Parallel download for large files
  if *obj.Size > 100*1024*1024 && !options.DisableParallelDownload {
      return p.downloadLargeFile(ctx, bucket, key, actualTarget, *obj.Size, options)
  }
```

### 2. Complete Download Options Implementation

Added full support for all download options to match OCI provider capabilities:
- `WithUseBaseNameOnly()` - Download only the filename without path structure
- `WithStripPrefix()` - Remove specified prefix from object paths
- `WithJoinWithTailOverlap()` - Smart path joining with overlap detection
- `WithExcludePatterns()` - Skip files matching glob patterns
- `WithSkipIfValid()` - Skip download if file exists with matching size
- `WithForceRedownload()` - Force re-download even if file exists
- `WithDisableParallelDownload()` - Disable parallel downloads for large files