### PR TITLE
[Misc]add static library .a in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,7 @@ coverage-*.html
 *target
 *Cargo.lock
 
+# static library
+*.a
+
 hack/python-sdk/openapi-generator-cli-*.jar


### PR DESCRIPTION

## What this PR does / why we need it:

This static library created by local build, it don't need to upload in repo.

## Does this PR introduce a user-facing change?

None.
