### PR TITLE
[Misc] Updates in model agent for model deletion: avoid model path deletion when it is also referred by other models

### DIFF
--- a/cmd/model-agent/main.go
+++ b/cmd/model-agent/main.go
@@ -239,7 +239,7 @@ func initializeComponents(
 	// Create default Hugging Face hub config
 	// Use log-only mode for cleaner logs in production
 	hfHubConfig, err := hub.NewHubConfig(
-		hub.WithViper(v), // Apply viper config first to set defaults
+		hub.WithViper(v),                                 // Apply viper config first to set defaults
 		hub.WithLogger(logging.ForZap(zapLogger)),        // Then set the logger
 		hub.WithProgressDisplayMode(hub.ProgressModeLog), // Use log mode for clean production logs
 		hub.WithDetailedLogs(false),                      // Disable detailed progress logging to reduce log flooding
@@ -270,7 +270,10 @@ func initializeComponents(
 		gopherTaskChan,
 		nodeLabelReconciler,
 		metrics,
-		logger)
+		logger,
+		baseModelInformer.Lister(),
+		clusterBaseModelInformer.Lister(),
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create gopher: %w", err)
 	}

--- a/pkg/modelagent/gopher.go
+++ b/pkg/modelagent/gopher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	omev1beta1lister "github.com/sgl-project/ome/pkg/client/listers/ome/v1beta1"
 	"github.com/sgl-project/ome/pkg/constants"
 	"github.com/sgl-project/ome/pkg/hfutil/hub"
 	"github.com/sgl-project/ome/pkg/logging"
@@ -41,19 +43,21 @@ type GopherTask struct {
 }
 
 type Gopher struct {
-	modelConfigParser    *ModelConfigParser
-	configMapReconciler  *ConfigMapReconciler
-	downloadRetry        int
-	concurrency          int
-	multipartConcurrency int
-	modelRootDir         string
-	hubClient            *hub.HubClient
-	kubeClient           kubernetes.Interface
-	gopherChan           <-chan *GopherTask
-	nodeLabelReconciler  *NodeLabelReconciler
-	metrics              *Metrics
-	logger               *zap.SugaredLogger
-	configMapMutex       sync.Mutex // Mutex to coordinate ConfigMap access
+	modelConfigParser      *ModelConfigParser
+	configMapReconciler    *ConfigMapReconciler
+	downloadRetry          int
+	concurrency            int
+	multipartConcurrency   int
+	modelRootDir           string
+	hubClient              *hub.HubClient
+	kubeClient             kubernetes.Interface
+	gopherChan             <-chan *GopherTask
+	nodeLabelReconciler    *NodeLabelReconciler
+	metrics                *Metrics
+	logger                 *zap.SugaredLogger
+	configMapMutex         sync.Mutex // Mutex to coordinate ConfigMap access
+	baseModelLister        omev1beta1lister.BaseModelLister
+	clusterBaseModelLister omev1beta1lister.ClusterBaseModelLister
 
 	// Track active downloads for cancellation
 	activeDownloads      map[string]context.CancelFunc // key: model UID
@@ -76,26 +80,30 @@ func NewGopher(
 	gopherChan <-chan *GopherTask,
 	nodeLabelReconciler *NodeLabelReconciler,
 	metrics *Metrics,
-	logger *zap.SugaredLogger) (*Gopher, error) {
+	logger *zap.SugaredLogger,
+	baseModelLister omev1beta1lister.BaseModelLister,
+	clusterBaseModelLister omev1beta1lister.ClusterBaseModelLister) (*Gopher, error) {
 
 	if hubClient == nil {
 		return nil, fmt.Errorf("hugging face hub client cannot be nil")
 	}
 
 	return &Gopher{
-		modelConfigParser:    modelConfigParser,
-		configMapReconciler:  configMapReconciler,
-		downloadRetry:        downloadRetry,
-		concurrency:          concurrency,
-		multipartConcurrency: multipartConcurrency,
-		modelRootDir:         modelRootDir,
-		hubClient:            hubClient,
-		kubeClient:           kubeClient,
-		gopherChan:           gopherChan,
-		nodeLabelReconciler:  nodeLabelReconciler,
-		metrics:              metrics,
-		logger:               logger,
-		activeDownloads:      make(map[string]context.CancelFunc),
+		modelConfigParser:      modelConfigParser,
+		configMapReconciler:    configMapReconciler,
+		downloadRetry:          downloadRetry,
+		concurrency:            concurrency,
+		multipartConcurrency:   multipartConcurrency,
+		modelRootDir:           modelRootDir,
+		hubClient:              hubClient,
+		kubeClient:             kubeClient,
+		gopherChan:             gopherChan,
+		nodeLabelReconciler:    nodeLabelReconciler,
+		metrics:                metrics,
+		logger:                 logger,
+		activeDownloads:        make(map[string]context.CancelFunc),
+		baseModelLister:        baseModelLister,
+		clusterBaseModelLister: clusterBaseModelLister,
 	}, nil
 }
 
@@ -422,15 +430,25 @@ func (s *Gopher) processTask(task *GopherTask) error {
 		case storage.StorageTypeOCI:
 			s.logger.Infof("Starting deletion for model %s", modelInfo)
 			destPath := getDestPath(&baseModelSpec, s.modelRootDir)
-			err = s.deleteModel(destPath, task)
+
+			// Double-check if the path is still referenced by other models
+			isReferenced, err := s.isPathReferencedByOtherModels(destPath, task.BaseModel, task.ClusterBaseModel)
 			if err != nil {
-				s.logger.Errorf("Failed to delete model %s: %v", modelInfo, err)
-				return err
-			}
-			if task.BaseModel != nil {
-				s.logger.Infof("Successfully deleted the BaseModel %s in namespace %s", task.BaseModel.Name, task.BaseModel.Namespace)
+				// Cannot determine if the path is referenced; skip deletion to be safe
+				s.logger.Errorf("Failed to check if path %s is referenced by other models, skip the path deletion: %v", destPath, err)
+			} else if isReferenced {
+				s.logger.Infof("Skipping deletion of path %s for model %s as it is still referenced by other models", destPath, modelInfo)
 			} else {
-				s.logger.Infof("Successfully deleted the ClusterBaseModel %s", task.ClusterBaseModel.Name)
+				err = s.deleteModel(destPath, task)
+				if err != nil {
+					s.logger.Errorf("Failed to delete model %s: %v", modelInfo, err)
+					return err
+				}
+				if task.BaseModel != nil {
+					s.logger.Infof("Successfully deleted the BaseModel %s in namespace %s", task.BaseModel.Name, task.BaseModel.Namespace)
+				} else {
+					s.logger.Infof("Successfully deleted the ClusterBaseModel %s", task.ClusterBaseModel.Name)
+				}
 			}
 		case storage.StorageTypeVendor:
 			s.logger.Infof("Skipping deletion for model %s", modelInfo)
@@ -438,12 +456,22 @@ func (s *Gopher) processTask(task *GopherTask) error {
 			s.logger.Infof("Removing Hugging Face model %s", modelInfo)
 			// Use getDestPath to get the same path used during download
 			destPath := getDestPath(&baseModelSpec, s.modelRootDir)
-			err = s.deleteModel(destPath, task)
+
+			// Double-check if the path is still referenced by other models
+			isReferenced, err := s.isPathReferencedByOtherModels(destPath, task.BaseModel, task.ClusterBaseModel)
 			if err != nil {
-				s.logger.Errorf("Failed to delete Hugging Face model %s: %v", modelInfo, err)
-				return err
+				// Cannot determine if the path is referenced; skip deletion to be safe
+				s.logger.Errorf("Failed to check if path %s is referenced by other models, skip the path deletion: %v", destPath, err)
+			} else if isReferenced {
+				s.logger.Infof("Skipping deletion of path %s for model %s as it is still referenced by other models", destPath, modelInfo)
+			} else {
+				err = s.deleteModel(destPath, task)
+				if err != nil {
+					s.logger.Errorf("Failed to delete Hugging Face model %s: %v", modelInfo, err)
+					return err
+				}
+				s.logger.Infof("Successfully deleted Hugging Face model %s", modelInfo)
 			}
-			s.logger.Infof("Successfully deleted Hugging Face model %s", modelInfo)
 		case storage.StorageTypeLocal:
 			s.logger.Infof("Skipping deletion for local storage model %s (local files should not be deleted)", modelInfo)
 			// For local storage, we should NOT delete the actual files
@@ -476,6 +504,50 @@ func (s *Gopher) processTask(task *GopherTask) error {
 	}
 
 	return nil
+}
+
+// isPathReferencedByOtherModels checks if the given path is still referenced by other BaseModel or ClusterBaseModel resources
+// excluding the model being deleted
+func (s *Gopher) isPathReferencedByOtherModels(targetPath string, excludeBaseModel *v1beta1.BaseModel, excludeClusterBaseModel *v1beta1.ClusterBaseModel) (bool, error) {
+	// Check BaseModels
+	baseModels, err := s.baseModelLister.List(labels.Everything())
+	if err != nil {
+		return false, fmt.Errorf("failed to list BaseModels: %w", err)
+	}
+
+	for _, baseModel := range baseModels {
+		// Skip the model being deleted
+		if excludeBaseModel != nil && baseModel.Namespace == excludeBaseModel.Namespace && baseModel.Name == excludeBaseModel.Name {
+			continue
+		}
+
+		// Check if this BaseModel references the same path
+		if baseModel.Spec.Storage.Path != nil && *baseModel.Spec.Storage.Path == targetPath {
+			s.logger.Infof("Path %s is still referenced by BaseModel %s/%s", targetPath, baseModel.Namespace, baseModel.Name)
+			return true, nil
+		}
+	}
+
+	// Check ClusterBaseModels
+	clusterBaseModels, err := s.clusterBaseModelLister.List(labels.Everything())
+	if err != nil {
+		return false, fmt.Errorf("failed to list ClusterBaseModels: %w", err)
+	}
+
+	for _, clusterBaseModel := range clusterBaseModels {
+		// Skip the model being deleted
+		if excludeClusterBaseModel != nil && clusterBaseModel.Name == excludeClusterBaseModel.Name {
+			continue
+		}
+
+		// Check if this ClusterBaseModel references the same path
+		if clusterBaseModel.Spec.Storage.Path != nil && *clusterBaseModel.Spec.Storage.Path == targetPath {
+			s.logger.Infof("Path %s is still referenced by ClusterBaseModel %s", targetPath, clusterBaseModel.Name)
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func getModelInfoForLogging(task *GopherTask) string {

--- a/pkg/modelagent/gopher_test.go
+++ b/pkg/modelagent/gopher_test.go
@@ -1,14 +1,17 @@
 package modelagent
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	omev1beta1lister "github.com/sgl-project/ome/pkg/client/listers/ome/v1beta1"
 	"github.com/sgl-project/ome/pkg/utils/storage"
 )
 
@@ -231,6 +234,292 @@ func TestShouldDownloadModelPVC(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := scout.shouldDownloadModel(tc.storageSpec)
+			assert.Equal(t, tc.expectedResult, result, tc.description)
+		})
+	}
+}
+
+// Mock implementations for testing
+type mockBaseModelLister struct {
+	models []*v1beta1.BaseModel
+	err    error
+}
+
+func (m *mockBaseModelLister) List(selector labels.Selector) ([]*v1beta1.BaseModel, error) {
+	return m.models, m.err
+}
+
+func (m *mockBaseModelLister) BaseModels(namespace string) omev1beta1lister.BaseModelNamespaceLister {
+	return nil // Not used in our test
+}
+
+type mockClusterBaseModelLister struct {
+	models []*v1beta1.ClusterBaseModel
+	err    error
+}
+
+func (m *mockClusterBaseModelLister) List(selector labels.Selector) ([]*v1beta1.ClusterBaseModel, error) {
+	return m.models, m.err
+}
+
+func (m *mockClusterBaseModelLister) Get(name string) (*v1beta1.ClusterBaseModel, error) {
+	// Simple implementation for testing - find by name
+	for _, model := range m.models {
+		if model.Name == name {
+			return model, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+// TestIsPathReferencedByOtherModels tests the isPathReferencedByOtherModels method
+func TestIsPathReferencedByOtherModels(t *testing.T) {
+	// Create a test logger
+	logger, _ := zap.NewDevelopment()
+	sugaredLogger := logger.Sugar()
+	defer func(sugaredLogger *zap.SugaredLogger) {
+		_ = sugaredLogger.Sync()
+	}(sugaredLogger)
+
+	targetPath := "/models/llama2"
+
+	testCases := []struct {
+		name                      string
+		baseModels                []*v1beta1.BaseModel
+		clusterBaseModels         []*v1beta1.ClusterBaseModel
+		excludeBaseModel          *v1beta1.BaseModel
+		excludeClusterBaseModel   *v1beta1.ClusterBaseModel
+		baseModelListerErr        error
+		clusterBaseModelListerErr error
+		expectedResult            bool
+		expectedError             bool
+		errorContains             string
+		description               string
+	}{
+		{
+			name:           "no models exist",
+			description:    "should return false when no models exist",
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name: "path not referenced by any model",
+			baseModels: []*v1beta1.BaseModel{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "model1",
+						Namespace: "default",
+					},
+					Spec: v1beta1.BaseModelSpec{
+						Storage: &v1beta1.StorageSpec{
+							Path: stringPtr("/models/other-model"),
+						},
+					},
+				},
+			},
+			clusterBaseModels: []*v1beta1.ClusterBaseModel{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-model1",
+					},
+					Spec: v1beta1.BaseModelSpec{
+						Storage: &v1beta1.StorageSpec{
+							Path: stringPtr("/models/another-model"),
+						},
+					},
+				},
+			},
+			description:    "should return false when target path is not referenced",
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name: "path referenced by BaseModel",
+			baseModels: []*v1beta1.BaseModel{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "model1",
+						Namespace: "default",
+					},
+					Spec: v1beta1.BaseModelSpec{
+						Storage: &v1beta1.StorageSpec{
+							Path: stringPtr(targetPath),
+						},
+					},
+				},
+			},
+			description:    "should return true when path is referenced by BaseModel",
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name: "path referenced by ClusterBaseModel",
+			clusterBaseModels: []*v1beta1.ClusterBaseModel{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-model1",
+					},
+					Spec: v1beta1.BaseModelSpec{
+						Storage: &v1beta1.StorageSpec{
+							Path: stringPtr(targetPath),
+						},
+					},
+				},
+			},
+			description:    "should return true when path is referenced by ClusterBaseModel",
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name: "path referenced by BaseModel but excluded",
+			baseModels: []*v1beta1.BaseModel{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "model1",
+						Namespace: "default",
+					},
+					Spec: v1beta1.BaseModelSpec{
+						Storage: &v1beta1.StorageSpec{
+							Path: stringPtr(targetPath),
+						},
+					},
+				},
+			},
+			excludeBaseModel: &v1beta1.BaseModel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "model1",
+					Namespace: "default",
+				},
+				Spec: v1beta1.BaseModelSpec{
+					Storage: &v1beta1.StorageSpec{
+						Path: stringPtr(targetPath),
+					},
+				},
+			},
+			description:    "should return false when path is only referenced by excluded BaseModel",
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name: "path referenced by ClusterBaseModel but excluded",
+			clusterBaseModels: []*v1beta1.ClusterBaseModel{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-model1",
+					},
+					Spec: v1beta1.BaseModelSpec{
+						Storage: &v1beta1.StorageSpec{
+							Path: stringPtr(targetPath),
+						},
+					},
+				},
+			},
+			excludeClusterBaseModel: &v1beta1.ClusterBaseModel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-model1",
+				},
+				Spec: v1beta1.BaseModelSpec{
+					Storage: &v1beta1.StorageSpec{
+						Path: stringPtr(targetPath),
+					},
+				},
+			},
+			description:    "should return false when path is only referenced by excluded ClusterBaseModel",
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name: "path referenced by multiple models, one excluded",
+			baseModels: []*v1beta1.BaseModel{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "model1",
+						Namespace: "default",
+					},
+					Spec: v1beta1.BaseModelSpec{
+						Storage: &v1beta1.StorageSpec{
+							Path: stringPtr(targetPath),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "model2",
+						Namespace: "default",
+					},
+					Spec: v1beta1.BaseModelSpec{
+						Storage: &v1beta1.StorageSpec{
+							Path: stringPtr(targetPath),
+						},
+					},
+				},
+			},
+			excludeBaseModel: &v1beta1.BaseModel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "model1",
+					Namespace: "default",
+				},
+				Spec: v1beta1.BaseModelSpec{
+					Storage: &v1beta1.StorageSpec{
+						Path: stringPtr(targetPath),
+					},
+				},
+			},
+			description:    "should return true when path is referenced by multiple models but only one is excluded",
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name:               "BaseModel lister error",
+			baseModelListerErr: errors.New("lister error"),
+			description:        "should return error when BaseModel lister fails",
+			expectedResult:     false,
+			expectedError:      true,
+			errorContains:      "failed to list BaseModels",
+		},
+		{
+			name:                      "ClusterBaseModel lister error",
+			clusterBaseModelListerErr: errors.New("lister error"),
+			description:               "should return error when ClusterBaseModel lister fails",
+			expectedResult:            false,
+			expectedError:             true,
+			errorContains:             "failed to list ClusterBaseModels",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock listers
+			mockBaseModelLister := &mockBaseModelLister{
+				models: tc.baseModels,
+				err:    tc.baseModelListerErr,
+			}
+			mockClusterBaseModelLister := &mockClusterBaseModelLister{
+				models: tc.clusterBaseModels,
+				err:    tc.clusterBaseModelListerErr,
+			}
+
+			// Create a minimal Gopher instance for testing
+			gopher := &Gopher{
+				logger:                 sugaredLogger,
+				baseModelLister:        mockBaseModelLister,
+				clusterBaseModelLister: mockClusterBaseModelLister,
+			}
+
+			// Call the method under test
+			result, err := gopher.isPathReferencedByOtherModels(targetPath, tc.excludeBaseModel, tc.excludeClusterBaseModel)
+
+			// Check error conditions
+			if tc.expectedError {
+				assert.Error(t, err, tc.description)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains, tc.description)
+				}
+			} else {
+				assert.NoError(t, err, tc.description)
+			}
+
+			// Check result
 			assert.Equal(t, tc.expectedResult, result, tc.description)
 		})
 	}


### PR DESCRIPTION
## What type of PR is this?
/kind bug


## What this PR does / why we need it:
There are cases where multiple model CRs (serving different purposes) refer to the same model path. We need to avoid when one of such models is deleted, other models referring to the same path can still work fine in terms of hosting.

So in order to achieve it, we add a check before model path deletion to check if any other basemodel CRs or clusterbasemodel CRs are referring to the same model path, if there are such models, skip the model path deletion, only delete the target model CR.

## Does this PR introduce a user-facing change?
No