### PR TITLE
[Core]Integrate the accelerator‑aware runtime into the InferenceService con…

### DIFF
--- a/charts/ome-crd/templates/ome.io_clusterservingruntimes.yaml
+++ b/charts/ome-crd/templates/ome.io_clusterservingruntimes.yaml
@@ -1242,7 +1242,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest
@@ -14181,7 +14180,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest

--- a/charts/ome-crd/templates/ome.io_inferenceservices.yaml
+++ b/charts/ome-crd/templates/ome.io_inferenceservices.yaml
@@ -88,7 +88,6 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     policy:
-                      default: BestFit
                       enum:
                         - BestFit
                         - Cheapest
@@ -130,7 +129,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest
@@ -12362,7 +12360,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest

--- a/charts/ome-crd/templates/ome.io_servingruntimes.yaml
+++ b/charts/ome-crd/templates/ome.io_servingruntimes.yaml
@@ -1242,7 +1242,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest
@@ -14181,7 +14180,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest

--- a/config/crd/full/ome.io_clusterservingruntimes.yaml
+++ b/config/crd/full/ome.io_clusterservingruntimes.yaml
@@ -1242,7 +1242,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest
@@ -14181,7 +14180,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest

--- a/config/crd/full/ome.io_inferenceservices.yaml
+++ b/config/crd/full/ome.io_inferenceservices.yaml
@@ -88,7 +88,6 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     policy:
-                      default: BestFit
                       enum:
                         - BestFit
                         - Cheapest
@@ -130,7 +129,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest
@@ -12362,7 +12360,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest

--- a/config/crd/full/ome.io_servingruntimes.yaml
+++ b/config/crd/full/ome.io_servingruntimes.yaml
@@ -1242,7 +1242,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest
@@ -14181,7 +14180,6 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         policy:
-                          default: BestFit
                           enum:
                             - BestFit
                             - Cheapest

--- a/config/default/isvc_conversion_webhook.yaml
+++ b/config/default/isvc_conversion_webhook.yaml
@@ -13,7 +13,6 @@ spec:
         clientConfig:
           # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
           # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-          caBundle: Cg==
           service:
             namespace: $(omeNamespace)
             name: $(webhookServiceName)

--- a/pkg/acceleratorclassselector/errors.go
+++ b/pkg/acceleratorclassselector/errors.go
@@ -1,0 +1,41 @@
+package acceleratorclassselector
+
+import (
+	"fmt"
+)
+
+// AcceleratorCompatibilityError represents an error when an accelerator class doesn't meet requirements.
+type AcceleratorCompatibilityError struct {
+	AcceleratorClassName string
+	Component            string
+	Reason               string
+	DetailedError        error
+}
+
+// AcceleratorNotFoundError indicates that a specified accelerator class doesn't exist.
+type AcceleratorNotFoundError struct {
+	AcceleratorClassName string
+}
+
+// Error implements the error interface.
+func (e *AcceleratorNotFoundError) Error() string {
+	return fmt.Sprintf("accelerator class %s not found at cluster scope",
+		e.AcceleratorClassName)
+}
+
+// ConfigurationError indicates a configuration problem.
+type ConfigurationError struct {
+	Component string
+	Message   string
+}
+
+// Error implements the error interface.
+func (e *ConfigurationError) Error() string {
+	return fmt.Sprintf("configuration error in %s: %s", e.Component, e.Message)
+}
+
+// IsAcceleratorNotFoundError checks if an error is an AcceleratorNotFoundError.
+func IsAcceleratorNotFoundError(err error) bool {
+	_, ok := err.(*AcceleratorNotFoundError)
+	return ok
+}

--- a/pkg/acceleratorclassselector/fetcher.go
+++ b/pkg/acceleratorclassselector/fetcher.go
@@ -1,0 +1,63 @@
+package acceleratorclassselector
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+)
+
+// DefaultAcceleratorFetcher is the default implementation of AcceleratorFetcher.
+type DefaultAcceleratorFetcher struct {
+	client client.Client
+}
+
+// NewDefaultAcceleratorFetcher creates a new DefaultAcceleratorFetcher.
+func NewDefaultAcceleratorFetcher(client client.Client) AcceleratorFetcher {
+	return &DefaultAcceleratorFetcher{
+		client: client,
+	}
+}
+
+// FetchAcceleratorClasses returns both namespace and cluster scoped accelerator classes.
+func (f *DefaultAcceleratorFetcher) FetchAcceleratorClasses(ctx context.Context) (*AcceleratorCollection, error) {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Fetching accelerator classes")
+
+	collection := &AcceleratorCollection{}
+
+	// Fetch cluster-scoped AcceleratorClasses
+	var clusterAcceleratorClasses v1beta1.AcceleratorClassList
+	if err := f.client.List(ctx, &clusterAcceleratorClasses); err != nil {
+		return nil, fmt.Errorf("failed to list cluster-scoped accelerator classes: %w", err)
+	}
+	collection.ClusterAcceleratorClasses = clusterAcceleratorClasses.Items
+
+	logger.V(1).Info("Fetched accelerator classes",
+		"clusterAcceleratorClasses", len(collection.ClusterAcceleratorClasses))
+
+	return collection, nil
+}
+
+// GetAcceleratorClass fetches a specific accelerator class by name.
+// It first checks namespace-scoped accelerator classes, then cluster-scoped ones.
+func (f *DefaultAcceleratorFetcher) GetAcceleratorClass(ctx context.Context, name string) (*v1beta1.AcceleratorClassSpec, bool, error) {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Getting accelerator class", "name", name)
+
+	// If not found in namespace, try cluster-scoped AcceleratorClass
+	var clusterAcceleratorClass v1beta1.AcceleratorClass
+	acceleratorClassName := client.ObjectKey{Name: name}
+	if err := f.client.Get(ctx, acceleratorClassName, &clusterAcceleratorClass); err == nil {
+		logger.V(1).Info("Found cluster-scoped accelerator class", "name", name)
+		return &clusterAcceleratorClass.Spec, true, nil
+	}
+
+	// Not found in either scope
+	return nil, false, &AcceleratorNotFoundError{
+		AcceleratorClassName: name,
+	}
+}

--- a/pkg/acceleratorclassselector/fetcher_test.go
+++ b/pkg/acceleratorclassselector/fetcher_test.go
@@ -1,0 +1,414 @@
+package acceleratorclassselector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+)
+
+// Helper function to create resource.Quantity
+func mustParseQuantity(value string) resource.Quantity {
+	q, err := resource.ParseQuantity(value)
+	if err != nil {
+		panic(err)
+	}
+	return q
+}
+
+func TestNewDefaultAcceleratorFetcher(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Create a fake client
+	scheme := runtime.NewScheme()
+	g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+
+	c := ctrlclientfake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	// Create fetcher
+	fetcher := NewDefaultAcceleratorFetcher(c)
+
+	// Verify fetcher is not nil and implements AcceleratorFetcher interface
+	g.Expect(fetcher).NotTo(gomega.BeNil())
+
+	// Verify it implements the interface
+	var _ AcceleratorFetcher = fetcher
+}
+
+func TestDefaultAcceleratorFetcher_FetchAcceleratorClasses(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tests := []struct {
+		name                            string
+		clusterAcceleratorClasses       []v1beta1.AcceleratorClass
+		expectedClusterAcceleratorCount int
+		expectError                     bool
+	}{
+		{
+			name:                            "No accelerator classes",
+			clusterAcceleratorClasses:       []v1beta1.AcceleratorClass{},
+			expectedClusterAcceleratorCount: 0,
+			expectError:                     false,
+		},
+		{
+			name: "Single cluster-scoped accelerator class",
+			clusterAcceleratorClasses: []v1beta1.AcceleratorClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nvidia-h100",
+					},
+					Spec: v1beta1.AcceleratorClassSpec{
+						Discovery: v1beta1.AcceleratorDiscovery{
+							NodeSelector: map[string]string{
+								"accelerator": "nvidia-h100",
+							},
+						},
+						Capabilities: v1beta1.AcceleratorCapabilities{},
+					},
+				},
+			},
+			expectedClusterAcceleratorCount: 1,
+			expectError:                     false,
+		},
+		{
+			name: "Multiple cluster-scoped accelerator classes",
+			clusterAcceleratorClasses: []v1beta1.AcceleratorClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nvidia-h100",
+					},
+					Spec: v1beta1.AcceleratorClassSpec{
+						Discovery: v1beta1.AcceleratorDiscovery{
+							NodeSelector: map[string]string{
+								"accelerator": "nvidia-h100",
+							},
+						},
+						Capabilities: v1beta1.AcceleratorCapabilities{},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nvidia-a100",
+					},
+					Spec: v1beta1.AcceleratorClassSpec{
+						Discovery: v1beta1.AcceleratorDiscovery{
+							NodeSelector: map[string]string{
+								"accelerator": "nvidia-a100",
+							},
+						},
+						Capabilities: v1beta1.AcceleratorCapabilities{},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "amd-mi300x",
+					},
+					Spec: v1beta1.AcceleratorClassSpec{
+						Discovery: v1beta1.AcceleratorDiscovery{
+							NodeSelector: map[string]string{
+								"accelerator": "amd-mi300x",
+							},
+						},
+						Capabilities: v1beta1.AcceleratorCapabilities{},
+					},
+				},
+			},
+			expectedClusterAcceleratorCount: 3,
+			expectError:                     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create scheme
+			scheme := runtime.NewScheme()
+			g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+
+			// Create objects for fake client
+			objects := make([]client.Object, 0)
+			for i := range tt.clusterAcceleratorClasses {
+				objects = append(objects, &tt.clusterAcceleratorClasses[i])
+			}
+
+			// Create fake client
+			c := ctrlclientfake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			// Create fetcher
+			fetcher := NewDefaultAcceleratorFetcher(c)
+
+			// Fetch accelerator classes
+			collection, err := fetcher.FetchAcceleratorClasses(context.TODO())
+
+			if tt.expectError {
+				g.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(collection).NotTo(gomega.BeNil())
+				g.Expect(collection.ClusterAcceleratorClasses).To(gomega.HaveLen(tt.expectedClusterAcceleratorCount))
+
+				// Verify the accelerator classes are correct
+				if tt.expectedClusterAcceleratorCount > 0 {
+					// Create a map of expected classes by name
+					expectedByName := make(map[string]v1beta1.AcceleratorClass)
+					for _, expected := range tt.clusterAcceleratorClasses {
+						expectedByName[expected.Name] = expected
+					}
+
+					// Verify each returned class matches expected
+					for _, actual := range collection.ClusterAcceleratorClasses {
+						expected, found := expectedByName[actual.Name]
+						g.Expect(found).To(gomega.BeTrue(), "unexpected accelerator class: %s", actual.Name)
+						g.Expect(actual.Spec.Discovery.NodeSelector).To(gomega.Equal(expected.Spec.Discovery.NodeSelector))
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultAcceleratorFetcher_GetAcceleratorClass(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tests := []struct {
+		name                      string
+		acceleratorClassName      string
+		clusterAcceleratorClasses []v1beta1.AcceleratorClass
+		expectFound               bool
+		expectClusterScoped       bool
+		expectError               bool
+		validateSpec              func(*testing.T, *v1beta1.AcceleratorClassSpec)
+	}{
+		{
+			name:                 "Cluster-scoped accelerator class found",
+			acceleratorClassName: "nvidia-h100",
+			clusterAcceleratorClasses: []v1beta1.AcceleratorClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nvidia-h100",
+					},
+					Spec: v1beta1.AcceleratorClassSpec{
+						Discovery: v1beta1.AcceleratorDiscovery{
+							NodeSelector: map[string]string{
+								"accelerator": "nvidia-h100",
+							},
+						},
+						Capabilities: v1beta1.AcceleratorCapabilities{},
+						Resources: []v1beta1.AcceleratorResource{
+							{
+								Name:     "nvidia.com/gpu",
+								Quantity: mustParseQuantity("1"),
+							},
+						},
+					},
+				},
+			},
+			expectFound:         true,
+			expectClusterScoped: true,
+			expectError:         false,
+			validateSpec: func(t *testing.T, spec *v1beta1.AcceleratorClassSpec) {
+				g.Expect(spec).NotTo(gomega.BeNil())
+				g.Expect(spec.Discovery.NodeSelector).To(gomega.HaveKeyWithValue("accelerator", "nvidia-h100"))
+				g.Expect(spec.Resources).To(gomega.HaveLen(1))
+				g.Expect(spec.Resources[0].Name).To(gomega.Equal("nvidia.com/gpu"))
+			},
+		},
+		{
+			name:                 "Accelerator class not found",
+			acceleratorClassName: "non-existent",
+			clusterAcceleratorClasses: []v1beta1.AcceleratorClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nvidia-h100",
+					},
+					Spec: v1beta1.AcceleratorClassSpec{
+						Discovery:    v1beta1.AcceleratorDiscovery{},
+						Capabilities: v1beta1.AcceleratorCapabilities{},
+					},
+				},
+			},
+			expectFound:         false,
+			expectClusterScoped: false,
+			expectError:         true,
+			validateSpec: func(t *testing.T, spec *v1beta1.AcceleratorClassSpec) {
+				g.Expect(spec).To(gomega.BeNil())
+			},
+		},
+		{
+			name:                      "No accelerator classes in cluster",
+			acceleratorClassName:      "nvidia-a100",
+			clusterAcceleratorClasses: []v1beta1.AcceleratorClass{},
+			expectFound:               false,
+			expectClusterScoped:       false,
+			expectError:               true,
+			validateSpec: func(t *testing.T, spec *v1beta1.AcceleratorClassSpec) {
+				g.Expect(spec).To(gomega.BeNil())
+			},
+		},
+		{
+			name:                 "Multiple accelerator classes - find specific one",
+			acceleratorClassName: "amd-mi300x",
+			clusterAcceleratorClasses: []v1beta1.AcceleratorClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nvidia-h100",
+					},
+					Spec: v1beta1.AcceleratorClassSpec{
+						Discovery: v1beta1.AcceleratorDiscovery{
+							NodeSelector: map[string]string{
+								"accelerator": "nvidia-h100",
+							},
+						},
+						Capabilities: v1beta1.AcceleratorCapabilities{},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "amd-mi300x",
+					},
+					Spec: v1beta1.AcceleratorClassSpec{
+						Discovery: v1beta1.AcceleratorDiscovery{
+							NodeSelector: map[string]string{
+								"accelerator": "amd-mi300x",
+							},
+						},
+						Capabilities: v1beta1.AcceleratorCapabilities{},
+						Resources: []v1beta1.AcceleratorResource{
+							{
+								Name:     "amd.com/gpu",
+								Quantity: mustParseQuantity("1"),
+							},
+						},
+					},
+				},
+			},
+			expectFound:         true,
+			expectClusterScoped: true,
+			expectError:         false,
+			validateSpec: func(t *testing.T, spec *v1beta1.AcceleratorClassSpec) {
+				g.Expect(spec).NotTo(gomega.BeNil())
+				g.Expect(spec.Discovery.NodeSelector).To(gomega.HaveKeyWithValue("accelerator", "amd-mi300x"))
+				g.Expect(spec.Resources).To(gomega.HaveLen(1))
+				g.Expect(spec.Resources[0].Name).To(gomega.Equal("amd.com/gpu"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create scheme
+			scheme := runtime.NewScheme()
+			g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+
+			// Create objects for fake client
+			objects := make([]client.Object, 0)
+			for i := range tt.clusterAcceleratorClasses {
+				objects = append(objects, &tt.clusterAcceleratorClasses[i])
+			}
+
+			// Create fake client
+			c := ctrlclientfake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			// Create fetcher
+			fetcher := NewDefaultAcceleratorFetcher(c)
+
+			// Get accelerator class
+			spec, isClusterScoped, err := fetcher.GetAcceleratorClass(context.TODO(), tt.acceleratorClassName)
+
+			if tt.expectError {
+				g.Expect(err).To(gomega.HaveOccurred())
+				// Verify error is AcceleratorNotFoundError
+				var notFoundErr *AcceleratorNotFoundError
+				g.Expect(err).To(gomega.BeAssignableToTypeOf(notFoundErr))
+			} else {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+
+			if tt.expectFound {
+				g.Expect(spec).NotTo(gomega.BeNil())
+				g.Expect(isClusterScoped).To(gomega.Equal(tt.expectClusterScoped))
+			} else {
+				g.Expect(spec).To(gomega.BeNil())
+			}
+
+			// Run validation function if provided
+			if tt.validateSpec != nil {
+				tt.validateSpec(t, spec)
+			}
+		})
+	}
+}
+
+func TestDefaultAcceleratorFetcher_GetAcceleratorClass_ErrorType(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Create scheme
+	scheme := runtime.NewScheme()
+	g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+
+	// Create fake client with no accelerator classes
+	c := ctrlclientfake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	// Create fetcher
+	fetcher := NewDefaultAcceleratorFetcher(c)
+
+	// Try to get non-existent accelerator class
+	spec, isClusterScoped, err := fetcher.GetAcceleratorClass(context.TODO(), "non-existent")
+
+	// Verify error
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(spec).To(gomega.BeNil())
+	g.Expect(isClusterScoped).To(gomega.BeFalse())
+
+	// Verify error type and message
+	var notFoundErr *AcceleratorNotFoundError
+	g.Expect(err).To(gomega.BeAssignableToTypeOf(notFoundErr))
+
+	acceleratorErr, ok := err.(*AcceleratorNotFoundError)
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(acceleratorErr.AcceleratorClassName).To(gomega.Equal("non-existent"))
+	g.Expect(acceleratorErr.Error()).To(gomega.ContainSubstring("accelerator class non-existent not found at cluster scope"))
+}
+
+func TestAcceleratorCollection(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Test empty collection
+	emptyCollection := &AcceleratorCollection{}
+	g.Expect(emptyCollection.ClusterAcceleratorClasses).To(gomega.BeEmpty())
+
+	// Test collection with data
+	collection := &AcceleratorCollection{
+		ClusterAcceleratorClasses: []v1beta1.AcceleratorClass{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nvidia-h100",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nvidia-a100",
+				},
+			},
+		},
+	}
+	g.Expect(collection.ClusterAcceleratorClasses).To(gomega.HaveLen(2))
+	g.Expect(collection.ClusterAcceleratorClasses[0].Name).To(gomega.Equal("nvidia-h100"))
+	g.Expect(collection.ClusterAcceleratorClasses[1].Name).To(gomega.Equal("nvidia-a100"))
+}

--- a/pkg/acceleratorclassselector/selector.go
+++ b/pkg/acceleratorclassselector/selector.go
@@ -1,0 +1,188 @@
+package acceleratorclassselector
+
+import (
+	"context"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// defaultSelector is the default implementation of the Selector interface.
+type defaultSelector struct {
+	config  *Config
+	fetcher AcceleratorFetcher
+}
+
+// New creates a new Selector with default implementations.
+func New(client client.Client) Selector {
+	config := NewConfig(client)
+	return NewWithConfig(config)
+}
+
+// NewWithConfig creates a new Selector with the provided configuration.
+func NewWithConfig(config *Config) Selector {
+	return &defaultSelector{
+		config:  config,
+		fetcher: NewDefaultAcceleratorFetcher(config.Client),
+	}
+}
+
+// GetAcceleratorClass fetches a specific accelerator class by name.
+func (s *defaultSelector) FetchAcceleratorClass(ctx context.Context, name string) (*v1beta1.AcceleratorClassSpec, bool, error) {
+	return s.fetcher.GetAcceleratorClass(ctx, name)
+}
+
+// GetAcceleratorClass selects the best accelerator class for a given inference service, runtime, and component.
+// This is a convenience function that implements the original simple selection logic.
+// The selection follows this priority order:
+//  1. If runtime doesn't contain AcceleratorRequirements, return nil
+//  2. If runtime contains AcceleratorRequirements:
+//     a. For engine component: check if engine has AcceleratorOverride with AcceleratorClass
+//     b. For decoder component: check if decoder has AcceleratorOverride with AcceleratorClass
+//     c. If component doesn't have AcceleratorOverride, check if InferenceService has AcceleratorSelector with AcceleratorClass
+//     d. Otherwise, return the first AcceleratorClass from runtime.AcceleratorRequirements
+func (s *defaultSelector) GetAcceleratorClass(ctx context.Context, isvc *v1beta1.InferenceService, runtime *v1beta1.ServingRuntimeSpec, component v1beta1.ComponentType) (*v1beta1.AcceleratorClassSpec, string, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Getting accelerator classes for inference service with runtime", "isvc", isvc.Name, "component", component, "runtime", runtime)
+	acName := ""
+	// 1. If runtime doesn't contain AcceleratorRequirements, return nil
+	if runtime == nil || runtime.AcceleratorRequirements == nil || runtime.AcceleratorRequirements.AcceleratorClasses == nil {
+		return nil, "", nil
+	}
+
+	if len(runtime.AcceleratorRequirements.AcceleratorClasses) > 0 {
+		// get accelerator class by name if specified.
+		if acceleratorClass := s.getAcceleratorClassByName(isvc, component); acceleratorClass != nil {
+			acName = *acceleratorClass
+		}
+		// if accelerator class didn't have name specified, try to get accelerator class by policy
+		if acName == "" {
+			if acceleratorClass := s.getAcceleratorClassByPolicy(isvc, runtime, component); acceleratorClass != nil {
+				acName = *acceleratorClass
+			}
+		}
+	}
+
+	// fetch and return the selected accelerator class spec
+	if acName != "" {
+		acSpec, _, err := s.fetcher.GetAcceleratorClass(ctx, acName)
+		if err != nil {
+			logger.Error(err, "Failed to fetch accelerator class", "name", acName)
+			return nil, acName, err
+		}
+		return acSpec, acName, nil
+	}
+	return nil, "", nil
+}
+
+// getAcceleratorClassByName checks for component-specific AcceleratorOverride or InferenceService-level AcceleratorSelector
+func (s *defaultSelector) getAcceleratorClassByName(isvc *v1beta1.InferenceService, component v1beta1.ComponentType) *string {
+	// Use the component-specific AcceleratorOverride as the default.
+	if acceleratorClass := s.getComponentAcceleratorOverride(isvc, component); acceleratorClass != nil {
+		return acceleratorClass
+	}
+
+	// Check InferenceService-level AcceleratorSelector if specified
+	if acceleratorClass := s.getInferenceServiceAcceleratorClass(isvc); acceleratorClass != nil {
+		return acceleratorClass
+	}
+
+	return nil
+}
+
+// TODO: Consider accelerator class selector by AcceleratorSelectionPolicy, currently only FirstAvailablePolicy is implemented
+func (s *defaultSelector) getAcceleratorClassByPolicy(isvc *v1beta1.InferenceService, runtime *v1beta1.ServingRuntimeSpec, component v1beta1.ComponentType) *string {
+	acceleratorPolicy := s.getAcceleratorPolicy(isvc, component)
+	switch acceleratorPolicy {
+	case v1beta1.BestFitPolicy:
+		return nil
+	case v1beta1.CheapestPolicy:
+		return nil
+	case v1beta1.MostCapablePolicy:
+		return nil
+	case v1beta1.FirstAvailablePolicy:
+		// Return the first AcceleratorClass from runtime requirements as default for now
+		if len(runtime.AcceleratorRequirements.AcceleratorClasses) > 0 {
+			return &runtime.AcceleratorRequirements.AcceleratorClasses[0]
+		}
+	}
+	return nil
+}
+
+// getComponentAcceleratorOverride checks if the specified component has an AcceleratorOverride with AcceleratorClass
+func (s *defaultSelector) getComponentAcceleratorOverride(isvc *v1beta1.InferenceService, component v1beta1.ComponentType) *string {
+	if isvc == nil {
+		return nil
+	}
+
+	switch component {
+	case v1beta1.EngineComponent:
+		if isvc.Spec.Engine != nil &&
+			isvc.Spec.Engine.AcceleratorOverride != nil &&
+			isvc.Spec.Engine.AcceleratorOverride.AcceleratorClass != nil {
+			return isvc.Spec.Engine.AcceleratorOverride.AcceleratorClass
+		}
+	case v1beta1.DecoderComponent:
+		if isvc.Spec.Decoder != nil &&
+			isvc.Spec.Decoder.AcceleratorOverride != nil &&
+			isvc.Spec.Decoder.AcceleratorOverride.AcceleratorClass != nil {
+			return isvc.Spec.Decoder.AcceleratorOverride.AcceleratorClass
+		}
+	}
+
+	return nil
+}
+
+// getInferenceServiceAcceleratorClass checks if the InferenceService has an AcceleratorSelector with AcceleratorClass
+func (s *defaultSelector) getInferenceServiceAcceleratorClass(isvc *v1beta1.InferenceService) *string {
+	if isvc == nil ||
+		isvc.Spec.AcceleratorSelector == nil ||
+		isvc.Spec.AcceleratorSelector.AcceleratorClass == nil {
+		return nil
+	}
+
+	return isvc.Spec.AcceleratorSelector.AcceleratorClass
+}
+
+// getComponentAcceleratorPolicy checks if the specified component has an AcceleratorOverride with Policy
+func (s *defaultSelector) getComponentAcceleratorPolicy(isvc *v1beta1.InferenceService, component v1beta1.ComponentType) v1beta1.AcceleratorSelectionPolicy {
+	if isvc == nil {
+		return ""
+	}
+
+	// Check component-specific AcceleratorOverride by first
+	switch component {
+	case v1beta1.EngineComponent:
+		if isvc.Spec.Engine != nil &&
+			isvc.Spec.Engine.AcceleratorOverride != nil &&
+			isvc.Spec.Engine.AcceleratorOverride.Policy != "" {
+			return isvc.Spec.Engine.AcceleratorOverride.Policy
+		}
+	case v1beta1.DecoderComponent:
+		if isvc.Spec.Decoder != nil &&
+			isvc.Spec.Decoder.AcceleratorOverride != nil &&
+			isvc.Spec.Decoder.AcceleratorOverride.Policy != "" {
+			return isvc.Spec.Decoder.AcceleratorOverride.Policy
+		}
+	}
+
+	// if component-specific AcceleratorOverride not found, check InferenceService-level AcceleratorSelector
+	if isvc.Spec.AcceleratorSelector != nil &&
+		isvc.Spec.AcceleratorSelector.Policy != "" {
+		return isvc.Spec.AcceleratorSelector.Policy
+	}
+
+	return ""
+}
+
+// getAcceleratorPolicy determines the effective AcceleratorSelectionPolicy for the given component and InferenceService
+// defaulting to the selector's configured default policy if none is specified
+func (s *defaultSelector) getAcceleratorPolicy(isvc *v1beta1.InferenceService, component v1beta1.ComponentType) v1beta1.AcceleratorSelectionPolicy {
+	// Check component-specific AcceleratorOverride
+	if policy := s.getComponentAcceleratorPolicy(isvc, component); policy != "" {
+		return policy
+	}
+
+	return s.config.DefaultPolicy
+}

--- a/pkg/acceleratorclassselector/types.go
+++ b/pkg/acceleratorclassselector/types.go
@@ -1,0 +1,70 @@
+package acceleratorclassselector
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+)
+
+// Selector is the main interface for accelerator class selection.
+// It provides methods to select, validate, and list compatible accelerator classes.
+type Selector interface {
+	// GetAcceleratorClass selects the best accelerator class for a given inference service, runtime, and component.
+	// Returns the accelerator class spec, the accelerator class name, and an error if the fetch fails.
+	GetAcceleratorClass(ctx context.Context, isvc *v1beta1.InferenceService, runtime *v1beta1.ServingRuntimeSpec, component v1beta1.ComponentType) (*v1beta1.AcceleratorClassSpec, string, error)
+}
+
+// AcceleratorSelection represents the selected accelerator class with metadata.
+type AcceleratorSelection struct {
+	// Name is the name of the selected accelerator class
+	Name string
+
+	// Spec is the accelerator class specification
+	Spec *v1beta1.AcceleratorClassSpec
+
+	// NodeSelector that should be applied to pods
+	NodeSelector map[string]string
+
+	// ResourceRequests that should be applied to pods
+	ResourceRequests map[string]string
+}
+
+// AcceleratorFetcher abstracts the fetching of accelerator class resources.
+type AcceleratorFetcher interface {
+	// FetchAcceleratorClasses returns both namespace and cluster scoped accelerator classes.
+	FetchAcceleratorClasses(ctx context.Context) (*AcceleratorCollection, error)
+
+	// GetAcceleratorClass fetches a specific accelerator class by name.
+	// It first checks namespace-scoped accelerator classes, then cluster-scoped ones.
+	GetAcceleratorClass(ctx context.Context, name string) (*v1beta1.AcceleratorClassSpec, bool, error)
+}
+
+// AcceleratorCollection holds both namespace and cluster scoped accelerator classes.
+type AcceleratorCollection struct {
+
+	// ClusterAcceleratorClasses contains cluster-scoped AcceleratorClasses
+	ClusterAcceleratorClasses []v1beta1.AcceleratorClass
+}
+
+// Config holds configuration for the accelerator class selector.
+type Config struct {
+	// Client is the Kubernetes client (uses controller-runtime cache)
+	Client client.Client
+
+	// EnableDetailedLogging enables verbose logging for debugging
+	EnableDetailedLogging bool
+
+	// DefaultPriority is used when an accelerator class doesn't specify priority
+	DefaultPolicy v1beta1.AcceleratorSelectionPolicy
+}
+
+// NewConfig creates a new Config with default values.
+func NewConfig(client client.Client) *Config {
+	return &Config{
+		Client:                client,
+		EnableDetailedLogging: false,
+		DefaultPolicy:         v1beta1.FirstAvailablePolicy,
+	}
+}

--- a/pkg/apis/ome/v1beta1/inference_service.go
+++ b/pkg/apis/ome/v1beta1/inference_service.go
@@ -68,7 +68,6 @@ type AcceleratorSelector struct {
 
 	// Policy defines the selection policy when multiple accelerators match
 	// +kubebuilder:validation:Enum=BestFit;Cheapest;MostCapable;FirstAvailable
-	// +kubebuilder:default=BestFit
 	// +optional
 	Policy AcceleratorSelectionPolicy `json:"policy,omitempty"`
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/builder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/builder.go
@@ -25,6 +25,9 @@ type ComponentBuilder struct {
 	baseModelMeta          *metav1.ObjectMeta
 	runtime                *v1beta1.ServingRuntimeSpec
 	runtimeName            string
+	supportedModelFormat   *v1beta1.SupportedModelFormat
+	acceleratorClass       *v1beta1.AcceleratorClassSpec
+	acceleratorClassName   string
 	logger                 logr.Logger
 }
 
@@ -70,6 +73,19 @@ func (b *ComponentBuilder) WithLogger(logger logr.Logger) *ComponentBuilder {
 	return b
 }
 
+// WithAcceleratorClass sets the accelerator class
+func (b *ComponentBuilder) WithAcceleratorClass(acceleratorClass *v1beta1.AcceleratorClassSpec, acceleratorClassName string) *ComponentBuilder {
+	b.acceleratorClass = acceleratorClass
+	b.acceleratorClassName = acceleratorClassName
+	return b
+}
+
+// WithSupportedModelFormat sets the supported model format
+func (b *ComponentBuilder) WithSupportedModelFormat(format *v1beta1.SupportedModelFormat) *ComponentBuilder {
+	b.supportedModelFormat = format
+	return b
+}
+
 // buildBaseFields creates the common base fields
 func (b *ComponentBuilder) buildBaseFields() BaseComponentFields {
 	return BaseComponentFields{
@@ -101,6 +117,9 @@ func (b *ComponentBuilder) BuildEngine(spec *v1beta1.EngineSpec) Component {
 		spec,
 		b.runtime,
 		b.runtimeName,
+		b.supportedModelFormat,
+		b.acceleratorClass,
+		b.acceleratorClassName,
 	)
 }
 
@@ -118,6 +137,9 @@ func (b *ComponentBuilder) BuildDecoder(spec *v1beta1.DecoderSpec) Component {
 		spec,
 		b.runtime,
 		b.runtimeName,
+		b.supportedModelFormat,
+		b.acceleratorClass,
+		b.acceleratorClassName,
 	)
 }
 
@@ -184,11 +206,16 @@ func (f *ComponentBuilderFactory) CreateEngineComponent(
 	engineSpec *v1beta1.EngineSpec,
 	runtime *v1beta1.ServingRuntimeSpec,
 	runtimeName string,
+	supportedModelFormat *v1beta1.SupportedModelFormat,
+	acceleratorClass *v1beta1.AcceleratorClassSpec,
+	acceleratorClassName string,
 ) Component {
 	return f.NewBuilder().
 		WithDeploymentMode(deploymentMode).
 		WithBaseModel(baseModel, baseModelMeta).
 		WithRuntime(runtime, runtimeName).
+		WithAcceleratorClass(acceleratorClass, acceleratorClassName).
+		WithSupportedModelFormat(supportedModelFormat).
 		BuildEngine(engineSpec)
 }
 
@@ -200,11 +227,16 @@ func (f *ComponentBuilderFactory) CreateDecoderComponent(
 	decoderSpec *v1beta1.DecoderSpec,
 	runtime *v1beta1.ServingRuntimeSpec,
 	runtimeName string,
+	supportedModelFormat *v1beta1.SupportedModelFormat,
+	acceleratorClass *v1beta1.AcceleratorClassSpec,
+	acceleratorClassName string,
 ) Component {
 	return f.NewBuilder().
 		WithDeploymentMode(deploymentMode).
 		WithBaseModel(baseModel, baseModelMeta).
 		WithRuntime(runtime, runtimeName).
+		WithAcceleratorClass(acceleratorClass, acceleratorClassName).
+		WithSupportedModelFormat(supportedModelFormat).
 		BuildDecoder(decoderSpec)
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/components/component.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/component.go
@@ -13,13 +13,6 @@ type Component interface {
 	Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, error)
 }
 
-// ComponentType constants for different component types
-const (
-	ComponentTypePredictor = "predictor"
-	ComponentTypeEngine    = "engine"
-	ComponentTypeDecoder   = "decoder"
-)
-
 // ComponentConfig defines the interface for component-specific configuration
 type ComponentConfig interface {
 	// GetComponentType returns the component type (engine, decoder, etc.)

--- a/pkg/controller/v1beta1/inferenceservice/components/engine_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine_test.go
@@ -585,6 +585,9 @@ func TestEngineReconcile(t *testing.T) {
 				tt.engineSpec,
 				nil, // runtime
 				tt.runtimeName,
+				nil, // supportedModelFormat
+				nil, // acceleratorClass
+				"",  // acceleratorClassName
 			).(*Engine)
 
 			// Set fine-tuned fields if needed
@@ -763,6 +766,9 @@ func TestEngineReconcileObjectMeta(t *testing.T) {
 				tt.engineSpec,
 				nil, // runtime
 				tt.runtimeName,
+				nil, // supportedModelFormat
+				nil, // acceleratorClass
+				"",  // acceleratorClassName
 			).(*Engine)
 
 			// Set fine-tuned fields if needed
@@ -899,6 +905,9 @@ func TestEngineWorkerPodSpec(t *testing.T) {
 				tt.engineSpec,
 				nil, // runtime
 				"",  // runtimeName
+				nil, // supportedModelFormat
+				nil, // acceleratorClass
+				"",  // acceleratorClassName
 			).(*Engine)
 
 			podSpec, err := engine.reconcileWorkerPodSpec(isvc, objectMeta)

--- a/pkg/controller/v1beta1/inferenceservice/components/router.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/router.go
@@ -24,6 +24,7 @@ import (
 )
 
 var _ Component = &Router{}
+var _ ComponentConfig = &Router{}
 
 // Router reconciles resources for the router component
 type Router struct {
@@ -261,4 +262,31 @@ func (r *Router) reconcilePodSpec(isvc *v1beta1.InferenceService, objectMeta *me
 
 	r.Log.Info("Router PodSpec updated", "inference service", isvc.Name, "namespace", isvc.Namespace)
 	return podSpec, nil
+}
+
+// GetComponentType implements ComponentConfig interface
+func (r *Router) GetComponentType() v1beta1.ComponentType {
+	return v1beta1.RouterComponent
+}
+
+// GetComponentSpec implements ComponentConfig interface
+func (r *Router) GetComponentSpec() *v1beta1.ComponentExtensionSpec {
+	if r.routerSpec == nil {
+		return nil
+	}
+	return &r.routerSpec.ComponentExtensionSpec
+}
+
+// GetServiceSuffix implements ComponentConfig interface
+func (r *Router) GetServiceSuffix() string {
+	return "-router"
+}
+
+// ValidateSpec implements ComponentConfig interface
+func (r *Router) ValidateSpec() error {
+	if r.routerSpec == nil {
+		return errors.New("router spec is nil")
+	}
+	// Add more validation logic as needed
+	return nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	lws "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
+	"github.com/sgl-project/ome/pkg/acceleratorclassselector"
 	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
 	"github.com/sgl-project/ome/pkg/constants"
 	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/status"
@@ -706,14 +707,15 @@ func TestInferenceServiceReconcile(t *testing.T) {
 
 			// Create reconciler
 			reconciler := &InferenceServiceReconciler{
-				Client:          c,
-				ClientConfig:    &rest.Config{},
-				Clientset:       clientset,
-				Log:             ctrl.Log.WithName("test"),
-				Scheme:          scheme,
-				Recorder:        recorder,
-				StatusManager:   status.NewStatusReconciler(),
-				RuntimeSelector: runtimeselector.New(c),
+				Client:                   c,
+				ClientConfig:             &rest.Config{},
+				Clientset:                clientset,
+				Log:                      ctrl.Log.WithName("test"),
+				Scheme:                   scheme,
+				Recorder:                 recorder,
+				StatusManager:            status.NewStatusReconciler(),
+				RuntimeSelector:          runtimeselector.New(c),
+				AcceleratorClassSelector: acceleratorclassselector.New(c),
 			}
 
 			// Ensure the InferenceService exists in the client

--- a/pkg/controller/v1beta1/inferenceservice/utils/container.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/container.go
@@ -60,6 +60,15 @@ func UpdateEnvVars(container *v1.Container, envVar *v1.EnvVar) {
 	}
 }
 
+func AppendEnvVarIfNotExist(container *v1.Container, envVar *v1.EnvVar) {
+	for i := range container.Env {
+		if container.Env[i].Name == envVar.Name {
+			return
+		}
+	}
+	container.Env = append(container.Env, *envVar)
+}
+
 // GetGpuCountFromContainer extracts the GPU count from container resources.
 // It checks both Limits and Requests, preferring Limits.
 func GetGpuCountFromContainer(container *v1.Container) int {

--- a/pkg/controller/v1beta1/inferenceservice/utils/merging_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/merging_test.go
@@ -1,0 +1,233 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeMultilineArgs(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerArgs []string
+		overrideArgs  []string
+		expected      []string
+	}{
+		{
+			name: "Merge multiline args with backslash continuation",
+			containerArgs: []string{`python3 -m sglang.launch_server \
+--host=0.0.0.0 \
+--port=8080 \
+--enable-metrics \
+--log-requests \
+--model-path="$MODEL_PATH" \
+--mem-frac=0.9`},
+			overrideArgs: []string{`--tp-size=4`},
+			expected: []string{`python3 -m sglang.launch_server \
+--host=0.0.0.0 \
+--port=8080 \
+--enable-metrics \
+--log-requests \
+--model-path="$MODEL_PATH" \
+--mem-frac=0.9 \
+--tp-size=4`},
+		},
+		{
+			name: "Merge multiline args without trailing backslash",
+			containerArgs: []string{`python3 -m sglang.launch_server \
+--host=0.0.0.0 \
+--mem-frac=0.9`},
+			overrideArgs: []string{`--tp-size=8`},
+			expected: []string{`python3 -m sglang.launch_server \
+--host=0.0.0.0 \
+--mem-frac=0.9 \
+--tp-size=8`},
+		},
+		{
+			name:          "Empty override args returns container args",
+			containerArgs: []string{`python3 -m server`},
+			overrideArgs:  []string{},
+			expected:      []string{`python3 -m server`},
+		},
+		{
+			name:          "Empty container args returns override args",
+			containerArgs: []string{},
+			overrideArgs:  []string{`--tp-size=4`},
+			expected:      []string{`--tp-size=4`},
+		},
+		{
+			name:          "Single-line args are appended",
+			containerArgs: []string{`python3 -m server`},
+			overrideArgs:  []string{`--debug`},
+			expected:      []string{`python3 -m server`, `--debug`},
+		},
+		{
+			name: "Multiple override args",
+			containerArgs: []string{`python3 -m sglang.launch_server \
+--host=0.0.0.0`},
+			overrideArgs: []string{`--tp-size=4`, `--pp-size=2`},
+			expected: []string{`python3 -m sglang.launch_server \
+--host=0.0.0.0 \
+--tp-size=4
+--pp-size=2`},
+		},
+		{
+			name: "Container args with multiple elements",
+			containerArgs: []string{`python3 -m server \
+--port=8080`, `extra-arg`},
+			overrideArgs: []string{`--tp-size=4`},
+			expected: []string{`python3 -m server \
+--port=8080 \
+--tp-size=4`, `extra-arg`},
+		},
+		{
+			name:          "Multiline args with newlines",
+			containerArgs: []string{"python3 -m sglang.launch_server\n--host=0.0.0.0\n--port=8080"},
+			overrideArgs:  []string{`--tp-size=4`},
+			expected:      []string{"python3 -m sglang.launch_server\n--host=0.0.0.0\n--port=8080 \\\n--tp-size=4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MergeMultilineArgs(tt.containerArgs, tt.overrideArgs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestOverrideIntParam(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerArgs []string
+		key           string
+		value         int64
+		expectedArgs  []string
+		expectedFound bool
+	}{
+		{
+			name: "Override existing parameter with equals sign",
+			containerArgs: []string{`python3 -m sglang.launch_server \
+--host=0.0.0.0 \
+--tp-size=4 \
+--mem-frac=0.9`},
+			key:   "--tp-size",
+			value: 8,
+			expectedArgs: []string{`python3 -m sglang.launch_server \
+--host=0.0.0.0 \
+--tp-size=8 \
+--mem-frac=0.9`},
+			expectedFound: true,
+		},
+		{
+			name: "Override existing parameter with space",
+			containerArgs: []string{`python3 -m server \
+--tp-size 4 \
+--mem-frac=0.9`},
+			key:   "--tp-size",
+			value: 8,
+			expectedArgs: []string{`python3 -m server \
+--tp-size=8 \
+--mem-frac=0.9`},
+			expectedFound: true,
+		},
+		{
+			name: "Parameter not found",
+			containerArgs: []string{`python3 -m server \
+--host=0.0.0.0`},
+			key:   "--tp-size",
+			value: 8,
+			expectedArgs: []string{`python3 -m server \
+--host=0.0.0.0`},
+			expectedFound: false,
+		},
+		{
+			name:          "Empty container args",
+			containerArgs: []string{},
+			key:           "--tp-size",
+			value:         8,
+			expectedArgs:  []string{},
+			expectedFound: false,
+		},
+		{
+			name: "Override pipeline parallel size",
+			containerArgs: []string{`python3 -m server \
+--pp-size=2 \
+--tp-size=4`},
+			key:   "--pp-size",
+			value: 4,
+			expectedArgs: []string{`python3 -m server \
+--pp-size=4 \
+--tp-size=4`},
+			expectedFound: true,
+		},
+		{
+			name: "Override tensor-parallel-size (long form)",
+			containerArgs: []string{`python3 -m server \
+--tensor-parallel-size=4`},
+			key:   "--tensor-parallel-size",
+			value: 8,
+			expectedArgs: []string{`python3 -m server \
+--tensor-parallel-size=8`},
+			expectedFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, found := OverrideIntParam(tt.containerArgs, tt.key, tt.value)
+			assert.Equal(t, tt.expectedFound, found)
+			assert.Equal(t, tt.expectedArgs, result)
+		})
+	}
+}
+
+func TestMergeMultilineArgsEdgeCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerArgs []string
+		overrideArgs  []string
+		expected      []string
+	}{
+		{
+			name:          "Nil container args",
+			containerArgs: nil,
+			overrideArgs:  []string{`--tp-size=4`},
+			expected:      []string{`--tp-size=4`},
+		},
+		{
+			name:          "Nil override args",
+			containerArgs: []string{`python3 -m server`},
+			overrideArgs:  nil,
+			expected:      []string{`python3 -m server`},
+		},
+		{
+			name:          "Both nil",
+			containerArgs: nil,
+			overrideArgs:  nil,
+			expected:      nil,
+		},
+		{
+			name:          "Both empty",
+			containerArgs: []string{},
+			overrideArgs:  []string{},
+			expected:      []string{},
+		},
+		{
+			name: "Override with whitespace",
+			containerArgs: []string{`python3 -m server \
+--port=8080`},
+			overrideArgs: []string{`  --tp-size=4  `},
+			expected: []string{`python3 -m server \
+--port=8080 \
+--tp-size=4`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MergeMultilineArgs(tt.containerArgs, tt.overrideArgs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/reconciliation.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/reconciliation.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
+
 	goerrors "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +66,7 @@ func ReconcileBaseModel(cl client.Client, isvc *v1beta1.InferenceService) (*v1be
 }
 
 // MergeRuntimeSpecs merges the runtime and isvc specs to get final engine, decoder, and router specs
-func MergeRuntimeSpecs(isvc *v1beta1.InferenceService, runtime *v1beta1.ServingRuntimeSpec) (*v1beta1.EngineSpec, *v1beta1.DecoderSpec, *v1beta1.RouterSpec, error) {
+func MergeRuntimeSpecs(isvc *v1beta1.InferenceService, runtime *v1beta1.ServingRuntimeSpec, log logr.Logger) (*v1beta1.EngineSpec, *v1beta1.DecoderSpec, *v1beta1.RouterSpec, error) {
 	var runtimeEngine *v1beta1.EngineSpec
 	var runtimeDecoder *v1beta1.DecoderSpec
 	var runtimeRouter *v1beta1.RouterSpec

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1842,7 +1842,7 @@ func schema_pkg_apis_ome_v1beta1_ComponentExtensionSpec(ref common.ReferenceCall
 					},
 					"minAvailable": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MinAvailiable specifies how many component pods must still be aviliable after the eviction",
+							Description: "MinAvailable specifies how many component pods must still be available after the eviction",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
@@ -2515,7 +2515,7 @@ func schema_pkg_apis_ome_v1beta1_DecoderSpec(ref common.ReferenceCallback) commo
 					},
 					"minAvailable": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MinAvailiable specifies how many component pods must still be aviliable after the eviction",
+							Description: "MinAvailable specifies how many component pods must still be available after the eviction",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
@@ -3190,7 +3190,7 @@ func schema_pkg_apis_ome_v1beta1_EngineSpec(ref common.ReferenceCallback) common
 					},
 					"minAvailable": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MinAvailiable specifies how many component pods must still be aviliable after the eviction",
+							Description: "MinAvailable specifies how many component pods must still be available after the eviction",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
@@ -6595,7 +6595,7 @@ func schema_pkg_apis_ome_v1beta1_PredictorSpec(ref common.ReferenceCallback) com
 					},
 					"minAvailable": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MinAvailiable specifies how many component pods must still be aviliable after the eviction",
+							Description: "MinAvailable specifies how many component pods must still be available after the eviction",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
@@ -7188,7 +7188,7 @@ func schema_pkg_apis_ome_v1beta1_RouterSpec(ref common.ReferenceCallback) common
 					},
 					"minAvailable": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MinAvailiable specifies how many component pods must still be aviliable after the eviction",
+							Description: "MinAvailable specifies how many component pods must still be available after the eviction",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -966,7 +966,7 @@
           "$ref": "#/definitions/k8s.io.apimachinery.pkg.util.intstr.IntOrString"
         },
         "minAvailable": {
-          "description": "MinAvailiable specifies how many component pods must still be aviliable after the eviction",
+          "description": "MinAvailable specifies how many component pods must still be available after the eviction",
           "$ref": "#/definitions/k8s.io.apimachinery.pkg.util.intstr.IntOrString"
         },
         "minReplicas": {
@@ -1207,7 +1207,7 @@
           "$ref": "#/definitions/k8s.io.apimachinery.pkg.util.intstr.IntOrString"
         },
         "minAvailable": {
-          "description": "MinAvailiable specifies how many component pods must still be aviliable after the eviction",
+          "description": "MinAvailable specifies how many component pods must still be available after the eviction",
           "$ref": "#/definitions/k8s.io.apimachinery.pkg.util.intstr.IntOrString"
         },
         "minReplicas": {
@@ -1600,7 +1600,7 @@
           "$ref": "#/definitions/k8s.io.apimachinery.pkg.util.intstr.IntOrString"
         },
         "minAvailable": {
-          "description": "MinAvailiable specifies how many component pods must still be aviliable after the eviction",
+          "description": "MinAvailable specifies how many component pods must still be available after the eviction",
           "$ref": "#/definitions/k8s.io.apimachinery.pkg.util.intstr.IntOrString"
         },
         "minReplicas": {
@@ -3506,7 +3506,7 @@
           "$ref": "#/definitions/k8s.io.apimachinery.pkg.util.intstr.IntOrString"
         },
         "minAvailable": {
-          "description": "MinAvailiable specifies how many component pods must still be aviliable after the eviction",
+          "description": "MinAvailable specifies how many component pods must still be available after the eviction",
           "$ref": "#/definitions/k8s.io.apimachinery.pkg.util.intstr.IntOrString"
         },
         "minReplicas": {
@@ -3861,7 +3861,7 @@
           "$ref": "#/definitions/k8s.io.apimachinery.pkg.util.intstr.IntOrString"
         },
         "minAvailable": {
-          "description": "MinAvailiable specifies how many component pods must still be aviliable after the eviction",
+          "description": "MinAvailable specifies how many component pods must still be available after the eviction",
           "$ref": "#/definitions/k8s.io.apimachinery.pkg.util.intstr.IntOrString"
         },
         "minReplicas": {

--- a/pkg/runtimeselector/scorer.go
+++ b/pkg/runtimeselector/scorer.go
@@ -47,7 +47,7 @@ func (s *DefaultRuntimeScorer) CalculateScore(runtime *v1beta1.ServingRuntimeSpe
 		}
 
 		// Calculate score for this format
-		score := s.calculateFormatScore(model, supportedFormat, priority)
+		score := s.CalculateFormatScore(model, supportedFormat, priority)
 
 		if score > maxScore {
 			maxScore = score
@@ -101,7 +101,7 @@ func (s *DefaultRuntimeScorer) CompareRuntimes(r1, r2 RuntimeMatch, model *v1bet
 
 // calculateFormatScore calculates the score for a specific supported format.
 // This matches the exact logic from the original score() function.
-func (s *DefaultRuntimeScorer) calculateFormatScore(model *v1beta1.BaseModelSpec, supportedFormat v1beta1.SupportedModelFormat, priority int64) int64 {
+func (s *DefaultRuntimeScorer) CalculateFormatScore(model *v1beta1.BaseModelSpec, supportedFormat v1beta1.SupportedModelFormat, priority int64) int64 {
 	// Compare model format
 	modelFormatMatches := false
 	if supportedFormat.ModelFormat != nil && &model.ModelFormat.Name != nil {

--- a/pkg/runtimeselector/selector.go
+++ b/pkg/runtimeselector/selector.go
@@ -316,3 +316,22 @@ func getModelName(model *v1beta1.BaseModelSpec) string {
 	}
 	return "unknown"
 }
+
+func (s *defaultSelector) GetSupportedModelFormat(ctx context.Context, runtime *v1beta1.ServingRuntimeSpec, model *v1beta1.BaseModelSpec) *v1beta1.SupportedModelFormat {
+	if runtime.SupportedModelFormats == nil {
+		return nil
+	}
+	maxScore := int64(0)
+	bestSupportedFormat := v1beta1.SupportedModelFormat{}
+	for _, supportedFormat := range runtime.SupportedModelFormats {
+		score := s.scorer.CalculateFormatScore(model, supportedFormat, int64(s.config.DefaultPriority))
+		if score > maxScore {
+			maxScore = score
+			bestSupportedFormat = supportedFormat
+		}
+	}
+	if maxScore > 0 {
+		return &bestSupportedFormat
+	}
+	return nil
+}

--- a/pkg/runtimeselector/types.go
+++ b/pkg/runtimeselector/types.go
@@ -27,6 +27,8 @@ type Selector interface {
 	// GetRuntime fetches a specific runtime by name.
 	// Returns the runtime spec and whether it's cluster-scoped.
 	GetRuntime(ctx context.Context, name string, namespace string) (*v1beta1.ServingRuntimeSpec, bool, error)
+
+	GetSupportedModelFormat(ctx context.Context, runtime *v1beta1.ServingRuntimeSpec, model *v1beta1.BaseModelSpec) *v1beta1.SupportedModelFormat
 }
 
 // RuntimeSelection represents the selected runtime with metadata.
@@ -138,6 +140,10 @@ type RuntimeScorer interface {
 	// CompareRuntimes compares two runtimes for a given model.
 	// Returns positive if r1 is better, negative if r2 is better, 0 if equal.
 	CompareRuntimes(r1, r2 RuntimeMatch, model *v1beta1.BaseModelSpec) int
+
+	// CalculateFormatScore calculates the score contribution for a specific model format.
+	// Higher scores indicate better matches.
+	CalculateFormatScore(model *v1beta1.BaseModelSpec, supportedFormat v1beta1.SupportedModelFormat, priority int64) int64
 }
 
 // Config holds configuration for the runtime selector.


### PR DESCRIPTION
## What type of PR is this?

/kind feature
/kind design

## What this PR does / why we need it:

Integrates accelerator-aware runtime selection into the InferenceService controller to automatically match workloads with appropriate GPU/accelerator hardware.

1. add acceleratorclassselector in pkg/acceleratorclassselector
Selector logic : Implements priority-based accelerator class selection for inference components (engine/decoder)
Priority: Component override → InferenceService selector → Runtime requirements
Fetcher: Queries cluster-scoped AcceleratorClass resources from Kubernetes API
Type definitions: Interfaces and data structures for accelerator selection
Error handling : Custom error types for not-found and compatibility issues

2. Controller Integration:
Added AcceleratorClassSelector to InferenceServiceReconciler
Selects accelerator classes for engine and decoder components during reconciliation
Passes accelerator specs to component builders

3. Component Enhancements and Spec Merging Logic: 
Base/Engine/Decoder: Extended to accept accelerator class specs and names
New utilities to merge runtime and InferenceService specs 
Handles accelerator requirements, resource requests, and node selectors
The main merging logic is:
args: customer's args + runtime
env: customer's env + runtime 
resource: choice the max number from customer's setting, runtime, AC
nodeSelector: customer's + AC

4. Remove default value for AcceleratorSelectionPolicy
the current main AC select logic is:
Implements priority-based accelerator class selection for inference components (engine/decoder)
if no AC specified, ac selection based on policy.
here is a following improvment for policy selection.

## Does this PR introduce a user-facing change?

None, all field is optional. If customer doesn't set it, they won't meet any different behavior.
