### PR TITLE
[API][Misc] Add new model capabilities and update its determination logic

### DIFF
--- a/pkg/apis/ome/v1beta1/model.go
+++ b/pkg/apis/ome/v1beta1/model.go
@@ -199,17 +199,26 @@ const (
 )
 
 // ModelCapability enum
-// +kubebuilder:validation:Enum=TEXT_GENERATION;TEXT_SUMMARIZATION;TEXT_EMBEDDINGS;TEXT_RERANK;CHAT
+// TODO: Remove legacy capabilities
+//
+// +kubebuilder:validation:Enum=TEXT_GENERATION;TEXT_SUMMARIZATION;TEXT_EMBEDDINGS;TEXT_RERANK;CHAT;VISION;EMBEDDING;RERANK;TEXT_TO_TEXT;IMAGE_TEXT_TO_TEXT
 type ModelCapability string
 
 const (
+	// Legacy capabilities (to be deprecated)
 	ModelCapabilityTextGeneration    ModelCapability = "TEXT_GENERATION"
 	ModelCapabilityTextSummarization ModelCapability = "TEXT_SUMMARIZATION"
 	ModelCapabilityTextEmbeddings    ModelCapability = "TEXT_EMBEDDINGS"
 	ModelCapabilityTextRerank        ModelCapability = "TEXT_RERANK"
 	ModelCapabilityChat              ModelCapability = "CHAT"
 	ModelCapabilityVision            ModelCapability = "VISION"
-	ModelCapabilityUnknown           ModelCapability = ""
+
+	// New capabilities (preferred naming)
+	ModelCapabilityEmbedding       ModelCapability = "EMBEDDING"
+	ModelCapabilityRerank          ModelCapability = "RERANK"
+	ModelCapabilityTextToText      ModelCapability = "TEXT_TO_TEXT"
+	ModelCapabilityImageTextToText ModelCapability = "IMAGE_TEXT_TO_TEXT"
+	ModelCapabilityUnknown         ModelCapability = ""
 )
 
 // ModelWeightStatus enum

--- a/pkg/modelagent/config_parser_test.go
+++ b/pkg/modelagent/config_parser_test.go
@@ -87,7 +87,7 @@ func TestExtractModelMetadataFromHF(t *testing.T) {
 					metadata.ModelFormat.Name == "safetensors" &&
 					*metadata.ModelFormat.Version == "1.0.0"
 			},
-			expectedCapability:   string(v1beta1.ModelCapabilityChat),
+			expectedCapability:   string(v1beta1.ModelCapabilityTextToText),
 			expectedQuantization: "", // No quantization
 		},
 		{
@@ -109,7 +109,7 @@ func TestExtractModelMetadataFromHF(t *testing.T) {
 					metadata.ModelParameterSize == "8B" &&
 					metadata.MaxTokens == 32768
 			},
-			expectedCapability:   string(v1beta1.ModelCapabilityChat),
+			expectedCapability:   string(v1beta1.ModelCapabilityTextToText),
 			expectedQuantization: v1beta1.ModelQuantizationINT4,
 		},
 		{
@@ -130,7 +130,7 @@ func TestExtractModelMetadataFromHF(t *testing.T) {
 					metadata.ModelArchitecture == "PhiForCausalLM" &&
 					metadata.ModelParameterSize == "2.8B"
 			},
-			expectedCapability:   string(v1beta1.ModelCapabilityChat),
+			expectedCapability:   string(v1beta1.ModelCapabilityTextToText),
 			expectedQuantization: v1beta1.ModelQuantizationFP8,
 		},
 		{
@@ -151,7 +151,7 @@ func TestExtractModelMetadataFromHF(t *testing.T) {
 					metadata.ModelArchitecture == "CLIPModel" &&
 					metadata.ModelParameterSize == "400M"
 			},
-			expectedCapability:   string(v1beta1.ModelCapabilityVision),
+			expectedCapability:   string(v1beta1.ModelCapabilityImageTextToText),
 			expectedQuantization: "",
 		},
 		{
@@ -173,7 +173,7 @@ func TestExtractModelMetadataFromHF(t *testing.T) {
 					metadata.ModelFramework.Name == "transformers" &&
 					metadata.ModelFramework.Version == nil // Should be nil when missing
 			},
-			expectedCapability:   string(v1beta1.ModelCapabilityTextEmbeddings),
+			expectedCapability:   string(v1beta1.ModelCapabilityEmbedding),
 			expectedQuantization: "",
 		},
 	}
@@ -246,7 +246,7 @@ func TestDetermineModelCapabilitiesFromHF(t *testing.T) {
 				architecture: "LlamaForCausalLM",
 				hasVision:    false,
 			},
-			expectedCapabilities: []string{string(v1beta1.ModelCapabilityChat)},
+			expectedCapabilities: []string{string(v1beta1.ModelCapabilityTextToText)},
 		},
 		{
 			name: "Vision Model",
@@ -255,7 +255,7 @@ func TestDetermineModelCapabilitiesFromHF(t *testing.T) {
 				architecture: "CLIPModel",
 				hasVision:    true,
 			},
-			expectedCapabilities: []string{string(v1beta1.ModelCapabilityVision)},
+			expectedCapabilities: []string{string(v1beta1.ModelCapabilityImageTextToText)},
 		},
 		{
 			name: "Text Embedding Model",
@@ -264,7 +264,7 @@ func TestDetermineModelCapabilitiesFromHF(t *testing.T) {
 				architecture: "BertModel",
 				hasVision:    false,
 			},
-			expectedCapabilities: []string{string(v1beta1.ModelCapabilityTextEmbeddings)},
+			expectedCapabilities: []string{string(v1beta1.ModelCapabilityEmbedding)},
 		},
 		{
 			name: "Sentence Transformer Model",
@@ -273,7 +273,7 @@ func TestDetermineModelCapabilitiesFromHF(t *testing.T) {
 				architecture: "SentenceTransformerModel",
 				hasVision:    false,
 			},
-			expectedCapabilities: []string{string(v1beta1.ModelCapabilityTextEmbeddings)},
+			expectedCapabilities: []string{string(v1beta1.ModelCapabilityEmbedding)},
 		},
 		{
 			name: "Special Case Mistral Embedding Model",
@@ -282,7 +282,7 @@ func TestDetermineModelCapabilitiesFromHF(t *testing.T) {
 				architecture: "MistralModel", // Not MistralForCausalLM
 				hasVision:    false,
 			},
-			expectedCapabilities: []string{string(v1beta1.ModelCapabilityTextEmbeddings)},
+			expectedCapabilities: []string{string(v1beta1.ModelCapabilityEmbedding)},
 		},
 		{
 			name: "Vision-capable LLM",
@@ -291,7 +291,7 @@ func TestDetermineModelCapabilitiesFromHF(t *testing.T) {
 				architecture: "GemmaForCausalLM",
 				hasVision:    true,
 			},
-			expectedCapabilities: []string{string(v1beta1.ModelCapabilityVision)},
+			expectedCapabilities: []string{string(v1beta1.ModelCapabilityImageTextToText)},
 		},
 	}
 
@@ -455,7 +455,7 @@ func TestUpdateModelSpec(t *testing.T) {
 		ModelType:          "llama",
 		ModelArchitecture:  "LlamaForCausalLM",
 		ModelParameterSize: "7B",
-		ModelCapabilities:  []string{string(v1beta1.ModelCapabilityChat)},
+		ModelCapabilities:  []string{string(v1beta1.ModelCapabilityTextToText)},
 	}
 
 	// Basic test: Empty spec gets fields set
@@ -473,7 +473,7 @@ func TestUpdateModelSpec(t *testing.T) {
 	assert.Equal(t, "7B", *emptySpec.ModelParameterSize)
 
 	// Verify slice
-	assert.Equal(t, []string{string(v1beta1.ModelCapabilityChat)}, emptySpec.ModelCapabilities)
+	assert.Equal(t, []string{string(v1beta1.ModelCapabilityTextToText)}, emptySpec.ModelCapabilities)
 
 	// Test that existing values aren't overwritten
 	existingType := "something-else"


### PR DESCRIPTION
## What type of PR is this?
/kind feature


## What this PR does / why we need it:
1. Added official capability names that align with industry standards (particularly HuggingFace):

- EMBEDDING - For text embedding models
- RERANK - For reranking models
- TEXT_TO_TEXT - For general text generation/chat models
- IMAGE_TEXT_TO_TEXT - For vision-language models

The legacy capabilities (TEXT_GENERATION, TEXT_SUMMARIZATION, TEXT_EMBEDDINGS, TEXT_RERANK, CHAT, VISION) are preserved for backward compatibility but marked for future deprecation.

2. Refactored Capability Determination Logic
- Removed unreachable code: The old logic had an if-else chain where the TEXT_GENERATION capability could never be reached due to the preceding conditions always matching first;
- Migrated to use new capability names.

3. Updated unit tests


## Does this PR introduce a user-facing change?
Yes

Model capabilities are now reported using standardized names aligned with HuggingFace conventions. Models will now return capabilities such as `TEXT_TO_TEXT` (instead of `CHAT`), `EMBEDDING` (instead of `TEXT_EMBEDDINGS`), and `IMAGE_TEXT_TO_TEXT` (instead of `VISION`). The old capability names remain supported for backward compatibility but are considered legacy, and users can still pass old capability names in the model spec.
