### PR TITLE
[Misc] Add more OCI instance types in instance_type_util

### DIFF
--- a/pkg/utils/instance_type_util.go
+++ b/pkg/utils/instance_type_util.go
@@ -12,6 +12,9 @@ var instanceTypeMap = map[string]string{
 	"BM.GPU4.8":        "A100-40G",
 	"BM.GPU.B4.8":      "A100-40G",
 	"BM.GPU.H100.8":    "H100",
+	"BM.GPU.H100-NC.8": "H100",
+	"BM.GPU.H200.8":    "H200",
+	"BM.GPU.H200-NC.8": "H200",
 
 	// AWS instance types
 	"p5.48xlarge": "H100",

--- a/pkg/utils/instance_type_util_test.go
+++ b/pkg/utils/instance_type_util_test.go
@@ -33,6 +33,12 @@ func TestGetInstanceTypeShortName(t *testing.T) {
 			expected:     "H100",
 			expectError:  false,
 		},
+		{
+			name:         "OCI H200 instance",
+			instanceType: "BM.GPU.H200.8",
+			expected:     "H200",
+			expectError:  false,
+		},
 		// AWS tests
 		{
 			name:         "AWS H100 instance",


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it:
Add more OCI instance types supported in instance_type_util

## Does this PR introduce a user-facing change?
Model agent and model enigma would support more OCI instance types as added in this PR.