### PR TITLE
[Misc][Helm] Add retry logic to scout cache sync

### DIFF
--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -63,17 +63,24 @@ spec:
         {{- with .Values.modelAgent.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        startupProbe:
+          httpGet:
+            path: /livez
+            port: {{ .Values.modelAgent.health.port }}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         livenessProbe:
           httpGet:
             path: /livez
             port: {{ .Values.modelAgent.health.port }}
-          initialDelaySeconds: 60
-          periodSeconds: 5
+          periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /healthz
             port: {{ .Values.modelAgent.health.port }}
-          initialDelaySeconds: 60
+          periodSeconds: 10
         {{- if .Values.modelAgent.resources }}
         resources:
           {{- toYaml .Values.modelAgent.resources | nindent 10 }}

--- a/config/model-agent/daemonset.yaml
+++ b/config/model-agent/daemonset.yaml
@@ -60,20 +60,24 @@ spec:
         - name: host-models
           readOnly: false
           mountPath: /raid/models
+        startupProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
         livenessProbe:
           httpGet:
             path: /livez
             port: 8080
-          initialDelaySeconds: 60
-          periodSeconds: 30
-          timeoutSeconds: 20
+          periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 60
-          periodSeconds: 30
-          timeoutSeconds: 20
+          periodSeconds: 10
         resources:
           limits:
             cpu: '10'


### PR DESCRIPTION
## What type of PR is this?
/kind improvement

## Summary
Improves model-agent reliability during startup by adding retry logic with exponential backoff for K8S informer cache synchronization and enhancing health probe configuration.

## Why we need it?
Observed for model agent, scout would fail immediately if its cache sync did not succeed on the first attempt, causing unnecessary pod restarts;

## What does this PR do?
1. Added a retry logic to scout cache sync:
   - Added retry mechanism (up to 5 attempts) with exponential backoff (2s → 15s max) for cache sync operation;
2. Updated model agent daemonset health probe configurations:
   - Added startup probe with 50-second window (10s initial delay + 5 failures × 10s period) to allow adequate initialization time; The startup probe pattern can separate one-time initialization overhead (21 seconds HF client jitter delays and cache sync retries) from steady-state health monitoring, enabling the liveness probe to detect and recover from failures more rapidly.
   - Removed initialDelaySeconds from liveness and readiness probes (now handled by startup probe);
   - Standardized probe period to 10 seconds.


## Whether it is tested
Tested in cluster
