### PR TITLE
[Bugfix]fix runnerspec during migration

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/utils/migration_util.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/migration_util.go
@@ -80,7 +80,7 @@ func IsPredictorUsed(isvc *v1beta2.InferenceService) bool {
 	}
 
 	// Check if MinReplicas or MaxReplicas are set
-	if predictor.MinReplicas != nil {
+	if predictor.MinReplicas != nil || predictor.MaxReplicas != 0 {
 		return true
 	}
 
@@ -235,6 +235,11 @@ func MigratePredictor(isvc *v1beta2.InferenceService) error {
 				Name:  "PROTOCOL_VERSION",
 				Value: string(*isvc.Spec.Predictor.Model.ProtocolVersion),
 			})
+		}
+
+		// No containers in Model spec, set runnerSpec as nil
+		if runnerSpec.Container.Name == "" {
+			runnerSpec = nil
 		}
 
 		isvc.Spec.Engine.Runner = runnerSpec


### PR DESCRIPTION
<!-- 
Thank you for contributing to OME! Please read the contributing guidelines:
https://github.com/sgl-project/ome/blob/main/CONTRIBUTING.md
-->

## What type of PR is this?

/kind bug

## What this PR does / why we need it:
During migration from predictor to engine. 
The original isvc spec would like this:
```
spec:
  predictor:
    maxReplicas: 1
    minReplicas: 1
    model:
      baseModel: llama-3-3-70b-instruct
      name: ''
      resources: {}
      runtime: srt-llama-3-3-70b-instruct
```
without this fix, it will migrate predictor to engine like:
```
engine:
    maxReplicas: 1
    minReplicas: 1
    runner:
       container: ""
```
if will cause inference service reconcile failure.


## Does this PR introduce a user-facing change?

None, it only happend during migration.

```release-note

```