### PR TITLE
[Misc] Support qwen3_vl model for config parsing; Improve qwen3 vision model parameter estimation logic

### DIFF
--- a/pkg/hfutil/modelconfig/qwen3_vl_test.go
+++ b/pkg/hfutil/modelconfig/qwen3_vl_test.go
@@ -50,11 +50,13 @@ func TestQwen3VLConfig(t *testing.T) {
 		t.Errorf("Expected context length to be %d, but got %d", expectedLength, contextLength)
 	}
 
-	// Check parameter count (should be approximately 7B)
+	// Check parameter count (should be approximately 235B)
 	paramCount := config.GetParameterCount()
-	expectedCount := int64(235_000_000_000) // 7B parameters
-	if paramCount != expectedCount {
-		t.Errorf("Expected parameter count to be %d, but got %d", expectedCount, paramCount)
+	expectedCount := int64(235_000_000_000) // 235B parameters
+	// Allow 5% tolerance for parameter estimation
+	tolerance := expectedCount / 20 // 5% tolerance
+	if paramCount < expectedCount-tolerance || paramCount > expectedCount+tolerance {
+		t.Errorf("Expected parameter count to be around %d (±%d), but got %d", expectedCount, tolerance, paramCount)
 	}
 
 	// Check RoPE theta value (specific to Qwen3)
@@ -71,5 +73,175 @@ func TestQwen3VLConfig(t *testing.T) {
 	modelSize := config.GetModelSizeBytes()
 	if modelSize <= 0 {
 		t.Errorf("Expected model size bytes to be positive, but got %d", modelSize)
+	}
+}
+
+func TestQwen3VLConfig30B(t *testing.T) {
+	configPath := filepath.Join("testdata", "qwen3_vl_30b_a3b_instruct.json")
+
+	// Load the config
+	config, err := LoadModelConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load Qwen3VL config: %v", err)
+	}
+
+	// Check that it's the correct model type
+	if config.GetModelType() != "qwen3_vl_moe" {
+		t.Errorf("Expected model type 'qwen3_vl_moe' but got '%s'", config.GetModelType())
+	}
+
+	// Check that it's parsed as a Qwen3Config
+	qwen3VLConfig, ok := config.(*Qwen3VLConfig)
+	textConfig := qwen3VLConfig.TextConfig
+	if !ok {
+		t.Fatalf("Expected config to be of type *Qwen3VLConfig, but got %T", config)
+	}
+
+	// Check key fields for 30B model
+	if textConfig.HiddenSize != 2048 {
+		t.Errorf("Expected hidden size to be 2048, but got %d", textConfig.HiddenSize)
+	}
+
+	if textConfig.NumHiddenLayers != 48 {
+		t.Errorf("Expected hidden layers to be 48, but got %d", textConfig.NumHiddenLayers)
+	}
+
+	if textConfig.NumAttentionHeads != 32 {
+		t.Errorf("Expected attention heads to be 32, but got %d", textConfig.NumAttentionHeads)
+	}
+
+	if textConfig.NumKeyValueHeads != 4 {
+		t.Errorf("Expected key-value heads to be 4, but got %d", textConfig.NumKeyValueHeads)
+	}
+
+	// Check MoE configuration
+	if textConfig.NumExperts != 128 {
+		t.Errorf("Expected num experts to be 128, but got %d", textConfig.NumExperts)
+	}
+
+	if textConfig.MoeIntermediateSize != 768 {
+		t.Errorf("Expected MoE intermediate size to be 768, but got %d", textConfig.MoeIntermediateSize)
+	}
+
+	if textConfig.NumExpertsPerTok != 8 {
+		t.Errorf("Expected num experts per token to be 8, but got %d", textConfig.NumExpertsPerTok)
+	}
+
+	// Check context length
+	contextLength := config.GetContextLength()
+	expectedLength := 262144
+	if contextLength != expectedLength {
+		t.Errorf("Expected context length to be %d, but got %d", expectedLength, contextLength)
+	}
+
+	// Check RoPE theta value (specific to Qwen3)
+	if textConfig.RopeTheta != 5000000.0 {
+		t.Errorf("Expected RoPE theta to be 5000000.0, but got %f", textConfig.RopeTheta)
+	}
+
+	// Test vision capability
+	if !config.HasVision() {
+		t.Errorf("Expected HasVision() to return true, got %v", config.HasVision())
+	}
+
+	// Check model size bytes (should be non-zero)
+	modelSize := config.GetModelSizeBytes()
+	if modelSize <= 0 {
+		t.Errorf("Expected model size bytes to be positive, but got %d", modelSize)
+	}
+
+	// Check parameter count
+	paramCount := config.GetParameterCount()
+	// Expected around 30B parameters with 10% tolerance
+	expectedCount := int64(30_000_000_000) // 30B parameters
+	tolerance := expectedCount / 20        // 5% tolerance
+	if paramCount < expectedCount-tolerance || paramCount > expectedCount+tolerance {
+		t.Errorf("Expected parameter count to be around %d (±%d), but got %d", expectedCount, tolerance, paramCount)
+	}
+
+	// Check vision config
+	visionConfig := qwen3VLConfig.VisionConfig
+	if visionConfig.HiddenSize != 1152 {
+		t.Errorf("Expected vision hidden size to be 1152, but got %d", visionConfig.HiddenSize)
+	}
+
+	if visionConfig.Depth != 27 {
+		t.Errorf("Expected vision depth to be 27, but got %d", visionConfig.Depth)
+	}
+}
+
+func TestQwen3VLConfigNonMoE(t *testing.T) {
+	configPath := filepath.Join("testdata", "qwen3_vl_2b_instruct.json")
+
+	// Load the config
+	config, err := LoadModelConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load Qwen3VL config: %v", err)
+	}
+
+	// Check that it's the correct model type
+	if config.GetModelType() != "qwen3_vl" {
+		t.Errorf("Expected model type 'qwen3_vl' but got '%s'", config.GetModelType())
+	}
+
+	// Check that it's parsed as a Qwen3Config
+	qwen3VLConfig, ok := config.(*Qwen3VLConfig)
+	textConfig := qwen3VLConfig.TextConfig
+	if !ok {
+		t.Fatalf("Expected config to be of type *Qwen3VLConfig, but got %T", config)
+	}
+
+	// Check key fields for non-MoE model
+	if textConfig.HiddenSize != 2048 {
+		t.Errorf("Expected hidden size to be 2048, but got %d", textConfig.HiddenSize)
+	}
+
+	if textConfig.NumHiddenLayers != 28 {
+		t.Errorf("Expected hidden layers to be 28, but got %d", textConfig.NumHiddenLayers)
+	}
+
+	if textConfig.NumAttentionHeads != 16 {
+		t.Errorf("Expected attention heads to be 16, but got %d", textConfig.NumAttentionHeads)
+	}
+
+	if textConfig.NumKeyValueHeads != 8 {
+		t.Errorf("Expected key-value heads to be 8, but got %d", textConfig.NumKeyValueHeads)
+	}
+
+	// Check that it's not a MoE model
+	if textConfig.NumExperts != 0 {
+		t.Errorf("Expected num experts to be 0 for non-MoE model, but got %d", textConfig.NumExperts)
+	}
+
+	// Check context length
+	contextLength := config.GetContextLength()
+	expectedLength := 262144
+	if contextLength != expectedLength {
+		t.Errorf("Expected context length to be %d, but got %d", expectedLength, contextLength)
+	}
+
+	// Check RoPE theta value (specific to Qwen3)
+	if textConfig.RopeTheta != 5000000.0 {
+		t.Errorf("Expected RoPE theta to be 5000000.0, but got %f", textConfig.RopeTheta)
+	}
+
+	// Test vision capability
+	if !config.HasVision() {
+		t.Errorf("Expected HasVision() to return true, got %v", config.HasVision())
+	}
+
+	// Check model size bytes (should be non-zero)
+	modelSize := config.GetModelSizeBytes()
+	if modelSize <= 0 {
+		t.Errorf("Expected model size bytes to be positive, but got %d", modelSize)
+	}
+
+	// Check parameter count
+	paramCount := config.GetParameterCount()
+	// For 2B model, expect around 2B parameters with 20% tolerance
+	expectedCount := int64(2_000_000_000) // 2B parameters
+	tolerance := expectedCount / 20       // 5% tolerance
+	if paramCount < expectedCount-tolerance || paramCount > expectedCount+tolerance {
+		t.Errorf("Expected parameter count to be around %d (±%d), but got %d", expectedCount, tolerance, paramCount)
 	}
 }

--- a/pkg/hfutil/modelconfig/testdata/qwen3_vl_2b_instruct.json
+++ b/pkg/hfutil/modelconfig/testdata/qwen3_vl_2b_instruct.json
@@ -1,0 +1,63 @@
+{
+  "architectures": [
+    "Qwen3VLForConditionalGeneration"
+  ],
+  "image_token_id": 151655,
+  "model_type": "qwen3_vl",
+  "text_config": {
+    "attention_bias": false,
+    "attention_dropout": 0.0,
+    "bos_token_id": 151643,
+    "dtype": "bfloat16",
+    "eos_token_id": 151645,
+    "head_dim": 128,
+    "hidden_act": "silu",
+    "hidden_size": 2048,
+    "initializer_range": 0.02,
+    "intermediate_size": 6144,
+    "max_position_embeddings": 262144,
+    "model_type": "qwen3_vl_text",
+    "num_attention_heads": 16,
+    "num_hidden_layers": 28,
+    "num_key_value_heads": 8,
+    "rms_norm_eps": 1e-06,
+    "rope_scaling": {
+      "mrope_interleaved": true,
+      "mrope_section": [
+        24,
+        20,
+        20
+      ],
+      "rope_type": "default"
+    },
+    "rope_theta": 5000000,
+    "tie_word_embeddings": true,
+    "use_cache": true,
+    "vocab_size": 151936
+  },
+  "tie_word_embeddings": true,
+  "transformers_version": "4.57.0.dev0",
+  "video_token_id": 151656,
+  "vision_config": {
+    "deepstack_visual_indexes": [
+      5,
+      11,
+      17
+    ],
+    "depth": 24,
+    "hidden_act": "gelu_pytorch_tanh",
+    "hidden_size": 1024,
+    "in_channels": 3,
+    "initializer_range": 0.02,
+    "intermediate_size": 4096,
+    "model_type": "qwen3_vl",
+    "num_heads": 16,
+    "num_position_embeddings": 2304,
+    "out_hidden_size": 2048,
+    "patch_size": 16,
+    "spatial_merge_size": 2,
+    "temporal_patch_size": 2
+  },
+  "vision_end_token_id": 151653,
+  "vision_start_token_id": 151652
+}

--- a/pkg/hfutil/modelconfig/testdata/qwen3_vl_30b_a3b_instruct.json
+++ b/pkg/hfutil/modelconfig/testdata/qwen3_vl_30b_a3b_instruct.json
@@ -1,0 +1,68 @@
+{
+  "architectures": [
+    "Qwen3VLMoeForConditionalGeneration"
+  ],
+  "image_token_id": 151655,
+  "model_type": "qwen3_vl_moe",
+  "text_config": {
+    "attention_bias": false,
+    "attention_dropout": 0.0,
+    "bos_token_id": 151643,
+    "decoder_sparse_step": 1,
+    "dtype": "bfloat16",
+    "eos_token_id": 151645,
+    "head_dim": 128,
+    "hidden_act": "silu",
+    "hidden_size": 2048,
+    "initializer_range": 0.02,
+    "intermediate_size": 6144,
+    "max_position_embeddings": 262144,
+    "mlp_only_layers": [],
+    "model_type": "qwen3_vl_moe_text",
+    "moe_intermediate_size": 768,
+    "norm_topk_prob": true,
+    "num_attention_heads": 32,
+    "num_experts": 128,
+    "num_experts_per_tok": 8,
+    "num_hidden_layers": 48,
+    "num_key_value_heads": 4,
+    "rms_norm_eps": 1e-06,
+    "rope_scaling": {
+      "mrope_interleaved": true,
+      "mrope_section": [
+        24,
+        20,
+        20
+      ],
+      "rope_type": "default"
+    },
+    "rope_theta": 5000000,
+    "use_cache": true,
+    "vocab_size": 151936
+  },
+  "tie_word_embeddings": false,
+  "transformers_version": "4.57.0.dev0",
+  "video_token_id": 151656,
+  "vision_config": {
+    "deepstack_visual_indexes": [
+      8,
+      16,
+      24
+    ],
+    "depth": 27,
+    "hidden_act": "gelu_pytorch_tanh",
+    "hidden_size": 1152,
+    "in_channels": 3,
+    "initializer_range": 0.02,
+    "intermediate_size": 4304,
+    "model_type": "qwen3_vl_moe",
+    "num_heads": 16,
+    "num_position_embeddings": 2304,
+    "out_hidden_size": 2048,
+    "patch_size": 16,
+    "spatial_merge_size": 2,
+    "temporal_patch_size": 2
+  },
+  "vision_end_token_id": 151653,
+  "vision_start_token_id": 151652
+}


### PR DESCRIPTION
## What type of PR is this?
/kind feature


## What this PR does / why we need it:
1. Added support for qwen3_vl multimodal model type in hfutil package for model configuration parsing;
2. Improved qwen3 vision model parameter estimation logic so that removing the hardcoded parameter count setup;
3. Updated the unit tests.

## Tests
Tested 

## Does this PR introduce a user-facing change?
Yes. model-agent and ome-agent now can correctly parse qwen3_vl model configs. No action needed.