### PR TITLE
unify retry logic in basemodel controller and update Kong docs link

### DIFF
--- a/site/content/en/docs/administration/ingress.md
+++ b/site/content/en/docs/administration/ingress.md
@@ -15,7 +15,7 @@ OME supports the following ingress solutions:
 ### Standard Kubernetes Ingress Controllers
 - **NGINX Ingress Controller** - [Installation Guide](https://kubernetes.github.io/ingress-nginx/deploy/)
 - **Traefik** - [Installation Guide](https://doc.traefik.io/traefik/getting-started/install-traefik/)
-- **Kong Ingress Controller** - [Installation Guide](https://docs.konghq.com/kubernetes-ingress-controller/latest/install/)
+- **Kong Ingress Controller** - [Installation Guide](https://developer.konghq.com/kubernetes-ingress-controller/install/)
 - **HAProxy Ingress** - [Installation Guide](https://haproxy-ingress.github.io/docs/getting-started/)
 - **Contour** - [Installation Guide](https://projectcontour.io/getting-started/)
 


### PR DESCRIPTION
<!-- 
Thank you for contributing to OME! Please read the contributing guidelines:
https://github.com/sgl-project/ome/blob/main/CONTRIBUTING.md
-->

## What type of PR is this?

/kind feature

## What this PR does / why we need it:

* Extracted duplicate retry logic from `retrySpecUpdate` and `retryStatusUpdate` into shared `retryUpdate` function
* Fixed Kong ingress docs link

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```