### PR TITLE
[Misc] refactor router status update using util function

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/router.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/router.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/common"
 	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/rbac"
 	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/status"
-	isvcutils "github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/utils"
 	"github.com/sgl-project/ome/pkg/utils"
 )
 
@@ -141,16 +140,7 @@ func (r *Router) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta 
 
 // updateRouterStatus updates the status of the router component
 func (r *Router) updateRouterStatus(isvc *v1beta1.InferenceService, objectMeta metav1.ObjectMeta) error {
-	rawDeployment := r.DeploymentMode == constants.RawDeployment
-	statusSpec := isvc.Status.Components[v1beta1.RouterComponent]
-	podLabelKey, podLabelValue := r.getPodLabelInfo(rawDeployment, objectMeta, statusSpec)
-
-	routerPods, err := isvcutils.ListPodsByLabel(r.Client, isvc.ObjectMeta.Namespace, podLabelKey, podLabelValue)
-	if err != nil {
-		return errors.Wrapf(err, "failed to list router pods by label")
-	}
-	r.StatusManager.PropagateModelStatus(&isvc.Status, statusSpec, routerPods, rawDeployment)
-	return nil
+	return UpdateComponentStatus(&r.BaseComponentFields, isvc, v1beta1.RouterComponent, objectMeta, r.getPodLabelInfo)
 }
 
 // getPodLabelInfo returns the pod label key and value based on the deployment mode


### PR DESCRIPTION
## What this PR does / why we need it:
a tiny refactor to use common function in util.

the common function for reference
```
func UpdateComponentStatus(b *BaseComponentFields, isvc *v1beta1.InferenceService, componentType v1beta1.ComponentType, objectMeta metav1.ObjectMeta, getPodLabelInfo func(bool, metav1.ObjectMeta, v1beta1.ComponentStatusSpec) (string, string)) error {
	// Always initialize the component ready condition to ensure it's visible from the start
	// The deployment reconciler will update the condition based on the actual deployment status:
	// - MultiNode: Updates when LWS becomes available
	// - RawDeployment: Updates when Deployment becomes available
	// - Serverless: Updates when Knative Service becomes ready
	b.StatusManager.InitializeComponentCondition(&isvc.Status, componentType)

	// Update model status for all deployment modes based on actual pod information
	rawDeployment := b.DeploymentMode == constants.RawDeployment
	statusSpec := isvc.Status.Components[componentType]
	podLabelKey, podLabelValue := getPodLabelInfo(rawDeployment, objectMeta, statusSpec)

	pods, err := isvcutils.ListPodsByLabel(b.Client, isvc.ObjectMeta.Namespace, podLabelKey, podLabelValue)
	if err != nil {
		return errors.Wrapf(err, "failed to list %s pods by label", componentType)
	}
	b.StatusManager.PropagateModelStatus(&isvc.Status, statusSpec, pods, rawDeployment)

	return nil
}
```