### PR TITLE
[Bugfix] fix MergeNodeSelector with different componentType

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -209,7 +209,7 @@ func UpdateEnvVariables(b *BaseComponentFields, isvc *v1beta1.InferenceService, 
 }
 
 // UpdatePodSpecNodeSelector updates pod spec with node selector for model scheduling
-func UpdatePodSpecNodeSelector(b *BaseComponentFields, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec) {
+func UpdatePodSpecNodeSelector(b *BaseComponentFields, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec, componentType v1beta1.ComponentType) {
 	// Only add node selector if we have a base model
 	if b.BaseModel == nil || b.BaseModelMeta == nil {
 		return
@@ -245,7 +245,7 @@ func UpdatePodSpecNodeSelector(b *BaseComponentFields, isvc *v1beta1.InferenceSe
 
 	// Add node selector merged from AcceleratorClass if applicable
 	// Only add mergedNodeSelector to engine and decoder component.
-	mergedNodeSelector := isvcutils.MergeNodeSelector(b.Runtime, b.AcceleratorClass, isvc, v1beta1.EngineComponent)
+	mergedNodeSelector := isvcutils.MergeNodeSelector(b.Runtime, b.AcceleratorClass, isvc, componentType)
 	if len(mergedNodeSelector) > 0 {
 		for k, v := range mergedNodeSelector {
 			podSpec.NodeSelector[k] = v

--- a/pkg/controller/v1beta1/inferenceservice/components/base_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base_test.go
@@ -138,7 +138,7 @@ func TestUpdatePodSpecNodeSelector(t *testing.T) {
 			}
 
 			// Call the function
-			UpdatePodSpecNodeSelector(b, isvc, podSpec)
+			UpdatePodSpecNodeSelector(b, isvc, podSpec, "")
 
 			// Verify the result
 			g.Expect(podSpec.NodeSelector).To(gomega.Equal(tt.expectedNodeSelector))

--- a/pkg/controller/v1beta1/inferenceservice/components/decoder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder.go
@@ -298,7 +298,7 @@ func (d *Decoder) reconcilePodSpec(isvc *v1beta1.InferenceService, objectMeta *m
 	}
 
 	UpdatePodSpecVolumes(&d.BaseComponentFields, isvc, podSpec, objectMeta)
-	UpdatePodSpecNodeSelector(&d.BaseComponentFields, isvc, podSpec)
+	UpdatePodSpecNodeSelector(&d.BaseComponentFields, isvc, podSpec, v1beta1.DecoderComponent)
 	UpdateDecoderAffinity(&d.BaseComponentFields, isvc, podSpec)
 
 	d.Log.Info("Decoder PodSpec updated", "inference service", isvc.Name, "namespace", isvc.Namespace)
@@ -331,7 +331,7 @@ func (d *Decoder) reconcileWorkerPodSpec(isvc *v1beta1.InferenceService, objectM
 		return nil, err
 	}
 	UpdatePodSpecVolumes(&d.BaseComponentFields, isvc, workerPodSpec, objectMeta)
-	UpdatePodSpecNodeSelector(&d.BaseComponentFields, isvc, workerPodSpec)
+	UpdatePodSpecNodeSelector(&d.BaseComponentFields, isvc, workerPodSpec, v1beta1.DecoderComponent)
 	UpdateDecoderAffinity(&d.BaseComponentFields, isvc, workerPodSpec)
 
 	d.Log.Info("Decoder Worker PodSpec updated", "inference service", isvc.Name, "namespace", isvc.Namespace)

--- a/pkg/controller/v1beta1/inferenceservice/components/engine.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine.go
@@ -301,7 +301,7 @@ func (e *Engine) reconcilePodSpec(isvc *v1beta1.InferenceService, objectMeta *me
 		return nil, err
 	}
 	UpdatePodSpecVolumes(&e.BaseComponentFields, isvc, podSpec, objectMeta)
-	UpdatePodSpecNodeSelector(&e.BaseComponentFields, isvc, podSpec)
+	UpdatePodSpecNodeSelector(&e.BaseComponentFields, isvc, podSpec, v1beta1.EngineComponent)
 	UpdateEngineAffinity(&e.BaseComponentFields, isvc, podSpec)
 
 	e.Log.Info("Engine PodSpec updated", "inference service", isvc.Name, "namespace", isvc.Namespace)
@@ -334,7 +334,7 @@ func (e *Engine) reconcileWorkerPodSpec(isvc *v1beta1.InferenceService, objectMe
 		return nil, err
 	}
 	UpdatePodSpecVolumes(&e.BaseComponentFields, isvc, workerPodSpec, objectMeta)
-	UpdatePodSpecNodeSelector(&e.BaseComponentFields, isvc, workerPodSpec)
+	UpdatePodSpecNodeSelector(&e.BaseComponentFields, isvc, workerPodSpec, v1beta1.EngineComponent)
 	UpdateEngineAffinity(&e.BaseComponentFields, isvc, workerPodSpec)
 	e.Log.Info("Engine Worker PodSpec updated", "inference service", isvc.Name, "namespace", isvc.Namespace)
 	return workerPodSpec, nil


### PR DESCRIPTION

## What type of PR is this?
/kind bug

## What this PR does / why we need it:
fix a tiny bug in mergeNodeSelector function. The arguments needs to pass in different componentType rather than engine only.

## Which issue(s) this PR fixes:

<!-- 
Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
-->
Fixes #

## Special notes for your reviewer:

<!-- 
Any specific areas you'd like reviewed? Any concerns?
-->

## Does this PR introduce a user-facing change?

None
```release-note

```