### PR TITLE
[Core] Update to only append an env variable when it is not provided in runtime/runner

### DIFF
--- a/pkg/controller/v1beta1/benchmark/utils/utils.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils.go
@@ -141,7 +141,7 @@ func UpdateVolumeMounts(container *v1.Container, baseModelName string, baseModel
 	}
 
 	isvcutils.AppendVolumeMount(container, &volumeMount)
-	isvcutils.AppendEnvVars(container, &[]v1.EnvVar{
+	isvcutils.AppendEnvVarsIfNotExist(container, &[]v1.EnvVar{
 		{Name: "MODEL_PATH", Value: *baseModel.Storage.Path},
 	})
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -158,8 +158,8 @@ func UpdateEnvVariables(b *BaseComponentFields, isvc *v1beta1.InferenceService, 
 		// Base model serving - add MODEL_PATH env variable if necessary
 		if isvcutils.IsOriginalModelVolumeMountNecessary(objectMeta.Annotations) {
 			if b.BaseModel != nil && b.BaseModel.Storage != nil && b.BaseModel.Storage.Path != nil {
-				b.Log.Info("Base model serving - adding MODEL_PATH env variable", "inference service", isvc.Name, "namespace", isvc.Namespace)
-				isvcutils.AppendEnvVars(container, &[]corev1.EnvVar{
+				b.Log.Info("Base model serving - adding MODEL_PATH env variable if not provided", "inference service", isvc.Name, "namespace", isvc.Namespace)
+				isvcutils.AppendEnvVarsIfNotExist(container, &[]corev1.EnvVar{
 					{Name: constants.ModelPathEnvVarKey, Value: *b.BaseModel.Storage.Path},
 				})
 			}
@@ -176,13 +176,13 @@ func UpdateEnvVariables(b *BaseComponentFields, isvc *v1beta1.InferenceService, 
 						objectMeta.Annotations[constants.FineTunedAdapterInjectionKey],
 					),
 				})
-				isvcutils.AppendEnvVars(container, &[]corev1.EnvVar{
+				isvcutils.AppendEnvVarsIfNotExist(container, &[]corev1.EnvVar{
 					{Name: constants.ModelPathEnvVarKey, Value: constants.ModelDefaultMountPath},
 				})
 			} else if *b.BaseModel.Vendor == string(constants.Cohere) {
 				// Cohere vendor specific env vars
 				if isvcutils.IsCohereCommand1TFewFTServing(objectMeta) {
-					isvcutils.AppendEnvVars(container, &[]corev1.EnvVar{
+					isvcutils.AppendEnvVarsIfNotExist(container, &[]corev1.EnvVar{
 						{Name: constants.TFewWeightPathEnvVarKey, Value: constants.CohereTFewFineTunedWeightDefaultPath},
 					})
 				}

--- a/pkg/controller/v1beta1/inferenceservice/utils/container.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/container.go
@@ -40,8 +40,23 @@ func AppendVolumeMountIfNotExist(container *v1.Container, volumeMount *v1.Volume
 	container.VolumeMounts = append(container.VolumeMounts, *volumeMount)
 }
 
-func AppendEnvVars(container *v1.Container, envVars *[]v1.EnvVar) {
-	container.Env = append(container.Env, *envVars...)
+func AppendEnvVarsIfNotExist(container *v1.Container, envVars *[]v1.EnvVar) {
+	if envVars == nil {
+		return
+	}
+
+	for _, envVar := range *envVars {
+		var exists bool
+		for i := range container.Env {
+			if container.Env[i].Name == envVar.Name {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			container.Env = append(container.Env, envVar)
+		}
+	}
 }
 
 func UpdateEnvVars(container *v1.Container, envVar *v1.EnvVar) {


### PR DESCRIPTION
## What type of PR is this?
/kind Improvement

## What this PR does / why we need it:
Enable customized env variables, not only tied to the values hardcoded now in reconcile. For example, for MODEL_PATH env variable, different models may require different values for it than its pure top level path. 

## Which issue(s) this PR fixes:
Instead of appending env variable directly into container, switch to use the logic appending if not exists, so that:
1. Enable customizations for env variables in runtime;
2. No error out caused by duplicate env variable if customers add them in runtime.

