### PR TITLE
[ome-console]  API & Error Handling

### DIFF
--- a/web-console/frontend/src/app/(dashboard)/models/import/page.tsx
+++ b/web-console/frontend/src/app/(dashboard)/models/import/page.tsx
@@ -28,6 +28,8 @@ export default function ImportModelPage() {
   const [namespace, setNamespace] = useState('default')
   const [modelName, setModelName] = useState('')
   const [storagePath, setStoragePath] = useState('')
+  const [vendor, setVendor] = useState('')
+  const [version, setVersion] = useState('')
   const [huggingfaceToken, setHuggingfaceToken] = useState('')
   const [error, setError] = useState<string | null>(null)
 
@@ -82,6 +84,11 @@ export default function ImportModelPage() {
     setSelectedModel(model)
     // Auto-generate model name from HF model ID
     setModelName(model.modelId.replace('/', '-').toLowerCase())
+    // Auto-populate vendor from the model author (first part of modelId)
+    const authorPart = model.modelId.split('/')[0]
+    if (authorPart) {
+      setVendor(authorPart)
+    }
     setStep('scope')
   }
 
@@ -118,7 +125,7 @@ export default function ImportModelPage() {
       }
 
       // Build model spec
-      const modelSpec = {
+      const modelSpec: Record<string, unknown> = {
         modelFormat: {
           name: detectedFormat,
         },
@@ -126,6 +133,14 @@ export default function ImportModelPage() {
         modelArchitecture: modelConfig?.architectures?.[0] || '',
         storage: storageSpec,
         displayName: selectedModel.modelId,
+      }
+
+      // Add optional fields if provided
+      if (vendor.trim()) {
+        modelSpec.vendor = vendor.trim()
+      }
+      if (version.trim()) {
+        modelSpec.version = version.trim()
       }
 
       // Prepare model data based on scope
@@ -385,6 +400,38 @@ export default function ImportModelPage() {
                 </p>
               </div>
 
+              {/* Vendor and Version Row */}
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label htmlFor="vendor" className="block text-sm font-medium text-gray-700">
+                    Vendor
+                  </label>
+                  <input
+                    type="text"
+                    id="vendor"
+                    value={vendor}
+                    onChange={(e) => setVendor(e.target.value)}
+                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500"
+                    placeholder="meta-llama"
+                  />
+                  <p className="mt-1 text-sm text-gray-500">Model provider or organization</p>
+                </div>
+                <div>
+                  <label htmlFor="version" className="block text-sm font-medium text-gray-700">
+                    Version
+                  </label>
+                  <input
+                    type="text"
+                    id="version"
+                    value={version}
+                    onChange={(e) => setVersion(e.target.value)}
+                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500"
+                    placeholder="1.0.0"
+                  />
+                  <p className="mt-1 text-sm text-gray-500">Optional version identifier</p>
+                </div>
+              </div>
+
               {/* Storage Path */}
               <div>
                 <label htmlFor="storagePath" className="block text-sm font-medium text-gray-700">
@@ -474,6 +521,18 @@ export default function ImportModelPage() {
                       <dt className="text-gray-500">Model Name</dt>
                       <dd className="font-medium text-gray-900">{modelName}</dd>
                     </div>
+                    {vendor && (
+                      <div>
+                        <dt className="text-gray-500">Vendor</dt>
+                        <dd className="font-medium text-gray-900">{vendor}</dd>
+                      </div>
+                    )}
+                    {version && (
+                      <div>
+                        <dt className="text-gray-500">Version</dt>
+                        <dd className="font-medium text-gray-900">{version}</dd>
+                      </div>
+                    )}
                     <div>
                       <dt className="text-gray-500">Storage URI</dt>
                       <dd className="font-medium text-gray-900 font-mono text-xs">

--- a/web-console/frontend/src/lib/api/accelerators.ts
+++ b/web-console/frontend/src/lib/api/accelerators.ts
@@ -1,14 +1,10 @@
 import { apiClient } from './client'
 import { AcceleratorClass } from '../types/accelerator'
-
-export interface AcceleratorListResponse {
-  items: AcceleratorClass[]
-  total: number
-}
+import { ListResponse } from '../types/common'
 
 export const acceleratorsApi = {
-  list: async (): Promise<AcceleratorListResponse> => {
-    const response = await apiClient.get<AcceleratorListResponse>('/accelerators')
+  list: async (): Promise<ListResponse<AcceleratorClass>> => {
+    const response = await apiClient.get<ListResponse<AcceleratorClass>>('/accelerators')
     return response.data
   },
 

--- a/web-console/frontend/src/lib/api/models.ts
+++ b/web-console/frontend/src/lib/api/models.ts
@@ -1,21 +1,12 @@
 import { apiClient } from './client'
 import { ClusterBaseModel, BaseModel } from '../types/model'
-
-export interface ModelListResponse {
-  items: ClusterBaseModel[]
-  total: number
-}
-
-export interface BaseModelListResponse {
-  items: BaseModel[]
-  total: number
-}
+import { ListResponse } from '../types/common'
 
 // ClusterBaseModel API (cluster-scoped)
 export const modelsApi = {
-  list: async (namespace?: string): Promise<ModelListResponse> => {
+  list: async (namespace?: string): Promise<ListResponse<ClusterBaseModel>> => {
     const params = namespace ? { namespace } : {}
-    const response = await apiClient.get<ModelListResponse>('/models', { params })
+    const response = await apiClient.get<ListResponse<ClusterBaseModel>>('/models', { params })
     return response.data
   },
 
@@ -41,7 +32,7 @@ export const modelsApi = {
     await apiClient.delete(`/models/${name}`)
   },
 
-  getStatus: async (name: string): Promise<any> => {
+  getStatus: async (name: string): Promise<unknown> => {
     const response = await apiClient.get(`/models/${name}/status`)
     return response.data
   },
@@ -49,8 +40,8 @@ export const modelsApi = {
 
 // BaseModel API (namespace-scoped)
 export const baseModelsApi = {
-  list: async (namespace: string): Promise<BaseModelListResponse> => {
-    const response = await apiClient.get<BaseModelListResponse>(`/namespaces/${namespace}/models`)
+  list: async (namespace: string): Promise<ListResponse<BaseModel>> => {
+    const response = await apiClient.get<ListResponse<BaseModel>>(`/namespaces/${namespace}/models`)
     return response.data
   },
 

--- a/web-console/frontend/src/lib/api/runtimes.ts
+++ b/web-console/frontend/src/lib/api/runtimes.ts
@@ -5,11 +5,7 @@ import {
   CompatibilityCheck,
   RuntimeValidationResult,
 } from '../types/runtime'
-
-export interface RuntimeListResponse {
-  items: ClusterServingRuntime[]
-  total: number
-}
+import { ListResponse } from '../types/common'
 
 export interface CompatibleRuntimesResponse {
   matches: RuntimeMatch[]
@@ -17,9 +13,11 @@ export interface CompatibleRuntimesResponse {
 }
 
 export const runtimesApi = {
-  list: async (namespace?: string): Promise<RuntimeListResponse> => {
+  list: async (namespace?: string): Promise<ListResponse<ClusterServingRuntime>> => {
     const params = namespace ? { namespace } : {}
-    const response = await apiClient.get<RuntimeListResponse>('/runtimes', { params })
+    const response = await apiClient.get<ListResponse<ClusterServingRuntime>>('/runtimes', {
+      params,
+    })
     return response.data
   },
 

--- a/web-console/frontend/src/lib/api/services.ts
+++ b/web-console/frontend/src/lib/api/services.ts
@@ -1,15 +1,11 @@
 import { apiClient } from './client'
 import { InferenceService } from '../types/service'
-
-export interface ServiceListResponse {
-  items: InferenceService[]
-  total: number
-}
+import { ListResponse } from '../types/common'
 
 export const servicesApi = {
-  list: async (namespace?: string): Promise<ServiceListResponse> => {
+  list: async (namespace?: string): Promise<ListResponse<InferenceService>> => {
     const params = namespace ? { namespace } : {}
-    const response = await apiClient.get<ServiceListResponse>('/services', { params })
+    const response = await apiClient.get<ListResponse<InferenceService>>('/services', { params })
     return response.data
   },
 
@@ -33,7 +29,7 @@ export const servicesApi = {
     await apiClient.delete(`/services/${name}`)
   },
 
-  getStatus: async (name: string, namespace?: string): Promise<any> => {
+  getStatus: async (name: string, namespace?: string): Promise<unknown> => {
     const params = namespace ? { namespace } : {}
     const response = await apiClient.get(`/services/${name}/status`, { params })
     return response.data

--- a/web-console/frontend/src/lib/hooks/createResourceHooks.ts
+++ b/web-console/frontend/src/lib/hooks/createResourceHooks.ts
@@ -1,176 +1,103 @@
 import { useQuery, useMutation, useQueryClient, QueryKey } from '@tanstack/react-query'
 import { ListResponse } from '../types/common'
+import { isApiError } from '../types/api'
 
-/**
- * Generic API interface for standard resource operations.
- * APIs may have additional methods beyond these core operations.
- *
- * This interface is intentionally flexible to accommodate different API patterns:
- * - Cluster-scoped resources (no namespace in get/update/delete)
- * - Namespace-scoped resources (namespace required or optional)
- */
-export interface ResourceApi<T, CreateInput = Partial<T>, UpdateInput = Partial<T>> {
+export const DEFAULT_QUERY_CONFIG = {
+  staleTime: 30000,
+  gcTime: 300000,
+  retry: (failureCount: number, error: unknown): boolean => {
+    if (isApiError(error) && error.status >= 400 && error.status < 500) return false
+    return failureCount < 3
+  },
+  retryDelay: (attempt: number): number => Math.min(1000 * 2 ** attempt, 30000),
+}
+
+export const queryKeys = {
+  list: (key: string, ns?: string): QueryKey => (ns ? [key, { namespace: ns }] : [key]),
+  detail: (key: string, name: string, ns?: string): QueryKey =>
+    ns ? [key, 'detail', name, { namespace: ns }] : [key, 'detail', name],
+  all: (key: string): QueryKey => [key],
+  related: (key: string, name: string, relation: string, ...args: unknown[]): QueryKey => [
+    key,
+    name,
+    relation,
+    ...args.filter((a) => a !== undefined),
+  ],
+}
+
+export interface ResourceApi<T, C = Partial<T>, U = Partial<T>> {
   list: (namespace?: string) => Promise<ListResponse<T>>
   get: (name: string, namespace?: string) => Promise<T>
-  create: (data: CreateInput) => Promise<T>
-  update: (name: string, data: UpdateInput) => Promise<T>
+  create: (data: C) => Promise<T>
+  update: (name: string, data: U) => Promise<T>
   delete: (name: string) => Promise<void>
 }
 
-export interface ResourceHooksOptions {
-  /** Query key prefix, e.g., 'models', 'services', 'runtimes' */
-  resourceKey: string
-  /** Default stale time in ms (default: 30000) */
-  staleTime?: number
-  /** Whether list queries should include namespace in query key */
-  namespaceInListKey?: boolean
-}
-
-/**
- * Creates a set of standard React Query hooks for a resource type.
- *
- * This factory eliminates duplicate hook code across useModels, useServices,
- * useRuntimes, etc. Each resource gets:
- * - useList: Fetch list with optional namespace filter
- * - useGet: Fetch single resource by name
- * - useCreate: Create new resource
- * - useUpdate: Update existing resource
- * - useDelete: Delete resource
- *
- * @example
- * ```ts
- * // Create hooks for models
- * const modelHooks = createResourceHooks<ClusterBaseModel>(modelsApi, {
- *   resourceKey: 'models',
- * })
- *
- * export const useModels = modelHooks.useList
- * export const useModel = modelHooks.useGet
- * export const useCreateModel = modelHooks.useCreate
- * export const useUpdateModel = modelHooks.useUpdate
- * export const useDeleteModel = modelHooks.useDelete
- * ```
- */
-export function createResourceHooks<T, CreateInput = Partial<T>, UpdateInput = Partial<T>>(
-  api: ResourceApi<T, CreateInput, UpdateInput>,
-  options: ResourceHooksOptions
+export function createResourceHooks<T, C = Partial<T>, U = Partial<T>>(
+  api: ResourceApi<T, C, U>,
+  options: { resourceKey: string; staleTime?: number; gcTime?: number }
 ) {
-  const { resourceKey, staleTime = 30000, namespaceInListKey = true } = options
-
-  /**
-   * Build a query key for the resource list
-   */
-  function getListQueryKey(namespace?: string): QueryKey {
-    if (namespaceInListKey && namespace) {
-      return [resourceKey, { namespace }]
-    }
-    return [resourceKey]
-  }
-
-  /**
-   * Build a query key for a single resource
-   */
-  function getItemQueryKey(name: string): QueryKey {
-    return [resourceKey, name]
-  }
+  const {
+    resourceKey,
+    staleTime = DEFAULT_QUERY_CONFIG.staleTime,
+    gcTime = DEFAULT_QUERY_CONFIG.gcTime,
+  } = options
 
   return {
-    /**
-     * Fetch list of resources, optionally filtered by namespace
-     */
-    useList: (namespace?: string) => {
-      return useQuery({
-        queryKey: getListQueryKey(namespace),
+    useList: (namespace?: string) =>
+      useQuery({
+        queryKey: queryKeys.list(resourceKey, namespace),
         queryFn: () => api.list(namespace),
         staleTime,
-      })
-    },
+        gcTime,
+        retry: DEFAULT_QUERY_CONFIG.retry,
+      }),
 
-    /**
-     * Fetch a single resource by name
-     */
-    useGet: (name: string) => {
-      return useQuery({
-        queryKey: getItemQueryKey(name),
-        queryFn: () => api.get(name),
+    useGet: (name: string, namespace?: string) =>
+      useQuery({
+        queryKey: queryKeys.detail(resourceKey, name, namespace),
+        queryFn: () => api.get(name, namespace),
         enabled: !!name,
         staleTime,
-      })
-    },
+        gcTime,
+        retry: DEFAULT_QUERY_CONFIG.retry,
+      }),
 
-    /**
-     * Create a new resource
-     */
     useCreate: () => {
-      const queryClient = useQueryClient()
+      const qc = useQueryClient()
       return useMutation({
-        mutationFn: (data: CreateInput) => api.create(data),
-        onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: [resourceKey] })
-        },
+        mutationFn: (data: C) => api.create(data),
+        onSuccess: () => qc.invalidateQueries({ queryKey: [resourceKey] }),
       })
     },
 
-    /**
-     * Update an existing resource
-     */
     useUpdate: () => {
-      const queryClient = useQueryClient()
+      const qc = useQueryClient()
       return useMutation({
-        mutationFn: ({ name, data }: { name: string; data: UpdateInput }) => api.update(name, data),
-        onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: [resourceKey] })
-        },
+        mutationFn: ({ name, data }: { name: string; data: U }) => api.update(name, data),
+        onSuccess: () => qc.invalidateQueries({ queryKey: [resourceKey] }),
       })
     },
 
-    /**
-     * Delete a resource
-     */
     useDelete: () => {
-      const queryClient = useQueryClient()
+      const qc = useQueryClient()
       return useMutation({
         mutationFn: (name: string) => api.delete(name),
-        onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: [resourceKey] })
-        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: [resourceKey] }),
       })
-    },
-
-    /**
-     * Get the query key builders for advanced use cases
-     * (e.g., prefetching, direct cache manipulation)
-     */
-    getListQueryKey,
-    getItemQueryKey,
-
-    /**
-     * Invalidate all queries for this resource type
-     */
-    useInvalidate: () => {
-      const queryClient = useQueryClient()
-      return () => queryClient.invalidateQueries({ queryKey: [resourceKey] })
     },
   }
 }
 
-/**
- * Extended factory for resources with additional specialized operations
- * Can be combined with createResourceHooks
- */
-export function createResourceMutation<TData, TVariables>(
-  mutationFn: (variables: TVariables) => Promise<TData>,
+export function createResourceMutation<T, V>(
+  mutationFn: (v: V) => Promise<T>,
   invalidateKeys: string[]
 ) {
   return function useMutationHook() {
-    const queryClient = useQueryClient()
+    const qc = useQueryClient()
     return useMutation({
       mutationFn,
-      onSuccess: () => {
-        invalidateKeys.forEach((key) => {
-          queryClient.invalidateQueries({ queryKey: [key] })
-        })
-      },
+      onSuccess: () => invalidateKeys.forEach((k) => qc.invalidateQueries({ queryKey: [k] })),
     })
   }
 }

--- a/web-console/frontend/src/lib/hooks/useRuntimes.ts
+++ b/web-console/frontend/src/lib/hooks/useRuntimes.ts
@@ -1,7 +1,14 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { runtimesApi } from '../api/runtimes'
 import { ClusterServingRuntime } from '../types/runtime'
-import { createResourceHooks, createResourceMutation } from './createResourceHooks'
+import {
+  createResourceHooks,
+  createResourceMutation,
+  DEFAULT_QUERY_CONFIG,
+  queryKeys,
+} from './createResourceHooks'
+
+const RESOURCE_KEY = 'runtimes'
 
 // Create base CRUD hooks using the factory
 const runtimeHooks = createResourceHooks<
@@ -9,7 +16,7 @@ const runtimeHooks = createResourceHooks<
   Partial<ClusterServingRuntime>,
   Partial<ClusterServingRuntime>
 >(runtimesApi, {
-  resourceKey: 'runtimes',
+  resourceKey: RESOURCE_KEY,
 })
 
 // Export standard CRUD hooks from factory
@@ -27,7 +34,7 @@ export function useUpdateRuntime() {
     mutationFn: ({ name, runtime }: { name: string; runtime: Partial<ClusterServingRuntime> }) =>
       runtimesApi.update(name, runtime),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['runtimes'] })
+      queryClient.invalidateQueries({ queryKey: queryKeys.all(RESOURCE_KEY) })
     },
   })
 }
@@ -36,25 +43,37 @@ export function useUpdateRuntime() {
 
 export function useCompatibleRuntimes(format?: string, framework?: string) {
   return useQuery({
-    queryKey: ['runtimes', 'compatible', format, framework],
+    queryKey: queryKeys.related(RESOURCE_KEY, 'compatible', 'search', format, framework),
     queryFn: () => runtimesApi.findCompatible(format!, framework),
     enabled: !!format,
+    staleTime: DEFAULT_QUERY_CONFIG.staleTime,
+    gcTime: DEFAULT_QUERY_CONFIG.gcTime,
+    retry: DEFAULT_QUERY_CONFIG.retry,
+    retryDelay: DEFAULT_QUERY_CONFIG.retryDelay,
   })
 }
 
 export function useRuntimeCompatibility(name?: string, format?: string, framework?: string) {
   return useQuery({
-    queryKey: ['runtimes', name, 'compatibility', format, framework],
+    queryKey: queryKeys.related(RESOURCE_KEY, name || '', 'compatibility', format, framework),
     queryFn: () => runtimesApi.checkCompatibility(name!, format!, framework),
     enabled: !!name && !!format,
+    staleTime: DEFAULT_QUERY_CONFIG.staleTime,
+    gcTime: DEFAULT_QUERY_CONFIG.gcTime,
+    retry: DEFAULT_QUERY_CONFIG.retry,
+    retryDelay: DEFAULT_QUERY_CONFIG.retryDelay,
   })
 }
 
 export function useRuntimeRecommendation(format?: string, framework?: string) {
   return useQuery({
-    queryKey: ['runtimes', 'recommend', format, framework],
+    queryKey: queryKeys.related(RESOURCE_KEY, 'recommend', 'search', format, framework),
     queryFn: () => runtimesApi.getRecommendation(format!, framework),
     enabled: !!format,
+    staleTime: DEFAULT_QUERY_CONFIG.staleTime,
+    gcTime: DEFAULT_QUERY_CONFIG.gcTime,
+    retry: DEFAULT_QUERY_CONFIG.retry,
+    retryDelay: DEFAULT_QUERY_CONFIG.retryDelay,
   })
 }
 
@@ -70,7 +89,7 @@ export function useCloneRuntime() {
     mutationFn: ({ name, newName }: { name: string; newName: string }) =>
       runtimesApi.clone(name, newName),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['runtimes'] })
+      queryClient.invalidateQueries({ queryKey: queryKeys.all(RESOURCE_KEY) })
     },
   })
 }

--- a/web-console/frontend/src/lib/types/api.ts
+++ b/web-console/frontend/src/lib/types/api.ts
@@ -1,0 +1,45 @@
+/**
+ * Standardized API error format
+ */
+export interface ApiError {
+  status: number
+  code: string
+  message: string
+  details?: unknown
+}
+
+export function isApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    'code' in error &&
+    'message' in error
+  )
+}
+
+export function transformAxiosError(error: unknown): ApiError {
+  const err = error as {
+    response?: {
+      status: number
+      data?: { message?: string; error?: string; code?: string; details?: unknown }
+    }
+    code?: string
+    message?: string
+  }
+  if (!err.response) {
+    return {
+      status: 0,
+      code: err.code === 'ECONNABORTED' ? 'TIMEOUT' : 'NETWORK_ERROR',
+      message: err.code === 'ECONNABORTED' ? 'Request timed out' : 'Network error',
+    }
+  }
+
+  const { status, data } = err.response
+  return {
+    status,
+    code: data?.code || 'ERROR',
+    message: data?.message || data?.error || err.message || 'An error occurred',
+    details: data?.details,
+  }
+}

--- a/web-console/frontend/src/lib/types/common.ts
+++ b/web-console/frontend/src/lib/types/common.ts
@@ -1,67 +1,45 @@
 // Common shared types for Kubernetes-style resources
-// This file consolidates duplicate type definitions from model.ts, service.ts, and runtime.ts
 
-/**
- * Standard Kubernetes ObjectMeta
- */
 export interface ObjectMeta {
   name: string
   namespace?: string
   labels?: Record<string, string>
   annotations?: Record<string, string>
   creationTimestamp?: string
-  [key: string]: unknown
+  uid?: string
+  resourceVersion?: string
 }
 
-/**
- * Kubernetes-style resource requirements for CPU/memory/GPU
- */
 export interface ResourceRequirements {
   limits?: Record<string, string>
   requests?: Record<string, string>
 }
 
-/**
- * Environment variable definition
- */
 export interface EnvVar {
   name: string
   value?: string
   valueFrom?: EnvVarSource
 }
 
-/**
- * Source for environment variable value
- */
 export interface EnvVarSource {
   configMapKeyRef?: KeyRef
   secretKeyRef?: KeyRef
   fieldRef?: { fieldPath: string }
 }
 
-/**
- * Reference to a key in a ConfigMap or Secret
- */
 export interface KeyRef {
   name: string
   key: string
   optional?: boolean
 }
 
-/**
- * Volume mount specification
- */
 export interface VolumeMount {
   name: string
   mountPath: string
   readOnly?: boolean
   subPath?: string
-  [key: string]: unknown
 }
 
-/**
- * Volume specification
- */
 export interface Volume {
   name: string
   configMap?: { name: string; items?: { key: string; path: string }[] }
@@ -69,12 +47,8 @@ export interface Volume {
   emptyDir?: Record<string, unknown>
   persistentVolumeClaim?: { claimName: string; readOnly?: boolean }
   hostPath?: { path: string; type?: string }
-  [key: string]: unknown
 }
 
-/**
- * Container port specification
- */
 export interface ContainerPort {
   name?: string
   containerPort: number
@@ -82,9 +56,6 @@ export interface ContainerPort {
   hostPort?: number
 }
 
-/**
- * Container specification
- */
 export interface Container {
   name: string
   image: string
@@ -96,27 +67,17 @@ export interface Container {
   ports?: ContainerPort[]
   workingDir?: string
   securityContext?: SecurityContext
-  [key: string]: unknown
 }
 
-/**
- * Security context for containers
- */
 export interface SecurityContext {
   runAsUser?: number
   runAsGroup?: number
   runAsNonRoot?: boolean
   readOnlyRootFilesystem?: boolean
   privileged?: boolean
-  capabilities?: {
-    add?: string[]
-    drop?: string[]
-  }
+  capabilities?: { add?: string[]; drop?: string[] }
 }
 
-/**
- * Kubernetes condition type (used in status)
- */
 export interface Condition {
   type: string
   status: 'True' | 'False' | 'Unknown'
@@ -125,36 +86,49 @@ export interface Condition {
   message?: string
 }
 
-/**
- * Pod toleration
- */
 export interface Toleration {
   key?: string
   operator?: 'Exists' | 'Equal'
   value?: string
   effect?: 'NoSchedule' | 'PreferNoSchedule' | 'NoExecute'
   tolerationSeconds?: number
-  [key: string]: unknown
 }
 
-/**
- * Local object reference (e.g., for imagePullSecrets)
- */
 export interface LocalObjectReference {
   name: string
 }
 
-/**
- * API response wrapper for list operations
- */
+export interface PodAffinity {
+  nodeAffinity?: {
+    requiredDuringSchedulingIgnoredDuringExecution?: { nodeSelectorTerms: NodeSelectorTerm[] }
+    preferredDuringSchedulingIgnoredDuringExecution?: {
+      weight: number
+      preference: NodeSelectorTerm
+    }[]
+  }
+  podAffinity?: PodAffinityTerm[]
+  podAntiAffinity?: PodAffinityTerm[]
+}
+
+interface NodeSelectorTerm {
+  matchExpressions?: { key: string; operator: string; values?: string[] }[]
+  matchFields?: { key: string; operator: string; values?: string[] }[]
+}
+
+interface PodAffinityTerm {
+  labelSelector?: {
+    matchLabels?: Record<string, string>
+    matchExpressions?: { key: string; operator: string; values?: string[] }[]
+  }
+  topologyKey: string
+  namespaces?: string[]
+}
+
 export interface ListResponse<T> {
   items: T[]
   total: number
 }
 
-/**
- * Common resource states across different resource types
- */
 export type ResourceState =
   | 'Creating'
   | 'Ready'

--- a/web-console/frontend/src/lib/types/model.ts
+++ b/web-console/frontend/src/lib/types/model.ts
@@ -1,5 +1,5 @@
 // Import shared types from common
-import { ResourceRequirements, ObjectMeta } from './common'
+import { ObjectMeta, ResourceRequirements } from './common'
 
 // Re-export for backwards compatibility
 export type { ResourceRequirements } from './common'
@@ -75,11 +75,7 @@ export interface ModelStatusSpec {
 export interface ClusterBaseModel {
   apiVersion: string
   kind: string
-  metadata: {
-    name: string
-    creationTimestamp?: string
-    [key: string]: any
-  }
+  metadata: ObjectMeta
   spec: BaseModelSpec
   status?: ModelStatusSpec
 }
@@ -88,12 +84,7 @@ export interface ClusterBaseModel {
 export interface BaseModel {
   apiVersion: string
   kind: string
-  metadata: {
-    name: string
-    namespace: string
-    creationTimestamp?: string
-    [key: string]: any
-  }
+  metadata: ObjectMeta & { namespace: string }
   spec: BaseModelSpec
   status?: ModelStatusSpec
 }
@@ -143,21 +134,40 @@ export interface HuggingFaceModelInfo {
   pipeline_tag?: string
   library_name?: string
   siblings?: HuggingFaceFileSibling[]
-  config?: Record<string, any>
-  cardData?: Record<string, any>
+  config?: HuggingFaceModelConfig
+  cardData?: HuggingFaceCardData
+}
+
+export interface HuggingFaceCardData {
+  license?: string
+  language?: string | string[]
+  tags?: string[]
+  datasets?: string[]
+  library_name?: string
+  pipeline_tag?: string
+  base_model?: string
 }
 
 export interface HuggingFaceModelConfig {
   architectures?: string[]
   model_type?: string
-  task_specific_params?: Record<string, any>
+  task_specific_params?: Record<string, unknown>
   max_position_embeddings?: number
   vocab_size?: number
   hidden_size?: number
   num_hidden_layers?: number
   num_attention_heads?: number
   torch_dtype?: string
-  quantization_config?: Record<string, any>
+  quantization_config?: QuantizationConfig
+}
+
+export interface QuantizationConfig {
+  quant_method?: string
+  bits?: number
+  group_size?: number
+  desc_act?: boolean
+  sym?: boolean
+  checkpoint_format?: string
 }
 
 export interface HuggingFaceModelInfoResponse {

--- a/web-console/frontend/src/lib/types/runtime.ts
+++ b/web-console/frontend/src/lib/types/runtime.ts
@@ -2,6 +2,7 @@
 
 // Import shared types from common
 import {
+  ObjectMeta,
   ResourceRequirements,
   EnvVar,
   VolumeMount,
@@ -9,6 +10,7 @@ import {
   Container,
   Toleration,
   LocalObjectReference,
+  PodAffinity,
 } from './common'
 
 // Re-export for backwards compatibility
@@ -25,11 +27,7 @@ export type {
 export interface ClusterServingRuntime {
   apiVersion: string
   kind: string
-  metadata: {
-    name: string
-    creationTimestamp?: string
-    [key: string]: any
-  }
+  metadata: ObjectMeta
   spec: ServingRuntimeSpec
   status?: ServingRuntimeStatus
 }
@@ -38,6 +36,7 @@ export interface ServingRuntimeSpec {
   supportedModelFormats?: SupportedModelFormat[]
   modelSizeRange?: ModelSizeRange
   disabled?: boolean
+  multiModel?: boolean
   routerConfig?: RouterConfig
   engineConfig?: EngineConfig
   decoderConfig?: DecoderConfig
@@ -46,7 +45,7 @@ export interface ServingRuntimeSpec {
   containers?: ContainerSpec[]
   volumes?: Volume[]
   nodeSelector?: Record<string, string>
-  affinity?: any
+  affinity?: PodAffinity
   tolerations?: Toleration[]
   labels?: Record<string, string>
   annotations?: Record<string, string>
@@ -59,7 +58,6 @@ export interface ServingRuntimeSpec {
   workers?: WorkerPodSpec
   // AcceleratorRequirements
   acceleratorRequirements?: AcceleratorRequirements
-  [key: string]: any
 }
 
 export interface SupportedModelFormat {
@@ -155,7 +153,8 @@ export interface RunnerSpec {
   env?: EnvVar[]
   resources?: ResourceRequirements
   volumeMounts?: VolumeMount[]
-  [key: string]: any
+  imagePullPolicy?: 'Always' | 'Never' | 'IfNotPresent'
+  workingDir?: string
 }
 
 export interface LeaderSpec {
@@ -203,8 +202,6 @@ export interface AcceleratorConstraints {
   architectureFamilies?: string[]
 }
 
-// Volume, VolumeMount, Container, Toleration, LocalObjectReference now imported from common.ts
-
 export interface ContainerSpec {
   name: string
   image: string
@@ -212,7 +209,10 @@ export interface ContainerSpec {
   args?: string[]
   env?: EnvVar[]
   resources?: ResourceRequirements
-  [key: string]: any
+  volumeMounts?: VolumeMount[]
+  ports?: { containerPort: number; protocol?: string; name?: string }[]
+  imagePullPolicy?: 'Always' | 'Never' | 'IfNotPresent'
+  workingDir?: string
 }
 
 export interface AdapterSpec {
@@ -220,13 +220,13 @@ export interface AdapterSpec {
   runtimeManagementPort?: number
   memBufferBytes?: number
   modelLoadingTimeoutMillis?: number
-  [key: string]: any
 }
 
-// EnvVar and ResourceRequirements now imported from common.ts
-
 export interface ServingRuntimeStatus {
-  [key: string]: any
+  replicas?: number
+  readyReplicas?: number
+  availableReplicas?: number
+  conditions?: { type: string; status: string; reason?: string; message?: string }[]
 }
 
 // Runtime Intelligence Types

--- a/web-console/frontend/src/lib/types/service.ts
+++ b/web-console/frontend/src/lib/types/service.ts
@@ -1,7 +1,7 @@
 // InferenceService TypeScript types
 
 // Import shared types from common
-import { ResourceRequirements, Condition } from './common'
+import { ObjectMeta, ResourceRequirements, Condition } from './common'
 
 // Re-export for backwards compatibility
 export type { ResourceRequirements, Condition } from './common'
@@ -9,19 +9,15 @@ export type { ResourceRequirements, Condition } from './common'
 export interface InferenceService {
   apiVersion: string
   kind: string
-  metadata: {
-    name: string
-    namespace?: string
-    creationTimestamp?: string
-    [key: string]: unknown
-  }
+  metadata: ObjectMeta
   spec: InferenceServiceSpec
   status?: InferenceServiceStatus
 }
 
 export interface InferenceServiceSpec {
   predictor: PredictorSpec
-  [key: string]: unknown
+  transformer?: TransformerSpec
+  explainer?: ExplainerSpec
 }
 
 export interface PredictorSpec {
@@ -31,12 +27,46 @@ export interface PredictorSpec {
   minReplicas?: number
   maxReplicas?: number
   resources?: ResourceRequirements
-  [key: string]: unknown
+  nodeSelector?: Record<string, string>
+  tolerations?: { key?: string; operator?: string; value?: string; effect?: string }[]
+  labels?: Record<string, string>
+  annotations?: Record<string, string>
+}
+
+export interface TransformerSpec {
+  containers?: { name: string; image: string; resources?: ResourceRequirements }[]
+  minReplicas?: number
+  maxReplicas?: number
+}
+
+export interface ExplainerSpec {
+  type?: string
+  containers?: { name: string; image: string; resources?: ResourceRequirements }[]
+  minReplicas?: number
+  maxReplicas?: number
 }
 
 export interface InferenceServiceStatus {
   state?: string
   url?: string
+  address?: {
+    url?: string
+    internal?: string
+    external?: string
+  }
   conditions?: Condition[]
-  [key: string]: unknown
+  modelStatus?: {
+    states?: Record<string, { state: string; reason?: string; message?: string }>
+    transitionStatus?: string
+  }
+  components?: Record<
+    string,
+    {
+      url?: string
+      address?: { url?: string }
+      traffic?: number
+      latestCreatedRevision?: string
+      latestReadyRevision?: string
+    }
+  >
 }


### PR DESCRIPTION
- Added src/lib/types/api.ts with ApiError type and transformAxiosError function
- Simplified client.ts - just axios instance + error interceptor (30 lines)

Type Consolidation:
- Removed duplicate *ListResponse interfaces from models.ts, services.ts, runtimes.ts, accelerators.ts
- All now use generic ListResponse<T> from common.ts
- Removed [key: string]: any index signatures from runtime.ts, service.ts, model.ts

Hook Standardization:
- Added queryKeys factory with list, detail, all, related patterns
- Added DEFAULT_QUERY_CONFIG (staleTime: 30s, gcTime: 5min, retry logic)
- Updated useModels, useServices, useRuntimes to use standardized patterns

## What type of PR is this?

/kind cleanup
