### PR TITLE
[Core] Enable Multi-Node Ray Cluster VLLM Deployment in inference service

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/decoder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder.go
@@ -154,6 +154,8 @@ func (d *Decoder) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta
 		return d.deploymentReconciler.ReconcileRawDeployment(isvc, objectMeta, podSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
 	case constants.MultiNode:
 		return d.deploymentReconciler.ReconcileMultiNodeDeployment(isvc, objectMeta, podSpec, workerSize, workerPodSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
+	case constants.MultiNodeRayVLLM:
+		return d.deploymentReconciler.ReconcileMultiNodeRayVLLMDeployment(isvc, objectMeta, podSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
 	case constants.Serverless:
 		return d.deploymentReconciler.ReconcileKnativeDeployment(isvc, objectMeta, podSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
 	default:

--- a/pkg/controller/v1beta1/inferenceservice/components/decoder_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder_test.go
@@ -21,13 +21,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	lws "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
 	"github.com/sgl-project/ome/pkg/constants"
 	"github.com/sgl-project/ome/pkg/controller/v1beta1/controllerconfig"
-	omeTesting "github.com/sgl-project/ome/pkg/testing"
 )
 
 // Helper function for creating int32 pointers
@@ -37,14 +35,6 @@ func int32Ptr(i int32) *int32 {
 
 func TestDecoderReconcile(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-
-	testEnv := omeTesting.SetupEnvTest()
-	cfg, err := testEnv.Start()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(cfg).NotTo(gomega.BeNil())
-	defer func(testEnv *envtest.Environment) {
-		_ = testEnv.Stop()
-	}(testEnv)
 
 	// Create scheme
 	scheme := runtime.NewScheme()

--- a/pkg/controller/v1beta1/inferenceservice/components/engine.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine.go
@@ -155,6 +155,8 @@ func (e *Engine) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta 
 		return e.deploymentReconciler.ReconcileRawDeployment(isvc, objectMeta, podSpec, &e.engineSpec.ComponentExtensionSpec, v1beta1.EngineComponent)
 	case constants.MultiNode:
 		return e.deploymentReconciler.ReconcileMultiNodeDeployment(isvc, objectMeta, podSpec, workerSize, workerPodSpec, &e.engineSpec.ComponentExtensionSpec, v1beta1.EngineComponent)
+	case constants.MultiNodeRayVLLM:
+		return e.deploymentReconciler.ReconcileMultiNodeRayVLLMDeployment(isvc, objectMeta, podSpec, &e.engineSpec.ComponentExtensionSpec, v1beta1.EngineComponent)
 	case constants.Serverless:
 		return e.deploymentReconciler.ReconcileKnativeDeployment(isvc, objectMeta, podSpec, &e.engineSpec.ComponentExtensionSpec, v1beta1.EngineComponent)
 	default:
@@ -272,7 +274,7 @@ func (e *Engine) reconcilePodSpec(isvc *v1beta1.InferenceService, objectMeta *me
 	var runnerSpec *v1beta1.RunnerSpec
 
 	switch deploymentMode {
-	case constants.MultiNode:
+	case constants.MultiNode, constants.MultiNodeRayVLLM:
 		// For multi-node, use leader spec
 		if e.engineSpec.Leader != nil {
 			basePodSpec = e.engineSpec.Leader.PodSpec

--- a/pkg/controller/v1beta1/inferenceservice/utils/annotations.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/annotations.go
@@ -10,16 +10,30 @@ import (
 )
 
 /*
+GetDeploymentModeFromAnnotations extracts a valid deployment mode from annotations if present.
+Returns the deployment mode and true if found and valid, otherwise returns empty string and false.
+*/
+func GetDeploymentModeFromAnnotations(annotations map[string]string) (constants.DeploymentModeType, bool) {
+	if annotations == nil {
+		return "", false
+	}
+	if mode, exists := annotations[constants.DeploymentMode]; exists {
+		deploymentMode := constants.DeploymentModeType(mode)
+		if deploymentMode.IsValid() {
+			return deploymentMode, true
+		}
+	}
+	return "", false
+}
+
+/*
 GetDeploymentMode returns the current deployment mode based on annotations and config.
 If a valid deployment mode is specified in annotations, it is used.
 Otherwise, returns the default deployment mode from config.
 */
 func GetDeploymentMode(annotations map[string]string, deployConfig *controllerconfig.DeployConfig) constants.DeploymentModeType {
-	if mode, exists := annotations[constants.DeploymentMode]; exists {
-		deploymentMode := constants.DeploymentModeType(mode)
-		if deploymentMode.IsValid() {
-			return deploymentMode
-		}
+	if mode, found := GetDeploymentModeFromAnnotations(annotations); found {
+		return mode
 	}
 	return constants.DeploymentModeType(deployConfig.DefaultDeploymentMode)
 }

--- a/pkg/controller/v1beta1/inferenceservice/utils/annotations_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/annotations_test.go
@@ -147,3 +147,158 @@ func TestResolveIngressConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDeploymentModeFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		expectedMode  constants.DeploymentModeType
+		expectedFound bool
+	}{
+		{
+			name:          "nil annotations - returns empty and false",
+			annotations:   nil,
+			expectedMode:  "",
+			expectedFound: false,
+		},
+		{
+			name:          "empty annotations - returns empty and false",
+			annotations:   map[string]string{},
+			expectedMode:  "",
+			expectedFound: false,
+		},
+		{
+			name: "valid Serverless mode",
+			annotations: map[string]string{
+				constants.DeploymentMode: string(constants.Serverless),
+			},
+			expectedMode:  constants.Serverless,
+			expectedFound: true,
+		},
+		{
+			name: "valid RawDeployment mode",
+			annotations: map[string]string{
+				constants.DeploymentMode: string(constants.RawDeployment),
+			},
+			expectedMode:  constants.RawDeployment,
+			expectedFound: true,
+		},
+		{
+			name: "valid MultiNodeRayVLLM mode",
+			annotations: map[string]string{
+				constants.DeploymentMode: string(constants.MultiNodeRayVLLM),
+			},
+			expectedMode:  constants.MultiNodeRayVLLM,
+			expectedFound: true,
+		},
+		{
+			name: "valid MultiNode mode",
+			annotations: map[string]string{
+				constants.DeploymentMode: string(constants.MultiNode),
+			},
+			expectedMode:  constants.MultiNode,
+			expectedFound: true,
+		},
+		{
+			name: "valid VirtualDeployment mode",
+			annotations: map[string]string{
+				constants.DeploymentMode: string(constants.VirtualDeployment),
+			},
+			expectedMode:  constants.VirtualDeployment,
+			expectedFound: true,
+		},
+		{
+			name: "invalid deployment mode - returns empty and false",
+			annotations: map[string]string{
+				constants.DeploymentMode: "InvalidMode",
+			},
+			expectedMode:  "",
+			expectedFound: false,
+		},
+		{
+			name: "empty string deployment mode - returns empty and false",
+			annotations: map[string]string{
+				constants.DeploymentMode: "",
+			},
+			expectedMode:  "",
+			expectedFound: false,
+		},
+		{
+			name: "other annotations present but no deployment mode",
+			annotations: map[string]string{
+				"some.other/annotation": "value",
+			},
+			expectedMode:  "",
+			expectedFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mode, found := GetDeploymentModeFromAnnotations(tt.annotations)
+			assert.Equal(t, tt.expectedMode, mode)
+			assert.Equal(t, tt.expectedFound, found)
+		})
+	}
+}
+
+func TestGetDeploymentMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		deployConfig *controllerconfig.DeployConfig
+		expectedMode constants.DeploymentModeType
+	}{
+		{
+			name: "valid annotation overrides config",
+			annotations: map[string]string{
+				constants.DeploymentMode: string(constants.RawDeployment),
+			},
+			deployConfig: &controllerconfig.DeployConfig{
+				DefaultDeploymentMode: string(constants.Serverless),
+			},
+			expectedMode: constants.RawDeployment,
+		},
+		{
+			name:        "no annotation uses config default",
+			annotations: map[string]string{},
+			deployConfig: &controllerconfig.DeployConfig{
+				DefaultDeploymentMode: string(constants.Serverless),
+			},
+			expectedMode: constants.Serverless,
+		},
+		{
+			name:        "nil annotations uses config default",
+			annotations: nil,
+			deployConfig: &controllerconfig.DeployConfig{
+				DefaultDeploymentMode: string(constants.RawDeployment),
+			},
+			expectedMode: constants.RawDeployment,
+		},
+		{
+			name: "invalid annotation falls back to config default",
+			annotations: map[string]string{
+				constants.DeploymentMode: "InvalidMode",
+			},
+			deployConfig: &controllerconfig.DeployConfig{
+				DefaultDeploymentMode: string(constants.MultiNode),
+			},
+			expectedMode: constants.MultiNode,
+		},
+		{
+			name:        "empty config default returns empty string",
+			annotations: map[string]string{},
+			deployConfig: &controllerconfig.DeployConfig{
+				DefaultDeploymentMode: "",
+			},
+			expectedMode: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mode := GetDeploymentMode(tt.annotations, tt.deployConfig)
+			assert.Equal(t, tt.expectedMode, mode)
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/deployment.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/deployment.go
@@ -14,6 +14,11 @@ func DetermineEngineDeploymentMode(engine *v1beta1.EngineSpec) constants.Deploym
 		return constants.RawDeployment
 	}
 
+	// Check for deployment mode annotation (e.g., MultiNodeRayVLLM)
+	if mode, found := GetDeploymentModeFromAnnotations(engine.Annotations); found {
+		return mode
+	}
+
 	// Multi-node if leader and worker are defined
 	if engine.Leader != nil || engine.Worker != nil {
 		return constants.MultiNode

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -1539,6 +1539,69 @@ func TestDetermineEngineDeploymentMode(t *testing.T) {
 			},
 			expectedMode: constants.MultiNode,
 		},
+		{
+			name: "annotation with MultiNodeRayVLLM takes highest precedence",
+			engine: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					Annotations: map[string]string{
+						constants.DeploymentMode: string(constants.MultiNodeRayVLLM),
+					},
+					MinReplicas: intPtr(1),
+				},
+				Leader: &v1beta1.LeaderSpec{},
+			},
+			expectedMode: constants.MultiNodeRayVLLM,
+		},
+		{
+			name: "annotation with MultiNode takes highest precedence",
+			engine: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					Annotations: map[string]string{
+						constants.DeploymentMode: string(constants.MultiNode),
+					},
+					MinReplicas: intPtr(0),
+				},
+			},
+			expectedMode: constants.MultiNode,
+		},
+		{
+			name: "invalid annotation is ignored, falls back to leader check",
+			engine: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					Annotations: map[string]string{
+						constants.DeploymentMode: "InvalidMode",
+					},
+					MinReplicas: intPtr(1),
+				},
+				Leader: &v1beta1.LeaderSpec{},
+			},
+			expectedMode: constants.MultiNode,
+		},
+		{
+			name: "empty annotations map, falls back to leader check",
+			engine: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					Annotations: map[string]string{},
+					MinReplicas: intPtr(1),
+				},
+				Leader: &v1beta1.LeaderSpec{},
+			},
+			expectedMode: constants.MultiNode,
+		},
+		{
+			name: "annotation overrides leader and min replicas 0",
+			engine: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					Annotations: map[string]string{
+						constants.DeploymentMode: string(constants.RawDeployment),
+					},
+					MinReplicas: intPtr(0),
+				},
+				Leader: &v1beta1.LeaderSpec{},
+				Worker: &v1beta1.WorkerSpec{},
+			},
+			expectedMode: constants.RawDeployment,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What type of PR is this?
/kind improvement

## What this PR does / why we need it:
Enables the support for deploying VLLM inference services across multiple nodes using Ray Cluster.

- New deployment mode: Integrated `MultiNodeRayVLLM` deployment mode into the engine/decoder reconcile logic;
- Deployment mode determination: Updated logic to detect `MultiNodeRayVLLM` via engine annotation;
- Added test cases

## Special notes for your reviewer:
Tested changes in cluster - successfully hosted llama3.1 405b model using `MultiNodeRayVLLM` deployment mode.
