### PR TITLE
[config] Add sglang supported model configurations

### DIFF
--- a/config/models/Alibaba-NLP/gme-Qwen2-VL-2B-Instruct.yaml
+++ b/config/models/Alibaba-NLP/gme-Qwen2-VL-2B-Instruct.yaml
@@ -1,0 +1,15 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: gme-qwen2-vl-2b-instruct
+spec:
+  modelCapabilities:
+    - TEXT_TO_EMBEDDING
+    - IMAGE_TEXT_TO_EMBEDDING
+  vendor: Alibaba-NLP
+  displayName: Alibaba-NLP.gme-qwen2-vl-2b-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Alibaba-NLP/gme-Qwen2-VL-2B-Instruct
+    path: /raid/models/Alibaba-NLP/gme-Qwen2-VL-2B-Instruct

--- a/config/models/Alibaba-NLP/gte-Qwen2-7B-instruct.yaml
+++ b/config/models/Alibaba-NLP/gte-Qwen2-7B-instruct.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: gte-qwen2-7b-instruct
+spec:
+  modelCapabilities:
+    - TEXT_TO_EMBEDDING
+  vendor: Alibaba-NLP
+  displayName: Alibaba-NLP.gte-qwen2-7b-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Alibaba-NLP/gte-Qwen2-7B-instruct
+    path: /raid/models/Alibaba-NLP/gte-Qwen2-7B-instruct

--- a/config/models/BAAI/bge-large-en-v1.5.yaml
+++ b/config/models/BAAI/bge-large-en-v1.5.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: bge-large-en-v1-5
+spec:
+  modelCapabilities:
+    - TEXT_TO_EMBEDDING
+  vendor: BAAI
+  displayName: BAAI.bge-large-en-v1.5
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://BAAI/bge-large-en-v1.5
+    path: /raid/models/BAAI/bge-large-en-v1.5

--- a/config/models/BAAI/bge-reranker-v2-m3.yaml
+++ b/config/models/BAAI/bge-reranker-v2-m3.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: bge-reranker-v2-m3
+spec:
+  modelCapabilities:
+    - RERANK
+  vendor: BAAI
+  displayName: BAAI.bge-reranker-v2-m3
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://BAAI/bge-reranker-v2-m3
+    path: /raid/models/BAAI/bge-reranker-v2-m3

--- a/config/models/CofeAI/Tele-FLM.yaml
+++ b/config/models/CofeAI/Tele-FLM.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: tele-flm
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: CofeAI
+  displayName: CofeAI.tele-flm
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://CofeAI/Tele-FLM
+    path: /raid/models/CofeAI/Tele-FLM

--- a/config/models/CohereForAI/c4ai-command-r-v01.yaml
+++ b/config/models/CohereForAI/c4ai-command-r-v01.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: c4ai-command-r-v01
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: CohereForAI
+  displayName: CohereForAI.c4ai-command-r-v01
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://CohereForAI/c4ai-command-r-v01
+    path: /raid/models/CohereForAI/c4ai-command-r-v01

--- a/config/models/Efficient-Large-Model/NVILA-8B.yaml
+++ b/config/models/Efficient-Large-Model/NVILA-8B.yaml
@@ -1,0 +1,15 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: nvila-8b
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+    - VIDEO_TEXT_TO_TEXT
+  vendor: Efficient-Large-Model
+  displayName: Efficient-Large-Model.nvila-8b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Efficient-Large-Model/NVILA-8B
+    path: /raid/models/Efficient-Large-Model/NVILA-8B

--- a/config/models/HuggingFaceTB/SmolLM-1.7B.yaml
+++ b/config/models/HuggingFaceTB/SmolLM-1.7B.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: smollm-1-7b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: HuggingFaceTB
+  displayName: HuggingFaceTB.smollm-1.7b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://HuggingFaceTB/SmolLM-1.7B
+    path: /raid/models/HuggingFaceTB/SmolLM-1.7B

--- a/config/models/LGAI-EXAONE/EXAONE-3.5-7.8B-Instruct.yaml
+++ b/config/models/LGAI-EXAONE/EXAONE-3.5-7.8B-Instruct.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: exaone-3-5-7-8b-instruct
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: LGAI-EXAONE
+  displayName: LGAI-EXAONE.exaone-3.5-7.8b-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://LGAI-EXAONE/EXAONE-3.5-7.8B-Instruct
+    path: /raid/models/LGAI-EXAONE/EXAONE-3.5-7.8B-Instruct

--- a/config/models/OrionStarAI/Orion-14B-Base.yaml
+++ b/config/models/OrionStarAI/Orion-14B-Base.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: orion-14b-base
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: OrionStarAI
+  displayName: OrionStarAI.orion-14b-base
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://OrionStarAI/Orion-14B-Base
+    path: /raid/models/OrionStarAI/Orion-14B-Base

--- a/config/models/Qwen/Qwen3-0.6B.yaml
+++ b/config/models/Qwen/Qwen3-0.6B.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: qwen3-0-6b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: Qwen
+  displayName: Qwen.qwen3-0.6b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Qwen/Qwen3-0.6B
+    path: /raid/models/Qwen/Qwen3-0.6B

--- a/config/models/Qwen/Qwen3-30B-A3B.yaml
+++ b/config/models/Qwen/Qwen3-30B-A3B.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: qwen3-30b-a3b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: Qwen
+  displayName: Qwen.qwen3-30b-a3b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Qwen/Qwen3-30B-A3B
+    path: /raid/models/Qwen/Qwen3-30B-A3B

--- a/config/models/Qwen/Qwen3-Embedding-0.6B.yaml
+++ b/config/models/Qwen/Qwen3-Embedding-0.6B.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: qwen3-embedding-0-6b
+spec:
+  modelCapabilities:
+    - TEXT_TO_EMBEDDING
+  vendor: Qwen
+  displayName: Qwen.qwen3-embedding-0.6b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Qwen/Qwen3-Embedding-0.6B
+    path: /raid/models/Qwen/Qwen3-Embedding-0.6B

--- a/config/models/Qwen/Qwen3-Embedding-4B.yaml
+++ b/config/models/Qwen/Qwen3-Embedding-4B.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: qwen3-embedding-4b
+spec:
+  modelCapabilities:
+    - TEXT_TO_EMBEDDING
+  vendor: Qwen
+  displayName: Qwen.qwen3-embedding-4b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Qwen/Qwen3-Embedding-4B
+    path: /raid/models/Qwen/Qwen3-Embedding-4B

--- a/config/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/config/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: qwen3-next-80b-a3b-instruct
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: Qwen
+  displayName: Qwen.qwen3-next-80b-a3b-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Qwen/Qwen3-Next-80B-A3B-Instruct
+    path: /raid/models/Qwen/Qwen3-Next-80B-A3B-Instruct

--- a/config/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/config/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -1,0 +1,15 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: qwen3-vl-235b-a22b-instruct
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+    - VIDEO_TEXT_TO_TEXT
+  vendor: Qwen
+  displayName: Qwen.qwen3-vl-235b-a22b-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Qwen/Qwen3-VL-235B-A22B-Instruct
+    path: /raid/models/Qwen/Qwen3-VL-235B-A22B-Instruct

--- a/config/models/THUDM/chatglm2-6b.yaml
+++ b/config/models/THUDM/chatglm2-6b.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: chatglm2-6b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: THUDM
+  displayName: THUDM.chatglm2-6b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://THUDM/chatglm2-6b
+    path: /raid/models/THUDM/chatglm2-6b

--- a/config/models/XiaomiMiMo/MiMo-7B-RL.yaml
+++ b/config/models/XiaomiMiMo/MiMo-7B-RL.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: mimo-7b-rl
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: XiaomiMiMo
+  displayName: XiaomiMiMo.mimo-7b-rl
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://XiaomiMiMo/MiMo-7B-RL
+    path: /raid/models/XiaomiMiMo/MiMo-7B-RL

--- a/config/models/XiaomiMiMo/MiMo-VL-7B-RL.yaml
+++ b/config/models/XiaomiMiMo/MiMo-VL-7B-RL.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: mimo-vl-7b-rl
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+  vendor: XiaomiMiMo
+  displayName: XiaomiMiMo.mimo-vl-7b-rl
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://XiaomiMiMo/MiMo-VL-7B-RL
+    path: /raid/models/XiaomiMiMo/MiMo-VL-7B-RL

--- a/config/models/ZhipuAI/glm-4-9b-chat.yaml
+++ b/config/models/ZhipuAI/glm-4-9b-chat.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: glm-4-9b-chat
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: ZhipuAI
+  displayName: ZhipuAI.glm-4-9b-chat
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://ZhipuAI/glm-4-9b-chat
+    path: /raid/models/ZhipuAI/glm-4-9b-chat

--- a/config/models/adept/persimmon-8b-chat.yaml
+++ b/config/models/adept/persimmon-8b-chat.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: persimmon-8b-chat
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: adept
+  displayName: adept.persimmon-8b-chat
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://adept/persimmon-8b-chat
+    path: /raid/models/adept/persimmon-8b-chat

--- a/config/models/allenai/OLMo-2-1124-7B-Instruct.yaml
+++ b/config/models/allenai/OLMo-2-1124-7B-Instruct.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: olmo-2-1124-7b-instruct
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: allenai
+  displayName: allenai.olmo-2-1124-7b-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://allenai/OLMo-2-1124-7B-Instruct
+    path: /raid/models/allenai/OLMo-2-1124-7B-Instruct

--- a/config/models/allenai/OLMoE-1B-7B-0924.yaml
+++ b/config/models/allenai/OLMoE-1B-7B-0924.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: olmoe-1b-7b-0924
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: allenai
+  displayName: allenai.olmoe-1b-7b-0924
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://allenai/OLMoE-1B-7B-0924
+    path: /raid/models/allenai/OLMoE-1B-7B-0924

--- a/config/models/arcee-ai/AFM-4.5B-Base.yaml
+++ b/config/models/arcee-ai/AFM-4.5B-Base.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: afm-4-5b-base
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: arcee-ai
+  displayName: arcee-ai.afm-4.5b-base
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://arcee-ai/AFM-4.5B-Base
+    path: /raid/models/arcee-ai/AFM-4.5B-Base

--- a/config/models/baichuan-inc/Baichuan2-13B-Chat.yaml
+++ b/config/models/baichuan-inc/Baichuan2-13B-Chat.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: baichuan2-13b-chat
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: baichuan-inc
+  displayName: baichuan-inc.baichuan2-13b-chat
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://baichuan-inc/Baichuan2-13B-Chat
+    path: /raid/models/baichuan-inc/Baichuan2-13B-Chat

--- a/config/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
+++ b/config/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: ernie-4-5-21b-a3b-pt
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: baidu
+  displayName: baidu.ernie-4.5-21b-a3b-pt
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://baidu/ERNIE-4.5-21B-A3B-PT
+    path: /raid/models/baidu/ERNIE-4.5-21B-A3B-PT

--- a/config/models/bigcode/starcoder2-7b.yaml
+++ b/config/models/bigcode/starcoder2-7b.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: starcoder2-7b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: bigcode
+  displayName: bigcode.starcoder2-7b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://bigcode/starcoder2-7b
+    path: /raid/models/bigcode/starcoder2-7b

--- a/config/models/databricks/dbrx-instruct.yaml
+++ b/config/models/databricks/dbrx-instruct.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: dbrx-instruct
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: databricks
+  displayName: databricks.dbrx-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://databricks/dbrx-instruct
+    path: /raid/models/databricks/dbrx-instruct

--- a/config/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/config/models/deepseek-ai/DeepSeek-R1.yaml
@@ -3,7 +3,10 @@ kind: ClusterBaseModel
 metadata:
   name: deepseek-r1
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: deepseek-ai
+  displayName: deepseek-ai.deepseek-r1
   disabled: false
   version: "1.0.0"
   storage:

--- a/config/models/deepseek-ai/DeepSeek-V3-0324.yaml
+++ b/config/models/deepseek-ai/DeepSeek-V3-0324.yaml
@@ -3,7 +3,10 @@ kind: ClusterBaseModel
 metadata:
   name: deepseek-v3-0324
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: deepseek-ai
+  displayName: deepseek-ai.deepseek-v3-0324
   disabled: false
   version: "1.0.0"
   storage:

--- a/config/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/config/models/deepseek-ai/DeepSeek-V3.yaml
@@ -3,7 +3,10 @@ kind: ClusterBaseModel
 metadata:
   name: deepseek-v3
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: deepseek-ai
+  displayName: deepseek-ai.deepseek-v3
   disabled: false
   version: "1.0.0"
   storage:

--- a/config/models/deepseek-ai/Janus-Pro-7B.yaml
+++ b/config/models/deepseek-ai/Janus-Pro-7B.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: janus-pro-7b
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+  vendor: deepseek-ai
+  displayName: deepseek-ai.janus-pro-7b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://deepseek-ai/Janus-Pro-7B
+    path: /raid/models/deepseek-ai/Janus-Pro-7B

--- a/config/models/deepseek-ai/deepseek-vl2.yaml
+++ b/config/models/deepseek-ai/deepseek-vl2.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: deepseek-vl2
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+  vendor: deepseek-ai
+  displayName: deepseek-ai.deepseek-vl2
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://deepseek-ai/deepseek-vl2
+    path: /raid/models/deepseek-ai/deepseek-vl2

--- a/config/models/google/gemma-3-1b-it.yaml
+++ b/config/models/google/gemma-3-1b-it.yaml
@@ -1,0 +1,15 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: gemma-3-1b-it
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+    - IMAGE_TEXT_TO_TEXT
+  vendor: google
+  displayName: google.gemma-3-1b-it
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://google/gemma-3-1b-it
+    path: /raid/models/google/gemma-3-1b-it

--- a/config/models/google/gemma-3-4b-it.yaml
+++ b/config/models/google/gemma-3-4b-it.yaml
@@ -1,0 +1,15 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: gemma-3-4b-it
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+    - IMAGE_TEXT_TO_TEXT
+  vendor: google
+  displayName: google.gemma-3-4b-it
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://google/gemma-3-4b-it
+    path: /raid/models/google/gemma-3-4b-it

--- a/config/models/ibm-granite/granite-3.0-3b-a800m-instruct.yaml
+++ b/config/models/ibm-granite/granite-3.0-3b-a800m-instruct.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: granite-3-0-3b-a800m-instruct
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: ibm-granite
+  displayName: ibm-granite.granite-3.0-3b-a800m-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://ibm-granite/granite-3.0-3b-a800m-instruct
+    path: /raid/models/ibm-granite/granite-3.0-3b-a800m-instruct

--- a/config/models/ibm-granite/granite-3.1-8b-instruct.yaml
+++ b/config/models/ibm-granite/granite-3.1-8b-instruct.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: granite-3-1-8b-instruct
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: ibm-granite
+  displayName: ibm-granite.granite-3.1-8b-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://ibm-granite/granite-3.1-8b-instruct
+    path: /raid/models/ibm-granite/granite-3.1-8b-instruct

--- a/config/models/inclusionAI/Ling-lite.yaml
+++ b/config/models/inclusionAI/Ling-lite.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: ling-lite
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: inclusionAI
+  displayName: inclusionAI.ling-lite
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://inclusionAI/Ling-lite
+    path: /raid/models/inclusionAI/Ling-lite

--- a/config/models/inclusionAI/Ling-plus.yaml
+++ b/config/models/inclusionAI/Ling-plus.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: ling-plus
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: inclusionAI
+  displayName: inclusionAI.ling-plus
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://inclusionAI/Ling-plus
+    path: /raid/models/inclusionAI/Ling-plus

--- a/config/models/internlm/internlm2-7b.yaml
+++ b/config/models/internlm/internlm2-7b.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: internlm2-7b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: internlm
+  displayName: internlm.internlm2-7b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://internlm/internlm2-7b
+    path: /raid/models/internlm/internlm2-7b

--- a/config/models/intfloat/e5-mistral-7b-instruct.yaml
+++ b/config/models/intfloat/e5-mistral-7b-instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: e5-mistral-7b-instruct
 spec:
+  modelCapabilities:
+    - TEXT_TO_EMBEDDING
   disabled: false
   displayName: intfloat.e5-mistral-7b-instruct
   storage:

--- a/config/models/jet-ai/Jet-Nemotron-2B.yaml
+++ b/config/models/jet-ai/Jet-Nemotron-2B.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: jet-nemotron-2b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: jet-ai
+  displayName: jet-ai.jet-nemotron-2b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://jet-ai/Jet-Nemotron-2B
+    path: /raid/models/jet-ai/Jet-Nemotron-2B

--- a/config/models/kustomization.yaml
+++ b/config/models/kustomization.yaml
@@ -2,19 +2,174 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - intfloat/e5-mistral-7b-instruct.yaml
-  - microsoft/Phi-3-vision-128k-instruct.yaml
-  - deepseek-ai/DeepSeek-V3.yaml
+  # adept
+  - adept/persimmon-8b-chat.yaml
+
+  # Alibaba-NLP
+  - Alibaba-NLP/gme-Qwen2-VL-2B-Instruct.yaml
+  - Alibaba-NLP/gte-Qwen2-7B-instruct.yaml
+
+  # allenai
+  - allenai/OLMo-2-1124-7B-Instruct.yaml
+  - allenai/OLMoE-1B-7B-0924.yaml
+
+  # arcee-ai
+  - arcee-ai/AFM-4.5B-Base.yaml
+
+  # BAAI
+  - BAAI/bge-large-en-v1.5.yaml
+  - BAAI/bge-reranker-v2-m3.yaml
+
+  # baichuan-inc
+  - baichuan-inc/Baichuan2-13B-Chat.yaml
+
+  # baidu
+  - baidu/ERNIE-4.5-21B-A3B-PT.yaml
+
+  # bigcode
+  - bigcode/starcoder2-7b.yaml
+
+  # CofeAI
+  - CofeAI/Tele-FLM.yaml
+
+  # CohereForAI
+  - CohereForAI/c4ai-command-r-v01.yaml
+
+  # databricks
+  - databricks/dbrx-instruct.yaml
+
+  # deepseek-ai
   - deepseek-ai/DeepSeek-R1.yaml
+  - deepseek-ai/DeepSeek-V3-0324.yaml
+  - deepseek-ai/DeepSeek-V3.yaml
+  - deepseek-ai/deepseek-vl2.yaml
+  - deepseek-ai/Janus-Pro-7B.yaml
+
+  # Efficient-Large-Model
+  - Efficient-Large-Model/NVILA-8B.yaml
+
+  # google
+  - google/gemma-3-1b-it.yaml
+  - google/gemma-3-4b-it.yaml
+
+  # HuggingFaceTB
+  - HuggingFaceTB/SmolLM-1.7B.yaml
+
+  # ibm-granite
+  - ibm-granite/granite-3.0-3b-a800m-instruct.yaml
+  - ibm-granite/granite-3.1-8b-instruct.yaml
+
+  # inclusionAI
+  - inclusionAI/Ling-lite.yaml
+  - inclusionAI/Ling-plus.yaml
+
+  # internlm
+  - internlm/internlm2-7b.yaml
+
+  # intfloat
+  - intfloat/e5-mistral-7b-instruct.yaml
+
+  # jet-ai
+  - jet-ai/Jet-Nemotron-2B.yaml
+
+  # LGAI-EXAONE
+  - LGAI-EXAONE/EXAONE-3.5-7.8B-Instruct.yaml
+
+  # liuhaotian
+  - liuhaotian/llava-v1.5-13b.yaml
+
+  # lmms-lab
+  - lmms-lab/llava-next-72b.yaml
+  - lmms-lab/llava-onevision-qwen2-7b-ov.yaml
+
+  # lmsys
+  - lmsys/gpt-oss-120b.yaml
+  - lmsys/gpt-oss-20b.yaml
+
+  # meta
+  - meta/Llama-3-70B-Instruct.yaml
   - meta/Llama-3.1-405B-Instruct-FP8.yaml
-  - meta/Llama-3.1-8B-Instruct.yaml
   - meta/Llama-3.1-70B-Instruct.yaml
+  - meta/Llama-3.1-8B-Instruct.yaml
   - meta/Llama-3.2-11B-Vision-Instruct.yaml
-  - meta/Llama-3.2-90B-Vision-Instruct.yaml
+  - meta/Llama-3.2-1B-Instruct.yaml
+  - meta/Llama-3.2-3B-Instruct.yaml
   - meta/Llama-3.2-90B-Vision-Instruct-FP8.yaml
-  - meta/Llama-3.3-70B-Instruct.yaml
+  - meta/Llama-3.2-90B-Vision-Instruct.yaml
   - meta/Llama-3.3-70B-Instruct-FP8-dynamic.yaml
+  - meta/Llama-3.3-70B-instruct.yaml
   - meta/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+  - meta/Llama-4-Maverick-17B-128E-Instruct.yaml
   - meta/Llama-4-Scout-17B-16E-Instruct.yaml
-  - openai/gpt-oss-20b.yaml
+
+  # microsoft
+  - microsoft/Phi-3-vision-128k-instruct.yaml
+  - microsoft/Phi-3.5-MoE-instruct.yaml
+  - microsoft/Phi-4-multimodal-instruct.yaml
+
+  # minimax
+  - minimax/MiniMax-M2.yaml
+
+  # mistralai
+  - mistralai/Mistral-7B-Instruct-v0.2.yaml
+  - mistralai/Mistral-Small-3.1-24B-Instruct-2503.yaml
+
+  # moonshotai
+  - moonshotai/Kimi-K2-Instruct.yaml
+  - moonshotai/Kimi-VL-A3B-Instruct.yaml
+
+  # nvidia
+  - nvidia/Llama-3_1-Nemotron-Ultra-253B-v1.yaml
+  - nvidia/Llama-3_3-Nemotron-Super-49B-v1.yaml
+  - nvidia/Llama-3.1-Nemotron-Nano-8B-v1.yaml
+  - nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
+  - nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
+
+  # openai
+  - openai/clip-vit-large-patch14-336.yaml
   - openai/gpt-oss-120b.yaml
+  - openai/gpt-oss-20b.yaml
+
+  # openbmb
+  - openbmb/MiniCPM-V-2_6.yaml
+  - openbmb/MiniCPM3-4B.yaml
+
+  # OrionStarAI
+  - OrionStarAI/Orion-14B-Base.yaml
+
+  # Qwen
+  - Qwen/Qwen3-0.6B.yaml
+  - Qwen/Qwen3-30B-A3B.yaml
+  - Qwen/Qwen3-Embedding-0.6B.yaml
+  - Qwen/Qwen3-Embedding-4B.yaml
+  - Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+  - Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+
+  # rednote-hilab
+  - rednote-hilab/dots.ocr.yaml
+  - rednote-hilab/dots.vlm1.inst.yaml
+
+  # stabilityai
+  - stabilityai/stablelm-tuned-alpha-7b.yaml
+
+  # THUDM
+  - THUDM/chatglm2-6b.yaml
+
+  # upstage
+  - upstage/SOLAR-10.7B-Instruct-v1.0.yaml
+
+  # xai-org
+  - xai-org/grok-1.yaml
+
+  # XiaomiMiMo
+  - XiaomiMiMo/MiMo-7B-RL.yaml
+  - XiaomiMiMo/MiMo-VL-7B-RL.yaml
+
+  # xverse
+  - xverse/XVERSE-MoE-A36B.yaml
+
+  # zai-org
+  - zai-org/GLM-4.5V.yaml
+
+  # ZhipuAI
+  - ZhipuAI/glm-4-9b-chat.yaml

--- a/config/models/liuhaotian/llava-v1.5-13b.yaml
+++ b/config/models/liuhaotian/llava-v1.5-13b.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: llava-v1-5-13b
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+  vendor: liuhaotian
+  displayName: liuhaotian.llava-v1.5-13b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://liuhaotian/llava-v1.5-13b
+    path: /raid/models/liuhaotian/llava-v1.5-13b

--- a/config/models/lmms-lab/llava-next-72b.yaml
+++ b/config/models/lmms-lab/llava-next-72b.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: llava-next-72b
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+  vendor: lmms-lab
+  displayName: lmms-lab.llava-next-72b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://lmms-lab/llava-next-72b
+    path: /raid/models/lmms-lab/llava-next-72b

--- a/config/models/lmms-lab/llava-onevision-qwen2-7b-ov.yaml
+++ b/config/models/lmms-lab/llava-onevision-qwen2-7b-ov.yaml
@@ -1,0 +1,15 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: llava-onevision-qwen2-7b-ov
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+    - VIDEO_TEXT_TO_TEXT
+  vendor: lmms-lab
+  displayName: lmms-lab.llava-onevision-qwen2-7b-ov
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://lmms-lab/llava-onevision-qwen2-7b-ov
+    path: /raid/models/lmms-lab/llava-onevision-qwen2-7b-ov

--- a/config/models/lmsys/gpt-oss-120b.yaml
+++ b/config/models/lmsys/gpt-oss-120b.yaml
@@ -8,7 +8,7 @@ spec:
   version: "1.0.0"
   displayName: openai.gpt-oss-120b-bf16
   modelCapabilities:
-    - "CHAT"
+    - TEXT_TO_TEXT
   storage:
     storageUri: hf://lmsys/gpt-oss-120b-bf16
     path: /raid/models/lmsys/gpt-oss-120b-bf16

--- a/config/models/lmsys/gpt-oss-20b.yaml
+++ b/config/models/lmsys/gpt-oss-20b.yaml
@@ -8,7 +8,7 @@ spec:
   version: "1.0.0"
   displayName: openai.gpt-oss-20b-bf16
   modelCapabilities:
-    - "CHAT"
+    - TEXT_TO_TEXT
   storage:
     storageUri: hf://lmsys/gpt-oss-20b-bf16
     path: /raid/models/lmsys/gpt-oss-20b-bf16

--- a/config/models/meta/Llama-3-70B-Instruct.yaml
+++ b/config/models/meta/Llama-3-70B-Instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-70b-instruct
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   disabled: false
   displayName: meta.llama-3-70b-instruct
   storage:

--- a/config/models/meta/Llama-3.1-405B-Instruct-FP8.yaml
+++ b/config/models/meta/Llama-3.1-405B-Instruct-FP8.yaml
@@ -3,7 +3,10 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-1-405b-instruct-fp8
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: meta
+  displayName: meta.llama-3.1-405b-instruct-fp8
   disabled: false
   version: "1.0.0"
   storage:

--- a/config/models/meta/Llama-3.1-70B-Instruct.yaml
+++ b/config/models/meta/Llama-3.1-70B-Instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-1-70b-instruct
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: meta
   disabled: false
   version: "1.0.0"

--- a/config/models/meta/Llama-3.1-8B-Instruct.yaml
+++ b/config/models/meta/Llama-3.1-8B-Instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-1-8b-instruct
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: meta
   disabled: false
   version: "1.0.0"

--- a/config/models/meta/Llama-3.2-11B-Vision-Instruct.yaml
+++ b/config/models/meta/Llama-3.2-11B-Vision-Instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-2-11b-vision-instruct
 spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
   displayName: meta.llama-3.2-11b-vision-instruct
   vendor: meta
   disabled: false

--- a/config/models/meta/Llama-3.2-1B-Instruct.yaml
+++ b/config/models/meta/Llama-3.2-1B-Instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-2-1b-instruct
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   displayName: meta.llama-3.2-1b-instruct
   vendor: meta
   disabled: false

--- a/config/models/meta/Llama-3.2-3B-Instruct.yaml
+++ b/config/models/meta/Llama-3.2-3B-Instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-2-3b-instruct
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   displayName: meta.llama-3.2-3b-instruct
   vendor: meta
   disabled: false

--- a/config/models/meta/Llama-3.2-90B-Vision-Instruct-FP8.yaml
+++ b/config/models/meta/Llama-3.2-90B-Vision-Instruct-FP8.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-2-90b-vision-instruct-fp8
 spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
   displayName: meta.llama-3.2-90b-vision-instruct-fp8
   vendor: meta
   disabled: false

--- a/config/models/meta/Llama-3.2-90B-Vision-Instruct.yaml
+++ b/config/models/meta/Llama-3.2-90B-Vision-Instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-2-90b-vision-instruct
 spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
   displayName: meta.llama-3.2-90b-vision-instruct
   vendor: meta
   disabled: false

--- a/config/models/meta/Llama-3.3-70B-Instruct-FP8-dynamic.yaml
+++ b/config/models/meta/Llama-3.3-70B-Instruct-FP8-dynamic.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-3-70b-instruct-fp8-dynamic
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   disabled: false
   displayName: meta.llama-3.3-70b-instruct-fp8-dynamic
   storage:

--- a/config/models/meta/Llama-3.3-70B-instruct.yaml
+++ b/config/models/meta/Llama-3.3-70B-instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-3-70b-instruct
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   disabled: false
   displayName: meta.llama-3.3-70b-instruct
   storage:

--- a/config/models/meta/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/config/models/meta/Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-4-maverick-17b-128e-instruct-fp8
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: meta
   disabled: false
   displayName: meta.llama-4-maverick-17b-128e-instruct-fp8

--- a/config/models/meta/Llama-4-Maverick-17B-128E-Instruct.yaml
+++ b/config/models/meta/Llama-4-Maverick-17B-128E-Instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-4-maverick-17b-128e-instruct
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: meta
   disabled: false
   displayName: meta.llama-4-maverick-17b-128e-instruct

--- a/config/models/meta/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/config/models/meta/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-4-scout-17b-16e-instruct
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: meta
   disabled: false
   displayName: meta.llama-4-scout-17b-16e-instruct

--- a/config/models/microsoft/Phi-3-vision-128k-instruct.yaml
+++ b/config/models/microsoft/Phi-3-vision-128k-instruct.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: phi-3-vision-128k-instruct
 spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
   disabled: false
   displayName: microsoft.phi-3-vision-128k-instruct
   storage:

--- a/config/models/microsoft/Phi-3.5-MoE-instruct.yaml
+++ b/config/models/microsoft/Phi-3.5-MoE-instruct.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: phi-3-5-moe-instruct
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: microsoft
+  displayName: microsoft.phi-3.5-moe-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://microsoft/Phi-3.5-MoE-instruct
+    path: /raid/models/microsoft/Phi-3.5-MoE-instruct

--- a/config/models/microsoft/Phi-4-multimodal-instruct.yaml
+++ b/config/models/microsoft/Phi-4-multimodal-instruct.yaml
@@ -1,0 +1,16 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: phi-4-multimodal-instruct
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+    - VIDEO_TEXT_TO_TEXT
+    - AUDIO_TEXT_TO_TEXT
+  vendor: microsoft
+  displayName: microsoft.phi-4-multimodal-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://microsoft/Phi-4-multimodal-instruct
+    path: /raid/models/microsoft/Phi-4-multimodal-instruct

--- a/config/models/minimax/MiniMax-M2.yaml
+++ b/config/models/minimax/MiniMax-M2.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: minimax-m2
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+  vendor: minimax
+  displayName: minimax.minimax-m2
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://minimax/MiniMax-M2
+    path: /raid/models/minimax/MiniMax-M2

--- a/config/models/mistralai/Mistral-7B-Instruct-v0.2.yaml
+++ b/config/models/mistralai/Mistral-7B-Instruct-v0.2.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: mistral-7b-instruct-v0-2
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: mistralai
+  displayName: mistralai.mistral-7b-instruct-v0.2
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://mistralai/Mistral-7B-Instruct-v0.2
+    path: /raid/models/mistralai/Mistral-7B-Instruct-v0.2

--- a/config/models/mistralai/Mistral-Small-3.1-24B-Instruct-2503.yaml
+++ b/config/models/mistralai/Mistral-Small-3.1-24B-Instruct-2503.yaml
@@ -1,0 +1,15 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: mistral-small-3-1-24b-instruct-2503
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+    - IMAGE_TEXT_TO_TEXT
+  vendor: mistralai
+  displayName: mistralai.mistral-small-3.1-24b-instruct-2503
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://mistralai/Mistral-Small-3.1-24B-Instruct-2503
+    path: /raid/models/mistralai/Mistral-Small-3.1-24B-Instruct-2503

--- a/config/models/moonshotai/Kimi-K2-Instruct.yaml
+++ b/config/models/moonshotai/Kimi-K2-Instruct.yaml
@@ -3,7 +3,10 @@ kind: ClusterBaseModel
 metadata:
   name: kimi-k2-instruct
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: moonshotai
+  displayName: moonshotai.kimi-k2-instruct
   disabled: false
   version: "1.0.0"
   storage:

--- a/config/models/moonshotai/Kimi-VL-A3B-Instruct.yaml
+++ b/config/models/moonshotai/Kimi-VL-A3B-Instruct.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: kimi-vl-a3b-instruct
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+  vendor: moonshotai
+  displayName: moonshotai.kimi-vl-a3b-instruct
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://moonshotai/Kimi-VL-A3B-Instruct
+    path: /raid/models/moonshotai/Kimi-VL-A3B-Instruct

--- a/config/models/nvidia/Llama-3.1-Nemotron-Nano-8B-v1.yaml
+++ b/config/models/nvidia/Llama-3.1-Nemotron-Nano-8B-v1.yaml
@@ -3,12 +3,14 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-1-nemotron-nano-8b-v1
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: nvidia
   disabled: false
   version: "1.0.0"
   displayName: nvidia.llama-3.1-nemotron-nano-8b-v1
   modelCapabilities:
-    - "CHAT"
+    - TEXT_TO_TEXT
   storage:
     storageUri: hf://nvidia/Llama-3.1-Nemotron-Nano-8B-Instruct
     path: /raid/models/nvidia/llama-3-1-nemotron-nano-8b-v1

--- a/config/models/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1.yaml
+++ b/config/models/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1.yaml
@@ -3,7 +3,10 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-1-nemotron-ultra-253b-v1
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   vendor: nvidia
+  displayName: nvidia.llama-3.1-nemotron-70b-instruct
   disabled: false
   version: "1.0.0"
   storage:

--- a/config/models/nvidia/Llama-3_3-Nemotron-Super-49B-v1.yaml
+++ b/config/models/nvidia/Llama-3_3-Nemotron-Super-49B-v1.yaml
@@ -3,6 +3,8 @@ kind: ClusterBaseModel
 metadata:
   name: llama-3-3-nemotron-super-49b-v1
 spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
   disabled: false
   displayName: nvidia.llama-3_3-nemotron-super-49b-v1
   storage:

--- a/config/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
+++ b/config/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
@@ -1,0 +1,15 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: nvidia-nemotron-nano-12b-v2-vl-bf16
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+    - VIDEO_TEXT_TO_TEXT
+  vendor: nvidia
+  displayName: nvidia.nvidia-nemotron-nano-12b-v2-vl-bf16
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
+    path: /raid/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16

--- a/config/models/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
+++ b/config/models/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: nvidia-nemotron-nano-9b-v2
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: nvidia
+  displayName: nvidia.nvidia-nemotron-nano-9b-v2
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://nvidia/NVIDIA-Nemotron-Nano-9B-v2
+    path: /raid/models/nvidia/NVIDIA-Nemotron-Nano-9B-v2

--- a/config/models/openai/clip-vit-large-patch14-336.yaml
+++ b/config/models/openai/clip-vit-large-patch14-336.yaml
@@ -1,0 +1,15 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: clip-vit-large-patch14-336
+spec:
+  modelCapabilities:
+    - TEXT_TO_EMBEDDING
+    - IMAGE_TEXT_TO_EMBEDDING
+  vendor: openai
+  displayName: openai.clip-vit-large-patch14-336
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://openai/clip-vit-large-patch14-336
+    path: /raid/models/openai/clip-vit-large-patch14-336

--- a/config/models/openai/gpt-oss-120b.yaml
+++ b/config/models/openai/gpt-oss-120b.yaml
@@ -8,7 +8,7 @@ spec:
   version: "1.0.0"
   displayName: openai.gpt-oss-120b
   modelCapabilities:
-    - "CHAT"
+    - TEXT_TO_TEXT
   modelFramework:
     name: transformers
     version: "4.55.0"

--- a/config/models/openai/gpt-oss-20b.yaml
+++ b/config/models/openai/gpt-oss-20b.yaml
@@ -8,7 +8,7 @@ spec:
   version: "1.0.0"
   displayName: openai.gpt-oss-20b
   modelCapabilities:
-    - "CHAT"
+    - TEXT_TO_TEXT
   modelFramework:
     name: transformers
     version: "4.55.0"

--- a/config/models/openbmb/MiniCPM-V-2_6.yaml
+++ b/config/models/openbmb/MiniCPM-V-2_6.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: minicpm-v-2-6
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+  vendor: openbmb
+  displayName: openbmb.minicpm-v-2_6
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://openbmb/MiniCPM-V-2_6
+    path: /raid/models/openbmb/MiniCPM-V-2_6

--- a/config/models/openbmb/MiniCPM3-4B.yaml
+++ b/config/models/openbmb/MiniCPM3-4B.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: minicpm3-4b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: openbmb
+  displayName: openbmb.minicpm3-4b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://openbmb/MiniCPM3-4B
+    path: /raid/models/openbmb/MiniCPM3-4B

--- a/config/models/rednote-hilab/dots.ocr.yaml
+++ b/config/models/rednote-hilab/dots.ocr.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: dots-ocr
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+  vendor: rednote-hilab
+  displayName: rednote-hilab.dots.ocr
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://rednote-hilab/dots.ocr
+    path: /raid/models/rednote-hilab/dots.ocr

--- a/config/models/rednote-hilab/dots.vlm1.inst.yaml
+++ b/config/models/rednote-hilab/dots.vlm1.inst.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: dots-vlm1-inst
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+  vendor: rednote-hilab
+  displayName: rednote-hilab.dots.vlm1.inst
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://rednote-hilab/dots.vlm1.inst
+    path: /raid/models/rednote-hilab/dots.vlm1.inst

--- a/config/models/stabilityai/stablelm-tuned-alpha-7b.yaml
+++ b/config/models/stabilityai/stablelm-tuned-alpha-7b.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: stablelm-tuned-alpha-7b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: stabilityai
+  displayName: stabilityai.stablelm-tuned-alpha-7b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://stabilityai/stablelm-tuned-alpha-7b
+    path: /raid/models/stabilityai/stablelm-tuned-alpha-7b

--- a/config/models/upstage/SOLAR-10.7B-Instruct-v1.0.yaml
+++ b/config/models/upstage/SOLAR-10.7B-Instruct-v1.0.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: solar-10-7b-instruct-v1-0
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: upstage
+  displayName: upstage.solar-10.7b-instruct-v1.0
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://upstage/SOLAR-10.7B-Instruct-v1.0
+    path: /raid/models/upstage/SOLAR-10.7B-Instruct-v1.0

--- a/config/models/xai-org/grok-1.yaml
+++ b/config/models/xai-org/grok-1.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: grok-1
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: xai-org
+  displayName: xai-org.grok-1
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://xai-org/grok-1
+    path: /raid/models/xai-org/grok-1

--- a/config/models/xverse/XVERSE-MoE-A36B.yaml
+++ b/config/models/xverse/XVERSE-MoE-A36B.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: xverse-moe-a36b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: xverse
+  displayName: xverse.xverse-moe-a36b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://xverse/XVERSE-MoE-A36B
+    path: /raid/models/xverse/XVERSE-MoE-A36B

--- a/config/models/zai-org/GLM-4.5V.yaml
+++ b/config/models/zai-org/GLM-4.5V.yaml
@@ -1,0 +1,15 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: glm-4-5v
+spec:
+  modelCapabilities:
+    - IMAGE_TEXT_TO_TEXT
+    - VIDEO_TEXT_TO_TEXT
+  vendor: zai-org
+  displayName: zai-org.glm-4.5v
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://zai-org/GLM-4.5V
+    path: /raid/models/zai-org/GLM-4.5V


### PR DESCRIPTION
## Summary

- Add ClusterBaseModel configurations for all sglang-supported models
- Expand model coverage from 17 to 87 model configurations
- Update kustomization.yaml to reference all model files

## Models Added

### Generative Models (40+)

| Vendor | Models |
|--------|--------|
| Qwen | Qwen3-0.6B, Qwen3-30B-A3B, Qwen3-Next-80B-A3B-Instruct |
| Google | gemma-3-1b-it, gemma-3-4b-it |
| Microsoft | Phi-3.5-MoE-instruct, Phi-4-multimodal-instruct |
| Mistral | Mistral-7B-Instruct-v0.2, Mistral-Small-3.1-24B-Instruct-2503 |
| AllenAI | OLMo-2-1124-7B-Instruct, OLMoE-1B-7B-0924 |
| OpenBMB | MiniCPM3-4B |
| NVIDIA | NVIDIA-Nemotron-Nano-9B-v2, Jet-Nemotron-2B |
| Others | Grok-1, ChatGLM2, InternLM2, EXAONE, Baichuan2, DBRX, Command-R, StableLM, SmolLM, GLM-4, MiMo, ERNIE-4.5, Granite, StarCoder2, SOLAR, Orion, Ling, Tele-FLM, AFM, Persimmon |

### Multimodal Models (15+)

| Vendor | Models |
|--------|--------|
| Qwen | Qwen3-VL-235B-A22B-Instruct |
| Microsoft | Phi-4-multimodal-instruct |
| OpenBMB | MiniCPM-V-2_6 |
| DeepSeek | deepseek-vl2, Janus-Pro-7B |
| LLaVA | llava-v1.5-13b, llava-next-72b, llava-onevision-qwen2-7b-ov |
| NVIDIA | NVILA-8B, NVIDIA-Nemotron-Nano-12B-v2-VL-BF16 |
| Others | Kimi-VL-A3B, dots.vlm1, MiMo-VL-7B-RL, GLM-4.5V, MiniMax-M2 |

### Embedding Models

- **Alibaba-NLP**: gte-Qwen2-7B-instruct, gme-Qwen2-VL-2B-Instruct
- **Qwen**: Qwen3-Embedding-4B, Qwen3-Embedding-0.6B
- **BAAI**: bge-large-en-v1.5
- **OpenAI**: clip-vit-large-patch14-336

### Rerank Models

- **BAAI**: bge-reranker-v2-m3

## Test Plan

- Verify kustomize build succeeds: `kustomize build config/models`
- Validate YAML syntax for all new model files
- Confirm HuggingFace storage URIs are correct