### PR TITLE
Allow a different base image for manager and ome-agent images

### DIFF
--- a/dockerfiles/manager.Dockerfile
+++ b/dockerfiles/manager.Dockerfile
@@ -1,3 +1,9 @@
+# Configurable base image - must be declared before any FROM statement
+# Defaults to Oracle Linux 10 for OCI SDK compatibility
+# Can be overridden with --build-arg BASE_IMAGE=ubuntu:24.04
+# Note: Ubuntu 22.04 has glibc 2.35, but golang:1.25 requires glibc 2.38+
+ARG BASE_IMAGE=oraclelinux:10-slim
+
 # Build the manager binary
 FROM golang:1.25 AS builder
 
@@ -47,17 +53,30 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -ldflags "-X github.com/sgl-project/ome/pkg/version.GitVersion=${GIT_TAG} -X github.com/sgl-project/ome/pkg/version.GitCommit=${GIT_COMMIT}" \
     -o manager ./cmd/manager
 
-# Use Oracle Linux 10 as base image (has glibc for CGO binaries)
-FROM oraclelinux:10-slim
-RUN microdnf update -y && microdnf clean all
+# Use the base image specified at the top of the file
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
-# Install runtime dependencies for the XET library
-RUN microdnf install -y \
-    glibc \
-    libgcc \
-    libstdc++ \
-    openssl-libs \
-    && microdnf clean all
+# Install/update packages and runtime dependencies based on the base image
+RUN if [ -f /usr/bin/microdnf ]; then \
+        microdnf update -y && \
+        microdnf install -y \
+            glibc \
+            libgcc \
+            libstdc++ \
+            openssl-libs && \
+        microdnf clean all; \
+    elif [ -f /usr/bin/apt-get ]; then \
+        apt-get update && \
+        apt-get install -y \
+            ca-certificates \
+            libc6 \
+            libgcc-s1 \
+            libstdc++6 \
+            libssl3 && \
+        apt-get upgrade -y && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/dockerfiles/ome-agent.Dockerfile
+++ b/dockerfiles/ome-agent.Dockerfile
@@ -1,4 +1,10 @@
-# Build the ome-agent binary
+# Configurable base image - must be declared before any FROM statement
+# Defaults to Oracle Linux 10 for OCI SDK compatibility
+# Can be overridden with --build-arg BASE_IMAGE=ubuntu:24.04
+# Note: Ubuntu 22.04 has glibc 2.35, but golang:1.24 requires glibc 2.38+
+ARG BASE_IMAGE=oraclelinux:10-slim
+
+# Build the model-agent binary
 FROM golang:1.25 AS builder
 
 # Install Rust and Cargo for building the XET library
@@ -23,8 +29,9 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# Download dependencies
-RUN go mod download
+# Download dependencies with Go module cache
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 # Copy source code
 COPY cmd/ cmd/
@@ -33,6 +40,10 @@ COPY internal/ internal/
 
 # Build the XET library first
 RUN cd pkg/xet && make build
+
+# Verify static library exists and remove dynamic library to force static linking
+RUN ls -lh /workspace/pkg/xet/target/release/libxet.* && \
+    rm -f /workspace/pkg/xet/target/release/libxet.so
 
 # Build arguments for version info
 ARG VERSION
@@ -45,17 +56,30 @@ RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     -ldflags "-X github.com/sgl-project/ome/pkg/version.GitVersion=${GIT_TAG} -X github.com/sgl-project/ome/pkg/version.GitCommit=${GIT_COMMIT}" \
     -o ome-agent ./cmd/ome-agent
 
-# Use Oracle Linux 10 as base image for OCI SDK compatibility
-FROM oraclelinux:10-slim
-RUN microdnf update -y && microdnf clean all
+# Use the base image specified at the top of the file
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
-# Install runtime dependencies for the XET library
-RUN microdnf install -y \
-    glibc \
-    libgcc \
-    libstdc++ \
-    openssl-libs \
-    && microdnf clean all
+# Install/update packages and runtime dependencies based on the base image
+RUN if [ -f /usr/bin/microdnf ]; then \
+        microdnf update -y && \
+        microdnf install -y \
+            glibc \
+            libgcc \
+            libstdc++ \
+            openssl-libs && \
+        microdnf clean all; \
+    elif [ -f /usr/bin/apt-get ]; then \
+        apt-get update && \
+        apt-get install -y \
+            ca-certificates \
+            libc6 \
+            libgcc-s1 \
+            libstdc++6 \
+            libssl3 && \
+        apt-get upgrade -y && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi
 
 COPY --from=builder /workspace/ome-agent /
 COPY config/ome-agent/ome-agent.yaml /


### PR DESCRIPTION
Facilitate image build on mac where it can't build oracle-linux based images

Fix the issue in the previous PR where it accidentally changes the name of the binary