### PR TITLE
[core] Skip Model Artifact Deletion Feature

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -483,6 +483,7 @@ var (
 	ModelsLabelPrefix                = "models.ome/"
 	TargetInstanceShapes             = "models.ome.io/target-instance-shapes"
 	ModelStatusConfigMapLabel        = "models.ome/basemodel-status"
+	ReserveModelArtifact             = "models.ome/reserve-model-artifact"
 
 	ModelLabelDomain          = "models.ome.io"
 	ClusterBaseModelLabelType = "clusterbasemodel"


### PR DESCRIPTION
Introduce the logic of skipping the model artifact file on the node if the target label exists

## What this PR does
Add the logic of skipping model artifact file on the tnode if ```models.ome/reserve-model-artifact``` label exists on the model custom resource

## Why we need it

<!-- Motivation, context, or link to issue -->

[Fixes #378]

## How to test

new method covered by unite test

## Checklist

- [ x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
