### PR TITLE
[Bugs]resolve too long domain name

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -688,6 +688,10 @@ func DefaultRayHeadServiceName(name string, index int) string {
 	return rayutils.CheckName(fmt.Sprintf("%s-%d", name, index))
 }
 
+func TruncateDomainName(name string, maxLength int) string {
+	return truncateWithHash(name, maxLength)
+}
+
 // Kubernetes naming constraints
 const (
 	// Maximum length for label names (after domain/)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/services/domain_service.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/services/domain_service.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"text/template"
 
+	"github.com/sgl-project/ome/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -76,6 +77,11 @@ func (d *DefaultDomainService) GenerateDomainName(name string, obj interface{}, 
 
 	// Resolve effective ingress config with annotation overrides
 	effectiveConfig := utils.ResolveIngressConfig(ingressConfig, objMeta.Annotations)
+
+	// Truncate name to ensure the final domain does not exceed DNS limits 63.
+	// If the name fits within maxLength, it's returned as-is
+	// Otherwise, it returns: {hash_prefix}-{suffix}
+	name = constants.TruncateDomainName(name, 63)
 
 	values := DomainTemplateValues{
 		Name:          name,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/services/domain_service_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/services/domain_service_test.go
@@ -444,22 +444,6 @@ func TestDefaultDomainService_EdgeCases(t *testing.T) {
 			expectedError: true,
 			errorContains: "can't evaluate field UndefinedField",
 		},
-		{
-			name:        "very long domain name",
-			serviceName: "very-long-service-name-that-exceeds-normal-limits-and-keeps-going",
-			obj: &v1beta1.InferenceService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "very-long-service-name-that-exceeds-normal-limits-and-keeps-going",
-					Namespace: "very-long-namespace-name-that-also-exceeds-limits",
-				},
-			},
-			ingressConfig: &controllerconfig.IngressConfig{
-				IngressDomain:  "very-long-domain-name-example.com",
-				DomainTemplate: "{{.Name}}.{{.Namespace}}.{{.IngressDomain}}",
-			},
-			expectedError: true, // Should exceed domain name limits
-			errorContains: "invalid domain name",
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What this PR does

in our service our inferenceServiceName-engine will exceed url 63 character limit. In order to keep all url consistent, modify the generateDomainName with name strip.

## Why we need it

<!-- Motivation, context, or link to issue -->

Fixes #

## How to test



## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
