### PR TITLE
[API] Add model capabilities for the supported endpoints

### DIFF
--- a/pkg/apis/ome/v1beta1/model.go
+++ b/pkg/apis/ome/v1beta1/model.go
@@ -134,10 +134,10 @@ type BaseModelSpec struct {
 	// +optional
 	ModelCapabilities []string `json:"modelCapabilities,omitempty"`
 
-	// Endpoints supported by the model, e.g., "OPENAI_V1_CHAT_COMPLETIONS"
+	// API capabilities supported by the model, e.g., "OPENAI_V1_CHAT_COMPLETIONS"
 	// +listType=atomic
 	// +optional
-	Endpoints []ModelEndpoint `json:"endpoints,omitempty"`
+	ApiCapabilities []ModelAPICapability `json:"apiCapabilities,omitempty"`
 
 	// Configuration of the model, stored as generic JSON for flexibility.
 	// +optional
@@ -231,20 +231,20 @@ const (
 	ModelCapabilityUnknown          ModelCapability = ""
 )
 
-// ModelEndpoint enum
+// ModelAPICapability enum
 // +kubebuilder:validation:Enum=OPENAI_V1_CHAT_COMPLETIONS;OPENAI_V1_RESPONSES;OPENAI_V1_EMBEDDINGS;OPENAI_V1_IMAGES_GENERATIONS;OPENAI_V1_IMAGES_EDITS;OPENAI_V1_AUDIO_SPEECH;OPENAI_V1_AUDIO_TRANSCRIPTIONS;OPENAI_V1_AUDIO_TRANSLATIONS;OPENAI_V1_REALTIME
-type ModelEndpoint string
+type ModelAPICapability string
 
 const (
-	ModelEndpointOpenAIv1ChatCompletions     ModelEndpoint = "OPENAI_V1_CHAT_COMPLETIONS"
-	ModelEndpointOpenAIv1Responses           ModelEndpoint = "OPENAI_V1_RESPONSES"
-	ModelEndpointOpenAIv1Embeddings          ModelEndpoint = "OPENAI_V1_EMBEDDINGS"
-	ModelEndpointOpenAIv1ImagesGenerations   ModelEndpoint = "OPENAI_V1_IMAGES_GENERATIONS"
-	ModelEndpointOpenAIv1ImagesEdits         ModelEndpoint = "OPENAI_V1_IMAGES_EDITS"
-	ModelEndpointOpenAIv1AudioSpeech         ModelEndpoint = "OPENAI_V1_AUDIO_SPEECH"
-	ModelEndpointOpenAIv1AudioTranscriptions ModelEndpoint = "OPENAI_V1_AUDIO_TRANSCRIPTIONS"
-	ModelEndpointOpenAIv1AudioTranslations   ModelEndpoint = "OPENAI_V1_AUDIO_TRANSLATIONS"
-	ModelEndpointOpenAIv1Realtime            ModelEndpoint = "OPENAI_V1_REALTIME"
+	ModelAPICapabilityOpenAIv1ChatCompletions     ModelAPICapability = "OPENAI_V1_CHAT_COMPLETIONS"
+	ModelAPICapabilityOpenAIv1Responses           ModelAPICapability = "OPENAI_V1_RESPONSES"
+	ModelAPICapabilityOpenAIv1Embeddings          ModelAPICapability = "OPENAI_V1_EMBEDDINGS"
+	ModelAPICapabilityOpenAIv1ImagesGenerations   ModelAPICapability = "OPENAI_V1_IMAGES_GENERATIONS"
+	ModelAPICapabilityOpenAIv1ImagesEdits         ModelAPICapability = "OPENAI_V1_IMAGES_EDITS"
+	ModelAPICapabilityOpenAIv1AudioSpeech         ModelAPICapability = "OPENAI_V1_AUDIO_SPEECH"
+	ModelAPICapabilityOpenAIv1AudioTranscriptions ModelAPICapability = "OPENAI_V1_AUDIO_TRANSCRIPTIONS"
+	ModelAPICapabilityOpenAIv1AudioTranslations   ModelAPICapability = "OPENAI_V1_AUDIO_TRANSLATIONS"
+	ModelAPICapabilityOpenAIv1Realtime            ModelAPICapability = "OPENAI_V1_REALTIME"
 )
 
 // ModelWeightStatus enum

--- a/pkg/apis/ome/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/ome/v1beta1/zz_generated.deepcopy.go
@@ -604,9 +604,9 @@ func (in *BaseModelSpec) DeepCopyInto(out *BaseModelSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.Endpoints != nil {
-		in, out := &in.Endpoints, &out.Endpoints
-		*out = make([]ModelEndpoint, len(*in))
+	if in.ApiCapabilities != nil {
+		in, out := &in.ApiCapabilities, &out.ApiCapabilities
+		*out = make([]ModelAPICapability, len(*in))
 		copy(*out, *in)
 	}
 	in.ModelConfiguration.DeepCopyInto(&out.ModelConfiguration)

--- a/pkg/modelagent/config_parser.go
+++ b/pkg/modelagent/config_parser.go
@@ -322,10 +322,10 @@ func (p *ModelConfigParser) updateModelSpec(spec *v1beta1.BaseModelSpec, metadat
 				*c = new.(v1beta1.ModelFormat)
 				isUpdated = true
 			}
-		case *[]v1beta1.ModelEndpoint:
-			newEndpoints := new.([]v1beta1.ModelEndpoint)
-			if len(*c) == 0 && len(newEndpoints) > 0 {
-				*c = append([]v1beta1.ModelEndpoint(nil), newEndpoints...)
+		case *[]v1beta1.ModelAPICapability:
+			newAPICapabilities := new.([]v1beta1.ModelAPICapability)
+			if len(*c) == 0 && len(newAPICapabilities) > 0 {
+				*c = append([]v1beta1.ModelAPICapability(nil), newAPICapabilities...)
 				isUpdated = true
 			}
 		case **v1beta1.ModelFrameworkSpec:
@@ -363,7 +363,7 @@ func (p *ModelConfigParser) updateModelSpec(spec *v1beta1.BaseModelSpec, metadat
 	updateField(&spec.ModelParameterSize, metadata.ModelParameterSize, "ModelParameterSize")
 	updateField(&spec.MaxTokens, metadata.MaxTokens, "MaxTokens")
 	updateField(&spec.ModelCapabilities, metadata.ModelCapabilities, "ModelCapabilities")
-	updateField(&spec.Endpoints, metadata.Endpoints, "Endpoints")
+	updateField(&spec.ApiCapabilities, metadata.ApiCapabilities, "ApiCapabilities")
 	updateField(&spec.Quantization, metadata.Quantization, "Quantization")
 	updateField(&spec.ModelConfiguration, metadata.ModelConfiguration, "ModelConfiguration")
 

--- a/pkg/modelagent/configmap_reconciler.go
+++ b/pkg/modelagent/configmap_reconciler.go
@@ -226,10 +226,10 @@ func (c *ConfigMapReconciler) recreateConfigMap(ctx context.Context) {
 			config.ModelParameterSize = cacheEntry.ModelMetadata.ModelParameterSize
 			config.MaxTokens = cacheEntry.ModelMetadata.MaxTokens
 			config.Quantization = string(cacheEntry.ModelMetadata.Quantization)
-			if len(cacheEntry.ModelMetadata.Endpoints) > 0 {
-				config.Endpoints = make([]string, len(cacheEntry.ModelMetadata.Endpoints))
-				for i, endpoint := range cacheEntry.ModelMetadata.Endpoints {
-					config.Endpoints[i] = string(endpoint)
+			if len(cacheEntry.ModelMetadata.ApiCapabilities) > 0 {
+				config.ApiCapabilities = make([]string, len(cacheEntry.ModelMetadata.ApiCapabilities))
+				for i, capability := range cacheEntry.ModelMetadata.ApiCapabilities {
+					config.ApiCapabilities[i] = string(capability)
 				}
 			}
 
@@ -285,10 +285,10 @@ func (c *ConfigMapReconciler) restoreModelInConfigMap(modelID string, cacheEntry
 		config.ModelParameterSize = cacheEntry.ModelMetadata.ModelParameterSize
 		config.MaxTokens = cacheEntry.ModelMetadata.MaxTokens
 		config.Quantization = string(cacheEntry.ModelMetadata.Quantization)
-		if len(cacheEntry.ModelMetadata.Endpoints) > 0 {
-			config.Endpoints = make([]string, len(cacheEntry.ModelMetadata.Endpoints))
-			for i, endpoint := range cacheEntry.ModelMetadata.Endpoints {
-				config.Endpoints[i] = string(endpoint)
+		if len(cacheEntry.ModelMetadata.ApiCapabilities) > 0 {
+			config.ApiCapabilities = make([]string, len(cacheEntry.ModelMetadata.ApiCapabilities))
+			for i, capability := range cacheEntry.ModelMetadata.ApiCapabilities {
+				config.ApiCapabilities[i] = string(capability)
 			}
 		}
 

--- a/pkg/modelagent/model_data.go
+++ b/pkg/modelagent/model_data.go
@@ -34,7 +34,7 @@ type ModelMetadata struct {
 	ModelParameterSize        string
 	MaxTokens                 int32
 	ModelCapabilities         []string
-	Endpoints                 []v1beta1.ModelEndpoint
+	ApiCapabilities           []v1beta1.ModelAPICapability
 	ModelConfiguration        []byte
 	DecodedModelConfiguration map[string]interface{} `json:"DecodedModelConfiguration,omitempty"`
 	Quantization              v1beta1.ModelQuantization
@@ -55,7 +55,7 @@ type ModelConfig struct {
 	ModelParameterSize string   `json:"modelParameterSize,omitempty"` // Human-readable size, e.g., "7.11B"
 	MaxTokens          int32    `json:"maxTokens,omitempty"`          // Maximum context length, e.g., 32768
 	ModelCapabilities  []string `json:"modelCapabilities,omitempty"`  // e.g., ["TEXT_GENERATION", "TEXT_EMBEDDINGS"]
-	Endpoints          []string `json:"endpoints,omitempty"`          // e.g., ["OPENAI_V1_CHAT_COMPLETIONS"]
+	ApiCapabilities    []string `json:"apiCapabilities,omitempty"`    // e.g., ["OPENAI_V1_CHAT_COMPLETIONS"]
 
 	// Advanced information
 	DecodedModelConfiguration map[string]interface{} `json:"decodedModelConfiguration,omitempty"` // Detailed configuration
@@ -119,12 +119,12 @@ func ConvertMetadataToModelConfig(metadata ModelMetadata) *ModelConfig {
 		quantization = string(metadata.Quantization)
 	}
 
-	// Convert endpoints to strings
-	var endpoints []string
-	if len(metadata.Endpoints) > 0 {
-		endpoints = make([]string, len(metadata.Endpoints))
-		for i, endpoint := range metadata.Endpoints {
-			endpoints[i] = string(endpoint)
+	// Convert API capabilities to strings
+	var apiCapabilities []string
+	if len(metadata.ApiCapabilities) > 0 {
+		apiCapabilities = make([]string, len(metadata.ApiCapabilities))
+		for i, capability := range metadata.ApiCapabilities {
+			apiCapabilities[i] = string(capability)
 		}
 	}
 
@@ -146,7 +146,7 @@ func ConvertMetadataToModelConfig(metadata ModelMetadata) *ModelConfig {
 		ModelParameterSize:        metadata.ModelParameterSize,
 		MaxTokens:                 metadata.MaxTokens,
 		ModelCapabilities:         metadata.ModelCapabilities,
-		Endpoints:                 endpoints,
+		ApiCapabilities:           apiCapabilities,
 		DecodedModelConfiguration: decodedConfig,
 		Quantization:              quantization,
 	}

--- a/pkg/modelagent/model_data_test.go
+++ b/pkg/modelagent/model_data_test.go
@@ -29,7 +29,7 @@ func TestConvertMetadataToModelConfig(t *testing.T) {
 				ModelParameterSize: "7.11B",
 				MaxTokens:          4096,
 				ModelCapabilities:  []string{"TEXT_GENERATION", "CHAT_COMPLETION"},
-				Endpoints:          []v1beta1.ModelEndpoint{v1beta1.ModelEndpointOpenAIv1ChatCompletions},
+				ApiCapabilities:    []v1beta1.ModelAPICapability{v1beta1.ModelAPICapabilityOpenAIv1ChatCompletions},
 				Quantization:       "FP16",
 				DecodedModelConfiguration: map[string]interface{}{
 					"hidden_size":         4096,
@@ -45,7 +45,7 @@ func TestConvertMetadataToModelConfig(t *testing.T) {
 				ModelParameterSize: "7.11B",
 				MaxTokens:          4096,
 				ModelCapabilities:  []string{"TEXT_GENERATION", "CHAT_COMPLETION"},
-				Endpoints:          []string{"OPENAI_V1_CHAT_COMPLETIONS"},
+				ApiCapabilities:    []string{"OPENAI_V1_CHAT_COMPLETIONS"},
 				Quantization:       "FP16",
 				DecodedModelConfiguration: map[string]interface{}{
 					"hidden_size":         4096,
@@ -161,7 +161,7 @@ func TestModelEntryMarshaling(t *testing.T) {
 			ModelParameterSize: "70B",
 			MaxTokens:          4096,
 			ModelCapabilities:  []string{"TEXT_GENERATION", "CHAT_COMPLETION"},
-			Endpoints:          []string{string(v1beta1.ModelEndpointOpenAIv1ChatCompletions)},
+			ApiCapabilities:    []string{string(v1beta1.ModelAPICapabilityOpenAIv1ChatCompletions)},
 		},
 	}
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1160,14 +1160,14 @@ func schema_pkg_apis_ome_v1beta1_BaseModelSpec(ref common.ReferenceCallback) com
 							},
 						},
 					},
-					"endpoints": {
+					"apiCapabilities": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
 								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Endpoints supported by the model, e.g., \"OPENAI_V1_CHAT_COMPLETIONS\"",
+							Description: "API capabilities supported by the model, e.g., \"OPENAI_V1_CHAT_COMPLETIONS\"",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -589,8 +589,8 @@
           },
           "x-kubernetes-list-type": "atomic"
         },
-        "endpoints": {
-          "description": "Endpoints supported by the model, e.g., \"OPENAI_V1_CHAT_COMPLETIONS\"",
+        "apiCapabilities": {
+          "description": "API capabilities supported by the model, e.g., \"OPENAI_V1_CHAT_COMPLETIONS\"",
           "type": "array",
           "items": {
             "type": "string",


### PR DESCRIPTION
## What this PR does:

- Adds an explicit endpoints field and ModelEndpoint enum so models declare which OpenAI v1 endpoints they support.
- Keeps existing capabilities but stops overloading them for endpoint coverage; new constants cover images, audio, and realtime.
- Plumbs endpoints through model metadata/config so agents and consumers can see supported endpoints (e.g., gpt-image-1 exposes images/generations and images/edits; grok-2-image exposes only images/generations).

## Why we need it:

- To safely enable newer endpoints (image generation/edits, audio speech/transcription/translation, realtime), callers must know a model’s supported endpoints up front.

Fixes #

## How to test

N/A

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [X] `make test` passes locally
