### PR TITLE
Fix OME scale down Deployments to 1 replica temporarily whenever it changes something

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -98,6 +98,11 @@ func (r *DeploymentReconciler) checkDeploymentExist() (constants.CheckResultType
 		return constants.CheckResultUnknown, nil, err
 	}
 
+	if existingDeployment.Spec.Replicas != nil {
+		r.Deployment.Spec.Replicas = existingDeployment.Spec.Replicas
+		log.V(1).Info("Preserving existing replicas in target state", "namespace", r.Deployment.Namespace, "name", r.Deployment.Name, "replicas", *r.Deployment.Spec.Replicas)
+	}
+
 	diff, err := kmp.SafeDiff(r.Deployment.Spec, existingDeployment.Spec, ignoreFields)
 	if err != nil {
 		return constants.CheckResultUnknown, nil, err


### PR DESCRIPTION
## What this PR does

When the OME controller reconciles an InferenceService and detects a diff in the engine Deployment spec (e.g., annotation change, probe update), it performs an Update on the Deployment. Before this fix, the update would overwrite the existing `spec.replicas` with the controller's default (nil, which Kubernetes interprets as 1), causing replicas managed by HPA to be reset.

This PR adds 5 lines in `checkDeploymentExist()` to copy the existing Deployment's `spec.replicas` into the target state before the diff comparison and update, so the replica count is preserved.

## Why we need it

Fixes https://github.com/sgl-project/ome/issues/397

In production, this bug causes a replica flap (`N → 1 → N`) on every reconcile that touches the Deployment spec, leading to ~100s of reduced capacity while HPA recovers.

## E2E Test Report

Tested on a Kubernetes cluster by building two controller images — one from `main` (without the fix) and one from this branch (with the fix) — and comparing their behavior when a reconcile is triggered.

### Setup

- **InferenceService spec**: `minReplicas: 2`, `maxReplicas: 2`
- **Controller images**: built from `main` (tag `e2e-main`) and `feat/fix_1replica` (tag `e2e-pr412`)

With `minReplicas=2, maxReplicas=2`, the HPA immediately scales the deployment to 2 replicas after creation. Then we trigger a reconcile by patching an engine annotation.

### Results

**Without fix (`main` branch)**:

```
16:14:56 replicas=2   ← steady state (HPA min=2 max=2)
...
16:15:18 replicas=1   ← reconcile triggered, replicas reset to 1
...
16:16:57 replicas=1   ← stays at 1 for ~100s
16:16:58 replicas=2   ← HPA recovers
```

**With fix (this branch)**:

```
16:19:29 replicas=2   ← steady state
...
16:19:41 replicas=2   ← reconcile triggered, replicas unchanged
...
16:20:17 replicas=2   ← stays at 2
```

Both cases show `"Deployments differ"` → `"checkResult": "Update"` in controller logs, confirming the annotation diff was detected and the deployment was updated. The difference is that with the fix, `spec.replicas` is preserved.

| Scenario | Replicas | Recovery time | Verdict |
|----------|----------|---------------|---------|
| Without fix (`main`) | 2 → 1 → 2 | ~100s | Bug reproduced |
| With fix (this branch) | 2 → 2 (unchanged) | N/A | Fix works |

### Reproduction steps

1. Deploy OME (CRD + controller) to a cluster
2. Create a `ClusterBaseModel`, `ClusterServingRuntime`, and an `InferenceService` with `minReplicas: 2, maxReplicas: 2`
3. Wait for HPA to scale deployment to 2 replicas
4. Start polling `deployment.spec.replicas` every 0.5s:
   ```bash
   while true; do
     R=$(kubectl get deployment <engine-deploy> -n <ns> -o jsonpath='{.spec.replicas}')
     echo "$(date '+%H:%M:%S') replicas=${R}"
     sleep 0.5
   done > /tmp/replica-watch.log 2>&1 &
   ```
5. Trigger a reconcile by patching an engine annotation:
   ```bash
   kubectl patch isvc <name> -n <ns> --type merge \
     -p '{"spec":{"engine":{"annotations":{"e2e-test":"'$(date +%s)'"}}}}'
   ```
6. Check the log:
   ```bash
   grep -v "replicas=2" /tmp/replica-watch.log
   ```
   - **Without fix**: `replicas=1` entries appear (bug reproduced)
   - **With fix**: no output (replicas stayed at 2)

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
