### PR TITLE
[core] Fix external service get cleanup unexpectedly

### DIFF
--- a/charts/ome-resources/README.md
+++ b/charts/ome-resources/README.md
@@ -35,7 +35,7 @@ OME Resources and Controller
 | ome.controller.deploymentMode | string | `"RawDeployment"` |  |
 | ome.controller.image | string | `"ome-manager"` |  |
 | ome.controller.ingressGateway.additionalIngressDomains | string | `nil` |  |
-| ome.controller.ingressGateway.disableIngressCreation | bool | `false` |  |
+| ome.controller.ingressGateway.disableIngressCreation | bool | `true` |  |
 | ome.controller.ingressGateway.disableIstioVirtualHost | bool | `false` |  |
 | ome.controller.ingressGateway.domain | string | `"svc.cluster.local"` |  |
 | ome.controller.ingressGateway.domainTemplate | string | `"{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}"` |  |

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -49,7 +49,7 @@ ome:
       omeIngressGateway: ""
       additionalIngressDomains: null
       pathTemplate: ""
-      disableIngressCreation: false
+      disableIngressCreation: true
       enableGatewayAPI: false
     nodeSelector: {}
     tolerations: []

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -19,7 +19,7 @@ data:
         "urlScheme": "http",
         "disableIstioVirtualHost": false,
         "pathTemplate": "",
-        "disableIngressCreation": false,
+        "disableIngressCreation": true,
         "enableGatewayAPI": false
     }
 


### PR DESCRIPTION
## What this PR does

- Add ome.io/ingress-disable-creation=true annotation on inference service if IngressConfig.DisableIngressCreation is true
- Set IngressConfig.DisableIngressCreation to true

## Why we need it

- Currently the external service will get deleted by cleanup code as soon as it get created when IngressConfig.DisableIngressCreation is set to true, setting ome.io/ingress-disable-creation annotation will prevent the external service from getting deleted accidentally.
- Set IngressConfig.DisableIngressCreation to true so that external service will be created and url of inference service will be working
Fixes #413 

## How to test
Deployed to mle cluster, now external service is created and running properly:

<img width="1541" height="88" alt="Screenshot 2025-12-10 at 2 21 18 PM" src="https://github.com/user-attachments/assets/c92b4d38-0ac9-4141-bc4d-8eb9fe7abf5c" />
Note: you might notice the port number in external service didn't match with engine service, that is due to we're currently hard coding the port number when creating external service, I will add fix for it in a follow up PR for issue 407

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
