### PR TITLE
Revert "Fix annotations on Pods are also applied to other places like…

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/decoder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder.go
@@ -99,27 +99,19 @@ func (d *Decoder) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, error)
 	}
 
 	// Reconcile object metadata
-	objectMetaNormal, err := d.reconcileObjectMeta(isvc, false)
+	objectMeta, err := d.reconcileObjectMeta(isvc)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile object metadata")
-	}
-	objectMetaPod, err := d.reconcileObjectMeta(isvc, true)
-	if err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile object metadata")
-	}
-	objectMetaPack := isvcutils.ObjectMetaPack{
-		Normal: objectMetaNormal,
-		Pod:    objectMetaPod,
 	}
 
 	// Reconcile pod spec
-	podSpec, err := d.reconcilePodSpec(isvc, &objectMetaPack.Normal)
+	podSpec, err := d.reconcilePodSpec(isvc, &objectMeta)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile pod spec")
 	}
 
 	// Reconcile worker pod spec if needed
-	workerPodSpec, err := d.reconcileWorkerPodSpec(isvc, &objectMetaPack.Normal)
+	workerPodSpec, err := d.reconcileWorkerPodSpec(isvc, &objectMeta)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile worker pod spec")
 	}
@@ -128,12 +120,12 @@ func (d *Decoder) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, error)
 	size := d.getWorkerSize()
 
 	// Reconcile deployment based on deployment mode
-	if result, err := d.reconcileDeployment(isvc, objectMetaPack, podSpec, size, workerPodSpec); err != nil {
+	if result, err := d.reconcileDeployment(isvc, objectMeta, podSpec, size, workerPodSpec); err != nil {
 		return result, err
 	}
 
 	// Update decoder status
-	if err := d.updateDecoderStatus(isvc, objectMetaPack.Normal); err != nil {
+	if err := d.updateDecoderStatus(isvc, objectMeta); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -156,16 +148,16 @@ func (d *Decoder) getWorkerSize() int {
 }
 
 // reconcileDeployment manages the deployment logic for different deployment modes
-func (d *Decoder) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta isvcutils.ObjectMetaPack, podSpec *v1.PodSpec, workerSize int, workerPodSpec *v1.PodSpec) (ctrl.Result, error) {
+func (d *Decoder) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta metav1.ObjectMeta, podSpec *v1.PodSpec, workerSize int, workerPodSpec *v1.PodSpec) (ctrl.Result, error) {
 	switch d.DeploymentMode {
 	case constants.RawDeployment:
 		return d.deploymentReconciler.ReconcileRawDeployment(isvc, objectMeta, podSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
 	case constants.MultiNode:
-		return d.deploymentReconciler.ReconcileMultiNodeDeployment(isvc, objectMeta.Normal, podSpec, workerSize, workerPodSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
+		return d.deploymentReconciler.ReconcileMultiNodeDeployment(isvc, objectMeta, podSpec, workerSize, workerPodSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
 	case constants.MultiNodeRayVLLM:
-		return d.deploymentReconciler.ReconcileMultiNodeRayVLLMDeployment(isvc, objectMeta.Normal, podSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
+		return d.deploymentReconciler.ReconcileMultiNodeRayVLLMDeployment(isvc, objectMeta, podSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
 	case constants.Serverless:
-		return d.deploymentReconciler.ReconcileKnativeDeployment(isvc, objectMeta.Normal, podSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
+		return d.deploymentReconciler.ReconcileKnativeDeployment(isvc, objectMeta, podSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
 	default:
 		return ctrl.Result{}, errors.New("invalid deployment mode for decoder")
 	}
@@ -185,13 +177,13 @@ func (d *Decoder) getPodLabelInfo(rawDeployment bool, objectMeta metav1.ObjectMe
 }
 
 // reconcileObjectMeta creates the object metadata for the decoder component
-func (d *Decoder) reconcileObjectMeta(isvc *v1beta1.InferenceService, modePod bool) (metav1.ObjectMeta, error) {
+func (d *Decoder) reconcileObjectMeta(isvc *v1beta1.InferenceService) (metav1.ObjectMeta, error) {
 	decoderName, err := d.determineDecoderName(isvc)
 	if err != nil {
 		return metav1.ObjectMeta{}, err
 	}
 
-	annotations, err := d.processAnnotations(isvc, modePod)
+	annotations, err := d.processAnnotations(isvc)
 	if err != nil {
 		return metav1.ObjectMeta{
 			Name:      decoderName,
@@ -218,14 +210,14 @@ func (d *Decoder) reconcileObjectMeta(isvc *v1beta1.InferenceService, modePod bo
 }
 
 // processAnnotations processes the annotations for the decoder
-func (d *Decoder) processAnnotations(isvc *v1beta1.InferenceService, modePod bool) (map[string]string, error) {
+func (d *Decoder) processAnnotations(isvc *v1beta1.InferenceService) (map[string]string, error) {
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
 	})
 
 	// Merge with decoder annotations
 	mergedAnnotations := annotations
-	if d.decoderSpec != nil && modePod {
+	if d.decoderSpec != nil {
 		decoderAnnotations := d.decoderSpec.Annotations
 		mergedAnnotations = utils.Union(annotations, decoderAnnotations)
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/decoder_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder_test.go
@@ -533,7 +533,7 @@ func TestDecoderReconcileObjectMeta(t *testing.T) {
 			).(*Decoder)
 
 			// Test reconcileObjectMeta
-			objectMeta, err := decoder.reconcileObjectMeta(tt.isvc, true)
+			objectMeta, err := decoder.reconcileObjectMeta(tt.isvc)
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Validate name

--- a/pkg/controller/v1beta1/inferenceservice/components/engine_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine_test.go
@@ -979,7 +979,7 @@ func TestEngineReconcileObjectMeta(t *testing.T) {
 			}
 
 			// Test reconcileObjectMeta
-			objectMeta, err := engine.reconcileObjectMeta(tt.isvc, true)
+			objectMeta, err := engine.reconcileObjectMeta(tt.isvc)
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Validate name

--- a/pkg/controller/v1beta1/inferenceservice/components/router.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/router.go
@@ -3,8 +3,6 @@ package components
 import (
 	"context"
 
-	isvcutils "github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/utils"
-
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,24 +87,16 @@ func (r *Router) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, error) 
 	}
 
 	// Reconcile object metadata
-	objectMetaNormal, err := r.reconcileObjectMeta(isvc, false)
+	objectMeta, err := r.reconcileObjectMeta(isvc)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile object metadata")
-	}
-	objectMetaPod, err := r.reconcileObjectMeta(isvc, true)
-	if err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile object metadata")
-	}
-	objectMetaPack := isvcutils.ObjectMetaPack{
-		Normal: objectMetaNormal,
-		Pod:    objectMetaPod,
 	}
 
 	// Reconcile RBAC resources (ServiceAccount, Role, RoleBinding)
 	r.rbacReconciler = rbac.NewRBACReconciler(
 		r.Client,
 		r.Scheme,
-		objectMetaNormal,
+		objectMeta,
 		v1beta1.RouterComponent,
 		isvc.Name,
 	)
@@ -115,7 +105,7 @@ func (r *Router) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, error) 
 	}
 
 	// Reconcile pod spec
-	podSpec, err := r.reconcilePodSpec(isvc, &objectMetaNormal)
+	podSpec, err := r.reconcilePodSpec(isvc, &objectMeta)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile pod spec")
 	}
@@ -124,12 +114,12 @@ func (r *Router) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, error) 
 	podSpec.ServiceAccountName = r.rbacReconciler.GetServiceAccountName()
 
 	// Reconcile deployment based on deployment mode
-	if result, err := r.reconcileDeployment(isvc, objectMetaPack, podSpec); err != nil {
+	if result, err := r.reconcileDeployment(isvc, objectMeta, podSpec); err != nil {
 		return result, err
 	}
 
 	// Update router status
-	if err := r.updateRouterStatus(isvc, objectMetaNormal); err != nil {
+	if err := r.updateRouterStatus(isvc, objectMeta); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -137,12 +127,12 @@ func (r *Router) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, error) 
 }
 
 // reconcileDeployment manages the deployment logic for different deployment modes
-func (r *Router) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta isvcutils.ObjectMetaPack, podSpec *v1.PodSpec) (ctrl.Result, error) {
+func (r *Router) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta metav1.ObjectMeta, podSpec *v1.PodSpec) (ctrl.Result, error) {
 	switch r.DeploymentMode {
 	case constants.RawDeployment:
 		return r.deploymentReconciler.ReconcileRawDeployment(isvc, objectMeta, podSpec, &r.routerSpec.ComponentExtensionSpec, v1beta1.RouterComponent)
 	case constants.Serverless:
-		return r.deploymentReconciler.ReconcileKnativeDeployment(isvc, objectMeta.Normal, podSpec, &r.routerSpec.ComponentExtensionSpec, v1beta1.RouterComponent)
+		return r.deploymentReconciler.ReconcileKnativeDeployment(isvc, objectMeta, podSpec, &r.routerSpec.ComponentExtensionSpec, v1beta1.RouterComponent)
 	default:
 		return ctrl.Result{}, errors.New("invalid deployment mode for router")
 	}
@@ -162,13 +152,13 @@ func (r *Router) getPodLabelInfo(rawDeployment bool, objectMeta metav1.ObjectMet
 }
 
 // reconcileObjectMeta creates the object metadata for the router component
-func (r *Router) reconcileObjectMeta(isvc *v1beta1.InferenceService, modePod bool) (metav1.ObjectMeta, error) {
+func (r *Router) reconcileObjectMeta(isvc *v1beta1.InferenceService) (metav1.ObjectMeta, error) {
 	routerName, err := r.determineRouterName(isvc)
 	if err != nil {
 		return metav1.ObjectMeta{}, err
 	}
 
-	annotations, err := r.processAnnotations(isvc, modePod)
+	annotations, err := r.processAnnotations(isvc)
 	if err != nil {
 		return metav1.ObjectMeta{
 			Name:      routerName,
@@ -195,14 +185,14 @@ func (r *Router) reconcileObjectMeta(isvc *v1beta1.InferenceService, modePod boo
 }
 
 // processAnnotations processes the annotations for the router
-func (r *Router) processAnnotations(isvc *v1beta1.InferenceService, modePod bool) (map[string]string, error) {
+func (r *Router) processAnnotations(isvc *v1beta1.InferenceService) (map[string]string, error) {
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
 	})
 
 	// Merge with router annotations
 	mergedAnnotations := annotations
-	if r.routerSpec != nil && modePod {
+	if r.routerSpec != nil {
 		routerAnnotations := r.routerSpec.Annotations
 		mergedAnnotations = utils.Union(annotations, routerAnnotations)
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/common/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/common/deployment_reconciler.go
@@ -3,7 +3,6 @@ package common
 import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	isvcutils "github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +31,7 @@ type DeploymentReconciler struct {
 // ReconcileRawDeployment handles raw Kubernetes deployment
 func (r *DeploymentReconciler) ReconcileRawDeployment(
 	isvc *v1beta1.InferenceService,
-	objectMeta isvcutils.ObjectMetaPack,
+	objectMeta metav1.ObjectMeta,
 	podSpec *v1.PodSpec,
 	componentSpec *v1beta1.ComponentExtensionSpec,
 	componentType v1beta1.ComponentType,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -1,7 +1,6 @@
 package raw
 
 import (
-	isvcutils "github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +30,20 @@ type RawKubeReconciler struct {
 }
 
 // NewRawKubeReconciler creates raw kubernetes resource reconciler.
-func NewRawKubeReconciler(client client.Client, clientset kubernetes.Interface, scheme *runtime.Scheme, componentMeta isvcutils.ObjectMetaPack, inferenceServiceSpec *v1beta1.InferenceServiceSpec, podSpec *corev1.PodSpec) (*RawKubeReconciler, error) {
-	as, err := autoscaler.NewAutoscalerReconciler(client, clientset, scheme, componentMeta.Normal, inferenceServiceSpec)
+func NewRawKubeReconciler(client client.Client,
+	clientset kubernetes.Interface,
+	scheme *runtime.Scheme,
+	componentMeta metav1.ObjectMeta,
+	inferenceServiceSpec *v1beta1.InferenceServiceSpec,
+	podSpec *corev1.PodSpec,
+) (*RawKubeReconciler, error) {
+	as, err := autoscaler.NewAutoscalerReconciler(client, clientset, scheme, componentMeta, inferenceServiceSpec)
 	if err != nil {
 		return nil, err
 	}
 
-	pdb := pdb.NewPDBReconciler(client, scheme, componentMeta.Normal, &inferenceServiceSpec.Predictor.ComponentExtensionSpec)
-	url, err := createRawURL(clientset, componentMeta.Normal)
+	pdb := pdb.NewPDBReconciler(client, scheme, componentMeta, &inferenceServiceSpec.Predictor.ComponentExtensionSpec)
+	url, err := createRawURL(clientset, componentMeta)
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +55,8 @@ func NewRawKubeReconciler(client client.Client, clientset kubernetes.Interface, 
 	return &RawKubeReconciler{
 		client:              client,
 		scheme:              scheme,
-		Deployment:          deployment.NewDeploymentReconciler(client, scheme, componentMeta.Pod, componentExt, podSpec),
-		Service:             service.NewServiceReconciler(client, scheme, componentMeta.Normal, componentExt, podSpec, nil),
+		Deployment:          deployment.NewDeploymentReconciler(client, scheme, componentMeta, componentExt, podSpec),
+		Service:             service.NewServiceReconciler(client, scheme, componentMeta, componentExt, podSpec, nil),
 		Scaler:              as,
 		PodDisruptionBudget: pdb,
 		URL:                 url,

--- a/pkg/controller/v1beta1/inferenceservice/utils/types.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/types.go
@@ -1,9 +1,0 @@
-package utils
-
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-// ObjectMetaPack contains metav1.ObjectMeta for various cases
-type ObjectMetaPack struct {
-	Normal metav1.ObjectMeta
-	Pod    metav1.ObjectMeta
-}


### PR DESCRIPTION
This reverts commit 97779517e31700eec809b1eb022e8b3408ff2788.
For issue https://github.com/sgl-project/ome/issues/417

## Why we need it
in pod spec reconcile progress, we need these annotation to check if add env, volume, volume mount and so on. 

Fixes #391 

## How to test
test in cluster, after add annotations back, the inference service can start successfully again
## Checklist

- [ x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ x] `make test` passes locally
