### PR TITLE
[Bugs]deploymentname large than label 63 limits

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -282,54 +282,6 @@ func TestSetDefaultDeploymentSpec(t *testing.T) {
 	}
 }
 
-func TestUpdateDeploymentName(t *testing.T) {
-	tests := []struct {
-		name                 string
-		annotations          map[string]string
-		expectedNameModified bool
-	}{
-		{
-			name: "DAC without Volcano",
-			annotations: map[string]string{
-				constants.DedicatedAICluster: "true",
-			},
-			expectedNameModified: true,
-		},
-		{
-			name: "DAC with Volcano",
-			annotations: map[string]string{
-				constants.DedicatedAICluster: "true",
-				constants.VolcanoScheduler:   "true",
-			},
-			expectedNameModified: false,
-		},
-		{
-			name:                 "Non-DAC deployment",
-			annotations:          map[string]string{},
-			expectedNameModified: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "test-deployment",
-					Annotations: tt.annotations,
-				},
-			}
-
-			updateDeploymentName(deployment)
-
-			if tt.expectedNameModified {
-				assert.Equal(t, "test-deployment-new", deployment.Name)
-			} else {
-				assert.Equal(t, "test-deployment", deployment.Name)
-			}
-		})
-	}
-}
-
 func TestCreateRawDeployment(t *testing.T) {
 	testContainer := corev1.Container{
 		Name:  "test-container",
@@ -409,12 +361,7 @@ func TestCreateRawDeployment(t *testing.T) {
 				assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, deployment.Spec.Strategy.Type)
 			}
 
-			// Check DAC name update
-			if _, ok := tt.componentMeta.Annotations[constants.DedicatedAICluster]; ok {
-				assert.Equal(t, tt.componentMeta.Name+"-new", deployment.Name)
-			} else {
-				assert.Equal(t, tt.componentMeta.Name, deployment.Name)
-			}
+			assert.Equal(t, tt.componentMeta.Name, deployment.Name)
 
 			// Check defaults set
 			assert.NotNil(t, deployment.Spec.RevisionHistoryLimit)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/services/domain_service.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/services/domain_service.go
@@ -81,7 +81,7 @@ func (d *DefaultDomainService) GenerateDomainName(name string, obj interface{}, 
 	// Truncate name to ensure the final domain does not exceed DNS limits 63.
 	// If the name fits within maxLength, it's returned as-is
 	// Otherwise, it returns: {hash_prefix}-{suffix}
-	name = constants.TruncateDomainName(name, 63)
+	name = constants.TruncateNameWithMaxLength(name, 63)
 
 	values := DomainTemplateValues{
 		Name:          name,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
@@ -63,20 +63,6 @@ func createScaledObject(
 	minReplicas := calculateMinReplicas(componentExt)
 	maxReplicas := calculateMaxReplicas(componentExt, minReplicas)
 	triggers := getScaledObjectTriggers(componentMeta, inferenceServiceSpec)
-	/* Need a different name for ome.io based DAC inference service raw deployment under OME migration context since:
-	 *  1. Kueue required labels: kueue.x-k8s.io/queue-name & kueue.x-k8s.io/priority-class are 2 immutable fields;
-	 *  2. Kueue is only introduced in new OME, not old OME. So for OME migration from old OME to new OME, need to recreate a
-	 *     new deployment resource with a different name so new OME inference service can be up successfully with Kueue,
-	 *     it cannot directly update the existing old OME deployment resource due to above point #1;
-	 *  Note: Only need to adopt a new deployment name when it comes to migrate old OME DAC inference service, no need to do
-	 *        this for below:
-	 *     1). on-demand model serving;
-	 *     2). DAC inference service deployment from new OME with Volcano reconciled; (Out of scope, will handle its migration
-	 *         separately)
-	 *  when we create an inference service with Kueue enabled, we need to use inferencerservice name + "-new" as the deployment name
-	 *  for keda scale target ref.
-	 */
-	deploymentName := getDeploymentName(componentMeta)
 
 	return &kedav1.ScaledObject{
 		ObjectMeta: metav1.ObjectMeta{
@@ -89,7 +75,7 @@ func createScaledObject(
 			ScaleTargetRef: &kedav1.ScaleTarget{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
-				Name:       deploymentName,
+				Name:       componentMeta.Name,
 			},
 			MinReplicaCount: &minReplicas,
 			MaxReplicaCount: &maxReplicas,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/pdb/pdb_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/pdb/pdb_reconciler.go
@@ -68,7 +68,7 @@ func createPDB(componentMeta metav1.ObjectMeta,
 			MaxUnavailable: maxUnavailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": constants.GetRawServiceLabel(componentMeta.Name),
+					"app": constants.TruncateNameWithMaxLength(componentMeta.Name, 63),
 				},
 			},
 		},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -83,10 +83,13 @@ func buildServiceWithLoadBalancer(
 		spec.LoadBalancerIP = loadBalancerIP
 	}
 
-	return &corev1.Service{
+	service := &corev1.Service{
 		ObjectMeta: componentMeta,
 		Spec:       spec,
 	}
+	// service metadata name has 63 limitation, update metadata name if it reaches the limitation
+	service.Name = constants.TruncateNameWithMaxLength(service.Name, 63)
+	return service
 }
 
 // buildService constructs a Service object from the given specifications
@@ -98,7 +101,7 @@ func buildService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Compone
 	servicePorts := buildServicePorts(podSpec)
 	serviceType := determineServiceType(componentMeta)
 	if selector == nil {
-		selector = map[string]string{"app": constants.GetRawServiceLabel(componentMeta.Name)}
+		selector = map[string]string{"app": constants.TruncateNameWithMaxLength(componentMeta.Name, 63)}
 	}
 
 	return buildServiceWithLoadBalancer(componentMeta, serviceType, servicePorts, selector)


### PR DESCRIPTION
## What this PR does
1. Fixed bug where long InferenceService names cause deployment failures due to Kubernetes' 63-character limit on labels and DNS names
2. Removed legacy DAC migration code that appended "-new" suffix to deployment names

## Why we need it
1. Added truncateWithHashTweaks() - truncates strings to max length using format {hash_prefix}-{suffix}. And ensures first character is always a letter (required for DNS-1035)
In order to keep minial code change only update labelsUpdated reconcilers to use truncation:
deployment_reconciler.go - truncate "app" label selector
service_reconciler.go - truncate service name and selector
pdb_reconciler.go - truncate PDB selector
domain_service.go - use new truncation function
hpa_reconciler.go - simplified to use componentMeta.Name directly
keda_reconciler.go - simplified to use componentMeta.Name directly
2. Removed legacy code:
we add -new in deployment to force create a new deployment during migration to add some immutable annotation and labels. After we have engine, decoder, router in deployment name, it will have the same effect. the "-new" is necessary and useless.
Removed updateDeploymentName() function that appended "-new" suffix for DAC/Kueue migration
Removed redundant getDeploymentName() calls from HPA and KEDA reconcilers.

## Checklist

- [ x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x ] `make test` passes locally
