### PR TITLE
[Bugs]fix getTargetServicePort with truncated servicename

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -688,9 +688,6 @@ func DefaultRayHeadServiceName(name string, index int) string {
 	return rayutils.CheckName(fmt.Sprintf("%s-%d", name, index))
 }
 
-// label has 63 characters limit
-// we will have inferenceservicename-engine, inferenceservicename
-
 // Kubernetes naming constraints
 const (
 	// Maximum length for label names (after domain/)

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -68,7 +68,6 @@ func GetValueFromRawExtension(raw runtime.RawExtension, key string) (interface{}
 
 // GetTargetServicePort returns the port of the target service (router or engine).
 // For raw deployment mode, it uses RouterServiceName/EngineServiceName.
-// For serverless mode, it uses DefaultRouterServiceName/PredictorServiceName.
 // Returns the port from the service, or constants.CommonISVCPort as default if service lookup fails.
 func GetTargetServicePort(ctx context.Context, c client.Client, isvc *v1beta1.InferenceService) (int32, error) {
 	var serviceName string
@@ -77,6 +76,9 @@ func GetTargetServicePort(ctx context.Context, c client.Client, isvc *v1beta1.In
 	} else {
 		serviceName = constants.EngineServiceName(isvc.Name)
 	}
+
+	// if serviceName reached 63 character, the service name will be truncated during service creation. update name otherwise the service can't found
+	serviceName = constants.TruncateNameWithMaxLength(serviceName, 63)
 
 	service := &corev1.Service{}
 	if err := c.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: isvc.Namespace}, service); err != nil {


### PR DESCRIPTION
## What this PR does
we have domain name fix for large than 63 character limitation. After this the router and engine service name will be truncated.
Update method GetTargetServicePort when it get router and engine service.
## Why we need it

<!-- Motivation, context, or link to issue -->

## How to test

tested in our service.

## Checklist

- [x ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x ] `make test` passes locally
