### PR TITLE
[Misc] Set model kind to BaseModel when it is OCI OCID-style named model in isvc migration util

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/utils/migration_util.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/migration_util.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"regexp"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -88,6 +89,9 @@ func MigratePredictor(isvc *v1beta2.InferenceService) error {
 		// Set default kind and API group
 		kind := "ClusterBaseModel"
 		apiGroup := "ome.io"
+		if IsOCIDModelName(*isvc.Spec.Predictor.Model.BaseModel) {
+			kind = "BaseModel"
+		}
 		isvc.Spec.Model.Kind = &kind
 		isvc.Spec.Model.APIGroup = &apiGroup
 
@@ -232,4 +236,10 @@ func MigratePredictor(isvc *v1beta2.InferenceService) error {
 	isvc.Spec.Predictor = v1beta2.PredictorSpec{}
 
 	return nil
+}
+
+// IsOCIDModelName detects if the model name follows an OCI OCID-style naming pattern
+func IsOCIDModelName(name string) bool {
+	ocidModelNameRegex := regexp.MustCompile(`^[a-z0-9]{60,}$`)
+	return ocidModelNameRegex.MatchString(name)
 }


### PR DESCRIPTION
## What this PR does
Set model kind to BaseModel (instead of ClusterBaseModel) in isvc predictor migration logic when the model name follows the OCI OCID-styled naming.

## Changes
1. In isvc migration util, added a function to determine OCI OCID-styled named model via regex, and set model kind accordingly based on its return;
2. Added unit tests.

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
