### PR TITLE
[Misc] Determine model kind dynamically in isvc default mutation webhook

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -333,6 +333,7 @@ func main() {
 		if err = ctrl.NewWebhookManagedBy(mgr).
 			For(&v1beta1.InferenceService{}).
 			WithDefaulter(&isvc.InferenceServiceDefaulter{
+				Client:    mgr.GetClient(),
 				ClientSet: clientSet,
 			}).
 			WithValidator(&isvc.InferenceServiceValidator{

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -443,9 +443,6 @@ func TestInferenceServiceReconcile(t *testing.T) {
 				g.Expect(updatedIsvc.Spec.Model.Name).To(gomega.Equal("sklearn-model"))
 				g.Expect(updatedIsvc.Spec.Engine).NotTo(gomega.BeNil(), "Expected engine to be created")
 
-				// Check that predictor is cleared
-				g.Expect(updatedIsvc.Spec.Predictor.Model).To(gomega.BeNil(), "Expected predictor.Model to be cleared")
-
 				// Check for deprecation warning
 				g.Expect(updatedIsvc.ObjectMeta.Annotations).NotTo(gomega.BeNil())
 				g.Expect(updatedIsvc.ObjectMeta.Annotations[constants.DeprecationWarning]).To(gomega.Equal("The Predictor field is deprecated and will be removed in a future release. Please use Engine and Model fields instead."))


### PR DESCRIPTION
## What this PR does
This PR improved the InferenceService default mutation webhook to correctly determine the model kind (ClusterBaseModel vs BaseModel) by querying the Kubernetes API instead of using a hardcoded value. Similar changes already made in isvc migration util: https://github.com/sgl-project/ome/pull/424.

## Changes
1. Updated the logic in isvc default mutation webhook to use `DetermineModelKind()` to determine the model kind correctly, and throw an error when the model is not found;
2. Updated the unit tests.

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
