### PR TITLE
[helm] Add createModel and createRuntime options for selective resource creation

### DIFF
--- a/charts/ome-serving/README.md
+++ b/charts/ome-serving/README.md
@@ -65,6 +65,8 @@ models:
     clusterScope: true       # Create ClusterBaseModel (default: true)
     namespaceScope: false    # Create BaseModel (default: false)
     namespace: <name>        # Required if namespaceScope: true
+    createModel: true        # Create model resource (default: true)
+    createRuntime: true      # Create runtime resource (default: true)
 
     vendor: <vendor-name>
     capabilities: [TEXT_TO_TEXT|IMAGE_TEXT_TO_TEXT|EMBEDDING|...]
@@ -201,6 +203,41 @@ models:
     key: oci-credentials  # Optional: secret key
     runtime:
       gpus: 2
+```
+
+### Runtime Only (No Model Creation)
+
+Create only the ClusterServingRuntime without creating a model resource. Useful when the model already exists or is managed externally:
+
+```yaml
+models:
+  qwen3-8b:
+    enabled: true
+    createModel: false     # Don't create ClusterBaseModel/BaseModel
+    createRuntime: true    # Only create ClusterServingRuntime
+    vendor: qwen
+    capabilities: [TEXT_TO_TEXT]
+    hfModelId: Qwen/Qwen3-8B
+    runtime:
+      gpus: 1
+```
+
+### Model Only (No Runtime Creation)
+
+Create only the model resource without a runtime. Useful when using a shared runtime:
+
+```yaml
+models:
+  qwen3-8b:
+    enabled: true
+    createModel: true      # Create ClusterBaseModel
+    createRuntime: false   # Don't create ClusterServingRuntime
+    vendor: qwen
+    capabilities: [TEXT_TO_TEXT]
+    hfModelId: Qwen/Qwen3-8B
+    path: /raid/models/qwen/qwen3-8b
+    runtime:
+      gpus: 1
 ```
 
 ### PD Mode (Prefill-Decode Disaggregated)

--- a/charts/ome-serving/templates/basemodel.yaml
+++ b/charts/ome-serving/templates/basemodel.yaml
@@ -1,5 +1,5 @@
 {{- range $modelName, $model := .Values.models }}
-{{- if and $model.enabled $model.namespaceScope }}
+{{- if and $model.enabled $model.namespaceScope (ne $model.createModel false) }}
 {{/*
   Generate storageUri from simplified options:
   - hfModelId: Qwen/Qwen3-8B → hf://Qwen/Qwen3-8B

--- a/charts/ome-serving/templates/clusterbasemodel.yaml
+++ b/charts/ome-serving/templates/clusterbasemodel.yaml
@@ -1,5 +1,5 @@
 {{- range $modelName, $model := .Values.models }}
-{{- if and $model.enabled (ne $model.clusterScope false) }}
+{{- if and $model.enabled (ne $model.clusterScope false) (ne $model.createModel false) }}
 {{/*
   Generate storageUri from simplified options:
   - hfModelId: Qwen/Qwen3-8B → hf://Qwen/Qwen3-8B

--- a/charts/ome-serving/templates/clusterservingruntime.yaml
+++ b/charts/ome-serving/templates/clusterservingruntime.yaml
@@ -1,6 +1,6 @@
 {{- $registry := include "ome-serving.modelRegistry" . | fromYaml }}
 {{- range $modelName, $model := .Values.models }}
-{{- if $model.enabled }}
+{{- if and $model.enabled (ne $model.createRuntime false) }}
 {{- $modelInfo := index $registry $modelName }}
 {{- if not $modelInfo }}
 {{- fail (printf "Model '%s' not found in registry. Please check the model name or add it to the registry in _helpers.tpl" $modelName) }}


### PR DESCRIPTION
- Add createModel option to control ClusterBaseModel/BaseModel creation
- Add createRuntime option to control ClusterServingRuntime creation
- Both default to true for backward compatibility
- Allows creating runtime-only or model-only deployments
- Update README with examples for both use cases

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
