### PR TITLE
[Bugs]fix inference service ready condition to check engine status

### DIFF
--- a/pkg/apis/ome/v1beta1/inference_service_status.go
+++ b/pkg/apis/ome/v1beta1/inference_service_status.go
@@ -266,6 +266,7 @@ type FailureInfo struct {
 // Component-specific ready conditions (PredictorReady, EngineReady, DecoderReady) are managed separately
 var conditionSet = apis.NewLivingConditionSet(
 	IngressReady,
+	EngineReady,
 )
 
 var _ apis.ConditionsAccessor = (*InferenceServiceStatus)(nil)

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -475,8 +475,10 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	r.StatusManager.PropagateCrossComponentStatus(&isvc.Status, componentList, v1beta1.RoutesReady)
-	r.StatusManager.PropagateCrossComponentStatus(&isvc.Status, componentList, v1beta1.LatestDeploymentReady)
+	if deploymentMode == constants.Serverless {
+		r.StatusManager.PropagateCrossComponentStatus(&isvc.Status, componentList, v1beta1.RoutesReady)
+		r.StatusManager.PropagateCrossComponentStatus(&isvc.Status, componentList, v1beta1.LatestDeploymentReady)
+	}
 
 	if err = r.updateStatus(isvc, deploymentMode); err != nil {
 		r.Recorder.Event(isvc, v1.EventTypeWarning, "InternalError", err.Error())


### PR DESCRIPTION
## What this PR does
Fix inference service ready condition to check engine status

## Why we need it
1. When ingress DisableIngressCreation set to true, the ingressReady condition will alwasy be true. Add engineReady as Ready condition dependency will aovid inference service ready immedietly before engine ready.
2. Will have following pr to check routerReady, decoderReady later.
3. `PropagateCrossComponentStatus` only called by inference service with serverless mode. Add it under a deploymentmode check condition. it will not creat UNKNOWN status condition for other deployment mode.
This is the condition before move `PropagateCrossComponentStatus` function:
<img width="705" height="494" alt="Screenshot 2025-12-16 at 7 45 51 PM" src="https://github.com/user-attachments/assets/d4918d16-89ec-4f3f-b0ca-18fd978cd8ae" />

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
