### PR TITLE
[workflow] Create Workflow to Run Benchmark Job Weekly

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,8 +1,9 @@
 name: Benchmark Job
 
 on:
-  push:
-    branches: [ xinyue/add-benchmark-ci ]
+  schedule:
+    # Run every Saturday at 10 PM UTC (Saturday night)
+    - cron: '0 22 * * 6'
   workflow_dispatch:
     inputs:
       models:
@@ -29,6 +30,22 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set image tag variables
+        id: vars
+        run: |
+          # Use client_payload values if available (from repository_dispatch), otherwise compute defaults
+          if [ -n "${{ github.event.client_payload.full_tag }}" ]; then
+            echo "FULL_TAG=${{ github.event.client_payload.full_tag }}" >> $GITHUB_ENV
+          else
+            # Defaults
+            BRANCH_NAME="${GITHUB_REF_NAME//\//-}"
+            COMMIT_HASH="${GITHUB_SHA:0:7}"
+            VERSION="${BRANCH_NAME}-${COMMIT_HASH}"
+            echo "FULL_TAG=${VERSION}" >> $GITHUB_ENV
+          fi
       - name: Set up kubectl
         uses: azure/setup-kubectl@v3
         with:
@@ -154,6 +171,8 @@ jobs:
                 value: "${BUCKET_NAME}"
               - name: container-name
                 value: "${CONTAINER_NAME}"
+              - name: full-tag
+                value: "${FULL_TAG}"
 
             templates:
             - name: benchmark-pipeline
@@ -548,7 +567,7 @@ jobs:
               echo "- **Benchmark:** $BENCHMARK_EMOJI \`$BENCHMARK_STATUS\`" >> $GITHUB_STEP_SUMMARY
 
               if [ "$BENCHMARK_STATUS" = "SUCCESS" ]; then
-                echo "- **Results:** \`oci://n/${REGISTRY_NAMESPACE}/b/${BUCKET_NAME}/o/${CONTAINER_NAME}/${MODEL_NAME}\`" >> $GITHUB_STEP_SUMMARY
+                echo "- **Results:** \`oci://n/${REGISTRY_NAMESPACE}/b/${BUCKET_NAME}/o/${CONTAINER_NAME}/${FULL_TAG}/${MODEL_NAME}\`" >> $GITHUB_STEP_SUMMARY
               fi
               echo "" >> $GITHUB_STEP_SUMMARY
             done
@@ -568,6 +587,6 @@ jobs:
           echo "### 📈 Results Location" >> $GITHUB_STEP_SUMMARY
           echo "All benchmark results are stored in OCI Object Storage:" >> $GITHUB_STEP_SUMMARY
           echo "- **Bucket:** \`${BUCKET_NAME}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Path Pattern:** \`${CONTAINER_NAME}/${MODEL_NAME}/\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Path Pattern:** \`${CONTAINER_NAME}/${FULL_TAG}/${MODEL_NAME}/\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "_Note: All resources (InferenceServices and BenchmarkJobs) were cleaned up after completion._" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What this PR does

Create CI workflow to start inference service and run benchmark job on mle cluster for several defined models on Saturday night. Now only include 3 models (llama-4-scout-17b-16e-instruct,deepseek-v2-lite-chat,qwen3-32b), we can add more models as needed later. 

Currently, the workflow only takes care of inference service and benchmark job, the following setup is installed on mle cluster manually:

- OME operator
- Related ClusterBaseModel and ClusterServingRuntime
- ARC controller, related RBAC and ARC runner
- Secret for ARC runners(using PAT that grants repo, workflow permissions)
- ARGO controller and related RBAC

## Why we need it

To run benchmark regularly and automatically

Fixes #

## How to test
Run on personal branch successfully https://github.com/sgl-project/ome/actions/runs/20294318981
Snapshot of pods when workflow is running
<img width="1129" height="856" alt="Screenshot 2025-12-16 at 11 23 52 PM" src="https://github.com/user-attachments/assets/dd6a7d35-66de-4520-88fc-f727282fb208" />
Results in bucket:
<img width="1650" height="773" alt="Screenshot 2025-12-17 at 9 09 55 AM" src="https://github.com/user-attachments/assets/a63dc6f3-bc9c-4783-9f88-022955bd842b" />


## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
