### PR TITLE
[Bugs]check deployment with predictor label as old deployment rather …

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -355,6 +355,7 @@ func TestInferenceServiceReconcile(t *testing.T) {
 						Namespace: "default",
 						Labels: map[string]string{
 							constants.InferenceServicePodLabelKey: "test-legacy",
+							constants.OMEComponentLabel:           "predictor",
 						},
 					},
 					Spec: appsv1.DeploymentSpec{


### PR DESCRIPTION
## What this PR does
It is a small bug during cleanupOldPredictorDeployment. For migration, the old predictor deployment has different name.
inferenceServiceName or inferenceServiceNAME-NEW. In case other deployment name exist, switch check deploymentName to check lable in deployment.

## Why we need it
it fixed the migration progress to avoid downtime

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
