### PR TITLE
[core] Sanitize model config file before parsing

### DIFF
--- a/pkg/hfutil/modelconfig/interface.go
+++ b/pkg/hfutil/modelconfig/interface.go
@@ -285,6 +285,10 @@ func loadGenericConfig(configPath string) (*GenericModelConfig, error) {
 		return nil, fmt.Errorf("failed to read config file '%s': %w", configPath, err)
 	}
 
+	// Sanitize JSON to handle non-standard values like Infinity, -Infinity, NaN
+	// which are valid in Python but not in standard JSON
+	data = SanitizeJSONBytes(data)
+
 	var config GenericModelConfig
 	if err := json.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse config JSON from '%s': %w", configPath, err)


### PR DESCRIPTION
## What this PR does
Replace Infinity, neg infinity with a very large/small number in config.json, replace NaN with null.

## Why we need it
Some new models' config.json use "Infinity" in time_step_limit like [this one](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16/blob/main/config.json) and will cause config parsing failure, so need to sanitize the config.json before parsing

Fixes #

## How to test

Tested in dev ord cluster

## Checklist

- [ ] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
