### PR TITLE
[Mics]support for user-selected runtimes to consider all model formats

### DIFF
--- a/pkg/runtimeselector/selector.go
+++ b/pkg/runtimeselector/selector.go
@@ -317,14 +317,18 @@ func getModelName(model *v1beta1.BaseModelSpec) string {
 	return "unknown"
 }
 
-func (s *defaultSelector) GetSupportedModelFormat(ctx context.Context, runtime *v1beta1.ServingRuntimeSpec, model *v1beta1.BaseModelSpec) *v1beta1.SupportedModelFormat {
+// GetSupportedModelFormat fetches a supportedModelFormat in runtime
+// userSpecifiedRuntime indicates whether the runtime is a user-selected runtime or an automatically selected runtime
+// if userSpecifiedRuntime is true, the function will consider all supportedModelFormats in the runtime
+// if userSpecifiedRuntime is false, the function will only consider supportedModelFormats with autoSelect enabled
+func (s *defaultSelector) GetSupportedModelFormat(ctx context.Context, runtime *v1beta1.ServingRuntimeSpec, model *v1beta1.BaseModelSpec, userSpecifiedRuntime bool) *v1beta1.SupportedModelFormat {
 	if runtime.SupportedModelFormats == nil {
 		return nil
 	}
 	maxScore := int64(0)
 	bestSupportedFormat := v1beta1.SupportedModelFormat{}
 	for _, supportedFormat := range runtime.SupportedModelFormats {
-		if supportedFormat.AutoSelect == nil || !*supportedFormat.AutoSelect {
+		if !userSpecifiedRuntime && (supportedFormat.AutoSelect == nil || !*supportedFormat.AutoSelect) {
 			continue
 		}
 		score := s.scorer.CalculateFormatScore(model, supportedFormat, int64(s.config.DefaultPriority))

--- a/pkg/runtimeselector/types.go
+++ b/pkg/runtimeselector/types.go
@@ -28,7 +28,11 @@ type Selector interface {
 	// Returns the runtime spec and whether it's cluster-scoped.
 	GetRuntime(ctx context.Context, name string, namespace string) (*v1beta1.ServingRuntimeSpec, bool, error)
 
-	GetSupportedModelFormat(ctx context.Context, runtime *v1beta1.ServingRuntimeSpec, model *v1beta1.BaseModelSpec) *v1beta1.SupportedModelFormat
+	// GetSupportedModelFormat fetches a supportedModelFormat in runtime
+	// userSpecifiedRuntime indicates whether the runtime is a user-selected runtime or an automatically selected runtime
+	// if userSpecifiedRuntime is true, the function will consider all supportedModelFormats in the runtime
+	// if userSpecifiedRuntime is false, the function will only consider supportedModelFormats with autoSelect enabled
+	GetSupportedModelFormat(ctx context.Context, runtime *v1beta1.ServingRuntimeSpec, model *v1beta1.BaseModelSpec, userSpecifiedRuntime bool) *v1beta1.SupportedModelFormat
 }
 
 // RuntimeSelection represents the selected runtime with metadata.


### PR DESCRIPTION
## What this PR does

adding support for user-selected runtimes to consider all model formats (not just auto-select ones).

## Why we need it
The summary for runtime choose and ac choose progress

- first step: runtime
      - runtime provided, use this runtime
      - runtime not provided, use auto-select to choose one runtime
- next step: choose ac
      - ac name provided, use ac name
      - ac policy provided, use ac policy
      - there two not provided, use default policy return the first ac in runtime
- the last step: choose supportedModelFormat:
      - runtime provided. Ignore auto-select, choose the highest score supportedmodelformat
      - runtime not provided. use auto-select and choose the highest score supportedmodelformat

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
