### PR TITLE
[Misc] Cleanup blocklist volume, volume mount in inference service reconcile

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -101,7 +101,6 @@ var (
 	SetPrometheusAnnotation                  = OMEAPIGroupName + "/enable-prometheus-scraping"
 	DedicatedAICluster                       = OMEAPIGroupName + "/dedicated-ai-cluster"
 	VolcanoQueue                             = OMEAPIGroupName + "/volcano-queue"
-	BlockListDisableInjection                = OMEAPIGroupName + "/disable-blocklist"
 	ModelInitInjectionKey                    = OMEAPIGroupName + "/inject-model-init"
 	FineTunedAdapterInjectionKey             = OMEAPIGroupName + "/inject-fine-tuned-adapter"
 	ServingSidecarInjectionKey               = OMEAPIGroupName + "/inject-serving-sidecar"

--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -126,25 +126,6 @@ func UpdateVolumeMounts(b *BaseComponentFields, isvc *v1beta1.InferenceService, 
 			isvcutils.AppendVolumeMount(container, &tfewFineTunedWeightVolumeMount)
 		}
 	}
-
-	// Add blocklist volume mounts if enabled
-	if isvcutils.IsBlockListInjectionDisabled(objectMeta.Annotations) {
-		inputBlocklistVolumeMount := corev1.VolumeMount{
-			Name:      constants.BlocklistConfigMapVolumeName,
-			MountPath: constants.InputBlocklistMountPath,
-			ReadOnly:  true,
-			SubPath:   constants.InputBlocklistSubPath,
-		}
-		isvcutils.AppendVolumeMount(container, &inputBlocklistVolumeMount)
-
-		outputBlocklistVolumeMount := corev1.VolumeMount{
-			Name:      constants.BlocklistConfigMapVolumeName,
-			MountPath: constants.OutputBlocklistMountPath,
-			ReadOnly:  true,
-			SubPath:   constants.OutputBlocklistSubPath,
-		}
-		isvcutils.AppendVolumeMount(container, &outputBlocklistVolumeMount)
-	}
 }
 
 // UpdateEnvVariables updates environment variables for the container
@@ -270,21 +251,6 @@ func UpdatePodSpecVolumes(b *BaseComponentFields, isvc *v1beta1.InferenceService
 			},
 		}
 		podSpec.Volumes = utils.AppendVolumeIfNotExists(podSpec.Volumes, emptyModelDirVolume)
-	}
-
-	// Add blocklist configmap volume if enabled
-	if isvcutils.IsBlockListInjectionDisabled(objectMeta.Annotations) {
-		blockListConfigMapVolume := corev1.Volume{
-			Name: constants.BlocklistConfigMapVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: constants.ModelConfigName(isvc.Name),
-					},
-				},
-			},
-		}
-		podSpec.Volumes = append(podSpec.Volumes, blockListConfigMapVolume)
 	}
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/utils/annotations.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/annotations.go
@@ -38,11 +38,6 @@ func GetDeploymentMode(annotations map[string]string, deployConfig *controllerco
 	return constants.DeploymentModeType(deployConfig.DefaultDeploymentMode)
 }
 
-func IsBlockListInjectionDisabled(annotations map[string]string) bool {
-	inject, ok := annotations[constants.BlockListDisableInjection]
-	return ok && inject == "true"
-}
-
 func IsOriginalModelVolumeMountNecessary(annotations map[string]string) bool {
 	return annotations[constants.ModelInitInjectionKey] != "true" &&
 		annotations[constants.FTServingWithMergedWeightsAnnotationKey] != "true"


### PR DESCRIPTION
## What this PR does
Removed unnecessary blocklist volume/volume mount attachment in inference service reconcile. If the customer needs it, please add it via runtime spec.

## Why we need it
Removed customized code in reconcile logic to make code as generic as possible

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
