### PR TITLE
[Core] Add owner reference to RBAC resources for automatic cleanup

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/router.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/router.go
@@ -98,7 +98,7 @@ func (r *Router) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, error) 
 		r.Scheme,
 		objectMeta,
 		v1beta1.RouterComponent,
-		isvc.Name,
+		isvc,
 	)
 	if err := r.rbacReconciler.Reconcile(); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile RBAC resources")


### PR DESCRIPTION
## What this PR does

<!-- Brief description of the changes -->
This PR adds proper owner reference management to RBAC resources (ServiceAccount, Role, RoleBinding) to enable automatic garbage collection and prevent resource leaks.

## Why we need it

<!-- Motivation, context, or link to issue -->
Previously, RBAC resources created by the InferenceService controller did not have proper owner references set, which caused:
- **Resource leaks**: RBAC resources were not automatically cleaned up when InferenceService was deleted
- **Cleanup blocking issues**: Manual cleanup in the reconciler caused blocking problems during resource cleanup phase

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->
go test -v ./pkg/controller/v1beta1/inferenceservice/reconcilers/rbac/

**example**
```shell
apiVersion: ome.io/v1beta1
kind: InferenceService
metadata:
  name: qwen3-0-6b
spec:
  model:
    name: qwen3-0-6b
  runtime:
    name: srt-qwen3-0-6b
  router:
    minReplicas: 1
    maxReplicas: 1
  engine:
    minReplicas: 1
    maxReplicas: 1
```

**before**
```shell
NAMESPACE  NAME                                             READY  REASON              AGE
default    InferenceService/qwen3-0-6b                      False  Initializing        40s
default    ├─ConfigMap/modelconfig-qwen3-0-6b             -                          40s
default    ├─Deployment/qwen3-0-6b-engine                 -                          40s
default    │ └─ReplicaSet/qwen3-0-6b-engine-5bf986dbc5   -                          40s
default    │   ├─Pod/qwen3-0-6b-engine-5bf986dbc5-hk5wr  False  ContainersNotReady  25s
default    │   └─Pod/qwen3-0-6b-engine-5bf986dbc5-stpl5  False  ContainersNotReady  40s
default    ├─Deployment/qwen3-0-6b-router                 -                          40s
default    │ └─ReplicaSet/qwen3-0-6b-router-65f8988b7c   -                          40s
default    │   └─Pod/qwen3-0-6b-router-65f8988b7c-7nhxn  False  ContainersNotReady  40s
default    ├─HorizontalPodAutoscaler/qwen3-0-6b-engine    -                          40s
default    ├─HorizontalPodAutoscaler/qwen3-0-6b-router    -                          40s
default    ├─PodDisruptionBudget/qwen3-0-6b-engine        -                          40s
default    ├─PodDisruptionBudget/qwen3-0-6b-router        -                          40s
default    ├─Service/qwen3-0-6b                           -                          40s
default    │ └─EndpointSlice/qwen3-0-6b-w2kkk            -                          40s
default    ├─Service/qwen3-0-6b-engine                    -                          40s
default    │ └─EndpointSlice/qwen3-0-6b-engine-zgvgz     -                          40s
default    └─Service/qwen3-0-6b-router                    -                          40s
default      └─EndpointSlice/qwen3-0-6b-router-m5n8m      -                          40s

```

**after** Role/qwen3-0-6b-router, RoleBinding/qwen3-0-6b-router, ServiceAccount/qwen3-0-6b-router
```shell
NAMESPACE  NAME                                             READY  REASON              AGE
default    InferenceService/qwen3-0-6b                      True                       6m43s
default    ├─ConfigMap/modelconfig-qwen3-0-6b             -                          6m43s
default    ├─Deployment/qwen3-0-6b-engine                 -                          6m43s
default    │ └─ReplicaSet/qwen3-0-6b-engine-5bf986dbc5   -                          6m43s
default    │   └─Pod/qwen3-0-6b-engine-5bf986dbc5-stpl5  True                       6m43s
default    ├─Deployment/qwen3-0-6b-router                 -                          6m43s
default    │ └─ReplicaSet/qwen3-0-6b-router-65f8988b7c   -                          6m43s
default    │   └─Pod/qwen3-0-6b-router-65f8988b7c-7nhxn  False  ContainersNotReady  6m43s
default    ├─HorizontalPodAutoscaler/qwen3-0-6b-engine    -                          6m43s
default    ├─HorizontalPodAutoscaler/qwen3-0-6b-router    -                          6m43s
default    ├─PodDisruptionBudget/qwen3-0-6b-engine        -                          6m43s
default    ├─PodDisruptionBudget/qwen3-0-6b-router        -                          6m43s
default    ├─Role/qwen3-0-6b-router                       -                          6m43s
default    ├─RoleBinding/qwen3-0-6b-router                -                          6m43s
default    ├─Service/qwen3-0-6b                           -                          6m43s
default    │ └─EndpointSlice/qwen3-0-6b-w2kkk            -                          6m43s
default    ├─Service/qwen3-0-6b-engine                    -                          6m43s
default    │ └─EndpointSlice/qwen3-0-6b-engine-zgvgz     -                          6m43s
default    ├─Service/qwen3-0-6b-router                    -                          6m43s
default    │ └─EndpointSlice/qwen3-0-6b-router-m5n8m     -                          6m43s
default    └─ServiceAccount/qwen3-0-6b-router             -                          6m43s
```

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
