### PR TITLE
[Bugfix] Fix multinode Service selector to correctly match head pods

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/multinode/multinode_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/multinode/multinode_reconciler.go
@@ -47,7 +47,10 @@ func NewMultiNodeReconciler(client client.Client,
 	if ok && istioSidecarInjection == "true" {
 		enabled = true
 	}
-	selector := map[string]string{"ray.io/node-type": "head"}
+	selector := map[string]string{
+		"ray.io/node-type": "head",
+		"app":              constants.GetRawServiceLabel(componentMeta.Name),
+	}
 
 	return &MultiNodeReconciler{
 		client:       client,


### PR DESCRIPTION
## What this PR does

<!-- Brief description of the changes -->
This PR fixes an issue where the multinode Service selector was incomplete, causing the Service to fail to correctly select and route traffic to the LWS head pods in multinode deployments.

## Why we need it

<!-- Motivation, context, or link to issue -->

Added the `app` label (using `constants.GetRawServiceLabel(componentMeta.Name)`) to the Service selector to ensure precise pod selection. 

head `app` label in [link](https://github.com/sgl-project/ome/blob/main/pkg/controller/v1beta1/inferenceservice/reconcilers/lws/lws_reconciler.go#L56-L57)
```go
	headPodMeta.Labels["app"] = constants.GetRawServiceLabel(componentMeta.Name)
	headPodMeta.Labels["ray.io/node-type"] = "head"
```

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
