### PR TITLE
[Core] Refactor InferenceService workload reconciliation

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -44,6 +44,7 @@ import (
 	multimodelconfig "github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/modelconfig"
 	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/status"
 	isvcutils "github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/utils"
+	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/workload"
 	"github.com/sgl-project/ome/pkg/runtimeselector"
 	"github.com/sgl-project/ome/pkg/utils"
 )
@@ -112,6 +113,7 @@ type InferenceServiceReconciler struct {
 	StatusManager            *status.StatusReconciler
 	RuntimeSelector          runtimeselector.Selector
 	AcceleratorClassSelector acceleratorclassselector.Selector
+	StrategyManager          *workload.WorkloadStrategyManager
 }
 
 func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -202,9 +204,6 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// for NewInferenceServicesConfig. We will use that existing isvcConfig.
 	componentBuilderFactory := components.NewComponentBuilderFactory(r.Client, r.Clientset, r.Scheme, isvcConfig)
 
-	// Determine which components to reconcile based on the spec
-	var reconcilers []components.Component
-
 	// Migrate predictor spec to new architecture if needed
 	if err := r.migratePredictorToNewArchitecture(isvc); err != nil {
 		r.Log.Error(err, "Failed to migrate predictor spec", "namespace", isvc.Namespace, "inferenceService", isvc.Name)
@@ -281,91 +280,90 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		r.Log.Info("PD-disaggregated deployment detected", "namespace", isvc.Namespace, "inferenceService", isvc.Name)
 	}
 
-	// Step 5: Create reconcilers based on merged specs
+	// Step 5: Select workload strategy
+	strategy, err := r.StrategyManager.SelectStrategy(isvc, deploymentMode)
+	if err != nil {
+		r.Log.Error(err, "Failed to select workload strategy")
+		r.Recorder.Eventf(isvc, v1.EventTypeWarning, "StrategySelectionFailed", "Failed to select workload strategy: %v", err)
+		return reconcile.Result{}, err
+	}
+
+	r.Log.Info("Selected workload strategy",
+		"strategy", strategy.GetStrategyName(),
+		"namespace", isvc.Namespace,
+		"inferenceService", isvc.Name)
+
+	// Step 6: Validate deployment modes
+	deploymentModes := &workload.ComponentDeploymentModes{
+		Engine:  engineDeploymentMode,
+		Decoder: decoderDeploymentMode,
+		Router:  routerDeploymentMode,
+	}
+
+	if err := strategy.ValidateDeploymentModes(deploymentModes); err != nil {
+		r.Log.Error(err, "Deployment mode validation failed")
+		r.Recorder.Eventf(isvc, v1.EventTypeWarning, "InvalidDeploymentMode", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	// Step 7: Get AcceleratorClass and SupportedModelFormat for each component
+	var engineAC *v1beta1.AcceleratorClassSpec
+	var engineAcName string
+	var engineSupportedModelFormats *v1beta1.SupportedModelFormat
 	if mergedEngine != nil {
-		engineACObj, engineAcName, err := r.AcceleratorClassSelector.GetAcceleratorClass(ctx, isvc, rt, v1beta1.EngineComponent)
+		engineACObj, engineAcNameTmp, err := r.AcceleratorClassSelector.GetAcceleratorClass(ctx, isvc, rt, v1beta1.EngineComponent)
 		if err != nil {
 			r.Log.Error(err, "Failed to get accelerator class for engine component", "Name", isvc.Name)
 			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "AcceleratorClassError", "Failed to get accelerator class for engine: %v", err)
 			return reconcile.Result{}, err
 		}
-		var engineAC *v1beta1.AcceleratorClassSpec
 		if engineACObj == nil {
 			r.Log.Info("Accelerator class not specified for engine component", "inferenceService", isvc.Name)
 		} else {
+			engineAcName = engineAcNameTmp
 			engineAC = &engineACObj.Spec
 		}
-		engineSupportedModelFormats := r.RuntimeSelector.GetSupportedModelFormat(ctx, rt, baseModel, userSpecifiedRuntime)
-		r.Log.Info("Creating engine reconciler",
-			"deploymentMode", engineDeploymentMode,
-			"namespace", isvc.Namespace,
-			"inferenceService", isvc.Name,
-			"acceleratorClass", engineAcName)
-
-		engineReconciler := componentBuilderFactory.CreateEngineComponent(
-			engineDeploymentMode,
-			baseModel,
-			baseModelMeta,
-			mergedEngine,
-			rt,
-			rtName,
-			engineSupportedModelFormats,
-			engineAC,
-			engineAcName,
-		)
-		reconcilers = append(reconcilers, engineReconciler)
+		engineSupportedModelFormats = r.RuntimeSelector.GetSupportedModelFormat(ctx, rt, baseModel, userSpecifiedRuntime)
 	}
 
+	var decoderAC *v1beta1.AcceleratorClassSpec
+	var decoderAcName string
+	var decoderSupportedModelFormats *v1beta1.SupportedModelFormat
 	if mergedDecoder != nil {
-		decoderACObj, decoderAcName, err := r.AcceleratorClassSelector.GetAcceleratorClass(ctx, isvc, rt, v1beta1.DecoderComponent)
+		decoderACObj, decoderAcNameTmp, err := r.AcceleratorClassSelector.GetAcceleratorClass(ctx, isvc, rt, v1beta1.DecoderComponent)
 		if err != nil {
 			r.Log.Error(err, "Failed to get accelerator class for decoder component", "Name", isvc.Name)
 			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "AcceleratorClassError", "Failed to get accelerator class for decoder: %v", err)
 			return reconcile.Result{}, err
 		}
-		var decoderAC *v1beta1.AcceleratorClassSpec
 		if decoderACObj == nil {
 			r.Log.Info("Accelerator class not specified for decoder component", "inferenceService", isvc.Name)
 		} else {
+			decoderAcName = decoderAcNameTmp
 			decoderAC = &decoderACObj.Spec
 		}
-		decoderSupportedModelFormats := r.RuntimeSelector.GetSupportedModelFormat(ctx, rt, baseModel, userSpecifiedRuntime)
-		r.Log.Info("Creating decoder reconciler",
-			"deploymentMode", decoderDeploymentMode,
-			"namespace", isvc.Namespace,
-			"inferenceService", isvc.Name,
-			"acceleratorClass", decoderAcName)
-
-		decoderReconciler := componentBuilderFactory.CreateDecoderComponent(
-			decoderDeploymentMode,
-			baseModel,
-			baseModelMeta,
-			mergedDecoder,
-			rt,
-			rtName,
-			decoderSupportedModelFormats,
-			decoderAC,
-			decoderAcName,
-		)
-		reconcilers = append(reconcilers, decoderReconciler)
+		decoderSupportedModelFormats = r.RuntimeSelector.GetSupportedModelFormat(ctx, rt, baseModel, userSpecifiedRuntime)
 	}
 
-	// Add Router reconciler if merged router spec exists (using new v2 Router)
-	if mergedRouter != nil {
-		r.Log.Info("Creating router reconciler",
-			"deploymentMode", routerDeploymentMode, // Using the determined router deployment mode
-			"namespace", isvc.Namespace,
-			"inferenceService", isvc.Name)
-
-		routerReconciler := componentBuilderFactory.CreateRouterComponent(
-			routerDeploymentMode, // Using the determined router deployment mode
-			baseModel,
-			baseModelMeta,
-			mergedRouter, // Using the merged router spec instead of isvc.Spec.Router
-			rt,
-			rtName,
-		)
-		reconcilers = append(reconcilers, routerReconciler)
+	// Step 7: Build WorkloadReconcileRequest
+	request := &workload.WorkloadReconcileRequest{
+		InferenceService:            isvc,
+		BaseModel:                   baseModel,
+		BaseModelMeta:               baseModelMeta,
+		Runtime:                     rt,
+		RuntimeName:                 rtName,
+		MergedEngine:                mergedEngine,
+		MergedDecoder:               mergedDecoder,
+		MergedRouter:                mergedRouter,
+		DeploymentModes:             deploymentModes,
+		ComponentBuilderFactory:     componentBuilderFactory,
+		UserSpecifiedRuntime:        userSpecifiedRuntime,
+		EngineAcceleratorClass:      engineAC,
+		EngineAcceleratorClassName:  engineAcName,
+		DecoderAcceleratorClass:     decoderAC,
+		DecoderAcceleratorClassName: decoderAcName,
+		EngineSupportedModelFormat:  engineSupportedModelFormats,
+		DecoderSupportedModelFormat: decoderSupportedModelFormats,
 	}
 
 	// Determine the correct ingress deployment mode using the same logic as ingress reconciler
@@ -379,23 +377,27 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	r.Log.Info("Determined ingress deployment mode",
+		"strategy", strategy.GetStrategyName(),
 		"ingressDeploymentMode", ingressDeploymentMode,
 		"namespace", isvc.Namespace,
 		"inferenceService", isvc.Name)
 
-	// Step 6: Run all reconcilers
-	for _, reconciler := range reconcilers {
-		result, err := reconciler.Reconcile(isvc)
-		if err != nil {
-			r.Log.Error(err, "Failed to reconcile component",
-				"component", fmt.Sprintf("%T", reconciler),
-				"namespace", isvc.Namespace,
-				"inferenceService", isvc.Name)
-			return result, err
-		}
-		if result.Requeue || result.RequeueAfter > 0 {
-			return result, nil
-		}
+	// Step 8: Execute workload reconciliation
+	result, err = strategy.ReconcileWorkload(ctx, request)
+	if err != nil {
+		r.Log.Error(err, "Failed to reconcile workload")
+		r.Recorder.Eventf(isvc, v1.EventTypeWarning, "WorkloadReconcileFailed", "Failed to reconcile workload: %v", err)
+		return reconcile.Result{}, err
+	}
+
+	// If requeue is needed, return immediately
+	if result.Requeue || result.RequeueAfter > 0 {
+		r.Log.Info("Workload reconciliation requires requeue",
+			"namespace", isvc.Namespace,
+			"inferenceService", isvc.Name,
+			"requeue", result.Requeue,
+			"requeueAfter", result.RequeueAfter)
+		return result, nil
 	}
 
 	// Now reconcile ingress and external service after components have created their services
@@ -626,6 +628,16 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 
 	// Initialize AcceleratorClassSelector
 	r.AcceleratorClassSelector = acceleratorclassselector.New(mgr.GetClient())
+
+	// Initialize WorkloadStrategyManager
+	r.StrategyManager = workload.NewWorkloadStrategyManager(r.Log)
+
+	// Register SingleComponent Strategy (as default, registered last)
+	singleStrategy := workload.NewSingleComponentStrategy(r.Log)
+	if err := r.StrategyManager.RegisterStrategy(singleStrategy); err != nil {
+		return err
+	}
+	r.Log.Info("Registered workload strategies", "strategies", r.StrategyManager.ListStrategies())
 
 	ksvcFound, err := utils.IsCrdAvailable(r.ClientConfig, knservingv1.SchemeGroupVersion.String(), constants.KnativeServiceKind)
 	if err != nil {

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
 	"github.com/sgl-project/ome/pkg/constants"
 	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/status"
+	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/workload"
 	"github.com/sgl-project/ome/pkg/runtimeselector"
 	omeTesting "github.com/sgl-project/ome/pkg/testing"
 )
@@ -728,6 +729,12 @@ func TestInferenceServiceReconcile(t *testing.T) {
 				RuntimeSelector:          runtimeselector.New(c),
 				AcceleratorClassSelector: acceleratorclassselector.New(c),
 			}
+
+			// Initialize StrategyManager and register strategies
+			reconciler.StrategyManager = workload.NewWorkloadStrategyManager(reconciler.Log)
+			singleStrategy := workload.NewSingleComponentStrategy(reconciler.Log)
+			err = reconciler.StrategyManager.RegisterStrategy(singleStrategy)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Ensure the InferenceService exists in the client
 			existingIsvc := &v1beta1.InferenceService{}

--- a/pkg/controller/v1beta1/inferenceservice/workload/manager.go
+++ b/pkg/controller/v1beta1/inferenceservice/workload/manager.go
@@ -1,0 +1,114 @@
+package workload
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/constants"
+)
+
+// WorkloadStrategyManager manages and selects workload strategies.
+type WorkloadStrategyManager struct {
+	registers  map[string]struct{}
+	strategies []WorkloadStrategy // Slice to maintain registration order
+	mu         sync.RWMutex
+	log        logr.Logger
+}
+
+func NewWorkloadStrategyManager(log logr.Logger) *WorkloadStrategyManager {
+	return &WorkloadStrategyManager{
+		registers:  make(map[string]struct{}),
+		strategies: make([]WorkloadStrategy, 0),
+		log:        log,
+	}
+}
+
+// RegisterStrategy registers a workload strategy.
+func (m *WorkloadStrategyManager) RegisterStrategy(strategy WorkloadStrategy) error {
+	if strategy == nil {
+		return fmt.Errorf("cannot register nil strategy")
+	}
+
+	name := strategy.GetStrategyName()
+	if name == "" {
+		return fmt.Errorf("strategy name cannot be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.registers[name]; exists {
+		return fmt.Errorf("strategy %s is already registered", name)
+	}
+
+	// Add to both map and ordered slice
+	m.registers[name] = struct{}{}
+	m.strategies = append(m.strategies, strategy)
+	m.log.Info("Registered workload strategy", "strategy", name)
+	return nil
+}
+
+// SelectStrategy selects an appropriate strategy based on conditions.
+// Strategy selection process:
+// 1. Check deploymentMode
+// 2. Iterate through all registered strategies to find the first one where IsApplicable returns true
+// 3. Return an error if no applicable strategy is found
+func (m *WorkloadStrategyManager) SelectStrategy(isvc *v1beta1.InferenceService, deploymentMode constants.DeploymentModeType) (WorkloadStrategy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(m.strategies) == 0 {
+		return nil, fmt.Errorf("no workload strategies registered")
+	}
+
+	// Iterate through all strategies to find the first applicable one.
+	// Note: Strategy registration order matters - special strategies (like RBG) should be registered first,
+	// and default strategy (SingleComponent) should be registered last.
+	for _, strategy := range m.strategies {
+		if strategy.IsApplicable(isvc, deploymentMode) {
+			m.log.Info("Selected workload strategy",
+				"strategy", strategy.GetStrategyName(),
+				"namespace", isvc.Namespace,
+				"inferenceService", isvc.Name)
+			return strategy, nil
+		}
+	}
+
+	// If no strategy is applicable, return an error.
+	return nil, fmt.Errorf("no applicable workload strategy found for InferenceService %s/%s", isvc.Namespace, isvc.Name)
+}
+
+// GetStrategy retrieves a strategy instance by name.
+func (m *WorkloadStrategyManager) GetStrategy(name string) (WorkloadStrategy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	_, exists := m.registers[name]
+	if !exists {
+		return nil, fmt.Errorf("strategy %s not found", name)
+	}
+
+	for _, v := range m.strategies {
+		if v.GetStrategyName() == name {
+			return v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("internal inconsistency: strategy %s is in registers but not in slice", name)
+}
+
+// ListStrategies lists all registered strategies in registration order.
+func (m *WorkloadStrategyManager) ListStrategies() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	names := make([]string, 0, len(m.strategies))
+	for _, strategy := range m.strategies {
+		names = append(names, strategy.GetStrategyName())
+	}
+
+	return names
+}

--- a/pkg/controller/v1beta1/inferenceservice/workload/manager_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/workload/manager_test.go
@@ -1,0 +1,295 @@
+package workload
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/constants"
+)
+
+// MockStrategy is a mock implementation of WorkloadStrategy for testing.
+type MockStrategy struct {
+	name            string
+	isApplicable    bool
+	validateErr     error
+	reconcileResult ctrl.Result
+	reconcileErr    error
+	reconcileCalled int
+	mu              sync.Mutex
+}
+
+func NewMockStrategy(name string, isApplicable bool) *MockStrategy {
+	return &MockStrategy{
+		name:         name,
+		isApplicable: isApplicable,
+	}
+}
+
+func (m *MockStrategy) GetStrategyName() string {
+	return m.name
+}
+
+func (m *MockStrategy) IsApplicable(isvc *v1beta1.InferenceService, deploymentMode constants.DeploymentModeType) bool {
+	return m.isApplicable
+}
+
+func (m *MockStrategy) ValidateDeploymentModes(modes *ComponentDeploymentModes) error {
+	return m.validateErr
+}
+
+func (m *MockStrategy) ReconcileWorkload(ctx context.Context, request *WorkloadReconcileRequest) (ctrl.Result, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reconcileCalled++
+	return m.reconcileResult, m.reconcileErr
+}
+
+func (m *MockStrategy) SetValidateError(err error) {
+	m.validateErr = err
+}
+
+func (m *MockStrategy) SetReconcileResult(result ctrl.Result, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reconcileResult = result
+	m.reconcileErr = err
+}
+
+func (m *MockStrategy) GetReconcileCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.reconcileCalled
+}
+
+// TestRegisterStrategy tests various scenarios of registering strategies.
+func TestRegisterStrategy(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setup          func() (*WorkloadStrategyManager, WorkloadStrategy, WorkloadStrategy)
+		wantErr        bool
+		errContains    string
+		expectedCount  int
+		verifyOriginal bool
+	}{
+		{
+			name: "nil strategy",
+			setup: func() (*WorkloadStrategyManager, WorkloadStrategy, WorkloadStrategy) {
+				log := logr.Discard()
+				manager := NewWorkloadStrategyManager(log)
+				return manager, nil, nil
+			},
+			wantErr:       true,
+			errContains:   "cannot register nil strategy",
+			expectedCount: 0,
+		},
+		{
+			name: "empty name",
+			setup: func() (*WorkloadStrategyManager, WorkloadStrategy, WorkloadStrategy) {
+				log := logr.Discard()
+				manager := NewWorkloadStrategyManager(log)
+				strategy := NewMockStrategy("", true)
+				return manager, strategy, nil
+			},
+			wantErr:       true,
+			errContains:   "strategy name cannot be empty",
+			expectedCount: 0,
+		},
+		{
+			name: "duplicate strategy",
+			setup: func() (*WorkloadStrategyManager, WorkloadStrategy, WorkloadStrategy) {
+				log := logr.Discard()
+				manager := NewWorkloadStrategyManager(log)
+				strategy1 := NewMockStrategy("TestStrategy", true)
+				strategy2 := NewMockStrategy("TestStrategy", false)
+				err := manager.RegisterStrategy(strategy1)
+				require.NoError(t, err)
+				return manager, strategy2, strategy1
+			},
+			wantErr:        true,
+			errContains:    "already registered",
+			expectedCount:  1,
+			verifyOriginal: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, strategy, originalStrategy := tc.setup()
+
+			err := manager.RegisterStrategy(strategy)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectedCount, len(manager.registers))
+
+			// Verify original strategy is still in place for duplicate test
+			if tc.verifyOriginal {
+				retrieved, err := manager.GetStrategy("TestStrategy")
+				require.NoError(t, err)
+				assert.Equal(t, originalStrategy, retrieved)
+			}
+		})
+	}
+}
+
+// TestSelectStrategy tests various scenarios of selecting strategies.
+func TestSelectStrategy(t *testing.T) {
+	testCases := []struct {
+		name        string
+		setup       func() (*WorkloadStrategyManager, *v1beta1.InferenceService)
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "no strategy matches",
+			setup: func() (*WorkloadStrategyManager, *v1beta1.InferenceService) {
+				log := logr.Discard()
+				manager := NewWorkloadStrategyManager(log)
+				strategy := NewMockStrategy("TestStrategy", false)
+				err := manager.RegisterStrategy(strategy)
+				require.NoError(t, err)
+				isvc := &v1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-isvc",
+						Namespace: "default",
+					},
+				}
+				return manager, isvc
+			},
+			wantErr:     true,
+			errContains: "no applicable workload strategy found",
+		},
+		{
+			name: "no strategies registered",
+			setup: func() (*WorkloadStrategyManager, *v1beta1.InferenceService) {
+				log := logr.Discard()
+				manager := NewWorkloadStrategyManager(log)
+				isvc := &v1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-isvc",
+						Namespace: "default",
+					},
+				}
+				return manager, isvc
+			},
+			wantErr:     true,
+			errContains: "no workload strategies registered",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, isvc := tc.setup()
+			deploymentMode := constants.RawDeployment
+
+			selected, err := manager.SelectStrategy(isvc, deploymentMode)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, selected)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, selected)
+			}
+		})
+	}
+}
+
+// TestGetStrategy tests various scenarios of getting strategies.
+func TestGetStrategy(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setup          func() *WorkloadStrategyManager
+		strategyName   string
+		wantErr        bool
+		errContains    string
+		expectStrategy bool
+	}{
+		{
+			name: "strategy found",
+			setup: func() *WorkloadStrategyManager {
+				log := logr.Discard()
+				manager := NewWorkloadStrategyManager(log)
+				strategy := NewMockStrategy("TestStrategy", true)
+				err := manager.RegisterStrategy(strategy)
+				require.NoError(t, err)
+				return manager
+			},
+			strategyName:   "TestStrategy",
+			wantErr:        false,
+			expectStrategy: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := tc.setup()
+
+			retrieved, err := manager.GetStrategy(tc.strategyName)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, retrieved)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				require.NoError(t, err)
+				if tc.expectStrategy {
+					assert.NotNil(t, retrieved)
+				}
+			}
+		})
+	}
+}
+
+// TestGetStrategy_NotFound tests retrieving a non-existent strategy.
+func TestGetStrategy_NotFound(t *testing.T) {
+	log := logr.Discard()
+	manager := NewWorkloadStrategyManager(log)
+
+	retrieved, err := manager.GetStrategy("NonExistent")
+	require.Error(t, err)
+	assert.Nil(t, retrieved)
+	assert.Contains(t, err.Error(), "strategy NonExistent not found")
+}
+
+// TestListStrategies tests listing all registered strategies.
+func TestListStrategies(t *testing.T) {
+	log := logr.Discard()
+	manager := NewWorkloadStrategyManager(log)
+
+	strategy1 := NewMockStrategy("Strategy1", true)
+	strategy2 := NewMockStrategy("Strategy2", true)
+
+	err := manager.RegisterStrategy(strategy1)
+	require.NoError(t, err)
+	err = manager.RegisterStrategy(strategy2)
+	require.NoError(t, err)
+
+	names := manager.ListStrategies()
+	assert.Equal(t, 2, len(names))
+	assert.Contains(t, names, "Strategy1")
+	assert.Contains(t, names, "Strategy2")
+}
+
+// TestListStrategies_Empty tests listing when no strategies are registered.
+func TestListStrategies_Empty(t *testing.T) {
+	log := logr.Discard()
+	manager := NewWorkloadStrategyManager(log)
+
+	names := manager.ListStrategies()
+	assert.Equal(t, 0, len(names))
+}

--- a/pkg/controller/v1beta1/inferenceservice/workload/single_component_strategy.go
+++ b/pkg/controller/v1beta1/inferenceservice/workload/single_component_strategy.go
@@ -1,0 +1,132 @@
+package workload
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/constants"
+	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/components"
+)
+
+// SingleComponentStrategy implements the single component independent deployment strategy.
+// This is the default strategy where each component is reconciled independently without using All-in-One workloads.
+type SingleComponentStrategy struct {
+	log logr.Logger
+}
+
+func NewSingleComponentStrategy(log logr.Logger) *SingleComponentStrategy {
+	return &SingleComponentStrategy{
+		log: log,
+	}
+}
+
+func (s *SingleComponentStrategy) GetStrategyName() string {
+	return "SingleComponent"
+}
+
+func (s *SingleComponentStrategy) IsApplicable(isvc *v1beta1.InferenceService, deploymentMode constants.DeploymentModeType) bool {
+
+	// By default, SingleComponent strategy is always applicable.
+	return true
+}
+
+// ValidateDeploymentModes validates component deployment modes.
+func (s *SingleComponentStrategy) ValidateDeploymentModes(modes *ComponentDeploymentModes) error {
+	// SingleComponent strategy supports all deployment modes, no validation needed.
+	return nil
+}
+
+// ReconcileWorkload executes component workload reconciliation.
+func (s *SingleComponentStrategy) ReconcileWorkload(ctx context.Context, request *WorkloadReconcileRequest) (ctrl.Result, error) {
+	s.log.Info("Reconciling with SingleComponent strategy",
+		"namespace", request.InferenceService.Namespace,
+		"inferenceService", request.InferenceService.Name)
+
+	var reconcilers []components.Component
+
+	// Create Engine component
+	if request.MergedEngine != nil {
+		s.log.Info("Creating engine reconciler",
+			"deploymentMode", request.DeploymentModes.Engine,
+			"namespace", request.InferenceService.Namespace,
+			"inferenceService", request.InferenceService.Name)
+
+		engineReconciler := request.ComponentBuilderFactory.CreateEngineComponent(
+			request.DeploymentModes.Engine,
+			request.BaseModel,
+			request.BaseModelMeta,
+			request.MergedEngine,
+			request.Runtime,
+			request.RuntimeName,
+			request.EngineSupportedModelFormat,
+			request.EngineAcceleratorClass,
+			request.EngineAcceleratorClassName,
+		)
+		reconcilers = append(reconcilers, engineReconciler)
+	}
+
+	// Create Decoder component
+	if request.MergedDecoder != nil {
+		s.log.Info("Creating decoder reconciler",
+			"deploymentMode", request.DeploymentModes.Decoder,
+			"namespace", request.InferenceService.Namespace,
+			"inferenceService", request.InferenceService.Name)
+
+		decoderReconciler := request.ComponentBuilderFactory.CreateDecoderComponent(
+			request.DeploymentModes.Decoder,
+			request.BaseModel,
+			request.BaseModelMeta,
+			request.MergedDecoder,
+			request.Runtime,
+			request.RuntimeName,
+			request.DecoderSupportedModelFormat,
+			request.DecoderAcceleratorClass,
+			request.DecoderAcceleratorClassName,
+		)
+		reconcilers = append(reconcilers, decoderReconciler)
+	}
+
+	// Create Router component
+	if request.MergedRouter != nil {
+		s.log.Info("Creating router reconciler",
+			"deploymentMode", request.DeploymentModes.Router,
+			"namespace", request.InferenceService.Namespace,
+			"inferenceService", request.InferenceService.Name)
+
+		routerReconciler := request.ComponentBuilderFactory.CreateRouterComponent(
+			request.DeploymentModes.Router,
+			request.BaseModel,
+			request.BaseModelMeta,
+			request.MergedRouter,
+			request.Runtime,
+			request.RuntimeName,
+		)
+		reconcilers = append(reconcilers, routerReconciler)
+	}
+
+	// Run all reconcilers
+	for _, reconciler := range reconcilers {
+		result, err := reconciler.Reconcile(request.InferenceService)
+		if err != nil {
+			s.log.Error(err, "Failed to reconcile component",
+				"component", fmt.Sprintf("%T", reconciler),
+				"namespace", request.InferenceService.Namespace,
+				"inferenceService", request.InferenceService.Name)
+			return result, err
+		}
+		if result.Requeue || result.RequeueAfter > 0 {
+			return result, nil
+		}
+	}
+
+	s.log.Info("SingleComponent strategy reconciliation completed",
+		"namespace", request.InferenceService.Namespace,
+		"inferenceService", request.InferenceService.Name)
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/v1beta1/inferenceservice/workload/single_component_strategy_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/workload/single_component_strategy_test.go
@@ -1,0 +1,876 @@
+package workload
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	lws "sigs.k8s.io/lws/api/leaderworkerset/v1"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/constants"
+	"github.com/sgl-project/ome/pkg/controller/v1beta1/controllerconfig"
+	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/components"
+	omeTesting "github.com/sgl-project/ome/pkg/testing"
+)
+
+// Helper function to create a basic test InferenceService.
+func createTestInferenceService() *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-isvc",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec: v1beta1.InferenceServiceSpec{},
+	}
+}
+
+// TestGetStrategyName tests getting the strategy name.
+func TestGetStrategyName(t *testing.T) {
+	log := logr.Discard()
+	strategy := NewSingleComponentStrategy(log)
+
+	name := strategy.GetStrategyName()
+	assert.Equal(t, "SingleComponent", name)
+}
+
+func TestIsApplicable_AlwaysTrue(t *testing.T) {
+	log := logr.Discard()
+	strategy := NewSingleComponentStrategy(log)
+
+	testCases := []struct {
+		isvc           *v1beta1.InferenceService
+		deploymentMode constants.DeploymentModeType
+	}{
+		{
+			isvc:           createTestInferenceService(),
+			deploymentMode: constants.RawDeployment,
+		},
+		{
+			isvc:           createTestInferenceService(),
+			deploymentMode: constants.MultiNode,
+		},
+		{
+			isvc:           createTestInferenceService(),
+			deploymentMode: constants.Serverless,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			applicable := strategy.IsApplicable(tc.isvc, tc.deploymentMode)
+			assert.True(t, applicable, "SingleComponent strategy should always be applicable")
+		})
+	}
+}
+
+// TestValidateDeploymentModes tests component deployment mode validation.
+func TestValidateDeploymentModes(t *testing.T) {
+	log := logr.Discard()
+	strategy := NewSingleComponentStrategy(log)
+
+	testCases := []struct {
+		name  string
+		modes *ComponentDeploymentModes
+	}{
+		{
+			name: "all raw deployment",
+			modes: &ComponentDeploymentModes{
+				Engine:  constants.RawDeployment,
+				Decoder: constants.RawDeployment,
+				Router:  constants.RawDeployment,
+			},
+		},
+		{
+			name: "mixed deployment modes",
+			modes: &ComponentDeploymentModes{
+				Engine:  constants.RawDeployment,
+				Decoder: constants.MultiNode,
+				Router:  constants.Serverless,
+			},
+		},
+		{
+			name:  "nil modes",
+			modes: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := strategy.ValidateDeploymentModes(tc.modes)
+			assert.NoError(t, err, "SingleComponent strategy should support all deployment modes")
+		})
+	}
+}
+
+// TestSingleComponentStrategyReconcileWorkload tests the ReconcileWorkload method with integration setup.
+func TestSingleComponentStrategyReconcileWorkload(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Setup EnvTest environment
+	testEnv := omeTesting.SetupEnvTest()
+	cfg, err := testEnv.Start()
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(cfg).NotTo(gomega.BeNil())
+	defer func(testEnv *envtest.Environment) {
+		_ = testEnv.Stop()
+	}(testEnv)
+
+	// Create scheme
+	scheme := runtime.NewScheme()
+	g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	g.Expect(v1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	g.Expect(appsv1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	g.Expect(lws.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	g.Expect(autoscalingv2.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	g.Expect(policyv1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	g.Expect(rbacv1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+
+	tests := []struct {
+		name         string
+		isvc         *v1beta1.InferenceService
+		setupMocks   func(client.Client, *fake.Clientset)
+		buildRequest func(client.Client, *fake.Clientset, *v1beta1.InferenceService) *WorkloadReconcileRequest
+		validate     func(*testing.T, client.Client, string)
+	}{
+		{
+			name: "New architecture with engine only",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-engine-only",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Model: &v1beta1.ModelRef{
+						Name: "base-model-1",
+						Kind: stringPtr("BaseModel"),
+					},
+					Engine: &v1beta1.EngineSpec{
+						PodSpec: v1beta1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "ome-container",
+									Image: "engine:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMocks: func(c client.Client, cs *fake.Clientset) {
+				setupCommonMocks(g, c, cs, "base-model-1")
+
+				// Create ServingRuntime
+				rt := &v1beta1.ServingRuntime{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-runtime-1",
+						Namespace: "default",
+					},
+					Spec: v1beta1.ServingRuntimeSpec{
+						SupportedModelFormats: []v1beta1.SupportedModelFormat{
+							{
+								Name:       "safetensors",
+								Version:    stringPtr("*"),
+								AutoSelect: boolPtr(true),
+								ModelFormat: &v1beta1.ModelFormat{
+									Name:    "safetensors",
+									Version: stringPtr("1.0.0"),
+									Weight:  int64(1),
+								},
+							},
+						},
+						ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "ome-container",
+									Image: "runtime:v1",
+								},
+							},
+						},
+					},
+				}
+				err = c.Create(context.TODO(), rt)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+			},
+			buildRequest: func(c client.Client, cs *fake.Clientset, isvc *v1beta1.InferenceService) *WorkloadReconcileRequest {
+				// Get BaseModel
+				baseModel := &v1beta1.BaseModel{}
+				err := c.Get(context.TODO(), types.NamespacedName{Name: "base-model-1", Namespace: "default"}, baseModel)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Get ServingRuntime
+				rt := &v1beta1.ServingRuntime{}
+				err = c.Get(context.TODO(), types.NamespacedName{Name: "test-runtime-1", Namespace: "default"}, rt)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Create InferenceServiceConfig
+				isvcConfig, err := controllerconfig.NewInferenceServicesConfig(cs)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Create ComponentBuilderFactory
+				factory := components.NewComponentBuilderFactory(c, cs, c.Scheme(), isvcConfig)
+
+				return &WorkloadReconcileRequest{
+					InferenceService: isvc,
+					BaseModel:        &baseModel.Spec,
+					BaseModelMeta:    &baseModel.ObjectMeta,
+					Runtime:          &rt.Spec,
+					RuntimeName:      rt.Name,
+					MergedEngine: &v1beta1.EngineSpec{
+						PodSpec: v1beta1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "engine",
+									Image: "engine:latest",
+								},
+							},
+						},
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 3,
+						},
+					},
+					MergedDecoder: nil,
+					MergedRouter:  nil,
+					DeploymentModes: &ComponentDeploymentModes{
+						Engine:  constants.RawDeployment,
+						Decoder: "",
+						Router:  "",
+					},
+					ComponentBuilderFactory:     factory,
+					UserSpecifiedRuntime:        false,
+					EngineSupportedModelFormat:  &rt.Spec.SupportedModelFormats[0],
+					DecoderSupportedModelFormat: nil,
+				}
+			},
+			validate: func(t *testing.T, c client.Client, isvcName string) {
+				// Verify Engine Deployment
+				engineDeployment := &appsv1.Deployment{}
+				err := c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-engine",
+					Namespace: "default",
+				}, engineDeployment)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(engineDeployment.Spec.Template.Spec.Containers[0].Image).To(gomega.Equal("engine:latest"))
+
+				// Verify Engine Service
+				engineService := &v1.Service{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-engine",
+					Namespace: "default",
+				}, engineService)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify Engine HPA
+				engineHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-engine",
+					Namespace: "default",
+				}, engineHPA)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify Engine PDB
+				enginePDB := &policyv1.PodDisruptionBudget{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-engine",
+					Namespace: "default",
+				}, enginePDB)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify Decoder resources do NOT exist
+				decoderDeployment := &appsv1.Deployment{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-decoder",
+					Namespace: "default",
+				}, decoderDeployment)
+				g.Expect(err).To(gomega.HaveOccurred())
+
+				// Verify Router resources do NOT exist
+				routerDeployment := &appsv1.Deployment{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-router",
+					Namespace: "default",
+				}, routerDeployment)
+				g.Expect(err).To(gomega.HaveOccurred())
+			},
+		},
+		{
+			name: "New architecture with engine and decoder (PD-disaggregated)",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pd-disaggregated",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Model: &v1beta1.ModelRef{
+						Name: "base-model-2",
+						Kind: stringPtr("BaseModel"),
+					},
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name: "custom-runtime",
+					},
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 1,
+						},
+					},
+					Decoder: &v1beta1.DecoderSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 1,
+						},
+					},
+				},
+			},
+			setupMocks: func(c client.Client, cs *fake.Clientset) {
+				setupCommonMocks(g, c, cs, "base-model-2")
+
+				// Create ServingRuntime
+				rt := &v1beta1.ServingRuntime{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "custom-runtime",
+						Namespace: "default",
+					},
+					Spec: v1beta1.ServingRuntimeSpec{
+						SupportedModelFormats: []v1beta1.SupportedModelFormat{
+							{
+								Name:       "safetensors",
+								Version:    stringPtr("*"),
+								AutoSelect: boolPtr(true),
+								ModelFormat: &v1beta1.ModelFormat{
+									Name:    "safetensors",
+									Version: stringPtr("1.0.0"),
+									Weight:  int64(1),
+								},
+							},
+						},
+						EngineConfig: &v1beta1.EngineSpec{
+							PodSpec: v1beta1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "ome-container",
+										Image: "runtime:v1",
+									},
+								},
+							},
+						},
+						DecoderConfig: &v1beta1.DecoderSpec{
+							PodSpec: v1beta1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "ome-container",
+										Image: "runtime:v1",
+									},
+								},
+							},
+						},
+					},
+				}
+				err = c.Create(context.TODO(), rt)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+			},
+			buildRequest: func(c client.Client, cs *fake.Clientset, isvc *v1beta1.InferenceService) *WorkloadReconcileRequest {
+				// Get BaseModel
+				baseModel := &v1beta1.BaseModel{}
+				err := c.Get(context.TODO(), types.NamespacedName{Name: "base-model-2", Namespace: "default"}, baseModel)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Get ServingRuntime
+				rt := &v1beta1.ServingRuntime{}
+				err = c.Get(context.TODO(), types.NamespacedName{Name: "custom-runtime", Namespace: "default"}, rt)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Create InferenceServiceConfig
+				isvcConfig, err := controllerconfig.NewInferenceServicesConfig(cs)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Create ComponentBuilderFactory
+				factory := components.NewComponentBuilderFactory(c, cs, c.Scheme(), isvcConfig)
+
+				return &WorkloadReconcileRequest{
+					InferenceService: isvc,
+					BaseModel:        &baseModel.Spec,
+					BaseModelMeta:    &baseModel.ObjectMeta,
+					Runtime:          &rt.Spec,
+					RuntimeName:      rt.Name,
+					MergedEngine: &v1beta1.EngineSpec{
+						PodSpec: v1beta1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "ome-container",
+									Image: "runtime:v1",
+								},
+							},
+						},
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 1,
+						},
+					},
+					MergedDecoder: &v1beta1.DecoderSpec{
+						PodSpec: v1beta1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "ome-container",
+									Image: "runtime:v1",
+								},
+							},
+						},
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 1,
+						},
+					},
+					MergedRouter: nil,
+					DeploymentModes: &ComponentDeploymentModes{
+						Engine:  constants.RawDeployment,
+						Decoder: constants.RawDeployment,
+						Router:  "",
+					},
+					ComponentBuilderFactory:     factory,
+					UserSpecifiedRuntime:        true,
+					EngineSupportedModelFormat:  &rt.Spec.SupportedModelFormats[0],
+					DecoderSupportedModelFormat: &rt.Spec.SupportedModelFormats[0],
+				}
+			},
+			validate: func(t *testing.T, c client.Client, isvcName string) {
+				// Verify Engine resources
+				engineDeployment := &appsv1.Deployment{}
+				err := c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-engine",
+					Namespace: "default",
+				}, engineDeployment)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				engineService := &v1.Service{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-engine",
+					Namespace: "default",
+				}, engineService)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify Decoder resources
+				decoderDeployment := &appsv1.Deployment{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-decoder",
+					Namespace: "default",
+				}, decoderDeployment)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				decoderService := &v1.Service{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-decoder",
+					Namespace: "default",
+				}, decoderService)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify Router resources do NOT exist
+				routerDeployment := &appsv1.Deployment{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-router",
+					Namespace: "default",
+				}, routerDeployment)
+				g.Expect(err).To(gomega.HaveOccurred())
+			},
+		},
+		{
+			name: "Multi-node && specified runtime && PD-disaggregated && router",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-multinode",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Model: &v1beta1.ModelRef{
+						Name: "base-model-4",
+						Kind: stringPtr("BaseModel"),
+					},
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name: "custom-runtime",
+					},
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 1,
+						},
+					},
+					Decoder: &v1beta1.DecoderSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 1,
+						},
+					},
+					Router: &v1beta1.RouterSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 1,
+						},
+					},
+				},
+			},
+			setupMocks: func(c client.Client, cs *fake.Clientset) {
+				setupCommonMocks(g, c, cs, "base-model-4")
+				// Create ServingRuntime
+				rt := &v1beta1.ServingRuntime{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "custom-runtime",
+						Namespace: "default",
+					},
+					Spec: v1beta1.ServingRuntimeSpec{
+						SupportedModelFormats: []v1beta1.SupportedModelFormat{
+							{
+								Name:       "safetensors",
+								Version:    stringPtr("*"),
+								AutoSelect: boolPtr(true),
+								ModelFormat: &v1beta1.ModelFormat{
+									Name:    "safetensors",
+									Version: stringPtr("1.0.0"),
+									Weight:  int64(1),
+								},
+							},
+						},
+						EngineConfig: &v1beta1.EngineSpec{
+							Leader: &v1beta1.LeaderSpec{
+								PodSpec: v1beta1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "ome-container",
+											Image: "runtime:v1",
+										},
+									},
+								},
+							},
+							Worker: &v1beta1.WorkerSpec{
+								Size: intPtr(2),
+								PodSpec: v1beta1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "ome-container",
+											Image: "runtime:v1",
+										},
+									},
+								},
+							},
+						},
+						DecoderConfig: &v1beta1.DecoderSpec{
+							Leader: &v1beta1.LeaderSpec{
+								PodSpec: v1beta1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "ome-container",
+											Image: "runtime:v1",
+										},
+									},
+								},
+							},
+							Worker: &v1beta1.WorkerSpec{
+								Size: intPtr(2),
+								PodSpec: v1beta1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "ome-container",
+											Image: "runtime:v1",
+										},
+									},
+								},
+							},
+						},
+						RouterConfig: &v1beta1.RouterSpec{
+							PodSpec: v1beta1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "router",
+										Image: "runtime:v1",
+									},
+								},
+							},
+						},
+					},
+				}
+				err = c.Create(context.TODO(), rt)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+			},
+			buildRequest: func(c client.Client, cs *fake.Clientset, isvc *v1beta1.InferenceService) *WorkloadReconcileRequest {
+				// Get BaseModel
+				baseModel := &v1beta1.BaseModel{}
+				err := c.Get(context.TODO(), types.NamespacedName{Name: "base-model-4", Namespace: "default"}, baseModel)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Get ServingRuntime
+				rt := &v1beta1.ServingRuntime{}
+				err = c.Get(context.TODO(), types.NamespacedName{Name: "custom-runtime", Namespace: "default"}, rt)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Create InferenceServiceConfig
+				isvcConfig, err := controllerconfig.NewInferenceServicesConfig(cs)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Create ComponentBuilderFactory
+				factory := components.NewComponentBuilderFactory(c, cs, c.Scheme(), isvcConfig)
+
+				return &WorkloadReconcileRequest{
+					InferenceService: isvc,
+					BaseModel:        &baseModel.Spec,
+					BaseModelMeta:    &baseModel.ObjectMeta,
+					Runtime:          &rt.Spec,
+					RuntimeName:      rt.Name,
+					MergedEngine: &v1beta1.EngineSpec{
+						Leader: &v1beta1.LeaderSpec{
+							PodSpec: v1beta1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "ome-container",
+										Image: "runtime:v1",
+									},
+								},
+							},
+						},
+						Worker: &v1beta1.WorkerSpec{
+							Size: intPtr(2),
+							PodSpec: v1beta1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "ome-container",
+										Image: "runtime:v1",
+									},
+								},
+							},
+						},
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 1,
+						},
+					},
+					MergedDecoder: &v1beta1.DecoderSpec{
+						Leader: &v1beta1.LeaderSpec{
+							PodSpec: v1beta1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "ome-container",
+										Image: "runtime:v1",
+									},
+								},
+							},
+						},
+						Worker: &v1beta1.WorkerSpec{
+							Size: intPtr(2),
+							PodSpec: v1beta1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "ome-container",
+										Image: "runtime:v1",
+									},
+								},
+							},
+						},
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 1,
+						},
+					},
+					MergedRouter: &v1beta1.RouterSpec{
+						PodSpec: v1beta1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "router",
+									Image: "router:v1",
+								},
+							},
+						},
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: intPtr(1),
+							MaxReplicas: 1,
+						},
+					},
+					DeploymentModes: &ComponentDeploymentModes{
+						Engine:  constants.MultiNode,
+						Decoder: constants.MultiNode,
+						Router:  constants.RawDeployment,
+					},
+					ComponentBuilderFactory:     factory,
+					UserSpecifiedRuntime:        true,
+					EngineSupportedModelFormat:  &rt.Spec.SupportedModelFormats[0],
+					DecoderSupportedModelFormat: &rt.Spec.SupportedModelFormats[0],
+				}
+			},
+			validate: func(t *testing.T, c client.Client, isvcName string) {
+				// Verify Engine resources
+				engineDeployment := &lws.LeaderWorkerSet{}
+				err := c.Get(context.TODO(), types.NamespacedName{
+					Name:      constants.LWSName(isvcName + "-engine"),
+					Namespace: "default",
+				}, engineDeployment)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify Decoder resources
+				decoderDeployment := &lws.LeaderWorkerSet{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      constants.LWSName(isvcName + "-decoder"),
+					Namespace: "default",
+				}, decoderDeployment)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify Router resources
+				routerDeployment := &appsv1.Deployment{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-router",
+					Namespace: "default",
+				}, routerDeployment)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify services for all components
+				engineService := &v1.Service{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-engine",
+					Namespace: "default",
+				}, engineService)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				decoderService := &v1.Service{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-decoder",
+					Namespace: "default",
+				}, decoderService)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				routerService := &v1.Service{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-router",
+					Namespace: "default",
+				}, routerService)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify Router RBAC
+				routerSA := &v1.ServiceAccount{}
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Name:      isvcName + "-router",
+					Namespace: "default",
+				}, routerSA)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify all resources have correct labels
+				g.Expect(engineDeployment.Labels[constants.InferenceServicePodLabelKey]).To(gomega.Equal(isvcName))
+				g.Expect(decoderDeployment.Labels[constants.InferenceServicePodLabelKey]).To(gomega.Equal(isvcName))
+				g.Expect(routerDeployment.Labels[constants.InferenceServicePodLabelKey]).To(gomega.Equal(isvcName))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client
+			c := ctrlclientfake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+
+			// Create fake clientset
+			clientset := fake.NewClientset()
+
+			// Setup mocks
+			if tt.setupMocks != nil {
+				tt.setupMocks(c, clientset)
+			}
+
+			// Create InferenceService
+			err := c.Create(context.TODO(), tt.isvc)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Build reconcile request
+			request := tt.buildRequest(c, clientset, tt.isvc)
+
+			// Create strategy and reconcile
+			strategy := NewSingleComponentStrategy(ctrl.Log.WithName("test"))
+			result, err := strategy.ReconcileWorkload(context.TODO(), request)
+
+			// Verify reconcile result
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(result.Requeue).To(gomega.BeFalse())
+			g.Expect(result.RequeueAfter).To(gomega.BeZero())
+
+			// Run validation
+			if tt.validate != nil {
+				tt.validate(t, c, tt.isvc.Name)
+			}
+		})
+	}
+}
+
+// Helper functions for test setup
+func setupCommonMocks(g *gomega.WithT, c client.Client, cs *fake.Clientset, baseModelName string) {
+	// Create ConfigMap for InferenceService config
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "inferenceservice-config",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"config": "{}",
+		},
+	}
+	err := c.Create(context.TODO(), cm)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Create ConfigMap in ome namespace for deploy config
+	omeCm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "inferenceservice-config",
+			Namespace: "ome",
+		},
+		Data: map[string]string{
+			"deploy": `{"defaultDeploymentMode": "RawDeployment"}`,
+		},
+	}
+	_, err = cs.CoreV1().ConfigMaps("ome").Create(context.TODO(), omeCm, metav1.CreateOptions{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Create BaseModel
+	baseModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      baseModelName,
+			Namespace: "default",
+		},
+		Spec: v1beta1.BaseModelSpec{
+			ModelFormat: v1beta1.ModelFormat{
+				Name:    "safetensors",
+				Version: stringPtr("1.0.0"),
+			},
+			Storage: &v1beta1.StorageSpec{
+				Path: stringPtr("/mnt/models/test"),
+			},
+		},
+	}
+	err = c.Create(context.TODO(), baseModel)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+// Helper functions for creating pointers
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func intPtr(i int) *int {
+	return &i
+}

--- a/pkg/controller/v1beta1/inferenceservice/workload/strategy.go
+++ b/pkg/controller/v1beta1/inferenceservice/workload/strategy.go
@@ -1,0 +1,27 @@
+package workload
+
+import (
+	"context"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/constants"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// WorkloadStrategy defines the unified interface for workload strategies.
+// All workload strategies (SingleComponent, RBG, etc.) must implement this interface.
+type WorkloadStrategy interface {
+	// GetStrategyName returns the name of the strategy.
+	GetStrategyName() string
+
+	// IsApplicable determines whether this strategy is applicable to the current InferenceService.
+	IsApplicable(isvc *v1beta1.InferenceService, deploymentMode constants.DeploymentModeType) bool
+
+	// ValidateDeploymentModes validates whether component deployment modes are supported by this strategy.
+	// Different strategies may support different deployment modes.
+	ValidateDeploymentModes(modes *ComponentDeploymentModes) error
+
+	// ReconcileWorkload executes workload reconciliation.
+	// This is the core method of the strategy, responsible for creating and updating workload resources.
+	ReconcileWorkload(ctx context.Context, request *WorkloadReconcileRequest) (ctrl.Result, error)
+}

--- a/pkg/controller/v1beta1/inferenceservice/workload/types.go
+++ b/pkg/controller/v1beta1/inferenceservice/workload/types.go
@@ -1,0 +1,55 @@
+package workload
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/constants"
+	"github.com/sgl-project/ome/pkg/controller/v1beta1/inferenceservice/components"
+)
+
+// WorkloadReconcileRequest encapsulates parameters for workload reconciliation.
+// It contains all information required to execute workload reconciliation.
+type WorkloadReconcileRequest struct {
+	// InferenceService instance
+	InferenceService *v1beta1.InferenceService
+
+	// Base model information
+	BaseModel     *v1beta1.BaseModelSpec
+	BaseModelMeta *metav1.ObjectMeta
+
+	// Runtime information
+	Runtime     *v1beta1.ServingRuntimeSpec
+	RuntimeName string
+
+	// Merged component specifications
+	MergedEngine  *v1beta1.EngineSpec
+	MergedDecoder *v1beta1.DecoderSpec
+	MergedRouter  *v1beta1.RouterSpec
+
+	// Deployment modes configuration
+	DeploymentModes *ComponentDeploymentModes
+
+	// Component builder factory
+	ComponentBuilderFactory *components.ComponentBuilderFactory
+
+	// Whether runtime is user-specified
+	UserSpecifiedRuntime bool
+
+	// AcceleratorClass information
+	EngineAcceleratorClass      *v1beta1.AcceleratorClassSpec
+	EngineAcceleratorClassName  string
+	DecoderAcceleratorClass     *v1beta1.AcceleratorClassSpec
+	DecoderAcceleratorClassName string
+
+	// SupportedModelFormat information
+	EngineSupportedModelFormat  *v1beta1.SupportedModelFormat
+	DecoderSupportedModelFormat *v1beta1.SupportedModelFormat
+}
+
+// ComponentDeploymentModes encapsulates deployment modes for each component.
+type ComponentDeploymentModes struct {
+	Engine  constants.DeploymentModeType
+	Decoder constants.DeploymentModeType
+	Router  constants.DeploymentModeType
+}


### PR DESCRIPTION

## What this PR does

<!-- Brief description of the changes -->
This PR refactors the InferenceService controller's workload reconciliation logic by introducing a strategy pattern. The original tightly coupled component reconciliation logic has been extracted into a flexible, extensible workload strategy framework.

## Why we need it

<!-- Motivation, context, or link to issue -->
### Motivation
https://github.com/sgl-project/ome/pull/505

The original controller implementation had several limitations:
- Component reconciliation logic was tightly coupled within the main controller
- Difficult to extend for different deployment scenarios (e.g., All-in-One, RBG)
- Hard to maintain and test individual reconciliation strategies

### New Components

1. **Workload Strategy Framework** (`pkg/controller/v1beta1/inferenceservice/workload/`)
   - `strategy.go`: Defines the `WorkloadStrategy` interface
   - `manager.go`: Implements `WorkloadStrategyManager` for strategy registration and selection
   - `types.go`: Defines `WorkloadReconcileRequest` and `ComponentDeploymentModes` data structures
   - `single_component_strategy.go`: Implements the default `SingleComponentStrategy`

2. **Strategy Interface Methods**
   - `GetStrategyName()`: Returns strategy name
   - `IsApplicable()`: Determines if strategy applies to current InferenceService
   - `ValidateDeploymentModes()`: Validates component deployment modes
   - `ReconcileWorkload()`: Executes workload reconciliation

### Modified Components

1. **InferenceService Controller** (`pkg/controller/v1beta1/inferenceservice/controller.go`)
   - Added `StrategyManager` field to controller struct
   - Refactored reconciliation flow:
     - Strategy selection (Step 5)
     - Build `WorkloadReconcileRequest` (Step 7)
     - Execute workload reconciliation via strategy (Step 8)
   - Initialize and register strategies in `SetupWithManager()`


Fixes None

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->
```yaml
apiVersion: ome.io/v1beta1
kind: InferenceService
metadata:
  name: qwen3-0-6b
spec:
  model:
    name: qwen3-0-6b
  runtime:
    name: srt-qwen3-0-6b
  engine:
    minReplicas: 1
    maxReplicas: 1
```
```shell
NAMESPACE  NAME                                             READY  REASON  AGE
default    InferenceService/qwen3-0-6b                      True           4m38s
default    ├─ConfigMap/modelconfig-qwen3-0-6b             -              4m38s
default    ├─Deployment/qwen3-0-6b-engine                 -              4m38s
default    │ └─ReplicaSet/qwen3-0-6b-engine-5bf986dbc5   -              4m38s
default    │   └─Pod/qwen3-0-6b-engine-5bf986dbc5-dq6md  True           4m38s
default    ├─HorizontalPodAutoscaler/qwen3-0-6b-engine    -              4m38s
default    ├─PodDisruptionBudget/qwen3-0-6b-engine        -              4m38s
default    ├─Service/qwen3-0-6b                           -              4m38s
default    │ └─EndpointSlice/qwen3-0-6b-pf7dn            -              4m38s
default    └─Service/qwen3-0-6b-engine                    -              4m38s
default      └─EndpointSlice/qwen3-0-6b-engine-lx9dh      -              4m38s
```

```yaml
apiVersion: ome.io/v1beta1
kind: InferenceService
metadata:
  name: qwen3-0-6b-mn-pd
spec:
  model:
    name: qwen3-0-6b
  runtime:
    name: srt-qwen3-0-6b-mn-pd
  router:
    minReplicas: 1
    maxReplicas: 1
  engine:
    minReplicas: 1
    maxReplicas: 1
  decoder:
    minReplicas: 1
    maxReplicas: 1
```

```shell
NAMESPACE  NAME                                                                       READY  REASON  AGE
default    InferenceService/qwen3-0-6b-mn-pd                                          True           94s
default    ├─ConfigMap/modelconfig-qwen3-0-6b-mn-pd                                 -              94s
default    ├─Deployment/qwen3-0-6b-mn-pd-router                                     -              94s
default    │ └─ReplicaSet/qwen3-0-6b-mn-pd-router-567ddd9c9                        -              94s
default    │   └─Pod/qwen3-0-6b-mn-pd-router-567ddd9c9-9bwlz                       True           94s
default    ├─HorizontalPodAutoscaler/qwen3-0-6b-mn-pd-router                        -              94s
default    ├─LeaderWorkerSet/lws-qwen3-0-6b-mn-pd-decoder                           -              94s
default    │ ├─ControllerRevision/lws-qwen3-0-6b-mn-pd-decoder-57bc5b599-1         -              94s
default    │ ├─Service/lws-qwen3-0-6b-mn-pd-decoder                                -              94s
default    │ │ └─EndpointSlice/lws-qwen3-0-6b-mn-pd-decoder-trdsj                 -              94s
default    │ └─StatefulSet/lws-qwen3-0-6b-mn-pd-decoder                            -              94s
default    │   ├─ControllerRevision/lws-qwen3-0-6b-mn-pd-decoder-7647777b9f        -              94s
default    │   └─Pod/lws-qwen3-0-6b-mn-pd-decoder-0                                True           94s
default    │     └─StatefulSet/lws-qwen3-0-6b-mn-pd-decoder-0                      -              94s
default    │       ├─ControllerRevision/lws-qwen3-0-6b-mn-pd-decoder-0-5b5fc6d558  -              94s
default    │       └─Pod/lws-qwen3-0-6b-mn-pd-decoder-0-1                          True           94s
default    ├─LeaderWorkerSet/lws-qwen3-0-6b-mn-pd-engine                            -              94s
default    │ ├─ControllerRevision/lws-qwen3-0-6b-mn-pd-engine-74749ccbc9-1         -              94s
default    │ ├─Service/lws-qwen3-0-6b-mn-pd-engine                                 -              94s
default    │ │ └─EndpointSlice/lws-qwen3-0-6b-mn-pd-engine-kwdfk                  -              94s
default    │ └─StatefulSet/lws-qwen3-0-6b-mn-pd-engine                             -              94s
default    │   ├─ControllerRevision/lws-qwen3-0-6b-mn-pd-engine-7c756577b          -              94s
default    │   └─Pod/lws-qwen3-0-6b-mn-pd-engine-0                                 True           94s
default    │     └─StatefulSet/lws-qwen3-0-6b-mn-pd-engine-0                       -              94s
default    │       ├─ControllerRevision/lws-qwen3-0-6b-mn-pd-engine-0-674d8c78cb   -              94s
default    │       └─Pod/lws-qwen3-0-6b-mn-pd-engine-0-1                           True           94s
default    ├─PodDisruptionBudget/qwen3-0-6b-mn-pd-router                            -              94s
default    ├─Role/qwen3-0-6b-mn-pd-router                                           -              94s
default    ├─RoleBinding/qwen3-0-6b-mn-pd-router                                    -              94s
default    ├─Service/qwen3-0-6b-mn-pd                                               -              94s
default    │ └─EndpointSlice/qwen3-0-6b-mn-pd-82l4j                                -              94s
default    ├─Service/qwen3-0-6b-mn-pd-decoder                                       -              94s
default    │ └─EndpointSlice/qwen3-0-6b-mn-pd-decoder-zp7qp                        -              94s
default    ├─Service/qwen3-0-6b-mn-pd-engine                                        -              94s
default    │ └─EndpointSlice/qwen3-0-6b-mn-pd-engine-bd5lz                         -              94s
default    ├─Service/qwen3-0-6b-mn-pd-router                                        -              94s
default    │ └─EndpointSlice/qwen3-0-6b-mn-pd-router-m898l                         -              94s
default    └─ServiceAccount/qwen3-0-6b-mn-pd-router                                 -              94s
```



## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
