### PR TITLE
[Mics]skip accelerator class getting if not name and policy specified

### DIFF
--- a/pkg/acceleratorclassselector/types.go
+++ b/pkg/acceleratorclassselector/types.go
@@ -55,9 +55,6 @@ type Config struct {
 
 	// EnableDetailedLogging enables verbose logging for debugging
 	EnableDetailedLogging bool
-
-	// DefaultPriority is used when an accelerator class doesn't specify priority
-	DefaultPolicy v1beta1.AcceleratorSelectionPolicy
 }
 
 // NewConfig creates a new Config with default values.
@@ -65,6 +62,5 @@ func NewConfig(client client.Client) *Config {
 	return &Config{
 		Client:                client,
 		EnableDetailedLogging: false,
-		DefaultPolicy:         v1beta1.FirstAvailablePolicy,
 	}
 }

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -289,6 +289,9 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "AcceleratorClassError", "Failed to get accelerator class for engine: %v", err)
 			return reconcile.Result{}, err
 		}
+		if engineAC == nil {
+			r.Log.Info("Accelerator class not specified for engine component", "inferenceService", isvc.Name)
+		}
 		engineSupportedModelFormats := r.RuntimeSelector.GetSupportedModelFormat(ctx, rt, baseModel, userSpecifiedRuntime)
 		r.Log.Info("Creating engine reconciler",
 			"deploymentMode", engineDeploymentMode,
@@ -316,6 +319,9 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			r.Log.Error(err, "Failed to get accelerator class for decoder component", "Name", isvc.Name)
 			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "AcceleratorClassError", "Failed to get accelerator class for decoder: %v", err)
 			return reconcile.Result{}, err
+		}
+		if decoderAC == nil {
+			r.Log.Info("Accelerator class not specified for decoder component", "inferenceService", isvc.Name)
 		}
 		decoderSupportedModelFormats := r.RuntimeSelector.GetSupportedModelFormat(ctx, rt, baseModel, userSpecifiedRuntime)
 		r.Log.Info("Creating decoder reconciler",


### PR DESCRIPTION
## What this PR does
Update the logic to choose accelerator class.

## Why we need it
### Current behavior

AcceleratorClass (AC) selection follows this order:

Explicit AC name: If the user specifies an acceleratorClassName, the system uses that AC directly.

Policy-based selection: If no AC name is provided, the system selects an AC based on the configured policy.

Default policy: If no policy is configured, the system defaults to FirstAvailable, meaning it will still select an AC automatically.

### Proposed behavior

To give customers the option to opt out of AcceleratorClass selection entirely, we change the default behavior:

Explicit AC name: If the user specifies an acceleratorClassName, the system uses that AC directly.

Policy-based selection: If no AC name is provided, the system selects an AC based on the configured policy.

No implicit default: If no policy is configured, the system does not select any AC (i.e., no AcceleratorClass is applied by default).
Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
