### PR TITLE
[Mics]update runtime and inference service crd

### DIFF
--- a/charts/ome-crd/templates/ome.io_clusterservingruntimes.yaml
+++ b/charts/ome-crd/templates/ome.io_clusterservingruntimes.yaml
@@ -61,7 +61,9 @@ spec:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
-                    minComputeCapability:
+                    minArchitectureVersion:
+                      type: string
+                    minComputePerformanceTFLOPS:
                       format: int64
                       minimum: 0
                       type: integer
@@ -1229,12 +1231,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string
@@ -14183,12 +14192,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string

--- a/charts/ome-crd/templates/ome.io_inferenceservices.yaml
+++ b/charts/ome-crd/templates/ome.io_inferenceservices.yaml
@@ -75,12 +75,19 @@ spec:
                         maxMemory:
                           format: int64
                           type: integer
-                        minComputeCapability:
+                        minArchitectureVersion:
+                          type: string
+                        minComputePerformanceTFLOPS:
                           format: int64
                           type: integer
                         minMemory:
                           format: int64
                           type: integer
+                        preferredPrecisions:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
                         requiredFeatures:
                           items:
                             type: string
@@ -116,12 +123,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string
@@ -12363,12 +12377,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string

--- a/charts/ome-crd/templates/ome.io_servingruntimes.yaml
+++ b/charts/ome-crd/templates/ome.io_servingruntimes.yaml
@@ -61,7 +61,9 @@ spec:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
-                    minComputeCapability:
+                    minArchitectureVersion:
+                      type: string
+                    minComputePerformanceTFLOPS:
                       format: int64
                       minimum: 0
                       type: integer
@@ -1229,12 +1231,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string
@@ -14183,12 +14192,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string

--- a/config/crd/full/ome.io_clusterservingruntimes.yaml
+++ b/config/crd/full/ome.io_clusterservingruntimes.yaml
@@ -61,7 +61,9 @@ spec:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
-                    minComputeCapability:
+                    minArchitectureVersion:
+                      type: string
+                    minComputePerformanceTFLOPS:
                       format: int64
                       minimum: 0
                       type: integer
@@ -1229,12 +1231,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string
@@ -14183,12 +14192,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string

--- a/config/crd/full/ome.io_inferenceservices.yaml
+++ b/config/crd/full/ome.io_inferenceservices.yaml
@@ -75,12 +75,19 @@ spec:
                         maxMemory:
                           format: int64
                           type: integer
-                        minComputeCapability:
+                        minArchitectureVersion:
+                          type: string
+                        minComputePerformanceTFLOPS:
                           format: int64
                           type: integer
                         minMemory:
                           format: int64
                           type: integer
+                        preferredPrecisions:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
                         requiredFeatures:
                           items:
                             type: string
@@ -116,12 +123,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string
@@ -12363,12 +12377,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string

--- a/config/crd/full/ome.io_servingruntimes.yaml
+++ b/config/crd/full/ome.io_servingruntimes.yaml
@@ -61,7 +61,9 @@ spec:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
-                    minComputeCapability:
+                    minArchitectureVersion:
+                      type: string
+                    minComputePerformanceTFLOPS:
                       format: int64
                       minimum: 0
                       type: integer
@@ -1229,12 +1231,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string
@@ -14183,12 +14192,19 @@ spec:
                             maxMemory:
                               format: int64
                               type: integer
-                            minComputeCapability:
+                            minArchitectureVersion:
+                              type: string
+                            minComputePerformanceTFLOPS:
                               format: int64
                               type: integer
                             minMemory:
                               format: int64
                               type: integer
+                            preferredPrecisions:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             requiredFeatures:
                               items:
                                 type: string

--- a/pkg/apis/ome/v1beta1/inference_service.go
+++ b/pkg/apis/ome/v1beta1/inference_service.go
@@ -82,9 +82,13 @@ type AcceleratorConstraints struct {
 	// +optional
 	MaxMemory *int64 `json:"maxMemory,omitempty"`
 
-	// MinComputeCapability in TFLOPS
+	// MinComputePerformanceTFLOPS in TFLOPS
 	// +optional
-	MinComputeCapability *int64 `json:"minComputeCapability,omitempty"`
+	MinComputePerformanceTFLOPS *int64 `json:"minComputePerformanceTFLOPS,omitempty"`
+
+	//MinArchitectureVersion Compute capability (NVIDIA) or equivalent
+	// +optional
+	MinArchitectureVersion *string `json:"minArchitectureVersion,omitempty"`
 
 	// RequiredFeatures that must be present
 	// +optional
@@ -101,6 +105,12 @@ type AcceleratorConstraints struct {
 	// +optional
 	// +listType=atomic
 	ArchitectureFamilies []string `json:"architectureFamilies,omitempty"`
+
+	// PreferredPrecisions lists numeric precisions in order of preference
+	// Examples: ["fp8", "fp16", "fp32"]
+	// +optional
+	// +listType=atomic
+	PreferredPrecisions []string `json:"preferredPrecisions,omitempty"`
 }
 
 // AcceleratorSelectionPolicy defines how to select among matching accelerators

--- a/pkg/apis/ome/v1beta1/servingruntime_types.go
+++ b/pkg/apis/ome/v1beta1/servingruntime_types.go
@@ -242,10 +242,14 @@ type AcceleratorRequirements struct {
 	// +kubebuilder:validation:Minimum=0
 	MinMemory *int64 `json:"minMemory,omitempty"`
 
-	// MinComputeCapability specifies minimum compute capability in TFLOPS
+	// MinComputePerformanceTFLOPS specifies minimum compute capability in TFLOPS
 	// +optional
 	// +kubebuilder:validation:Minimum=0
-	MinComputeCapability *int64 `json:"minComputeCapability,omitempty"`
+	MinComputePerformanceTFLOPS *int64 `json:"minComputePerformanceTFLOPS,omitempty"`
+
+	//MinArchitectureVersion Compute capability (NVIDIA) or equivalent
+	// +optional
+	MinArchitectureVersion *string `json:"minArchitectureVersion,omitempty"`
 
 	// RequiredFeatures lists hardware features that must be present
 	// Examples: ["tensor-cores", "fp8", "nvlink"]

--- a/pkg/apis/ome/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/ome/v1beta1/zz_generated.deepcopy.go
@@ -190,9 +190,14 @@ func (in *AcceleratorConstraints) DeepCopyInto(out *AcceleratorConstraints) {
 		*out = new(int64)
 		**out = **in
 	}
-	if in.MinComputeCapability != nil {
-		in, out := &in.MinComputeCapability, &out.MinComputeCapability
+	if in.MinComputePerformanceTFLOPS != nil {
+		in, out := &in.MinComputePerformanceTFLOPS, &out.MinComputePerformanceTFLOPS
 		*out = new(int64)
+		**out = **in
+	}
+	if in.MinArchitectureVersion != nil {
+		in, out := &in.MinArchitectureVersion, &out.MinArchitectureVersion
+		*out = new(string)
 		**out = **in
 	}
 	if in.RequiredFeatures != nil {
@@ -207,6 +212,11 @@ func (in *AcceleratorConstraints) DeepCopyInto(out *AcceleratorConstraints) {
 	}
 	if in.ArchitectureFamilies != nil {
 		in, out := &in.ArchitectureFamilies, &out.ArchitectureFamilies
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.PreferredPrecisions != nil {
+		in, out := &in.PreferredPrecisions, &out.PreferredPrecisions
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
@@ -414,9 +424,14 @@ func (in *AcceleratorRequirements) DeepCopyInto(out *AcceleratorRequirements) {
 		*out = new(int64)
 		**out = **in
 	}
-	if in.MinComputeCapability != nil {
-		in, out := &in.MinComputeCapability, &out.MinComputeCapability
+	if in.MinComputePerformanceTFLOPS != nil {
+		in, out := &in.MinComputePerformanceTFLOPS, &out.MinComputePerformanceTFLOPS
 		*out = new(int64)
+		**out = **in
+	}
+	if in.MinArchitectureVersion != nil {
+		in, out := &in.MinArchitectureVersion, &out.MinArchitectureVersion
+		*out = new(string)
 		**out = **in
 	}
 	if in.RequiredFeatures != nil {

--- a/pkg/controller/v1beta1/acceleratorclass/controller.go
+++ b/pkg/controller/v1beta1/acceleratorclass/controller.go
@@ -3,7 +3,6 @@ package acceleratorclass
 import (
 	"context"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -240,18 +239,6 @@ func nodeMatchCapabilities(ac *v1beta1.AcceleratorClass, node *corev1.Node) bool
 		}
 	}
 
-	// computeCapability: require at least 1 GPU present
-	if ac.Spec.Capabilities.ComputeCapability != "" {
-		acCompute, err := strconv.ParseFloat(ac.Spec.Capabilities.ComputeCapability, 64)
-		if err != nil {
-			return false
-		}
-		// Get GPU count from node resources
-		total, _ := getGPUCapacity(node)
-		if total < int64(acCompute) {
-			return false
-		}
-	}
 	return true
 }
 

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -216,8 +216,12 @@
           "type": "integer",
           "format": "int64"
         },
-        "minComputeCapability": {
-          "description": "MinComputeCapability in TFLOPS",
+        "minArchitectureVersion": {
+          "description": "MinArchitectureVersion Compute capability (NVIDIA) or equivalent",
+          "type": "string"
+        },
+        "minComputePerformanceTFLOPS": {
+          "description": "MinComputePerformanceTFLOPS in TFLOPS",
           "type": "integer",
           "format": "int64"
         },
@@ -225,6 +229,15 @@
           "description": "MinMemory in GB",
           "type": "integer",
           "format": "int64"
+        },
+        "preferredPrecisions": {
+          "description": "PreferredPrecisions lists numeric precisions in order of preference Examples: [\"fp8\", \"fp16\", \"fp32\"]",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "default": ""
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "requiredFeatures": {
           "description": "RequiredFeatures that must be present",
@@ -390,8 +403,12 @@
           },
           "x-kubernetes-list-type": "atomic"
         },
-        "minComputeCapability": {
-          "description": "MinComputeCapability specifies minimum compute capability in TFLOPS",
+        "minArchitectureVersion": {
+          "description": "MinArchitectureVersion Compute capability (NVIDIA) or equivalent",
+          "type": "string"
+        },
+        "minComputePerformanceTFLOPS": {
+          "description": "MinComputePerformanceTFLOPS specifies minimum compute capability in TFLOPS",
           "type": "integer",
           "format": "int64"
         },
@@ -2165,6 +2182,14 @@
       "description": "KedaConfig stores the configuration settings for KEDA autoscaling within the InferenceService. It includes fields like the Prometheus server address, custom query, scaling threshold, and operator.",
       "type": "object",
       "properties": {
+        "authModes": {
+          "description": "AuthModes specifies the authentication mode(s) for the Prometheus scaler. Common values include: \"basic\", \"tls\", \"bearer\", \"custom\". Multiple modes can be specified comma-separated (e.g., \"tls,basic\").\n\nExample:\n  \"basic\" - Use basic authentication with username/password from TriggerAuthentication",
+          "type": "string"
+        },
+        "authenticationRef": {
+          "description": "AuthenticationRef references a TriggerAuthentication or ClusterTriggerAuthentication resource that contains the authentication configuration for the Prometheus server. This is required when the Prometheus server requires authentication (e.g., Grafana Cloud).\n\nExample:\n  authenticationRef:\n    name: grafana-cloud-auth\n    kind: TriggerAuthentication",
+          "$ref": "#/definitions/v1beta1.ScalerAuthenticationRef"
+        },
         "customPromQuery": {
           "description": "CustomPromQuery defines a custom Prometheus query that KEDA will execute to evaluate the desired metric for scaling. This query should return a single numerical value that represents the metric to be monitored.\n\nExample:\n  avg_over_time(http_requests_total{service=\"llama\"}[5m])",
           "type": "string"
@@ -4265,6 +4290,21 @@
         "workingDir": {
           "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
           "type": "string"
+        }
+      }
+    },
+    "v1beta1.ScalerAuthenticationRef": {
+      "description": "ScalerAuthenticationRef points to a KEDA TriggerAuthentication or ClusterTriggerAuthentication resource that contains the credentials for authenticating with the scaler's target (e.g., Prometheus server).",
+      "type": "object",
+      "properties": {
+        "kind": {
+          "description": "Kind of the authentication resource being referenced. Valid values are \"TriggerAuthentication\" (namespace-scoped) or \"ClusterTriggerAuthentication\" (cluster-scoped).",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the TriggerAuthentication or ClusterTriggerAuthentication resource.",
+          "type": "string",
+          "default": ""
         }
       }
     },


### PR DESCRIPTION
## What this PR does
improve inference service and runtime crd.

## Why we need it
In accelerator_class crd, the ComputeCapability should be a version number (NOT a performance metric) that identifies the GPU architecture generation and its supported features. To reduce the misleading of parameters' name.
Update minComputeCapability to minComputePerformanceTFLOPS in runtime and inference service crd.
Add minArchitectureVersion to check if customer want to specify computeCapacity.

Update accelerator_class controller to catch up the crd change.

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
