### PR TITLE
[Mics]add model ready label in podspec.nodeSelector to force pod sche…

### DIFF
--- a/pkg/acceleratorclassselector/selector.go
+++ b/pkg/acceleratorclassselector/selector.go
@@ -59,9 +59,10 @@ func (s *defaultSelector) GetAcceleratorClass(ctx context.Context, isvc *v1beta1
 		// if accelerator class didn't have name specified, try to get accelerator class by policy
 		// if policy is not specified, will skip getting acceleratorClass by policy
 		if acName == "" {
+			logger.Info("No acceleratorClass name found for component", "component", component, "inferenceService", isvc.Name)
 			acceleratorPolicy := s.getAcceleratorPolicy(isvc, component)
 			if acceleratorPolicy == "" {
-				logger.Info("No accelerator policy found for component", "component", component, "inferenceService", isvc.Name)
+				logger.Info("No acceleratorClass policy found for component", "component", component, "inferenceService", isvc.Name)
 				return nil, "", nil
 			}
 			if acceleratorClass := s.getAcceleratorClassByPolicy(isvc, runtime, acceleratorPolicy); acceleratorClass != nil {

--- a/pkg/controller/v1beta1/benchmark/controller.go
+++ b/pkg/controller/v1beta1/benchmark/controller.go
@@ -247,8 +247,8 @@ func (r *BenchmarkJobReconciler) addNodeSelectorFromInferenceService(ctx context
 		return err
 	}
 
-	isvcutils.AddPreferredNodeAffinityForModel(podSpec, baseModelMeta)
-	r.Log.Info("Added node affinity for benchmark job",
+	isvcutils.AddNodeSelectorForModelReadyNode(podSpec, baseModelMeta)
+	r.Log.Info("Added node selector for benchmark job",
 		"baseModel", baseModelMeta.Name,
 		"namespace", baseModelMeta.Namespace,
 		"benchmarkJob", benchmarkJob.Name)
@@ -423,6 +423,7 @@ func (r *BenchmarkJobReconciler) applyPodOverrides(podSpec *v1.PodSpec, override
 		Volumes:       podSpec.Volumes,
 		Tolerations:   podSpec.Tolerations,
 		Affinity:      podSpec.Affinity,
+		NodeSelector:  podSpec.NodeSelector,
 		RestartPolicy: v1.RestartPolicyNever,
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -205,7 +205,7 @@ func UpdatePodSpecNodeSelector(b *BaseComponentFields, isvc *v1beta1.InferenceSe
 	}
 
 	// Add preferred node affinity for model readiness using the shared utility function
-	isvcutils.AddPreferredNodeAffinityForModel(podSpec, b.BaseModelMeta)
+	isvcutils.AddNodeSelectorForModelReadyNode(podSpec, b.BaseModelMeta)
 
 	// Add node selector merged from AcceleratorClass if applicable
 	// Only add mergedNodeSelector to engine and decoder component.

--- a/pkg/controller/v1beta1/inferenceservice/components/decoder_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder_test.go
@@ -130,24 +130,11 @@ func TestDecoderReconcile(t *testing.T) {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(gomega.Equal("decoder:latest"))
 
-				// Check preferred node affinity was added for the base model
-				g.Expect(deployment.Spec.Template.Spec.Affinity).NotTo(gomega.BeNil())
-				g.Expect(deployment.Spec.Template.Spec.Affinity.NodeAffinity).NotTo(gomega.BeNil())
-				preferredTerms := deployment.Spec.Template.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-				g.Expect(preferredTerms).NotTo(gomega.BeEmpty())
-				// Find the model affinity term
-				var foundModelTerm bool
-				for _, term := range preferredTerms {
-					for _, expr := range term.Preference.MatchExpressions {
-						if expr.Key == "models.ome.io/default.basemodel.base-model-1" {
-							g.Expect(term.Weight).To(gomega.Equal(int32(100)))
-							g.Expect(expr.Operator).To(gomega.Equal(v1.NodeSelectorOpIn))
-							g.Expect(expr.Values).To(gomega.Equal([]string{"Ready"}))
-							foundModelTerm = true
-						}
-					}
-				}
-				g.Expect(foundModelTerm).To(gomega.BeTrue(), "Model affinity term not found")
+				// Check node selector was added for the base model
+				g.Expect(deployment.Spec.Template.Spec.NodeSelector).NotTo(gomega.BeNil())
+				value, found := deployment.Spec.Template.Spec.NodeSelector["models.ome.io/default.basemodel.base-model-1"]
+				g.Expect(found).To(gomega.BeTrue(), "Model node selector not found")
+				g.Expect(value).To(gomega.Equal("Ready"))
 
 				// Check service was created
 				service := &v1.Service{}
@@ -229,49 +216,21 @@ func TestDecoderReconcile(t *testing.T) {
 				g.Expect(lwsList.Items).To(gomega.HaveLen(1))
 				g.Expect(lwsList.Items[0].Spec.Replicas).To(gomega.Equal(int32Ptr(2)))
 
-				// Check preferred node affinity was added for both leader and worker pods
-				leaderAffinity := lwsList.Items[0].Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.Affinity
-				workerAffinity := lwsList.Items[0].Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Affinity
-				g.Expect(leaderAffinity).NotTo(gomega.BeNil())
-				g.Expect(leaderAffinity.NodeAffinity).NotTo(gomega.BeNil())
-				g.Expect(workerAffinity).NotTo(gomega.BeNil())
-				g.Expect(workerAffinity.NodeAffinity).NotTo(gomega.BeNil())
+				// Check node selector was added for both leader and worker pods
+				leaderNodeSelector := lwsList.Items[0].Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.NodeSelector
+				workerNodeSelector := lwsList.Items[0].Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.NodeSelector
 
-				// Verify leader pod has model affinity
-				var foundLeaderModelTerm bool
-				for _, term := range leaderAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-					for _, expr := range term.Preference.MatchExpressions {
-						if expr.Key == "models.ome.io/default.basemodel.base-model-2" {
-							g.Expect(term.Weight).To(gomega.Equal(int32(100)))
-							g.Expect(expr.Operator).To(gomega.Equal(v1.NodeSelectorOpIn))
-							g.Expect(expr.Values).To(gomega.Equal([]string{"Ready"}))
-							foundLeaderModelTerm = true
-							break
-						}
-					}
-					if foundLeaderModelTerm {
-						break
-					}
-				}
-				g.Expect(foundLeaderModelTerm).To(gomega.BeTrue(), "Leader model affinity term not found")
+				// Verify leader pod has model node selector
+				g.Expect(leaderNodeSelector).NotTo(gomega.BeNil())
+				leaderValue, leaderFound := leaderNodeSelector["models.ome.io/default.basemodel.base-model-2"]
+				g.Expect(leaderFound).To(gomega.BeTrue(), "Leader model node selector not found")
+				g.Expect(leaderValue).To(gomega.Equal("Ready"))
 
-				// Verify worker pod has model affinity
-				var foundWorkerModelTerm bool
-				for _, term := range workerAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-					for _, expr := range term.Preference.MatchExpressions {
-						if expr.Key == "models.ome.io/default.basemodel.base-model-2" {
-							g.Expect(term.Weight).To(gomega.Equal(int32(100)))
-							g.Expect(expr.Operator).To(gomega.Equal(v1.NodeSelectorOpIn))
-							g.Expect(expr.Values).To(gomega.Equal([]string{"Ready"}))
-							foundWorkerModelTerm = true
-							break
-						}
-					}
-					if foundWorkerModelTerm {
-						break
-					}
-				}
-				g.Expect(foundWorkerModelTerm).To(gomega.BeTrue(), "Worker model affinity term not found")
+				// Verify worker pod has model node selector
+				g.Expect(workerNodeSelector).NotTo(gomega.BeNil())
+				workerValue, workerFound := workerNodeSelector["models.ome.io/default.basemodel.base-model-2"]
+				g.Expect(workerFound).To(gomega.BeTrue(), "Worker model node selector not found")
+				g.Expect(workerValue).To(gomega.Equal("Ready"))
 			},
 		},
 		{
@@ -337,24 +296,11 @@ func TestDecoderReconcile(t *testing.T) {
 				}, deployment)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 
-				// Check preferred node affinity for ClusterBaseModel (no namespace in label)
-				g.Expect(deployment.Spec.Template.Spec.Affinity).NotTo(gomega.BeNil())
-				g.Expect(deployment.Spec.Template.Spec.Affinity.NodeAffinity).NotTo(gomega.BeNil())
-				preferredTerms := deployment.Spec.Template.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-				g.Expect(preferredTerms).NotTo(gomega.BeEmpty())
-				// Find the model affinity term
-				var foundModelTerm bool
-				for _, term := range preferredTerms {
-					for _, expr := range term.Preference.MatchExpressions {
-						if expr.Key == "models.ome.io/clusterbasemodel.cluster-decoder-model" {
-							g.Expect(term.Weight).To(gomega.Equal(int32(100)))
-							g.Expect(expr.Operator).To(gomega.Equal(v1.NodeSelectorOpIn))
-							g.Expect(expr.Values).To(gomega.Equal([]string{"Ready"}))
-							foundModelTerm = true
-						}
-					}
-				}
-				g.Expect(foundModelTerm).To(gomega.BeTrue(), "Model affinity term not found")
+				// Check node selector for ClusterBaseModel (no namespace in label)
+				g.Expect(deployment.Spec.Template.Spec.NodeSelector).NotTo(gomega.BeNil())
+				value, found := deployment.Spec.Template.Spec.NodeSelector["models.ome.io/clusterbasemodel.cluster-decoder-model"]
+				g.Expect(found).To(gomega.BeTrue(), "Model node selector not found")
+				g.Expect(value).To(gomega.Equal("Ready"))
 			},
 		},
 		{


### PR DESCRIPTION
## What this PR does
we add model ready label in nodeselector instead of PreferredNodeAffinity.  

## Why we need it
1. PreferredNodeAffinity is a preferred affinity which is not 100% guarantee to avoid scheduling pod on a node which model has not ready yet.
2. AC will override nodeaffinity and cause the preferredaffinity missed.

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
