### PR TITLE
[Misc] Enable instance metadata service for OCI SDK region lookup

### DIFF
--- a/pkg/ociobjectstore/os_data_store.go
+++ b/pkg/ociobjectstore/os_data_store.go
@@ -83,6 +83,7 @@ func NewOCIOSDataStore(config *Config) (*OCIOSDataStore, error) {
 		return nil, fmt.Errorf("ociobjectstore config is invalid: %+v", err)
 	}
 
+	common.EnableInstanceMetadataServiceLookup()
 	configProvider, err := getConfigProvider(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config provider: %+v", err)

--- a/pkg/vault/kmscrypto/client.go
+++ b/pkg/vault/kmscrypto/client.go
@@ -21,6 +21,7 @@ type KmsCrypto struct {
 
 // NewKmsCrypto initializes a new KmsCrypto instance with the given configuration and environment.
 func NewKmsCrypto(config *Config) (*KmsCrypto, error) {
+	common.EnableInstanceMetadataServiceLookup()
 	configProvider, err := getConfigProvider(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config provider: %w", err)

--- a/pkg/vault/kmsmgm/client.go
+++ b/pkg/vault/kmsmgm/client.go
@@ -37,6 +37,7 @@ type DefinedTags struct {
 
 // NewKmsMgm initializes a new KmsMgm instance with the given configuration and environment.
 func NewKmsMgm(config *Config) (*KmsMgm, error) {
+	common.EnableInstanceMetadataServiceLookup()
 	configProvider, err := getConfigProvider(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config provider: %w", err)

--- a/pkg/vault/kmsvault/kmsvault.go
+++ b/pkg/vault/kmsvault/kmsvault.go
@@ -20,6 +20,7 @@ type KMSVault struct {
 
 // NewKMSVault initializes a new KMSVault instance with the provided configuration and environment.
 func NewKMSVault(config *Config) (*KMSVault, error) {
+	common.EnableInstanceMetadataServiceLookup()
 	configProvider, err := getConfigProvider(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config provider: %w", err)

--- a/pkg/vault/secret/client.go
+++ b/pkg/vault/secret/client.go
@@ -21,6 +21,7 @@ type Secret struct {
 
 // NewSecret initializes a new Secret instance with the provided configuration and environment.
 func NewSecret(config *Config) (*Secret, error) {
+	common.EnableInstanceMetadataServiceLookup()
 	configProvider, err := getConfigProvider(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config provider: %w", err)

--- a/pkg/vault/secret_in_vault/secret_in_vault.go
+++ b/pkg/vault/secret_in_vault/secret_in_vault.go
@@ -25,6 +25,7 @@ func NewSecretInVault(config *SecretInVaultConfig) (*SecretInVault, error) {
 		return nil, fmt.Errorf("SecretInVaultConfig is invalid: %+v", err)
 	}
 
+	common.EnableInstanceMetadataServiceLookup()
 	configProvider, err := getConfigProvider(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config provider: %+v", err)

--- a/pkg/vault/secret_retrieval/secret_retrieval.go
+++ b/pkg/vault/secret_retrieval/secret_retrieval.go
@@ -3,6 +3,7 @@ package secret_retrieval
 import (
 	"context"
 	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
 	"net/http"
 
 	"github.com/oracle/oci-go-sdk/v65/secrets"
@@ -25,6 +26,7 @@ func NewSecretRetriever(config *SecretRetrievalConfig) (*SecretRetriever, error)
 		return nil, fmt.Errorf("invalid config: %v", err)
 	}
 
+	common.EnableInstanceMetadataServiceLookup()
 	configProvider, err := getConfigProvider(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config provider: %v", err)

--- a/pkg/vault/vault/vault_client.go
+++ b/pkg/vault/vault/vault_client.go
@@ -20,6 +20,7 @@ type VaultClient struct {
 
 // NewVaultClient initializes a new VaultClient with the provided configuration and environment.
 func NewVaultClient(config *Config) (*VaultClient, error) {
+	common.EnableInstanceMetadataServiceLookup()
 	configProvider, err := getConfigProvider(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config provider: %w", err)


### PR DESCRIPTION
## What this PR does

Enable IMDS (Instance Metadata Service) lookup in OCI SDK clients so they can automatically resolve the region from instance metadata when using instance principal authentication.

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
