### PR TITLE
[Bugfix][Core] Skip model init injection for FT serving with merged weights

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -384,9 +384,12 @@ func ProcessBaseAnnotations(b *BaseComponentFields, isvc *v1beta1.InferenceServi
 	}
 
 	if b.FineTunedServingWithMergedWeights {
-		// For FT serving using merged FT weights, no need base model
+		// For FT serving using merged FT weights, no need base model, so:
+		// 1) add annotation to indicate using merged weights for FT serving;
+		// 2) add annotation to skip model init injection;
 		b.Log.Info("Fine-tuned serving with merged weights", "namespace", isvc.Namespace)
 		annotations[constants.FTServingWithMergedWeightsAnnotationKey] = "true"
+		annotations[constants.ModelInitInjectionKey] = "false"
 	} else if b.BaseModelMeta != nil {
 		// Add model init required annotations (for non-merged FT or regular serving)
 		baseModelDecryptionKeyName, ok := b.BaseModelMeta.Annotations[constants.BaseModelDecryptionKeyName]


### PR DESCRIPTION
## What this PR does
For fine-tuned serving with merged weights, no separate base model required, so no need to inject model-init for potential base model decryption.

## Test
Tested in cluster

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
