### PR TITLE
Update model capability detection for Qwen3 embedding models

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1340,9 +1340,7 @@ k8s.io/component-helpers v0.31.4/go.mod h1:Ddq5GYRK/1uNoPNgJh9N5osPutvBweQEcIG6b
 k8s.io/controller-manager v0.30.12/go.mod h1:vbZ0OY4XMFGJDl9lTaPGc+BDocukZzMH41iNVc5BcY8=
 k8s.io/csi-translation-lib v0.30.12/go.mod h1:5lNKaS8VpgmTpH6rPAdwEbQ9HvCnpOGaqpP7OAUFj/I=
 k8s.io/dynamic-resource-allocation v0.30.12/go.mod h1:+1QBI9MRebuOMtLAqCK/RB+oKCh9f+2EhAgkEOV7Fz8=
-k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 h1:pWEwq4Asjm4vjW7vcsmijwBhOr1/shsbSYiWXmNGlks=
 k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
-k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 h1:si3PfKm8dDYxgfbeA6orqrtLkvvIeH8UqffFJDl0bz4=
 k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/hack/tools v0.0.0-20210917071902-331d2323a192/go.mod h1:DXW3Mv8xqJvjXWiBSBHrK2O4mq5LMD0clqkv3b1g9HA=

--- a/internal/ome-agent/model-metadata/metadata_test.go
+++ b/internal/ome-agent/model-metadata/metadata_test.go
@@ -28,6 +28,7 @@ type mockHuggingFaceModel struct {
 	torchDtype         string
 	modelSizeBytes     int64
 	hasVision          bool
+	isEmbedding        bool
 }
 
 func (m *mockHuggingFaceModel) GetModelType() string          { return m.modelType }
@@ -39,6 +40,7 @@ func (m *mockHuggingFaceModel) GetQuantizationType() string   { return m.quantiz
 func (m *mockHuggingFaceModel) GetTorchDtype() string         { return m.torchDtype }
 func (m *mockHuggingFaceModel) GetModelSizeBytes() int64      { return m.modelSizeBytes }
 func (m *mockHuggingFaceModel) HasVision() bool               { return m.hasVision }
+func (m *mockHuggingFaceModel) IsEmbedding() bool             { return m.isEmbedding }
 
 func TestMetadataExtractor_updateSpec(t *testing.T) {
 	zapLogger, _ := zap.NewDevelopment()

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -277,6 +277,10 @@ const (
 	ModelConfigKey = "models.json"
 )
 
+const (
+	SentenceTransformersConfigFileName = "config_sentence_transformers.json"
+)
+
 type InferenceServiceComponent string
 
 type InferenceServiceVerb string

--- a/pkg/hfutil/modelconfig/baichuan.go
+++ b/pkg/hfutil/modelconfig/baichuan.go
@@ -98,6 +98,11 @@ func (c *BaichuanConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *BaichuanConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the Baichuan model handler
 func init() {
 	RegisterModelLoader("baichuan", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/bert.go
+++ b/pkg/hfutil/modelconfig/bert.go
@@ -119,6 +119,11 @@ func (c *BertConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns true since this is an embedding model
+func (c *BertConfig) IsEmbedding() bool {
+	return true
+}
+
 // Register the BERT model handler
 func init() {
 	RegisterModelLoader("bert", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/chatglm.go
+++ b/pkg/hfutil/modelconfig/chatglm.go
@@ -121,6 +121,11 @@ func (c *ChatGLMConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *ChatGLMConfig) IsEmbedding() bool {
+	return false
+}
+
 // GetTorchDtype returns the torch data type used by the model
 func (c *ChatGLMConfig) GetTorchDtype() string {
 	if c.TorchDtype != "" {

--- a/pkg/hfutil/modelconfig/command_r.go
+++ b/pkg/hfutil/modelconfig/command_r.go
@@ -110,6 +110,11 @@ func (c *CommandRConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *CommandRConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the Command-R model handler
 func init() {
 	RegisterModelLoader("cohere", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/dbrx.go
+++ b/pkg/hfutil/modelconfig/dbrx.go
@@ -140,6 +140,11 @@ func (c *DBRXConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *DBRXConfig) IsEmbedding() bool {
+	return false
+}
+
 // GetArchitecture returns the model architecture
 func (c *DBRXConfig) GetArchitecture() string {
 	if len(c.Architectures) > 0 {

--- a/pkg/hfutil/modelconfig/deepseek_v3.go
+++ b/pkg/hfutil/modelconfig/deepseek_v3.go
@@ -187,6 +187,11 @@ func (c *DeepseekV3Config) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *DeepseekV3Config) IsEmbedding() bool {
+	return false
+}
+
 // Register the DeepSeek V3 model handler
 func init() {
 	RegisterModelLoader("deepseek_v3", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/deepseek_vl.go
+++ b/pkg/hfutil/modelconfig/deepseek_vl.go
@@ -181,6 +181,11 @@ func (c *DeepSeekVLConfig) HasVision() bool {
 	return true
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *DeepSeekVLConfig) IsEmbedding() bool {
+	return false
+}
+
 // GetArchitecture returns the model architecture
 func (c *DeepSeekVLConfig) GetArchitecture() string {
 	if len(c.Architectures) > 0 {

--- a/pkg/hfutil/modelconfig/exaone.go
+++ b/pkg/hfutil/modelconfig/exaone.go
@@ -112,6 +112,11 @@ func (c *ExaoneConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *ExaoneConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the ExaONE model handler
 func init() {
 	RegisterModelLoader("exaone", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/gemma.go
+++ b/pkg/hfutil/modelconfig/gemma.go
@@ -137,6 +137,11 @@ func (c *GemmaConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *GemmaConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the Gemma model handlers
 func init() {
 	// Register for "gemma", "gemma2", and "gemma3_text" model types

--- a/pkg/hfutil/modelconfig/gemma3.go
+++ b/pkg/hfutil/modelconfig/gemma3.go
@@ -143,6 +143,11 @@ func (c *Gemma3Config) HasVision() bool {
 	return true
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *Gemma3Config) IsEmbedding() bool {
+	return false
+}
+
 // Register the Gemma3 model handler
 func init() {
 	RegisterModelLoader("gemma3", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/gpt_oss.go
+++ b/pkg/hfutil/modelconfig/gpt_oss.go
@@ -227,6 +227,11 @@ func (c *GptOssConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *GptOssConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the GPT-OSS model handler
 func init() {
 	RegisterModelLoader("gpt_oss", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/interface.go
+++ b/pkg/hfutil/modelconfig/interface.go
@@ -40,6 +40,9 @@ type HuggingFaceModel interface {
 
 	// HasVision returns true if this is a multimodal vision model
 	HasVision() bool
+
+	// IsEmbedding returns true if this model is intended for generating embeddings
+	IsEmbedding() bool
 }
 
 // HuggingFaceDiffusionModel represents diffusion models that expose pipeline metadata.
@@ -90,6 +93,12 @@ func (c *BaseModelConfig) GetTorchDtype() string {
 
 // Default implementation for HasVision - most models don't have vision capabilities
 func (c *BaseModelConfig) HasVision() bool {
+	return false
+}
+
+// IsEmbedding returns true if this generic model can be reliably identified as an embedding model.
+// By default, this returns false.
+func (c *BaseModelConfig) IsEmbedding() bool {
 	return false
 }
 
@@ -411,6 +420,10 @@ func (c *GenericDiffusionModelConfig) GetModelSizeBytes() int64 {
 
 func (c *GenericDiffusionModelConfig) HasVision() bool {
 	return true
+}
+
+func (c *GenericDiffusionModelConfig) IsEmbedding() bool {
+	return false
 }
 
 // loadGenericModelConfig loads a generic model configuration as a fallback.

--- a/pkg/hfutil/modelconfig/internlm.go
+++ b/pkg/hfutil/modelconfig/internlm.go
@@ -99,6 +99,11 @@ func (c *InternLMConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *InternLMConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the InternLM model handler
 func init() {
 	RegisterModelLoader("internlm", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/kimi_k2.go
+++ b/pkg/hfutil/modelconfig/kimi_k2.go
@@ -182,6 +182,11 @@ func (c *KimiK2Config) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *KimiK2Config) IsEmbedding() bool {
+	return false
+}
+
 // Register the Kimi-K2 model handler
 func init() {
 	RegisterModelLoader("kimi_k2", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/llama.go
+++ b/pkg/hfutil/modelconfig/llama.go
@@ -208,6 +208,11 @@ func (c *LlamaConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *LlamaConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the Llama model handler
 func init() {
 	RegisterModelLoader("llama", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/llama4.go
+++ b/pkg/hfutil/modelconfig/llama4.go
@@ -249,6 +249,11 @@ func (c *Llama4Config) HasVision() bool {
 	return c.VisionConfig != nil
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *Llama4Config) IsEmbedding() bool {
+	return false
+}
+
 // Helper function to estimate MoE model parameters
 func estimateMoEParamCount(hiddenSize, layers, intermediateSize, numExperts, expertsPerToken int) int64 {
 	// Base parameters (shared across all experts)

--- a/pkg/hfutil/modelconfig/llava.go
+++ b/pkg/hfutil/modelconfig/llava.go
@@ -167,6 +167,11 @@ func (c *LLaVAConfig) HasVision() bool {
 	return true
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *LLaVAConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the LLaVA model handler
 func init() {
 	RegisterModelLoader("llava", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/minicpm.go
+++ b/pkg/hfutil/modelconfig/minicpm.go
@@ -105,6 +105,11 @@ func (c *MiniCPMConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *MiniCPMConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the MiniCPM model handler
 func init() {
 	RegisterModelLoader("minicpm", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/mistral.go
+++ b/pkg/hfutil/modelconfig/mistral.go
@@ -140,6 +140,11 @@ func (c *MistralConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns true since this is an embedding model
+func (c *MistralConfig) IsEmbedding() bool {
+	return true
+}
+
 // Register the Mistral model handler
 func init() {
 	RegisterModelLoader("mistral", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/mixtral.go
+++ b/pkg/hfutil/modelconfig/mixtral.go
@@ -155,6 +155,11 @@ func (c *MixtralConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *MixtralConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the Mixtral model handler
 func init() {
 	RegisterModelLoader("mixtral", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/mllama.go
+++ b/pkg/hfutil/modelconfig/mllama.go
@@ -183,6 +183,11 @@ func (c *MLlamaConfig) HasVision() bool {
 	return true
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *MLlamaConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the MLlama model handler
 func init() {
 	RegisterModelLoader("mllama", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/phi.go
+++ b/pkg/hfutil/modelconfig/phi.go
@@ -116,6 +116,11 @@ func (c *PhiModelConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *PhiModelConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the Phi model handler
 func init() {
 	RegisterModelLoader("phi", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/phi3.go
+++ b/pkg/hfutil/modelconfig/phi3.go
@@ -113,6 +113,11 @@ func (c *Phi3Config) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *Phi3Config) IsEmbedding() bool {
+	return false
+}
+
 // Register the Phi3 model handler
 func init() {
 	RegisterModelLoader("phi3", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/phi3_v.go
+++ b/pkg/hfutil/modelconfig/phi3_v.go
@@ -102,6 +102,11 @@ func (c *Phi3VConfig) HasVision() bool {
 	return c.ImgProcessor != nil
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *Phi3VConfig) IsEmbedding() bool {
+	return false
+}
+
 // Helper function to estimate model parameters
 func estimateModelParams(hiddenSize, numLayers, intermediateSize, vocabSize int) int64 {
 	// This is an approximation - actual parameter count may vary

--- a/pkg/hfutil/modelconfig/phi3small.go
+++ b/pkg/hfutil/modelconfig/phi3small.go
@@ -124,6 +124,11 @@ func (c *Phi3SmallConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *Phi3SmallConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the Phi3Small model handler
 func init() {
 	RegisterModelLoader("phi3small", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/phimoe.go
+++ b/pkg/hfutil/modelconfig/phimoe.go
@@ -126,6 +126,11 @@ func (c *PhiMoEConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *PhiMoEConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the PhiMoE model handler
 func init() {
 	RegisterModelLoader("phimoe", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/qwen.go
+++ b/pkg/hfutil/modelconfig/qwen.go
@@ -117,6 +117,11 @@ func (c *QwenConfig) HasVision() bool {
 	return false // Base Qwen v1 models don't have vision capabilities
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *QwenConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the Qwen v1 model handler
 func init() {
 	RegisterModelLoader("qwen", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/qwen2.go
+++ b/pkg/hfutil/modelconfig/qwen2.go
@@ -107,6 +107,11 @@ func (c *Qwen2Config) HasVision() bool {
 	return false // Base Qwen2 models don't have vision capabilities
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *Qwen2Config) IsEmbedding() bool {
+	return false
+}
+
 // Register the Qwen2 model handler
 func init() {
 	RegisterModelLoader("qwen2", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/qwen2_vl.go
+++ b/pkg/hfutil/modelconfig/qwen2_vl.go
@@ -148,6 +148,11 @@ func (c *Qwen2VLConfig) HasVision() bool {
 	return true // Qwen2-VL models have vision capabilities
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *Qwen2VLConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the Qwen2-VL and Qwen2.5-VL model handlers
 func init() {
 	RegisterModelLoader("qwen2_vl", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/qwen3.go
+++ b/pkg/hfutil/modelconfig/qwen3.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+
+	"github.com/sgl-project/ome/pkg/constants"
 )
 
 // Qwen3Config defines the configuration for Qwen3 models
@@ -39,6 +42,9 @@ type Qwen3Config struct {
 	TieWordEmbeddings bool `json:"tie_word_embeddings"`
 	UseCache          bool `json:"use_cache"`
 	UseSlidingWindow  bool `json:"use_sliding_window"`
+
+	// Embedding config
+	SimilarityFnName string `json:"similarity_fn_name"`
 }
 
 // LoadQwen3Config loads a Qwen3 model configuration from a JSON file
@@ -73,6 +79,8 @@ func (c *Qwen3Config) GetParameterCount() int64 {
 	// Hard-coded parameter counts based on model size
 	if c.HiddenSize == 2560 && c.NumHiddenLayers == 36 {
 		return 4_000_000_000 // 4B parameters
+	} else if c.HiddenSize == 4096 && c.NumHiddenLayers == 36 {
+		return 8_000_000_000 // 8B parameters
 	}
 
 	// For unknown configurations, estimate based on architecture
@@ -103,9 +111,45 @@ func (c *Qwen3Config) HasVision() bool {
 	return false // Base Qwen3 models don't have vision capabilities
 }
 
+// IsEmbedding returns true if this Qwen3 model is an embedding model (i.e., if
+// SimilarityFnName is set, as in Qwen3 Embedding models), and false for base models.
+func (c *Qwen3Config) IsEmbedding() bool {
+	return c.SimilarityFnName != ""
+}
+
+// GetSentenceTransformersConfigPath returns the full path to config_sentence_transformers.json
+// residing in the same directory as the given configPath, and verifies its existence.
+// Returns the full path if the file exists, or an error if not.
+func GetSentenceTransformersConfigPath(configPath string) (string, error) {
+	dir := filepath.Dir(configPath)
+	stConfigPath := filepath.Join(dir, constants.SentenceTransformersConfigFileName)
+	if _, err := os.Stat(stConfigPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("%s not found in %s", constants.SentenceTransformersConfigFileName, dir)
+		}
+		return "", fmt.Errorf("error checking %s: %w", stConfigPath, err)
+	}
+	return stConfigPath, nil
+}
+
 // Register the Qwen3 model handler
 func init() {
 	RegisterModelLoader("qwen3", func(configPath string) (HuggingFaceModel, error) {
-		return LoadQwen3Config(configPath)
+		qwen3Config, err := LoadQwen3Config(configPath)
+		if err != nil {
+			return nil, err
+		}
+		stConfigPath, err := GetSentenceTransformersConfigPath(configPath)
+		if err == nil {
+			// If sentence transformers config exists, load it to get SimilarityFnName
+			stConfig, err := LoadQwen3Config(stConfigPath)
+			if err == nil {
+				qwen3Config.SimilarityFnName = stConfig.SimilarityFnName
+			} else {
+				fmt.Printf("Warning: found config_sentence_transformers.json at %s but failed to parse: %v\n", stConfigPath, err)
+			}
+		}
+		// If st config is not found, this is not an embedding model; that's OK.
+		return qwen3Config, nil
 	})
 }

--- a/pkg/hfutil/modelconfig/qwen3_moe.go
+++ b/pkg/hfutil/modelconfig/qwen3_moe.go
@@ -113,6 +113,11 @@ func (c *Qwen3MoeConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *Qwen3MoeConfig) IsEmbedding() bool {
+	return false
+}
+
 func init() {
 	RegisterModelLoader("qwen3_moe", func(configPath string) (HuggingFaceModel, error) {
 		return LoadQwen3MoeConfig(configPath)

--- a/pkg/hfutil/modelconfig/qwen3_test.go
+++ b/pkg/hfutil/modelconfig/qwen3_test.go
@@ -51,7 +51,7 @@ func TestQwen3Config(t *testing.T) {
 
 	// Check parameter count (should be approximately 7B)
 	paramCount := config.GetParameterCount()
-	expectedCount := int64(4_000_000_000) // 7B parameters
+	expectedCount := int64(4_000_000_000) // 4B parameters
 	if paramCount != expectedCount {
 		t.Errorf("Expected parameter count to be %d, but got %d", expectedCount, paramCount)
 	}
@@ -64,6 +64,83 @@ func TestQwen3Config(t *testing.T) {
 	// Check vision capability (should be false for this model)
 	if config.HasVision() {
 		t.Error("Expected HasVision to return false for Qwen3, but got true")
+	}
+
+	// Check model size bytes (should be non-zero)
+	modelSize := config.GetModelSizeBytes()
+	if modelSize <= 0 {
+		t.Errorf("Expected model size bytes to be positive, but got %d", modelSize)
+	}
+}
+
+func TestQwen3EmbeddingConfig(t *testing.T) {
+	configPath := filepath.Join("testdata", "qwen3_embedding_8b.json")
+
+	// Load the config
+	config, err := LoadModelConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load Qwen3 embedding config: %v", err)
+	}
+
+	// Check that it's the correct model type
+	if config.GetModelType() != "qwen3" {
+		t.Errorf("Expected model type 'qwen3' but got '%s'", config.GetModelType())
+	}
+
+	// Check that it's parsed as a Qwen3Config
+	qwen3Config, ok := config.(*Qwen3Config)
+	if !ok {
+		t.Fatalf("Expected config to be of type *Qwen3Config, but got %T", config)
+	}
+
+	// Check key fields
+	if qwen3Config.HiddenSize != 4096 {
+		t.Errorf("Expected hidden size to be 4096, but got %d", qwen3Config.HiddenSize)
+	}
+
+	if qwen3Config.NumHiddenLayers != 36 {
+		t.Errorf("Expected hidden layers to be 36, but got %d", qwen3Config.NumHiddenLayers)
+	}
+
+	if qwen3Config.NumAttentionHeads != 32 {
+		t.Errorf("Expected attention heads to be 32, but got %d", qwen3Config.NumAttentionHeads)
+	}
+
+	if qwen3Config.NumKeyValueHeads != 8 {
+		t.Errorf("Expected key-value heads to be 8, but got %d", qwen3Config.NumKeyValueHeads)
+	}
+
+	if qwen3Config.SimilarityFnName != "cosine" {
+		t.Errorf("Expected similarity_fn_name to be cosine, but got %s", qwen3Config.SimilarityFnName)
+	}
+
+	// Check context length (should use seq_length)
+	contextLength := config.GetContextLength()
+	expectedLength := 40960
+	if contextLength != expectedLength {
+		t.Errorf("Expected context length to be %d, but got %d", expectedLength, contextLength)
+	}
+
+	// Check parameter count (should be approximately 8B)
+	paramCount := config.GetParameterCount()
+	expectedCount := int64(8_000_000_000) // 8B parameters
+	if paramCount != expectedCount {
+		t.Errorf("Expected parameter count to be %d, but got %d", expectedCount, paramCount)
+	}
+
+	// Check RoPE theta value (specific to Qwen3)
+	if qwen3Config.RopeTheta != 1000000.0 {
+		t.Errorf("Expected RoPE theta to be 1000000.0, but got %f", qwen3Config.RopeTheta)
+	}
+
+	// Check vision capability (should be false for this model)
+	if config.HasVision() {
+		t.Error("Expected HasVision to return false for Qwen3, but got true")
+	}
+
+	// Check embedding capability (should be true for this model)
+	if !config.IsEmbedding() {
+		t.Error("Expected IsEmbedding to return true for Qwen3, but got false")
 	}
 
 	// Check model size bytes (should be non-zero)

--- a/pkg/hfutil/modelconfig/qwen3_vl.go
+++ b/pkg/hfutil/modelconfig/qwen3_vl.go
@@ -148,6 +148,11 @@ func (c *Qwen3VLConfig) HasVision() bool {
 	return true
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *Qwen3VLConfig) IsEmbedding() bool {
+	return false
+}
+
 // estimateQwen3VLMoEParams estimates parameters for Qwen3-VL MoE models
 func estimateQwen3VLMoEParams(hiddenSize, numLayers, moeIntermediateSize, numExperts, vocabSize int) int64 {
 	// Embeddings

--- a/pkg/hfutil/modelconfig/stablelm.go
+++ b/pkg/hfutil/modelconfig/stablelm.go
@@ -96,6 +96,11 @@ func (c *StableLMConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *StableLMConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the StableLM model handler
 func init() {
 	RegisterModelLoader("stablelm", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/testdata/config_sentence_transformers.json
+++ b/pkg/hfutil/modelconfig/testdata/config_sentence_transformers.json
@@ -1,0 +1,8 @@
+{
+  "prompts": {
+    "query": "Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery:",
+    "document": ""
+  },
+  "default_prompt_name": null,
+  "similarity_fn_name": "cosine"
+}

--- a/pkg/hfutil/modelconfig/testdata/qwen3_embedding_8b.json
+++ b/pkg/hfutil/modelconfig/testdata/qwen3_embedding_8b.json
@@ -1,0 +1,30 @@
+{
+  "architectures": [
+    "Qwen3ForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 151643,
+  "eos_token_id": 151645,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 4096,
+  "initializer_range": 0.02,
+  "intermediate_size": 12288,
+  "max_position_embeddings": 40960,
+  "max_window_layers": 36,
+  "model_type": "qwen3",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 36,
+  "num_key_value_heads": 8,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 1000000,
+  "sliding_window": null,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.51.2",
+  "use_cache": true,
+  "use_sliding_window": false,
+  "vocab_size": 151665
+}

--- a/pkg/hfutil/modelconfig/xverse.go
+++ b/pkg/hfutil/modelconfig/xverse.go
@@ -96,6 +96,11 @@ func (c *XverseConfig) HasVision() bool {
 	return false
 }
 
+// IsEmbedding returns false since this is not an embedding model
+func (c *XverseConfig) IsEmbedding() bool {
+	return false
+}
+
 // Register the XVERSE model handler
 func init() {
 	RegisterModelLoader("xverse", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/modelagent/config_parser.go
+++ b/pkg/modelagent/config_parser.go
@@ -350,6 +350,7 @@ func (p *ModelConfigParser) extractModelMetadataFromHF(hfModel modelconfig.Huggi
 		ContextLength      int    `json:"context_length"`
 		ParameterCount     string `json:"parameter_count"`
 		HasVision          bool   `json:"has_vision"`
+		IsEmbedding        bool   `json:"is_embedding"`
 		TransformerVersion string `json:"transformers_version"`
 		TorchDtype         string `json:"torch_dtype"`
 		ModelSizeBytes     int64  `json:"model_size_bytes"`
@@ -359,6 +360,7 @@ func (p *ModelConfigParser) extractModelMetadataFromHF(hfModel modelconfig.Huggi
 		ContextLength:      hfModel.GetContextLength(),
 		ParameterCount:     modelconfig.FormatParamCount(hfModel.GetParameterCount()),
 		HasVision:          hfModel.HasVision(),
+		IsEmbedding:        hfModel.IsEmbedding(),
 		TransformerVersion: hfModel.GetTransformerVersion(),
 		TorchDtype:         hfModel.GetTorchDtype(),
 		ModelSizeBytes:     modelSizeBytes,
@@ -562,7 +564,8 @@ func (p *ModelConfigParser) determineModelCapabilitiesFromHF(hfModel modelconfig
 	}
 
 	// Check for text embedding capability
-	if strings.Contains(normalizedArchitecture, "embedding") ||
+	if hfModel.IsEmbedding() ||
+		strings.Contains(normalizedArchitecture, "embedding") ||
 		strings.Contains(normalizedArchitecture, "sentence") ||
 		strings.Contains(normalizedModelType, "bert") ||
 		// Special case for known embedding models

--- a/pkg/modelagent/config_parser_test.go
+++ b/pkg/modelagent/config_parser_test.go
@@ -26,6 +26,7 @@ type mockHuggingFaceModel struct {
 	torchDtype         string
 	modelSizeBytes     int64
 	hasVision          bool
+	isEmbedding        bool
 	diffusionModel     *modelconfig.DiffusionPipelineSpec
 }
 
@@ -48,6 +49,7 @@ func (m *mockHuggingFaceModel) GetQuantizationType() string   { return m.quantiz
 func (m *mockHuggingFaceModel) GetTorchDtype() string         { return m.torchDtype }
 func (m *mockHuggingFaceModel) GetModelSizeBytes() int64      { return m.modelSizeBytes }
 func (m *mockHuggingFaceModel) HasVision() bool               { return m.hasVision }
+func (m *mockHuggingFaceModel) IsEmbedding() bool             { return m.isEmbedding }
 
 // Define a helper function to create a mock model with default values
 func createDefaultMockModel() *mockHuggingFaceModel {
@@ -61,6 +63,7 @@ func createDefaultMockModel() *mockHuggingFaceModel {
 		torchDtype:         "float16",
 		modelSizeBytes:     14000000000, // 14GB
 		hasVision:          false,
+		isEmbedding:        false,
 	}
 }
 

--- a/pkg/webhook/admission/isvc/inference_service_validation.go
+++ b/pkg/webhook/admission/isvc/inference_service_validation.go
@@ -411,7 +411,7 @@ func (v *InferenceServiceValidator) resolveModelAndRuntime(ctx context.Context, 
 		// Check if runtime can be auto-selected
 		selection, err := v.RuntimeSelector.SelectRuntime(ctx, baseModel, isvc)
 		if err != nil {
-			return warnings, fmt.Errorf("no supporting runtime found for model %s and engine does not have complete runner configuration", isvc.Spec.Model.Name)
+			return warnings, fmt.Errorf("no supporting runtime found for model %s and engine does not have complete runner configuration: %w", isvc.Spec.Model.Name, err)
 		}
 		// Success - runtime will be auto-selected
 		warnings = append(warnings, fmt.Sprintf("Runtime %s will be auto-selected for model %s",


### PR DESCRIPTION
## What this PR does
This PR additionally reads the similarity_fn_name field in config_sentence_transformers.json to check if the model supports embedding functionality.

## Why we need it
When parsing Qwen3 embedding models, such as Qwen/Qwen3-Embedding-8B, the model agent cannot determine whether these models provide embedding capabilities solely by inspecting config.json. 

## How to test
Create a base model CR of qwen embedding model and check whether capability is EMBEDDINGS after model is parsed. 

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
