### PR TITLE
[BUG] Replace ome-instance-type-map with model-agent-config-map

### DIFF
--- a/config/model-agent/daemonset.yaml
+++ b/config/model-agent/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
         - name: INSTANCE_TYPE_MAP
           valueFrom:
             configMapKeyRef:
-              name: ome-instance-type-map
+              name: model-agent-config-map
               key: instance-type-map
         volumeMounts:
         - name: host-models

--- a/site/content/en/docs/administration/model-agent.md
+++ b/site/content/en/docs/administration/model-agent.md
@@ -182,8 +182,8 @@ For TensorRT-LLM models, the Model Agent provides intelligent shape filtering:
 2. **Shape Identification**: Maps GPU hardware to TensorRT-LLM shape identifiers (e.g., `GPU.A100.4`, `GPU.H100.8`)
 3. **File Filtering**: Only downloads model files that match the detected GPU shape
 
-The instance type to GPU short name mapping is configurable via the `ome-instance-type-map` ConfigMap, which is automatically deployed with the Model Agent. This allows you to add support for new cloud instance types without code changes.
-To add or modify mappings, you can edit this ConfigMap directly. For example, to add a mapping for a new instance type new-gpu-instance, you can use `kubectl edit configmap ome-instance-type-map -n <namespace>` and add the new entry to the instance-type-map data."
+The instance type to GPU short name mapping is configurable via the `model-agent-config-map` ConfigMap, which is automatically deployed with the Model Agent. This allows you to add support for new cloud instance types without code changes.
+To add or modify mappings, you can edit this ConfigMap directly. For example, to add a mapping for a new instance type new-gpu-instance, you can use `kubectl edit configmap model-agent-config-map -n <namespace>` and add the new entry to the instance-type-map data."
 
 #### Shape Filtering Logic
 


### PR DESCRIPTION
## What this PR does

Fix bug in OME model agent using model-agent-config-map as instance config map to replace ome-instance-type-map

## Why we need it

https://github.com/search?q=repo%3Asgl-project%2Fome+model-agent-config-map&type=code

Helm chart is using model-agent-config-map. Needs a consistent name for config as well. 

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [ ] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
