### PR TITLE
[Helm] Add OCI Compute Shape B200 support in model agent

### DIFF
--- a/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
@@ -21,6 +21,7 @@ data:
       "BM.GPU.H100-NC.8": "H100",
       "BM.GPU.H200.8": "H200",
       "BM.GPU.H200-NC.8": "H200",
+      "BM.GPU.B200.8": "B200",
       "p5.48xlarge": "H100",
       "Standard_ND96isr_H100_v5": "H100",
       "a3-highgpu-8g": "H100",

--- a/config/model-agent/configmap.yaml
+++ b/config/model-agent/configmap.yaml
@@ -21,6 +21,7 @@ data:
       "BM.GPU.H100-NC.8": "H100",
       "BM.GPU.H200.8": "H200",
       "BM.GPU.H200-NC.8": "H200",
+      "BM.GPU.B200.8": "B200",
       "p5.48xlarge": "H100",
       "Standard_ND96isr_H100_v5": "H100",
       "a3-highgpu-8g": "H100",

--- a/pkg/utils/instance_type_util.go
+++ b/pkg/utils/instance_type_util.go
@@ -26,6 +26,7 @@ var defaultInstanceTypeMap = map[string]string{
 	"BM.GPU.H100-NC.8": "H100",
 	"BM.GPU.H200.8":    "H200",
 	"BM.GPU.H200-NC.8": "H200",
+	"BM.GPU.B200.8":    "B200",
 
 	// AWS instance types
 	"p5.48xlarge": "H100",


### PR DESCRIPTION
## What this PR does

Add OCI Compute Shape B200, GB200 and GB300 support in model agent

## Why we need it

To support the new shapes in OCI

Fixes #

## How to test

make test

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
