### PR TITLE
Improve runtime recommendation explainability in web console

### DIFF
--- a/web-console/backend/internal/handlers/runtimes.go
+++ b/web-console/backend/internal/handlers/runtimes.go
@@ -412,21 +412,27 @@ func (h *RuntimesHandler) FetchYAML(c *gin.Context) {
 // FindCompatibleRuntimes handles GET /api/v1/runtimes/compatible?format=<format>&framework=<framework>
 func (h *RuntimesHandler) FindCompatibleRuntimes(c *gin.Context) {
 	ctx := c.Request.Context()
-	modelFormat := c.Query("format")
-	modelFramework := c.Query("framework")
+	profile := services.ModelProfile{
+		Format:        c.Query("format"),
+		Framework:     c.Query("framework"),
+		Architecture:  c.Query("architecture"),
+		ParameterSize: c.Query("size"),
+	}
 
-	if modelFormat == "" {
+	if profile.Format == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "Model format is required",
 		})
 		return
 	}
 
-	matches, err := h.intelligence.FindCompatibleRuntimes(ctx, modelFormat, modelFramework)
+	matches, err := h.intelligence.FindCompatibleRuntimes(ctx, profile)
 	if err != nil {
 		h.logger.Error("Failed to find compatible runtimes",
-			zap.String("format", modelFormat),
-			zap.String("framework", modelFramework),
+			zap.String("format", profile.Format),
+			zap.String("framework", profile.Framework),
+			zap.String("architecture", profile.Architecture),
+			zap.String("size", profile.ParameterSize),
 			zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "Failed to find compatible runtimes",
@@ -445,21 +451,28 @@ func (h *RuntimesHandler) FindCompatibleRuntimes(c *gin.Context) {
 func (h *RuntimesHandler) CheckCompatibility(c *gin.Context) {
 	ctx := c.Request.Context()
 	name := c.Param("name")
-	modelFormat := c.Query("format")
-	modelFramework := c.Query("framework")
+	profile := services.ModelProfile{
+		Format:        c.Query("format"),
+		Framework:     c.Query("framework"),
+		Architecture:  c.Query("architecture"),
+		ParameterSize: c.Query("size"),
+	}
 
-	if modelFormat == "" {
+	if profile.Format == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "Model format is required",
 		})
 		return
 	}
 
-	check, err := h.intelligence.CheckCompatibility(ctx, name, modelFormat, modelFramework)
+	check, err := h.intelligence.CheckCompatibility(ctx, name, profile)
 	if err != nil {
 		h.logger.Error("Failed to check compatibility",
 			zap.String("runtime", name),
-			zap.String("format", modelFormat),
+			zap.String("format", profile.Format),
+			zap.String("framework", profile.Framework),
+			zap.String("architecture", profile.Architecture),
+			zap.String("size", profile.ParameterSize),
 			zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error":   "Failed to check compatibility",
@@ -474,21 +487,27 @@ func (h *RuntimesHandler) CheckCompatibility(c *gin.Context) {
 // GetRecommendation handles GET /api/v1/runtimes/recommend?format=<format>&framework=<framework>
 func (h *RuntimesHandler) GetRecommendation(c *gin.Context) {
 	ctx := c.Request.Context()
-	modelFormat := c.Query("format")
-	modelFramework := c.Query("framework")
+	profile := services.ModelProfile{
+		Format:        c.Query("format"),
+		Framework:     c.Query("framework"),
+		Architecture:  c.Query("architecture"),
+		ParameterSize: c.Query("size"),
+	}
 
-	if modelFormat == "" {
+	if profile.Format == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "Model format is required",
 		})
 		return
 	}
 
-	recommendation, err := h.intelligence.GetRecommendation(ctx, modelFormat, modelFramework)
+	recommendation, err := h.intelligence.GetRecommendation(ctx, profile)
 	if err != nil {
 		h.logger.Error("Failed to get recommendation",
-			zap.String("format", modelFormat),
-			zap.String("framework", modelFramework),
+			zap.String("format", profile.Format),
+			zap.String("framework", profile.Framework),
+			zap.String("architecture", profile.Architecture),
+			zap.String("size", profile.ParameterSize),
 			zap.Error(err))
 		c.JSON(http.StatusNotFound, gin.H{
 			"error":   "No compatible runtime found",

--- a/web-console/backend/internal/services/runtime_intelligence.go
+++ b/web-console/backend/internal/services/runtime_intelligence.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/sgl-project/ome/web-console/backend/internal/k8s"
@@ -33,6 +34,18 @@ type RuntimeMatch struct {
 	Reasons        []string                   `json:"reasons"`
 	Warnings       []string                   `json:"warnings,omitempty"`
 	Recommendation string                     `json:"recommendation"`
+	Signals        RuntimeSignals             `json:"signals,omitempty"`
+}
+
+// RuntimeSignals contains the key decision signals behind a runtime recommendation.
+type RuntimeSignals struct {
+	MatchedFormat       string   `json:"matchedFormat,omitempty"`
+	MatchedFramework    string   `json:"matchedFramework,omitempty"`
+	MatchedArchitecture string   `json:"matchedArchitecture,omitempty"`
+	ModelSizeRange      string   `json:"modelSizeRange,omitempty"`
+	RuntimeFamily       string   `json:"runtimeFamily,omitempty"`
+	Protocols           []string `json:"protocols,omitempty"`
+	AutoSelectEnabled   bool     `json:"autoSelectEnabled"`
 }
 
 // CompatibilityCheck represents the result of a compatibility check
@@ -43,8 +56,24 @@ type CompatibilityCheck struct {
 	Score      int      `json:"score"`
 }
 
+// ModelProfile contains the model attributes used to evaluate runtime compatibility.
+type ModelProfile struct {
+	Format       string
+	Framework    string
+	Architecture string
+	ParameterSize string
+}
+
+type formatEvaluation struct {
+	score          int
+	compatibleWith []string
+	reasons        []string
+	warnings       []string
+	signals        RuntimeSignals
+}
+
 // FindCompatibleRuntimes finds all runtimes compatible with a given model
-func (s *RuntimeIntelligenceService) FindCompatibleRuntimes(ctx context.Context, modelFormat string, modelFramework string) ([]RuntimeMatch, error) {
+func (s *RuntimeIntelligenceService) FindCompatibleRuntimes(ctx context.Context, profile ModelProfile) ([]RuntimeMatch, error) {
 	// Get all cluster-scoped runtimes
 	runtimes, err := s.k8sClient.ListClusterServingRuntimes(ctx)
 	if err != nil {
@@ -53,7 +82,7 @@ func (s *RuntimeIntelligenceService) FindCompatibleRuntimes(ctx context.Context,
 
 	var matches []RuntimeMatch
 	for _, runtime := range runtimes.Items {
-		match := s.evaluateRuntimeCompatibility(&runtime, modelFormat, modelFramework)
+		match := s.evaluateRuntimeCompatibility(&runtime, profile)
 		if match.Score > 0 {
 			matches = append(matches, match)
 		}
@@ -68,13 +97,13 @@ func (s *RuntimeIntelligenceService) FindCompatibleRuntimes(ctx context.Context,
 }
 
 // CheckCompatibility checks if a specific runtime is compatible with a model
-func (s *RuntimeIntelligenceService) CheckCompatibility(ctx context.Context, runtimeName string, modelFormat string, modelFramework string) (*CompatibilityCheck, error) {
+func (s *RuntimeIntelligenceService) CheckCompatibility(ctx context.Context, runtimeName string, profile ModelProfile) (*CompatibilityCheck, error) {
 	runtime, err := s.k8sClient.GetClusterServingRuntime(ctx, runtimeName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get runtime: %w", err)
 	}
 
-	match := s.evaluateRuntimeCompatibility(runtime, modelFormat, modelFramework)
+	match := s.evaluateRuntimeCompatibility(runtime, profile)
 
 	return &CompatibilityCheck{
 		Compatible: match.Score > 0,
@@ -85,74 +114,40 @@ func (s *RuntimeIntelligenceService) CheckCompatibility(ctx context.Context, run
 }
 
 // GetRecommendation gets the best runtime recommendation for a model
-func (s *RuntimeIntelligenceService) GetRecommendation(ctx context.Context, modelFormat string, modelFramework string) (*RuntimeMatch, error) {
-	matches, err := s.FindCompatibleRuntimes(ctx, modelFormat, modelFramework)
+func (s *RuntimeIntelligenceService) GetRecommendation(ctx context.Context, profile ModelProfile) (*RuntimeMatch, error) {
+	matches, err := s.FindCompatibleRuntimes(ctx, profile)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("no compatible runtimes found for format=%s, framework=%s", modelFormat, modelFramework)
+		return nil, fmt.Errorf("no compatible runtimes found for format=%s, framework=%s, architecture=%s, size=%s",
+			profile.Format, profile.Framework, profile.Architecture, profile.ParameterSize)
 	}
 
 	// Return the highest scored match
 	best := matches[0]
-	best.Recommendation = "Best match based on compatibility score"
+	best.Recommendation = buildRecommendation(best)
 	return &best, nil
 }
 
 // evaluateRuntimeCompatibility evaluates how well a runtime matches a model
-func (s *RuntimeIntelligenceService) evaluateRuntimeCompatibility(runtime *unstructured.Unstructured, modelFormat string, modelFramework string) RuntimeMatch {
+func (s *RuntimeIntelligenceService) evaluateRuntimeCompatibility(runtime *unstructured.Unstructured, profile ModelProfile) RuntimeMatch {
 	match := RuntimeMatch{
 		Runtime:        runtime,
 		Score:          0,
 		CompatibleWith: []string{},
 		Reasons:        []string{},
 		Warnings:       []string{},
+		Signals:        RuntimeSignals{},
 	}
 
 	// Extract runtime spec
 	spec, found, err := unstructured.NestedMap(runtime.Object, "spec")
 	if !found || err != nil {
 		match.Warnings = append(match.Warnings, "Runtime spec not found or invalid")
+		match.Recommendation = "Runtime spec is incomplete"
 		return match
-	}
-
-	// Check supported model formats
-	supportedFormats, found, err := unstructured.NestedSlice(spec, "supportedModelFormats")
-	if !found || err != nil {
-		match.Warnings = append(match.Warnings, "No supported model formats specified")
-	} else {
-		formatMatched := false
-		for _, format := range supportedFormats {
-			formatMap, ok := format.(map[string]interface{})
-			if !ok {
-				continue
-			}
-
-			name, _ := formatMap["name"].(string)
-			version, _ := formatMap["version"].(string)
-
-			// Check if format matches
-			if matchesFormat(modelFormat, name, version) {
-				formatMatched = true
-				match.Score += 50 // High score for format match
-				match.CompatibleWith = append(match.CompatibleWith, fmt.Sprintf("%s:%s", name, version))
-				match.Reasons = append(match.Reasons, fmt.Sprintf("Supports model format %s", name))
-				break
-			}
-		}
-
-		if !formatMatched {
-			match.Warnings = append(match.Warnings, fmt.Sprintf("Model format %s may not be supported", modelFormat))
-		}
-	}
-
-	// Check if runtime supports multi-model (bonus points)
-	multiModel, found, err := unstructured.NestedBool(spec, "multiModel")
-	if found && err == nil && multiModel {
-		match.Score += 10
-		match.Reasons = append(match.Reasons, "Supports multi-model serving")
 	}
 
 	// Check if runtime is disabled
@@ -160,48 +155,87 @@ func (s *RuntimeIntelligenceService) evaluateRuntimeCompatibility(runtime *unstr
 	if found && err == nil && disabled {
 		match.Score = 0
 		match.Warnings = append(match.Warnings, "Runtime is disabled")
+		match.Recommendation = "Disabled runtimes cannot be selected"
 		return match
 	}
 
-	// Check protocol versions (bonus for HTTP/REST support)
-	protocolVersions, found, err := unstructured.NestedSlice(spec, "protocolVersions")
-	if found && err == nil {
-		for _, pv := range protocolVersions {
-			pvMap, ok := pv.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			name, _ := pvMap["name"].(string)
-			if strings.Contains(strings.ToLower(name), "http") || strings.Contains(strings.ToLower(name), "rest") {
-				match.Score += 5
-				match.Reasons = append(match.Reasons, "Supports HTTP/REST protocol")
-				break
+	match.Signals.Protocols = extractProtocolVersions(spec)
+	match.Signals.RuntimeFamily = detectRuntimeFamily(spec)
+
+	bestEval, evalFound := s.evaluateSupportedFormats(spec, profile)
+	if evalFound {
+		match.Score += bestEval.score
+		match.CompatibleWith = append(match.CompatibleWith, bestEval.compatibleWith...)
+		match.Reasons = append(match.Reasons, bestEval.reasons...)
+		match.Warnings = append(match.Warnings, bestEval.warnings...)
+		match.Signals = mergeSignals(match.Signals, bestEval.signals)
+	} else {
+		match.Warnings = append(match.Warnings, "No supported model formats specified")
+	}
+
+	if match.Score == 0 {
+		match.Recommendation = buildRecommendation(match)
+		return match
+	}
+
+	if profile.ParameterSize != "" {
+		rangeLabel, sizeMatched := matchModelSize(spec, profile.ParameterSize)
+		if rangeLabel != "" {
+			match.Signals.ModelSizeRange = rangeLabel
+			if sizeMatched {
+				match.Score += 10
+				match.Reasons = append(match.Reasons, fmt.Sprintf("Model size %s fits runtime range %s", profile.ParameterSize, rangeLabel))
+			} else {
+				match.Score = 0
+				match.Warnings = append(match.Warnings, fmt.Sprintf("Model size %s is outside runtime range %s", profile.ParameterSize, rangeLabel))
+				match.Recommendation = buildRecommendation(match)
+				return match
 			}
 		}
 	}
 
-	// Framework compatibility (if specified)
-	if modelFramework != "" {
-		// Check built-in adapters or container configurations for framework hints
-		containers, found, err := unstructured.NestedSlice(spec, "containers")
-		if found && err == nil {
-			for _, container := range containers {
-				containerMap, ok := container.(map[string]interface{})
-				if !ok {
-					continue
-				}
-
-				image, _ := containerMap["image"].(string)
-				if matchesFramework(modelFramework, image) {
-					match.Score += 20
-					match.Reasons = append(match.Reasons, fmt.Sprintf("Container image supports %s framework", modelFramework))
-					break
-				}
-			}
-		}
+	// Check if runtime supports multi-model (bonus points)
+	multiModel, found, err := unstructured.NestedBool(spec, "multiModel")
+	if found && err == nil && multiModel {
+		match.Score += 5
+		match.Reasons = append(match.Reasons, "Supports multi-model serving")
 	}
 
+	if hasHTTPProtocol(match.Signals.Protocols) {
+		match.Score += 5
+		match.Reasons = append(match.Reasons, "Supports OpenAI or HTTP-based serving protocols")
+	}
+
+	if match.Signals.RuntimeFamily != "" {
+		match.Reasons = append(match.Reasons, fmt.Sprintf("Uses %s serving stack", strings.ToUpper(match.Signals.RuntimeFamily)))
+	}
+
+	match.Recommendation = buildRecommendation(match)
 	return match
+}
+
+func (s *RuntimeIntelligenceService) evaluateSupportedFormats(spec map[string]interface{}, profile ModelProfile) (formatEvaluation, bool) {
+	supportedFormats, found, err := unstructured.NestedSlice(spec, "supportedModelFormats")
+	if !found || err != nil || len(supportedFormats) == 0 {
+		return formatEvaluation{}, false
+	}
+
+	var best formatEvaluation
+	var bestFound bool
+	for _, format := range supportedFormats {
+		formatMap, ok := format.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		eval := evaluateSupportedFormat(formatMap, profile)
+		if !bestFound || eval.score > best.score {
+			best = eval
+			bestFound = true
+		}
+	}
+
+	return best, bestFound
 }
 
 // matchesFormat checks if a model format matches a runtime's supported format
@@ -233,13 +267,242 @@ func matchesFormat(modelFormat, runtimeFormat, runtimeVersion string) bool {
 	return false
 }
 
-// matchesFramework checks if a framework is supported by a container image
-func matchesFramework(framework, containerImage string) bool {
-	frameworkLower := strings.ToLower(framework)
-	imageLower := strings.ToLower(containerImage)
+func evaluateSupportedFormat(format map[string]interface{}, profile ModelProfile) formatEvaluation {
+	eval := formatEvaluation{
+		compatibleWith: []string{},
+		reasons:        []string{},
+		warnings:       []string{},
+		signals:        RuntimeSignals{},
+	}
 
-	// Check if framework name appears in image
-	return strings.Contains(imageLower, frameworkLower)
+	modelFormat, _, _ := unstructured.NestedMap(format, "modelFormat")
+	modelFramework, _, _ := unstructured.NestedMap(format, "modelFramework")
+
+	formatName, _, _ := unstructured.NestedString(modelFormat, "name")
+	formatVersion, _, _ := unstructured.NestedString(modelFormat, "version")
+	frameworkName, _, _ := unstructured.NestedString(modelFramework, "name")
+	frameworkVersion, _, _ := unstructured.NestedString(modelFramework, "version")
+	architecture, _, _ := unstructured.NestedString(format, "modelArchitecture")
+	autoSelect, autoSelectFound, _ := unstructured.NestedBool(format, "autoSelect")
+
+	if !matchesFormat(profile.Format, formatName, formatVersion) {
+		eval.warnings = append(eval.warnings, fmt.Sprintf("Supports %s, not %s", formatLabel(formatName, formatVersion), profile.Format))
+		return eval
+	}
+
+	eval.score += 50
+	eval.compatibleWith = append(eval.compatibleWith, formatLabel(formatName, formatVersion))
+	eval.reasons = append(eval.reasons, fmt.Sprintf("Supports model format %s", formatLabel(formatName, formatVersion)))
+	eval.signals.MatchedFormat = formatLabel(formatName, formatVersion)
+
+	if profile.Framework != "" && frameworkName != "" {
+		if strings.EqualFold(profile.Framework, frameworkName) {
+			eval.score += 20
+			eval.reasons = append(eval.reasons, fmt.Sprintf("Matches framework %s", formatLabel(frameworkName, frameworkVersion)))
+			eval.signals.MatchedFramework = formatLabel(frameworkName, frameworkVersion)
+		} else {
+			eval.warnings = append(eval.warnings, fmt.Sprintf("Framework mismatch: runtime expects %s", formatLabel(frameworkName, frameworkVersion)))
+			eval.score = 0
+			return eval
+		}
+	}
+
+	if profile.Architecture != "" && architecture != "" {
+		if strings.EqualFold(profile.Architecture, architecture) {
+			eval.score += 20
+			eval.reasons = append(eval.reasons, fmt.Sprintf("Optimized for architecture %s", architecture))
+			eval.signals.MatchedArchitecture = architecture
+		} else {
+			eval.warnings = append(eval.warnings, fmt.Sprintf("Architecture mismatch: runtime targets %s", architecture))
+			eval.score = 0
+			return eval
+		}
+	}
+
+	if autoSelectFound {
+		eval.signals.AutoSelectEnabled = autoSelect
+		if autoSelect {
+			eval.score += 10
+			eval.reasons = append(eval.reasons, "Auto-select is enabled for this runtime format")
+		} else {
+			eval.warnings = append(eval.warnings, "Manual selection required because auto-select is disabled")
+		}
+	}
+
+	return eval
+}
+
+func extractProtocolVersions(spec map[string]interface{}) []string {
+	var protocols []string
+	rawProtocols, found, err := unstructured.NestedSlice(spec, "protocolVersions")
+	if !found || err != nil {
+		return protocols
+	}
+
+	for _, protocol := range rawProtocols {
+		switch value := protocol.(type) {
+		case string:
+			protocols = append(protocols, value)
+		case map[string]interface{}:
+			name, ok := value["name"].(string)
+			if ok && name != "" {
+				protocols = append(protocols, name)
+			}
+		}
+	}
+
+	return protocols
+}
+
+func detectRuntimeFamily(spec map[string]interface{}) string {
+	image, _, _ := unstructured.NestedString(spec, "engineConfig", "runner", "image")
+	imageLower := strings.ToLower(image)
+
+	switch {
+	case strings.Contains(imageLower, "sglang"):
+		return "sglang"
+	case strings.Contains(imageLower, "vllm"):
+		return "vllm"
+	case strings.Contains(imageLower, "triton"):
+		return "triton"
+	default:
+		return ""
+	}
+}
+
+func matchModelSize(spec map[string]interface{}, modelSize string) (string, bool) {
+	modelSizeRange, found, err := unstructured.NestedMap(spec, "modelSizeRange")
+	if !found || err != nil {
+		return "", true
+	}
+
+	minValue, _, _ := unstructured.NestedString(modelSizeRange, "min")
+	maxValue, _, _ := unstructured.NestedString(modelSizeRange, "max")
+	if minValue == "" || maxValue == "" {
+		return "", true
+	}
+
+	modelNumeric, ok := parseModelSize(modelSize)
+	if !ok {
+		return fmt.Sprintf("%s-%s", minValue, maxValue), true
+	}
+	minNumeric, minOK := parseModelSize(minValue)
+	maxNumeric, maxOK := parseModelSize(maxValue)
+	if !minOK || !maxOK {
+		return fmt.Sprintf("%s-%s", minValue, maxValue), true
+	}
+
+	rangeLabel := fmt.Sprintf("%s-%s", minValue, maxValue)
+	return rangeLabel, modelNumeric >= minNumeric && modelNumeric <= maxNumeric
+}
+
+func parseModelSize(size string) (float64, bool) {
+	value := strings.TrimSpace(strings.ToUpper(size))
+	if value == "" {
+		return 0, false
+	}
+
+	multiplier := 1.0
+	lastChar := value[len(value)-1]
+	switch lastChar {
+	case 'K':
+		multiplier = 1e3
+		value = value[:len(value)-1]
+	case 'M':
+		multiplier = 1e6
+		value = value[:len(value)-1]
+	case 'B':
+		multiplier = 1e9
+		value = value[:len(value)-1]
+	case 'T':
+		multiplier = 1e12
+		value = value[:len(value)-1]
+	}
+
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return parsed * multiplier, true
+}
+
+func formatLabel(name, version string) string {
+	switch {
+	case name == "" && version == "":
+		return ""
+	case version == "":
+		return name
+	case name == "":
+		return version
+	default:
+		return fmt.Sprintf("%s %s", name, version)
+	}
+}
+
+func hasHTTPProtocol(protocols []string) bool {
+	for _, protocol := range protocols {
+		protocolLower := strings.ToLower(protocol)
+		if strings.Contains(protocolLower, "http") || strings.Contains(protocolLower, "rest") || strings.Contains(protocolLower, "openai") {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeSignals(base RuntimeSignals, update RuntimeSignals) RuntimeSignals {
+	if update.MatchedFormat != "" {
+		base.MatchedFormat = update.MatchedFormat
+	}
+	if update.MatchedFramework != "" {
+		base.MatchedFramework = update.MatchedFramework
+	}
+	if update.MatchedArchitecture != "" {
+		base.MatchedArchitecture = update.MatchedArchitecture
+	}
+	if update.ModelSizeRange != "" {
+		base.ModelSizeRange = update.ModelSizeRange
+	}
+	if update.RuntimeFamily != "" {
+		base.RuntimeFamily = update.RuntimeFamily
+	}
+	if len(update.Protocols) > 0 {
+		base.Protocols = update.Protocols
+	}
+	base.AutoSelectEnabled = update.AutoSelectEnabled
+	return base
+}
+
+func buildRecommendation(match RuntimeMatch) string {
+	if match.Score == 0 {
+		if len(match.Warnings) > 0 {
+			return match.Warnings[0]
+		}
+		return "Runtime does not satisfy the selected model requirements"
+	}
+
+	parts := []string{}
+	if match.Signals.MatchedFormat != "" {
+		parts = append(parts, fmt.Sprintf("Best fit for %s models", match.Signals.MatchedFormat))
+	}
+	if match.Signals.MatchedFramework != "" {
+		parts = append(parts, fmt.Sprintf("using %s", match.Signals.MatchedFramework))
+	}
+	if match.Signals.MatchedArchitecture != "" {
+		parts = append(parts, fmt.Sprintf("optimized for %s", match.Signals.MatchedArchitecture))
+	}
+	if match.Signals.ModelSizeRange != "" {
+		parts = append(parts, fmt.Sprintf("within size range %s", match.Signals.ModelSizeRange))
+	}
+	if match.Signals.RuntimeFamily != "" {
+		parts = append(parts, fmt.Sprintf("on %s", strings.ToUpper(match.Signals.RuntimeFamily)))
+	}
+
+	if len(parts) == 0 {
+		return "Best match based on compatibility signals"
+	}
+
+	return strings.Join(parts, ", ")
 }
 
 // contains checks if a slice contains a string

--- a/web-console/backend/internal/services/runtime_intelligence_test.go
+++ b/web-console/backend/internal/services/runtime_intelligence_test.go
@@ -1,0 +1,164 @@
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestEvaluateRuntimeCompatibility_UsesNestedSignals(t *testing.T) {
+	service := &RuntimeIntelligenceService{}
+	runtime := newRuntime(
+		"vllm-llama-3-3-70b",
+		map[string]any{
+			"supportedModelFormats": []any{
+				map[string]any{
+					"modelFormat": map[string]any{
+						"name":    "safetensors",
+						"version": "1.0.0",
+					},
+					"modelFramework": map[string]any{
+						"name":    "transformers",
+						"version": "4.47.0.dev0",
+					},
+					"modelArchitecture": "LlamaForCausalLM",
+					"autoSelect":        true,
+				},
+			},
+			"modelSizeRange": map[string]any{
+				"min": "60B",
+				"max": "75B",
+			},
+			"protocolVersions": []any{"openAI"},
+			"engineConfig": map[string]any{
+				"runner": map[string]any{
+					"image": "docker.io/vllm/vllm-openai:v0.9.0.1",
+				},
+			},
+		},
+	)
+
+	match := service.evaluateRuntimeCompatibility(runtime, ModelProfile{
+		Format:        "safetensors",
+		Framework:     "transformers",
+		Architecture:  "LlamaForCausalLM",
+		ParameterSize: "70B",
+	})
+
+	if match.Score <= 0 {
+		t.Fatalf("expected positive score, got %d", match.Score)
+	}
+	if match.Signals.MatchedFormat != "safetensors 1.0.0" {
+		t.Fatalf("expected matched format to be parsed from nested modelFormat, got %q", match.Signals.MatchedFormat)
+	}
+	if match.Signals.MatchedFramework != "transformers 4.47.0.dev0" {
+		t.Fatalf("expected matched framework to be parsed from nested modelFramework, got %q", match.Signals.MatchedFramework)
+	}
+	if match.Signals.MatchedArchitecture != "LlamaForCausalLM" {
+		t.Fatalf("expected architecture signal, got %q", match.Signals.MatchedArchitecture)
+	}
+	if match.Signals.ModelSizeRange != "60B-75B" {
+		t.Fatalf("expected size range signal, got %q", match.Signals.ModelSizeRange)
+	}
+	if match.Signals.RuntimeFamily != "vllm" {
+		t.Fatalf("expected runtime family signal, got %q", match.Signals.RuntimeFamily)
+	}
+	if !containsString(match.Reasons, "Matches framework transformers 4.47.0.dev0") {
+		t.Fatalf("expected framework reason, got %v", match.Reasons)
+	}
+	if !strings.Contains(match.Recommendation, "safetensors") {
+		t.Fatalf("expected recommendation to mention matched format, got %q", match.Recommendation)
+	}
+}
+
+func TestEvaluateRuntimeCompatibility_RejectsOutOfRangeModelSize(t *testing.T) {
+	service := &RuntimeIntelligenceService{}
+	runtime := newRuntime(
+		"vllm-mistral-7b",
+		map[string]any{
+			"supportedModelFormats": []any{
+				map[string]any{
+					"modelFormat": map[string]any{
+						"name": "safetensors",
+					},
+					"autoSelect": true,
+				},
+			},
+			"modelSizeRange": map[string]any{
+				"min": "7B",
+				"max": "9B",
+			},
+		},
+	)
+
+	match := service.evaluateRuntimeCompatibility(runtime, ModelProfile{
+		Format:        "safetensors",
+		ParameterSize: "70B",
+	})
+
+	if match.Score != 0 {
+		t.Fatalf("expected incompatible size to zero the score, got %d", match.Score)
+	}
+	if !containsString(match.Warnings, "Model size 70B is outside runtime range 7B-9B") {
+		t.Fatalf("expected size-range warning, got %v", match.Warnings)
+	}
+}
+
+func TestEvaluateRuntimeCompatibility_WarnsWhenAutoSelectDisabled(t *testing.T) {
+	service := &RuntimeIntelligenceService{}
+	runtime := newRuntime(
+		"sglang-embedding",
+		map[string]any{
+			"supportedModelFormats": []any{
+				map[string]any{
+					"modelFormat": map[string]any{
+						"name": "safetensors",
+					},
+					"autoSelect": false,
+				},
+			},
+			"engineConfig": map[string]any{
+				"runner": map[string]any{
+					"image": "docker.io/lmsysorg/sglang:v0.5.5",
+				},
+			},
+		},
+	)
+
+	match := service.evaluateRuntimeCompatibility(runtime, ModelProfile{
+		Format: "safetensors",
+	})
+
+	if match.Score <= 0 {
+		t.Fatalf("expected manual-select runtime to remain compatible, got %d", match.Score)
+	}
+	if match.Signals.AutoSelectEnabled {
+		t.Fatalf("expected autoSelect signal to remain false")
+	}
+	if !containsString(match.Warnings, "Manual selection required because auto-select is disabled") {
+		t.Fatalf("expected auto-select warning, got %v", match.Warnings)
+	}
+}
+
+func newRuntime(name string, spec map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "ome.io/v1beta1",
+			"kind":       "ClusterServingRuntime",
+			"metadata": map[string]any{
+				"name": name,
+			},
+			"spec": spec,
+		},
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/web-console/frontend/src/app/(dashboard)/services/deploy/page.tsx
+++ b/web-console/frontend/src/app/(dashboard)/services/deploy/page.tsx
@@ -116,6 +116,41 @@ function RuntimeCard({
         <ScoreBadge score={match.score} />
       </div>
 
+      {match.signals && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {match.signals.runtimeFamily && (
+            <span className="inline-flex items-center rounded-md bg-primary/10 text-primary px-2 py-0.5 text-xs font-medium uppercase">
+              {match.signals.runtimeFamily}
+            </span>
+          )}
+          {match.signals.matchedFormat && (
+            <span className="inline-flex items-center rounded-md bg-muted text-muted-foreground px-2 py-0.5 text-xs">
+              Format: {match.signals.matchedFormat}
+            </span>
+          )}
+          {match.signals.matchedFramework && (
+            <span className="inline-flex items-center rounded-md bg-muted text-muted-foreground px-2 py-0.5 text-xs">
+              Framework: {match.signals.matchedFramework}
+            </span>
+          )}
+          {match.signals.matchedArchitecture && (
+            <span className="inline-flex items-center rounded-md bg-muted text-muted-foreground px-2 py-0.5 text-xs">
+              Arch: {match.signals.matchedArchitecture}
+            </span>
+          )}
+          {match.signals.modelSizeRange && (
+            <span className="inline-flex items-center rounded-md bg-muted text-muted-foreground px-2 py-0.5 text-xs">
+              Size: {match.signals.modelSizeRange}
+            </span>
+          )}
+          {match.signals.autoSelectEnabled && (
+            <span className="inline-flex items-center rounded-md bg-accent/10 text-accent px-2 py-0.5 text-xs">
+              Auto-select
+            </span>
+          )}
+        </div>
+      )}
+
       {/* Reasons */}
       {match.reasons.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-1">
@@ -206,13 +241,22 @@ export default function DeployServicePage() {
   // Extract model format and framework for smart selection
   const modelFormat = selectedModel?.spec.modelFormat?.name
   const modelFramework = selectedModel?.spec.modelFramework?.name
+  const modelArchitecture = selectedModel?.spec.modelArchitecture
+  const modelSize = selectedModel?.spec.modelParameterSize
 
   // Smart selection queries - only enabled when a model is selected
   const { data: compatibleData, isLoading: compatibleLoading } = useCompatibleRuntimes(
     modelFormat,
-    modelFramework
+    modelFramework,
+    modelArchitecture,
+    modelSize
   )
-  const { data: recommendedRuntime } = useRuntimeRecommendation(modelFormat, modelFramework)
+  const { data: recommendedRuntime } = useRuntimeRecommendation(
+    modelFormat,
+    modelFramework,
+    modelArchitecture,
+    modelSize
+  )
 
   const {
     register,
@@ -458,6 +502,11 @@ export default function DeployServicePage() {
                         {selectedModel.spec.modelFramework?.name && (
                           <span className="inline-flex items-center rounded-md bg-accent/10 text-accent px-2 py-0.5 text-xs font-medium">
                             Framework: {selectedModel.spec.modelFramework.name}
+                          </span>
+                        )}
+                        {selectedModel.spec.modelArchitecture && (
+                          <span className="inline-flex items-center rounded-md bg-muted text-muted-foreground px-2 py-0.5 text-xs font-medium">
+                            Arch: {selectedModel.spec.modelArchitecture}
                           </span>
                         )}
                         {selectedModel.spec.modelParameterSize && (

--- a/web-console/frontend/src/lib/api/runtimes.ts
+++ b/web-console/frontend/src/lib/api/runtimes.ts
@@ -12,6 +12,13 @@ export interface CompatibleRuntimesResponse {
   total: number
 }
 
+export interface RuntimeRecommendationParams {
+  format: string
+  framework?: string
+  architecture?: string
+  size?: string
+}
+
 export const runtimesApi = {
   list: async (namespace?: string): Promise<ListResponse<ClusterServingRuntime>> => {
     const params = namespace ? { namespace } : {}
@@ -44,12 +51,16 @@ export const runtimesApi = {
   },
 
   // Intelligence features
-  findCompatible: async (
-    format: string,
-    framework?: string
-  ): Promise<CompatibleRuntimesResponse> => {
+  findCompatible: async ({
+    format,
+    framework,
+    architecture,
+    size,
+  }: RuntimeRecommendationParams): Promise<CompatibleRuntimesResponse> => {
     const params: Record<string, string> = { format }
     if (framework) params.framework = framework
+    if (architecture) params.architecture = architecture
+    if (size) params.size = size
     const response = await apiClient.get<CompatibleRuntimesResponse>('/runtimes/compatible', {
       params,
     })
@@ -58,20 +69,28 @@ export const runtimesApi = {
 
   checkCompatibility: async (
     name: string,
-    format: string,
-    framework?: string
+    { format, framework, architecture, size }: RuntimeRecommendationParams
   ): Promise<CompatibilityCheck> => {
     const params: Record<string, string> = { format }
     if (framework) params.framework = framework
+    if (architecture) params.architecture = architecture
+    if (size) params.size = size
     const response = await apiClient.get<CompatibilityCheck>(`/runtimes/${name}/compatibility`, {
       params,
     })
     return response.data
   },
 
-  getRecommendation: async (format: string, framework?: string): Promise<RuntimeMatch> => {
+  getRecommendation: async ({
+    format,
+    framework,
+    architecture,
+    size,
+  }: RuntimeRecommendationParams): Promise<RuntimeMatch> => {
     const params: Record<string, string> = { format }
     if (framework) params.framework = framework
+    if (architecture) params.architecture = architecture
+    if (size) params.size = size
     const response = await apiClient.get<RuntimeMatch>('/runtimes/recommend', { params })
     return response.data
   },

--- a/web-console/frontend/src/lib/hooks/useRuntimes.ts
+++ b/web-console/frontend/src/lib/hooks/useRuntimes.ts
@@ -41,10 +41,23 @@ export function useUpdateRuntime() {
 
 // Runtime Intelligence Hooks (specialized operations not covered by factory)
 
-export function useCompatibleRuntimes(format?: string, framework?: string) {
+export function useCompatibleRuntimes(
+  format?: string,
+  framework?: string,
+  architecture?: string,
+  size?: string
+) {
   return useQuery({
-    queryKey: queryKeys.related(RESOURCE_KEY, 'compatible', 'search', format, framework),
-    queryFn: () => runtimesApi.findCompatible(format!, framework),
+    queryKey: queryKeys.related(
+      RESOURCE_KEY,
+      'compatible',
+      'search',
+      format,
+      framework,
+      architecture,
+      size
+    ),
+    queryFn: () => runtimesApi.findCompatible({ format: format!, framework, architecture, size }),
     enabled: !!format,
     staleTime: DEFAULT_QUERY_CONFIG.staleTime,
     gcTime: DEFAULT_QUERY_CONFIG.gcTime,
@@ -53,10 +66,25 @@ export function useCompatibleRuntimes(format?: string, framework?: string) {
   })
 }
 
-export function useRuntimeCompatibility(name?: string, format?: string, framework?: string) {
+export function useRuntimeCompatibility(
+  name?: string,
+  format?: string,
+  framework?: string,
+  architecture?: string,
+  size?: string
+) {
   return useQuery({
-    queryKey: queryKeys.related(RESOURCE_KEY, name || '', 'compatibility', format, framework),
-    queryFn: () => runtimesApi.checkCompatibility(name!, format!, framework),
+    queryKey: queryKeys.related(
+      RESOURCE_KEY,
+      name || '',
+      'compatibility',
+      format,
+      framework,
+      architecture,
+      size
+    ),
+    queryFn: () =>
+      runtimesApi.checkCompatibility(name!, { format: format!, framework, architecture, size }),
     enabled: !!name && !!format,
     staleTime: DEFAULT_QUERY_CONFIG.staleTime,
     gcTime: DEFAULT_QUERY_CONFIG.gcTime,
@@ -65,10 +93,23 @@ export function useRuntimeCompatibility(name?: string, format?: string, framewor
   })
 }
 
-export function useRuntimeRecommendation(format?: string, framework?: string) {
+export function useRuntimeRecommendation(
+  format?: string,
+  framework?: string,
+  architecture?: string,
+  size?: string
+) {
   return useQuery({
-    queryKey: queryKeys.related(RESOURCE_KEY, 'recommend', 'search', format, framework),
-    queryFn: () => runtimesApi.getRecommendation(format!, framework),
+    queryKey: queryKeys.related(
+      RESOURCE_KEY,
+      'recommend',
+      'search',
+      format,
+      framework,
+      architecture,
+      size
+    ),
+    queryFn: () => runtimesApi.getRecommendation({ format: format!, framework, architecture, size }),
     enabled: !!format,
     staleTime: DEFAULT_QUERY_CONFIG.staleTime,
     gcTime: DEFAULT_QUERY_CONFIG.gcTime,

--- a/web-console/frontend/src/lib/types/runtime.ts
+++ b/web-console/frontend/src/lib/types/runtime.ts
@@ -238,6 +238,7 @@ export interface RuntimeMatch {
   reasons: string[]
   warnings?: string[]
   recommendation: string
+  signals?: RuntimeSignals
 }
 
 export interface CompatibilityCheck {
@@ -251,4 +252,14 @@ export interface RuntimeValidationResult {
   valid: boolean
   errors: string[]
   warnings: string[]
+}
+
+export interface RuntimeSignals {
+  matchedFormat?: string
+  matchedFramework?: string
+  matchedArchitecture?: string
+  modelSizeRange?: string
+  runtimeFamily?: string
+  protocols?: string[]
+  autoSelectEnabled?: boolean
 }


### PR DESCRIPTION
## Summary
- fix web-console runtime recommendation parsing for nested `supportedModelFormats`
- include model architecture and model size in compatibility evaluation
- return structured recommendation signals for the deploy UI
- surface explainability details in the deploy page
- add backend tests for nested parsing, size-range rejection, and auto-select warnings

## Why
ADS recommendation flows are useful because they do not just pick an option; they explain the decision in a way users can validate and act on. This change brings that style to OME runtime selection in the web console.

## Testing
- Added backend unit tests for nested format parsing, model size range filtering, and `autoSelect: false` warnings
