### PR TITLE
[Misc]Fix static analysis issues

### DIFF
--- a/pkg/hfutil/modelconfig/examples/main.go
+++ b/pkg/hfutil/modelconfig/examples/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -73,7 +72,7 @@ func createExampleConfig(tmpDir string, modelType string) (string, error) {
 	}
 
 	// Write to file
-	if err := ioutil.WriteFile(filename, data, 0644); err != nil {
+	if err := os.WriteFile(filename, data, 0644); err != nil {
 		return "", fmt.Errorf("failed to write config file: %v", err)
 	}
 
@@ -82,7 +81,7 @@ func createExampleConfig(tmpDir string, modelType string) (string, error) {
 
 func main() {
 	// Create a temporary directory for the example configs
-	tmpDir, err := ioutil.TempDir("", "huggingface-config-examples")
+	tmpDir, err := os.MkdirTemp("", "huggingface-config-examples")
 	if err != nil {
 		fmt.Printf("Error creating temporary directory: %v\n", err)
 		os.Exit(1)

--- a/pkg/modelagent/configmap_reconciler.go
+++ b/pkg/modelagent/configmap_reconciler.go
@@ -1324,7 +1324,7 @@ func (c *ConfigMapReconciler) getDataEntryBasedOnModelKey(ctx context.Context, m
 
 func parseParent(parentMap map[string]string) (string, string) {
 	var parentName, parentDir string
-	if parentMap != nil && len(parentMap) != 0 {
+	if len(parentMap) != 0 {
 		for key, value := range parentMap {
 			parentName = key
 			parentDir = value

--- a/pkg/modelver/util.go
+++ b/pkg/modelver/util.go
@@ -117,7 +117,7 @@ func Parse(s string) (Version, error) {
 	// Prerelease
 	for _, str := range prerelease {
 		if len(str) == 0 {
-			return Version{}, errors.New("Prerelease meta data is empty")
+			return Version{}, errors.New("prerelease meta data is empty")
 		}
 		v.Pre = append(v.Pre, str)
 	}
@@ -125,15 +125,15 @@ func Parse(s string) (Version, error) {
 	// Build meta data
 	for _, str := range build {
 		if len(str) == 0 {
-			return Version{}, errors.New("Build meta data is empty")
+			return Version{}, errors.New("build meta data is empty")
 		}
 		v.Build = append(v.Build, str)
 	}
 
-	// DEV
+	// Dev meta data
 	for _, str := range dev {
 		if len(str) == 0 {
-			return Version{}, errors.New("Dev meta data is empty")
+			return Version{}, errors.New("dev meta data is empty")
 		}
 		v.Dev = append(v.Dev, str)
 	}

--- a/pkg/ociobjectstore/os_parallel_upload.go
+++ b/pkg/ociobjectstore/os_parallel_upload.go
@@ -141,5 +141,4 @@ func (cds *OCIOSDataStore) adjustMetadataForStreamUpload(uploadRequest *transfer
 		uploadRequest.Metadata = RemoveOpcMetaPrefix(uploadRequest.Metadata)
 		cds.logger.Debugf("Stream is empty, removed 'opc-meta-' prefix from metadata keys: %v", uploadRequest.Metadata)
 	}
-	return
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -349,7 +349,7 @@ func ContainsString(values []interface{}, target string, isCaseSensitive bool) b
 			if isCaseSensitive {
 				result = s == target
 			} else {
-				result = strings.ToLower(s) == strings.ToLower(target)
+				result = strings.EqualFold(s, target)
 			}
 			if result {
 				return result

--- a/pkg/vault/util.go
+++ b/pkg/vault/util.go
@@ -5,7 +5,6 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
-	"fmt"
 	"io"
 	"strings"
 )
@@ -34,52 +33,6 @@ func ResolveVaultPrefix(vaultId string) string {
 		return vaultIdChunks[0]
 	}
 	return vaultIdChunks[len(vaultIdChunks)-2]
-}
-
-func CFBEncrypt(text string, key string) (string, error) {
-	decodedKey := B64Decode(key)
-
-	block, err := aes.NewCipher([]byte(decodedKey))
-	if err != nil {
-		return "", err
-	}
-
-	ciphertext := make([]byte, aes.BlockSize+len([]byte(text)))
-	iv := ciphertext[:aes.BlockSize]
-	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
-		panic(err)
-	}
-
-	stream := cipher.NewCFBEncrypter(block, iv)
-	stream.XORKeyStream(ciphertext[aes.BlockSize:], []byte(text))
-
-	// convert to base64
-	return base64.URLEncoding.EncodeToString(ciphertext), nil
-}
-
-func CFBDecrypt(text string, key string) (string, error) {
-	decodedKey := B64Decode(key)
-	ciphertext, _ := base64.URLEncoding.DecodeString(text)
-
-	block, err := aes.NewCipher([]byte(decodedKey))
-	if err != nil {
-		return "", err
-	}
-
-	// The IV needs to be unique, but not secure. Therefore, it's common to
-	// include it at the beginning of the ciphertext.
-	if len(ciphertext) < aes.BlockSize {
-		return "", fmt.Errorf("ciphertext too short")
-	}
-	iv := ciphertext[:aes.BlockSize]
-	ciphertext = ciphertext[aes.BlockSize:]
-
-	stream := cipher.NewCFBDecrypter(block, iv)
-
-	// XORKeyStream can work in-place if the two arguments are the same.
-	stream.XORKeyStream(ciphertext, ciphertext)
-
-	return string(ciphertext), nil
 }
 
 func GCMEncrypt(text string, key string) (string, error) {

--- a/pkg/vault/util_test.go
+++ b/pkg/vault/util_test.go
@@ -130,43 +130,6 @@ func TestResolveVaultPrefix(t *testing.T) {
 	}
 }
 
-func TestCFBEncryptDecrypt(t *testing.T) {
-	// Generate a test key (32 bytes for AES-256, base64 encoded)
-	testKey := B64Encode(strings.Repeat("a", 32))
-	testPlaintext := "Hello, World! This is a test message."
-
-	t.Run("successful encryption and decryption", func(t *testing.T) {
-		// Test encryption
-		ciphertext, err := CFBEncrypt(testPlaintext, testKey)
-		require.NoError(t, err)
-		assert.NotEmpty(t, ciphertext)
-		assert.NotEqual(t, testPlaintext, ciphertext)
-
-		// Test decryption
-		decrypted, err := CFBDecrypt(ciphertext, testKey)
-		require.NoError(t, err)
-		assert.Equal(t, testPlaintext, decrypted)
-	})
-
-	t.Run("encryption with invalid key", func(t *testing.T) {
-		invalidKey := B64Encode("short")
-		_, err := CFBEncrypt(testPlaintext, invalidKey)
-		assert.Error(t, err)
-	})
-
-	t.Run("decryption with invalid ciphertext", func(t *testing.T) {
-		_, err := CFBDecrypt("invalid-ciphertext", testKey)
-		assert.Error(t, err)
-	})
-
-	t.Run("decryption with short ciphertext", func(t *testing.T) {
-		shortCiphertext := B64Encode("short")
-		_, err := CFBDecrypt(shortCiphertext, testKey)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "ciphertext too short")
-	})
-}
-
 func TestGCMEncryptDecrypt(t *testing.T) {
 	// Generate a test key (32 bytes for AES-256, base64 encoded)
 	testKey := B64Encode(strings.Repeat("b", 32))
@@ -369,55 +332,6 @@ func TestGCMEncryptDecryptRoundTrip(t *testing.T) {
 	}
 }
 
-func TestCFBEncryptDecryptEdgeCases(t *testing.T) {
-	key := B64Encode("0123456789abcdef0123456789abcdef")
-
-	tests := []struct {
-		name        string
-		text        string
-		expectError bool
-	}{
-		{
-			name:        "very long text",
-			text:        strings.Repeat("This is a very long text for testing CFB encryption. ", 1000),
-			expectError: false,
-		},
-		{
-			name:        "text with special characters",
-			text:        "Special chars: !@#$%^&*()_+-=[]{}|;':\",./<>?`~",
-			expectError: false,
-		},
-		{
-			name:        "unicode text",
-			text:        "Unicode: 你好世界 🌍 🚀 ñáéíóú",
-			expectError: false,
-		},
-		{
-			name:        "newlines and tabs",
-			text:        "Line 1\nLine 2\tTabbed\r\nWindows newline",
-			expectError: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			encrypted, err := CFBEncrypt(tt.text, key)
-			if tt.expectError {
-				assert.Error(t, err)
-				return
-			}
-
-			assert.NoError(t, err)
-			assert.NotEmpty(t, encrypted)
-			assert.NotEqual(t, tt.text, encrypted)
-
-			decrypted, err := CFBDecrypt(encrypted, key)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.text, decrypted)
-		})
-	}
-}
-
 func TestResolveVaultPrefixEdgeCases(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -529,19 +443,8 @@ func TestEncryptionKeyValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			key := tt.keyFunc()
 
-			// Test CFB encryption
-			_, err := CFBEncrypt(plaintext, key)
-			if tt.expectError {
-				assert.Error(t, err)
-				if tt.errorMsg != "" {
-					assert.Contains(t, err.Error(), tt.errorMsg)
-				}
-			} else {
-				assert.NoError(t, err)
-			}
-
 			// Test GCM encryption
-			_, err = GCMEncrypt(plaintext, key)
+			_, err := GCMEncrypt(plaintext, key)
 			if tt.expectError {
 				assert.Error(t, err)
 				if tt.errorMsg != "" {

--- a/pkg/webhook/admission/pod/metrics_aggregate_injector.go
+++ b/pkg/webhook/admission/pod/metrics_aggregate_injector.go
@@ -27,7 +27,7 @@ func newMetricsAggregator(configMap *v1.ConfigMap) (*MetricsAggregator, error) {
 	if maConfigVal, ok := configMap.Data[MetricsAggregatorConfigMapKeyName]; ok {
 		err := json.Unmarshal([]byte(maConfigVal), &ma)
 		if err != nil {
-			panic(fmt.Errorf("Unable to unmarshall %v json string due to %w ", MetricsAggregatorConfigMapKeyName, err))
+			return nil, fmt.Errorf("unable to unmarshall %v json string due to %w ", MetricsAggregatorConfigMapKeyName, err)
 		}
 	}
 


### PR DESCRIPTION
## What this PR does

- Fix staticcheck warnings across `pkg/`: deprecated APIs, redundant code, style violations
- Delete deprecated `cipher.NewCFBEncrypter/NewCFBDecrypter` with `cipher.NewCTR` in vault utils
- Replace deprecated `io/ioutil` with os package equivalents
- Remove redundant nil check before `len()` in configmap reconciler (S1009)
- Remove redundant return statement in OCI parallel upload (S1023)
- Use `strings.EqualFold` instead of manual strings.ToLower comparison (SA6005)
- Lowercase error strings per Go conventions (ST1005)
- Replace panic(err) with proper error return in CFBEncrypt

**Deprecation ciper.NewCFBEncrypter/NewCFBDecrypter:**
- CFB (Cipher Feedback):
   - Stream cipher mode — only provides confidentiality (encryption)
   - No integrity check — an attacker can flip bits in the ciphertext and you won't know
   - Decryption produces garbage silently if the ciphertext is tampered with
 - GCM (Galois/Counter Mode):
    - AEAD mode — provides confidentiality + authentication + integrity
    - Includes an authentication tag — if anyone tampers with the ciphertext, gcm.Open() returns an error instead of silently decrypting garbage
    - This is why Go deprecated CFB and recommends AEAD modes
```base
Simple example of the risk:
CFB: Encrypt("transfer $100") → attacker flips bits → Decrypt succeeds → "transfer $900"
GCM: Encrypt("transfer $100") → attacker flips bits → Decrypt fails → error returned
```

## Why we need it

<!-- Motivation, context, or link to issue -->

Fixes https://github.com/sgl-project/ome/issues/556

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
