### PR TITLE
[Misc]add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,85 @@
+default_stages: [pre-commit, pre-push, manual]
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--allow-multiple-documents, --unsafe]
+        exclude: ^deploy/helm/.*/templates/|^deploy/helm/.*/tests/|^charts/.*/templates/
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+        exclude: \.rs$
+      - id: detect-private-key
+        exclude: .*_test\.go$
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args: ['-L', 'AfterAll,NotIn,UpToDate,WithT,allReady']
+        exclude: |
+          (?x)^(
+            charts/.*/templates/.*\.yaml$|
+            config/crd/.*|
+            site/assets/.*\.svg$|
+            .*go\.sum$|
+            .*package-lock\.json$
+          )$
+
+  - repo: local
+    hooks:
+      - id: go-fmt
+        name: go fmt
+        description: Format Go code with gofmt
+        entry: gofmt -s -w .
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      - id: go-vet
+        name: go vet
+        description: Run go vet on Go packages
+        entry: go vet ./...
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      - id: helm-lint
+        name: helm lint
+        description: Lint Helm charts
+        entry: bash -c 'for chart in charts/*/; do helm lint "$chart" || exit 1; done'
+        language: system
+        always_run: true
+        pass_filenames: false
+
+      - id: branch-name-check
+        name: Branch naming convention
+        description: Ensure branch name follows <type>/<desc> or <username>/<desc> format
+        entry: |
+          bash -c '
+            branch=$(git rev-parse --abbrev-ref HEAD)
+            if [[ "$branch" != "main" && ! "$branch" =~ ^[a-z0-9]([a-z0-9._-]*[a-z0-9])?/[a-z0-9._-]+$ ]]; then
+              echo "Branch \"$branch\" does not follow naming convention: <type>/<description> or <username>/<description>"
+              exit 1
+            fi
+          '
+        language: system
+        stages: [pre-push]
+        always_run: true
+        pass_filenames: false
+
+      - id: go-mod-tidy
+        name: go mod tidy
+        description: Check that go.mod and go.sum are tidy
+        entry: bash -c 'go mod tidy && git diff --exit-code go.mod go.sum'
+        language: system
+        types: [go]
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,24 @@ When submitting a pull request:
 5. Fill out the pull request template completely. The template will guide you through providing all necessary information.
 6. Link any related issues using the "Fixes #123" syntax to automatically close them when the PR is merged.
 
+#### Pre-commit check
+**Pre-commit hooks** run these checks automatically on every commit.
+- **General Checks**: Trailing whitespace, end-of-file fixing, YAML/TOML validation, merge conflict detection, large file prevention
+- **Go Formatting**: `go-fmt`, `go-vet` with workspace-wide formatting
+- **Helm Linting**: `helm-lint` with all warnings treated as errors
+- **Spell Checking**: `codespell` for catching typos across all text files
+To set up:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+To run it:
+```bash
+pre-commit run --all-files #run all hooks on all files.
+pre-commit run go-fmt --all-files # run go-fmt hooks on all files.
+```
+
 ### PR Template
 
 It is required to classify your PR and make the commit message concise and useful. Prefix the PR title appropriately to indicate the type of change. Please use one of the following:
@@ -286,7 +304,7 @@ For VSCode or Cursor, follow these steps to set up the development environment:
    {
        "name": "OME Manager",
        "type": "go",
-       "request": "launch", 
+       "request": "launch",
        "mode": "debug",
        "program": "${workspaceFolder}/cmd/manager/main.go",
        "env": {


### PR DESCRIPTION
## What this PR does

Add pre-commit hooks configuration and document setup instructions in CONTRIBUTING.md.

**Hooks included:**

| Stage | Hook | Purpose |
|-------|------|---------|
| pre-commit | `trailing-whitespace`, `end-of-file-fixer` | Enforce consistent file formatting |
| pre-commit | `check-yaml`, `check-merge-conflict` | Catch invalid YAML and unresolved merge conflicts |
| pre-commit | `check-shebang-scripts-are-executable` | Ensure scripts with shebangs are executable |
| pre-commit | `detect-private-key` | Prevent accidental secret commits (excludes `*_test.go`) |
| pre-commit | `codespell` | Catch typos in comments and docs |
| pre-commit | `go-fmt` | Format Go code with `gofmt -s` |
| pre-commit | `go-vet` | Run `go vet ./...` for static analysis |
| pre-commit | `helm-lint` | Lint all Helm charts under `charts/` |
| pre-commit | `go-mod-tidy` | Ensure `go.mod` and `go.sum` are tidy |
| pre-push | `branch-name-check` | Enforce `<type>/<desc>` or `<user>/<desc>` branch naming |

**Excluded from checks:**
- Helm templates (`charts/*/templates/`) from YAML validation and codespell (Go templating isn't valid YAML)
- Generated CRD files (`config/crd/`) from codespell
- SVG files, `go.sum`, `package-lock.json` from codespell
- Go test files from `detect-private-key` (test fixtures contain fake keys)
- Go identifiers (`UpToDate`, `NotIn`, `WithT`, `AfterAll`, `allReady`) from codespell false positives

## Why we need it

<!-- Motivation, context, or link to issue -->

Fixes https://github.com/sgl-project/ome/issues/564

## How to test

The project currently has no local pre-commit checks, which means formatting issues, typos, and lint errors are only caught during CI or code review. Adding pre-commit hooks shifts these checks left, reducing review friction and CI failures. This is especially useful as the project grows with more contributors.

## Checklist

- [ ] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
