### PR TITLE
[Core] Surface GPU OOM errors from pod logs in InferenceService status

### DIFF
--- a/charts/ome-resources/templates/ome-controller/rbac/role.yaml
+++ b/charts/ome-resources/templates/ome-controller/rbac/role.yaml
@@ -34,6 +34,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -474,6 +474,19 @@ const (
 	StateReasonCrashLoopBackOff = "CrashLoopBackOff"
 )
 
+// Container log / termination message parsing
+var (
+	AnsiEscapeCodePattern = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+)
+
+const (
+	NotEnoughGPUMemoryMessage     = "not enough gpu memory"
+	CUDAOutOfMemoryMessage        = "cuda out of memory"
+	ModelLoadGPUOOMFailureMessage = "Model failed to load: not enough GPU memory"
+	InsufficientGPUMemoryReason   = "InsufficientGPUMemory"
+	InsufficientGPUMemoryMessage  = "Insufficient GPU memory to run the model container"
+)
+
 // CRD Kinds
 const (
 	IstioVirtualServiceKind = "VirtualService"
@@ -598,7 +611,7 @@ func GetModelsLabelWithUid(uid types.UID) string {
 
 // GetRawServiceLabel generate native service label
 func GetRawServiceLabel(service string) string {
-	return service
+	return TruncateNameWithMaxLength(service, 63)
 }
 
 func (e InferenceServiceComponent) String() string {

--- a/pkg/constants/constants_test.go
+++ b/pkg/constants/constants_test.go
@@ -1,1 +1,31 @@
 package constants
+
+import "testing"
+
+func TestGetRawServiceLabel(t *testing.T) {
+	tests := []struct {
+		name    string
+		service string
+		want    string
+	}{
+		{
+			name:    "short name unchanged",
+			service: "test-isvc-engine",
+			want:    "test-isvc-engine",
+		},
+		{
+			name:    "long name matches truncation helper",
+			service: "amaaaaaabgjpxjqa4tzjnvnaeioaw6ewzj5uevu2qlj6ii6vknafdarwgmfq-engine",
+			want:    TruncateNameWithMaxLength("a5b5c2cf-jqa4tzjnvnaeioaw6ewzj5uevu2qlj6ii6vknafdarwgmfq-engine", 63),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetRawServiceLabel(tt.service)
+			if got != tt.want {
+				t.Fatalf("GetRawServiceLabel(%q) = %q, want %q", tt.service, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -494,7 +494,7 @@ func UpdateComponentStatus(b *BaseComponentFields, isvc *v1beta1.InferenceServic
 	if err != nil {
 		return errors.Wrapf(err, "failed to list %s pods by label", componentType)
 	}
-	b.StatusManager.PropagateModelStatus(&isvc.Status, statusSpec, pods, rawDeployment)
+	b.StatusManager.PropagateModelStatus(&isvc.Status, componentType, statusSpec, pods, rawDeployment)
 
 	return nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/builder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/builder.go
@@ -88,6 +88,7 @@ func (b *ComponentBuilder) WithSupportedModelFormat(format *v1beta1.SupportedMod
 
 // buildBaseFields creates the common base fields
 func (b *ComponentBuilder) buildBaseFields() BaseComponentFields {
+	statusManager := status.NewStatusReconciler(b.clientset).WithLogger(b.logger.WithName("InferenceServiceStatus"))
 	return BaseComponentFields{
 		Client:                 b.client,
 		Clientset:              b.clientset,
@@ -98,7 +99,7 @@ func (b *ComponentBuilder) buildBaseFields() BaseComponentFields {
 		BaseModelMeta:          b.baseModelMeta,
 		Runtime:                b.runtime,
 		RuntimeName:            b.runtimeName,
-		StatusManager:          status.NewStatusReconciler(),
+		StatusManager:          statusManager,
 		Log:                    b.logger,
 	}
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/decoder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder.go
@@ -49,6 +49,8 @@ func NewDecoder(
 	acceleratorClass *v1beta1.AcceleratorClassSpec,
 	acceleratorClassName string,
 ) Component {
+	logger := ctrl.Log.WithName("DecoderReconciler")
+	statusManager := status.NewStatusReconciler(clientset).WithLogger(logger.WithName("InferenceServiceStatus"))
 	base := BaseComponentFields{
 		Client:                 client,
 		Clientset:              clientset,
@@ -59,8 +61,8 @@ func NewDecoder(
 		BaseModelMeta:          baseModelMeta,
 		Runtime:                runtime,
 		RuntimeName:            runtimeName,
-		StatusManager:          status.NewStatusReconciler(),
-		Log:                    ctrl.Log.WithName("DecoderReconciler"),
+		StatusManager:          statusManager,
+		Log:                    logger,
 		AcceleratorClass:       acceleratorClass,
 		AcceleratorClassName:   acceleratorClassName,
 		SupportedModelFormat:   supportedModelFormat,

--- a/pkg/controller/v1beta1/inferenceservice/components/engine.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine.go
@@ -50,6 +50,8 @@ func NewEngine(
 	acceleratorClass *v1beta1.AcceleratorClassSpec,
 	acceleratorClassName string,
 ) Component {
+	logger := ctrl.Log.WithName("EngineReconciler")
+	statusManager := status.NewStatusReconciler(clientset).WithLogger(logger.WithName("InferenceServiceStatus"))
 	base := BaseComponentFields{
 		Client:                 client,
 		Clientset:              clientset,
@@ -60,8 +62,8 @@ func NewEngine(
 		BaseModelMeta:          baseModelMeta,
 		Runtime:                runtime,
 		RuntimeName:            runtimeName,
-		StatusManager:          status.NewStatusReconciler(),
-		Log:                    ctrl.Log.WithName("EngineReconciler"),
+		StatusManager:          statusManager,
+		Log:                    logger,
 		AcceleratorClass:       acceleratorClass,
 		AcceleratorClassName:   acceleratorClassName,
 		SupportedModelFormat:   supportedModelFormat,

--- a/pkg/controller/v1beta1/inferenceservice/components/router.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/router.go
@@ -47,6 +47,8 @@ func NewRouter(
 	runtime *v1beta1.ServingRuntimeSpec,
 	runtimeName string,
 ) Component {
+	logger := ctrl.Log.WithName("RouterReconciler")
+	statusManager := status.NewStatusReconciler(clientset).WithLogger(logger.WithName("InferenceServiceStatus"))
 	base := BaseComponentFields{
 		Client:                 client,
 		Clientset:              clientset,
@@ -57,8 +59,8 @@ func NewRouter(
 		BaseModelMeta:          baseModelMeta,
 		Runtime:                runtime,
 		RuntimeName:            runtimeName,
-		StatusManager:          status.NewStatusReconciler(),
-		Log:                    ctrl.Log.WithName("RouterReconciler"),
+		StatusManager:          statusManager,
+		Log:                    logger,
 	}
 
 	return &Router{

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -78,6 +78,7 @@ import (
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
@@ -619,7 +620,7 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 	r.ClientConfig = mgr.GetConfig()
 
 	// NEW: Initialize StatusReconciler
-	r.StatusManager = status.NewStatusReconciler()
+	r.StatusManager = status.NewStatusReconciler(r.Clientset)
 
 	// Initialize RuntimeSelector
 	r.RuntimeSelector = runtimeselector.New(mgr.GetClient())

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -724,7 +724,7 @@ func TestInferenceServiceReconcile(t *testing.T) {
 				Log:                      ctrl.Log.WithName("test"),
 				Scheme:                   scheme,
 				Recorder:                 recorder,
-				StatusManager:            status.NewStatusReconciler(),
+				StatusManager:            status.NewStatusReconciler(nil),
 				RuntimeSelector:          runtimeselector.New(c),
 				AcceleratorClassSelector: acceleratorclassselector.New(c),
 			}

--- a/pkg/controller/v1beta1/inferenceservice/status/status_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_reconciler.go
@@ -3,10 +3,13 @@ package status
 import (
 	"reflect"
 
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	lwsspec "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
@@ -20,11 +23,27 @@ const (
 )
 
 // StatusReconciler handles all status-related operations for InferenceService
-type StatusReconciler struct{}
+type StatusReconciler struct {
+	Clientset     kubernetes.Interface
+	Log           logr.Logger
+	podLogFetcher func(namespace, podName, containerName string, previous bool) (string, error)
+}
 
-// NewStatusReconciler creates a new StatusReconciler instance
-func NewStatusReconciler() *StatusReconciler {
-	return &StatusReconciler{}
+// NewStatusReconciler creates a new StatusReconciler instance.
+// Pass a nil clientset when Kubernetes log fetching is not needed.
+func NewStatusReconciler(clientset kubernetes.Interface) *StatusReconciler {
+	reconciler := &StatusReconciler{
+		Clientset: clientset,
+		Log:       logf.Log.WithName("InferenceServiceStatus"),
+	}
+	reconciler.podLogFetcher = reconciler.fetchPodLogs
+	return reconciler
+}
+
+// WithLogger overrides the default logger and returns the reconciler for chaining.
+func (sr *StatusReconciler) WithLogger(log logr.Logger) *StatusReconciler {
+	sr.Log = log
+	return sr
 }
 
 // PropagateRawStatus propagates status from raw Kubernetes deployment
@@ -147,10 +166,10 @@ func (sr *StatusReconciler) PropagateStatus(
 // PropagateModelStatus propagates model status from pod information
 func (sr *StatusReconciler) PropagateModelStatus(
 	status *v1beta1.InferenceServiceStatus,
+	component v1beta1.ComponentType,
 	statusSpec v1beta1.ComponentStatusSpec,
 	podList *v1.PodList,
 	rawDeployment bool) {
-
 	// Check at least one pod is running for the latest revision of inferenceservice
 	totalCopies := len(podList.Items)
 	if totalCopies == 0 {
@@ -177,7 +196,7 @@ func (sr *StatusReconciler) PropagateModelStatus(
 	}
 
 	// Check container statuses
-	sr.checkContainerStatuses(status, firstPod, totalCopies)
+	sr.checkContainerStatuses(status, component, firstPod, totalCopies)
 }
 
 // UpdateModelRevisionStates updates the model revision states

--- a/pkg/controller/v1beta1/inferenceservice/status/status_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_reconciler.go
@@ -21,7 +21,7 @@ const (
 	RoutesReadyCondition         = "RoutesReady"
 	ConfigurationsReadyCondition = "ConfigurationsReady"
 	defaultPodLogTailLines       = int64(200)
-	defaultPodLogLimitBytes      = int64(256 * 1024)
+	defaultPodLogLimitBytes      = int64(32 * 1024)
 )
 
 // StatusReconciler handles all status-related operations for InferenceService

--- a/pkg/controller/v1beta1/inferenceservice/status/status_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_reconciler.go
@@ -20,29 +20,48 @@ const (
 	FullTrafficPercent           = 100
 	RoutesReadyCondition         = "RoutesReady"
 	ConfigurationsReadyCondition = "ConfigurationsReady"
+	defaultPodLogTailLines       = int64(200)
+	defaultPodLogLimitBytes      = int64(256 * 1024)
 )
 
 // StatusReconciler handles all status-related operations for InferenceService
 type StatusReconciler struct {
-	Clientset     kubernetes.Interface
-	Log           logr.Logger
-	podLogFetcher func(namespace, podName, containerName string, previous bool) (string, error)
+	Clientset        kubernetes.Interface
+	Log              logr.Logger
+	podLogFetcher    func(namespace, podName, containerName string, previous bool) (string, error)
+	podLogTailLines  int64
+	podLogLimitBytes int64
 }
 
 // NewStatusReconciler creates a new StatusReconciler instance.
 // Pass a nil clientset when Kubernetes log fetching is not needed.
 func NewStatusReconciler(clientset kubernetes.Interface) *StatusReconciler {
 	reconciler := &StatusReconciler{
-		Clientset: clientset,
-		Log:       logf.Log.WithName("InferenceServiceStatus"),
+		Clientset:        clientset,
+		Log:              logf.Log.WithName("InferenceServiceStatus"),
+		podLogTailLines:  defaultPodLogTailLines,
+		podLogLimitBytes: defaultPodLogLimitBytes,
 	}
-	reconciler.podLogFetcher = reconciler.fetchPodLogs
+	if clientset != nil {
+		reconciler.podLogFetcher = reconciler.fetchPodLogs
+	}
 	return reconciler
 }
 
 // WithLogger overrides the default logger and returns the reconciler for chaining.
 func (sr *StatusReconciler) WithLogger(log logr.Logger) *StatusReconciler {
 	sr.Log = log
+	return sr
+}
+
+// WithPodLogFetchLimits overrides the default pod log fetch bounds used for failure inspection.
+func (sr *StatusReconciler) WithPodLogFetchLimits(tailLines, limitBytes int64) *StatusReconciler {
+	if tailLines > 0 {
+		sr.podLogTailLines = tailLines
+	}
+	if limitBytes > 0 {
+		sr.podLogLimitBytes = limitBytes
+	}
 	return sr
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/status/status_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_reconciler.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,6 +23,7 @@ const (
 	ConfigurationsReadyCondition = "ConfigurationsReady"
 	defaultPodLogTailLines       = int64(200)
 	defaultPodLogLimitBytes      = int64(32 * 1024)
+	defaultPodLogFetchTimeout    = 2 * time.Second
 )
 
 // StatusReconciler handles all status-related operations for InferenceService

--- a/pkg/controller/v1beta1/inferenceservice/status/status_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -21,6 +22,26 @@ func TestNewStatusReconciler(t *testing.T) {
 	manager := NewStatusReconciler(nil)
 
 	assert.NotNil(t, manager)
+	assert.Equal(t, defaultPodLogTailLines, manager.podLogTailLines)
+	assert.Equal(t, defaultPodLogLimitBytes, manager.podLogLimitBytes)
+	assert.Nil(t, manager.podLogFetcher)
+}
+
+func TestNewStatusReconcilerWithClientsetInitializesPodLogFetcher(t *testing.T) {
+	manager := NewStatusReconciler(fake.NewSimpleClientset())
+
+	assert.NotNil(t, manager.podLogFetcher)
+}
+
+func TestStatusReconcilerWithPodLogFetchLimits(t *testing.T) {
+	manager := NewStatusReconciler(nil).WithPodLogFetchLimits(512, 1024)
+
+	assert.Equal(t, int64(512), manager.podLogTailLines)
+	assert.Equal(t, int64(1024), manager.podLogLimitBytes)
+
+	manager = NewStatusReconciler(nil).WithPodLogFetchLimits(0, -1)
+	assert.Equal(t, defaultPodLogTailLines, manager.podLogTailLines)
+	assert.Equal(t, defaultPodLogLimitBytes, manager.podLogLimitBytes)
 }
 
 func TestPropagateRawStatus(t *testing.T) {

--- a/pkg/controller/v1beta1/inferenceservice/status/status_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_reconciler_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestNewStatusReconciler(t *testing.T) {
-	manager := NewStatusReconciler()
+	manager := NewStatusReconciler(nil)
 
 	assert.NotNil(t, manager)
 }
@@ -222,7 +222,7 @@ func TestPropagateRawStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 
 			manager.PropagateRawStatus(tt.status, tt.component, tt.deployment, tt.url)
 
@@ -420,7 +420,7 @@ func TestPropagateMultiNodeStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 
 			manager.PropagateMultiNodeStatus(tt.status, tt.component, tt.lws, tt.url)
 
@@ -606,7 +606,7 @@ func TestPropagateStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 
 			manager.PropagateStatus(tt.status, tt.component, tt.serviceStatus)
 
@@ -722,9 +722,9 @@ func TestPropagateModelStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 
-			manager.PropagateModelStatus(tt.status, tt.statusSpec, tt.podList, tt.rawDeployment)
+			manager.PropagateModelStatus(tt.status, v1beta1.PredictorComponent, tt.statusSpec, tt.podList, tt.rawDeployment)
 
 			if tt.status.ModelStatus.ModelRevisionStates != nil {
 				assert.Equal(t, tt.expectedState, tt.status.ModelStatus.ModelRevisionStates.TargetModelState)
@@ -770,7 +770,7 @@ func TestUpdateModelRevisionStates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 
 			manager.UpdateModelRevisionStates(tt.status, tt.modelState, tt.totalCopies, tt.info)
 
@@ -809,7 +809,7 @@ func TestUpdateModelTransitionStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 
 			manager.UpdateModelTransitionStatus(tt.status, tt.transitionStatus, tt.info)
 
@@ -913,7 +913,7 @@ func TestPropagateCrossComponentStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			tt.setupStatus(tt.status)
 
 			manager.PropagateCrossComponentStatus(tt.status, tt.componentList, tt.conditionType)
@@ -970,7 +970,7 @@ func TestSetModelFailureInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 
 			changed := manager.SetModelFailureInfo(tt.status, tt.info)
 
@@ -1254,7 +1254,7 @@ func TestPropagateMultiNodeRayVLLMStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 
 			manager.PropagateMultiNodeRayVLLMStatus(tt.status, tt.component, tt.deployments, tt.url)
 

--- a/pkg/controller/v1beta1/inferenceservice/status/status_util.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_util.go
@@ -381,9 +381,13 @@ func (sr *StatusReconciler) fetchPodLogs(namespace, podName, containerName strin
 		"container", containerName,
 		"previous", previous)
 
+	tailLines := sr.podLogTailLines
+	limitBytes := sr.podLogLimitBytes
 	req := sr.Clientset.CoreV1().Pods(namespace).GetLogs(podName, &v1.PodLogOptions{
-		Container: containerName,
-		Previous:  previous,
+		Container:  containerName,
+		Previous:   previous,
+		TailLines:  &tailLines,
+		LimitBytes: &limitBytes,
 	})
 	logStream, err := req.Stream(context.Background())
 	if err != nil {

--- a/pkg/controller/v1beta1/inferenceservice/status/status_util.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_util.go
@@ -1,7 +1,10 @@
 package status
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -142,7 +145,7 @@ func (sr *StatusReconciler) InitializeComponentCondition(status *v1beta1.Inferen
 	readyCondition := sr.getReadyConditionsMap()[component]
 
 	// Only initialize if the condition doesn't exist yet
-	if !status.IsConditionReady(readyCondition) && !status.IsConditionUnknown(readyCondition) {
+	if status.GetCondition(readyCondition) == nil {
 		condition := &apis.Condition{
 			Type:    readyCondition,
 			Status:  v1.ConditionFalse,
@@ -259,7 +262,7 @@ func (sr *StatusReconciler) propagateServiceConditions(
 }
 
 // checkContainerStatuses checks the status of containers in a pod
-func (sr *StatusReconciler) checkContainerStatuses(status *v1beta1.InferenceServiceStatus, firstPod *v1.Pod, totalCopies int) {
+func (sr *StatusReconciler) checkContainerStatuses(status *v1beta1.InferenceServiceStatus, component v1beta1.ComponentType, firstPod *v1.Pod, totalCopies int) {
 	// Update model state to 'Loading' if storage initializer is running.
 	// If the storage initializer is terminated due to error or crashloopbackoff, update model
 	// state to 'ModelLoadFailed' with failure info.
@@ -276,6 +279,7 @@ func (sr *StatusReconciler) checkContainerStatuses(status *v1beta1.InferenceServ
 					Message:  message,
 					ExitCode: exitCode,
 				})
+				sr.updateComponentFailureCondition(status, component, message)
 				return
 			case cs.State.Waiting != nil && cs.State.Waiting.Reason == constants.StateReasonCrashLoopBackOff:
 				message, exitCode, hasTermination := sr.safeGetTerminationMessage(cs)
@@ -285,6 +289,7 @@ func (sr *StatusReconciler) checkContainerStatuses(status *v1beta1.InferenceServ
 						Message:  message,
 						ExitCode: exitCode,
 					})
+					sr.updateComponentFailureCondition(status, component, message)
 				}
 				return
 			}
@@ -297,20 +302,22 @@ func (sr *StatusReconciler) checkContainerStatuses(status *v1beta1.InferenceServ
 		if cs.Name == constants.MainContainerName {
 			switch {
 			case cs.State.Terminated != nil && cs.State.Terminated.Reason == constants.StateReasonError:
-				message, exitCode, _ := sr.safeGetTerminationMessage(cs)
+				message, exitCode, _ := sr.getContainerFailureMessage(firstPod, cs)
 				sr.UpdateModelRevisionStates(status, v1beta1.FailedToLoad, totalCopies, &v1beta1.FailureInfo{
 					Reason:   v1beta1.ModelLoadFailed,
 					Message:  message,
 					ExitCode: exitCode,
 				})
+				sr.updateComponentFailureCondition(status, component, message)
 			case cs.State.Waiting != nil && cs.State.Waiting.Reason == constants.StateReasonCrashLoopBackOff:
-				message, exitCode, hasTermination := sr.safeGetTerminationMessage(cs)
+				message, exitCode, hasTermination := sr.getContainerFailureMessage(firstPod, cs)
 				if hasTermination {
 					sr.UpdateModelRevisionStates(status, v1beta1.FailedToLoad, totalCopies, &v1beta1.FailureInfo{
 						Reason:   v1beta1.ModelLoadFailed,
 						Message:  message,
 						ExitCode: exitCode,
 					})
+					sr.updateComponentFailureCondition(status, component, message)
 				} else {
 					sr.UpdateModelRevisionStates(status, v1beta1.Pending, totalCopies, nil)
 				}
@@ -324,12 +331,99 @@ func (sr *StatusReconciler) checkContainerStatuses(status *v1beta1.InferenceServ
 // safeGetTerminationMessage safely extracts termination message from container status
 func (sr *StatusReconciler) safeGetTerminationMessage(cs v1.ContainerStatus) (message string, exitCode int32, hasTermination bool) {
 	if cs.State.Terminated != nil {
-		return cs.State.Terminated.Message, cs.State.Terminated.ExitCode, true
+		return normalizeFailureMessage(cs.State.Terminated.Message), cs.State.Terminated.ExitCode, true
 	}
 	if cs.State.Waiting != nil && cs.State.Waiting.Reason == constants.StateReasonCrashLoopBackOff {
 		if cs.LastTerminationState.Terminated != nil {
-			return cs.LastTerminationState.Terminated.Message, cs.LastTerminationState.Terminated.ExitCode, true
+			return normalizeFailureMessage(cs.LastTerminationState.Terminated.Message), cs.LastTerminationState.Terminated.ExitCode, true
 		}
 	}
 	return "", 0, false
+}
+
+func (sr *StatusReconciler) getContainerFailureMessage(pod *v1.Pod, cs v1.ContainerStatus) (message string, exitCode int32, hasTermination bool) {
+	message, exitCode, hasTermination = sr.safeGetTerminationMessage(cs)
+	if message == constants.ModelLoadGPUOOMFailureMessage {
+		return message, exitCode, true
+	}
+
+	if pod == nil || sr.podLogFetcher == nil {
+		return message, exitCode, hasTermination
+	}
+
+	previous := cs.State.Waiting != nil && cs.State.Waiting.Reason == constants.StateReasonCrashLoopBackOff
+	logs, err := sr.podLogFetcher(pod.Namespace, pod.Name, cs.Name, previous)
+	if err != nil {
+		sr.Log.Error(err, "Failed to fetch pod logs for failure inspection",
+			"pod", pod.Name,
+			"namespace", pod.Namespace,
+			"container", cs.Name,
+			"previous", previous)
+		return message, exitCode, hasTermination
+	}
+
+	normalizedLogMessage := normalizeFailureMessage(logs)
+	if normalizedLogMessage == constants.ModelLoadGPUOOMFailureMessage {
+		return normalizedLogMessage, exitCode, true
+	}
+
+	return message, exitCode, hasTermination
+}
+
+func (sr *StatusReconciler) fetchPodLogs(namespace, podName, containerName string, previous bool) (string, error) {
+	if sr.Clientset == nil {
+		return "", fmt.Errorf("clientset is not configured")
+	}
+
+	sr.Log.Info("Requesting pod logs",
+		"namespace", namespace,
+		"pod", podName,
+		"container", containerName,
+		"previous", previous)
+
+	req := sr.Clientset.CoreV1().Pods(namespace).GetLogs(podName, &v1.PodLogOptions{
+		Container: containerName,
+		Previous:  previous,
+	})
+	logStream, err := req.Stream(context.Background())
+	if err != nil {
+		return "", err
+	}
+	defer logStream.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(logStream)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func normalizeFailureMessage(message string) string {
+	cleaned := strings.TrimSpace(constants.AnsiEscapeCodePattern.ReplaceAllString(message, ""))
+	if cleaned == "" {
+		return ""
+	}
+
+	lowerMessage := strings.ToLower(cleaned)
+	if strings.Contains(lowerMessage, constants.NotEnoughGPUMemoryMessage) || strings.Contains(lowerMessage, constants.CUDAOutOfMemoryMessage) {
+		return constants.ModelLoadGPUOOMFailureMessage
+	}
+
+	return cleaned
+}
+
+func (sr *StatusReconciler) updateComponentFailureCondition(status *v1beta1.InferenceServiceStatus, component v1beta1.ComponentType, message string) {
+	if message != constants.ModelLoadGPUOOMFailureMessage {
+		return
+	}
+
+	readyCondition := sr.getReadyConditionsMap()[component]
+	sr.setCondition(status, readyCondition, &apis.Condition{
+		Type:    readyCondition,
+		Status:  v1.ConditionFalse,
+		Reason:  constants.InsufficientGPUMemoryReason,
+		Message: constants.InsufficientGPUMemoryMessage,
+	})
 }

--- a/pkg/controller/v1beta1/inferenceservice/status/status_util.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_util.go
@@ -389,7 +389,10 @@ func (sr *StatusReconciler) fetchPodLogs(namespace, podName, containerName strin
 		TailLines:  &tailLines,
 		LimitBytes: &limitBytes,
 	})
-	logStream, err := req.Stream(context.Background())
+	streamCtx, cancel := context.WithTimeout(context.Background(), defaultPodLogFetchTimeout)
+	defer cancel()
+
+	logStream, err := req.Stream(streamCtx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controller/v1beta1/inferenceservice/status/status_util_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_util_test.go
@@ -1,9 +1,11 @@
 package status
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,10 +80,70 @@ func TestInitializeComponentStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			result := manager.initializeComponentStatus(tt.status, tt.component)
 			assert.Equal(t, tt.expected, result)
 			assert.NotNil(t, tt.status.Components)
+		})
+	}
+}
+
+func TestInitializeComponentCondition(t *testing.T) {
+	tests := []struct {
+		name              string
+		initialCondition  *apis.Condition
+		expectedReason    string
+		expectedMessage   string
+		expectedCondition corev1.ConditionStatus
+	}{
+		{
+			name:              "initialize missing condition",
+			initialCondition:  nil,
+			expectedReason:    "Initializing",
+			expectedMessage:   "engine component initializing",
+			expectedCondition: corev1.ConditionFalse,
+		},
+		{
+			name: "preserve existing failure condition",
+			initialCondition: &apis.Condition{
+				Type:    v1beta1.EngineReady,
+				Status:  corev1.ConditionFalse,
+				Reason:  constants.InsufficientGPUMemoryReason,
+				Message: constants.InsufficientGPUMemoryMessage,
+			},
+			expectedReason:    constants.InsufficientGPUMemoryReason,
+			expectedMessage:   constants.InsufficientGPUMemoryMessage,
+			expectedCondition: corev1.ConditionFalse,
+		},
+		{
+			name: "preserve existing ready condition",
+			initialCondition: &apis.Condition{
+				Type:    v1beta1.EngineReady,
+				Status:  corev1.ConditionTrue,
+				Reason:  "MinimumReplicasAvailable",
+				Message: "Deployment has minimum availability.",
+			},
+			expectedReason:    "MinimumReplicasAvailable",
+			expectedMessage:   "Deployment has minimum availability.",
+			expectedCondition: corev1.ConditionTrue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewStatusReconciler(nil)
+			status := &v1beta1.InferenceServiceStatus{}
+			if tt.initialCondition != nil {
+				status.SetCondition(v1beta1.EngineReady, tt.initialCondition)
+			}
+
+			manager.InitializeComponentCondition(status, v1beta1.EngineComponent)
+
+			engineReady := status.GetCondition(v1beta1.EngineReady)
+			require.NotNil(t, engineReady)
+			assert.Equal(t, tt.expectedCondition, engineReady.Status)
+			assert.Equal(t, tt.expectedReason, engineReady.Reason)
+			assert.Equal(t, tt.expectedMessage, engineReady.Message)
 		})
 	}
 }
@@ -118,7 +180,7 @@ func TestGetFirstPod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			pod, err := manager.getFirstPod(tt.podList)
 
 			if tt.expectError {
@@ -163,7 +225,7 @@ func TestGetFirstDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			deployment, err := manager.getFirstDeployment(tt.deployments)
 
 			if tt.expectError {
@@ -272,7 +334,7 @@ func TestGetDeploymentCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			result := manager.getDeploymentCondition(tt.deployment, tt.conditionType)
 
 			assert.Equal(t, tt.expected.Type, result.Type)
@@ -355,7 +417,7 @@ func TestGetLWSConditions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			result := manager.getLWSConditions(tt.lws, tt.conditionType)
 
 			assert.Equal(t, tt.expected.Type, result.Type)
@@ -482,7 +544,7 @@ func TestGetMultiDeploymentCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			result := manager.getMultiDeploymentCondition(tt.deployments, tt.conditionType)
 
 			assert.Equal(t, tt.expected.Type, result.Type)
@@ -557,7 +619,7 @@ func TestSetCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			manager.setCondition(tt.status, tt.conditionType, tt.condition)
 
 			if tt.shouldSet {
@@ -572,7 +634,7 @@ func TestSetCondition(t *testing.T) {
 }
 
 func TestGetReadyConditionsMap(t *testing.T) {
-	manager := NewStatusReconciler()
+	manager := NewStatusReconciler(nil)
 	conditionsMap := manager.getReadyConditionsMap()
 
 	assert.NotNil(t, conditionsMap)
@@ -582,7 +644,7 @@ func TestGetReadyConditionsMap(t *testing.T) {
 }
 
 func TestGetRouteConditionsMap(t *testing.T) {
-	manager := NewStatusReconciler()
+	manager := NewStatusReconciler(nil)
 	conditionsMap := manager.getRouteConditionsMap()
 
 	assert.NotNil(t, conditionsMap)
@@ -592,7 +654,7 @@ func TestGetRouteConditionsMap(t *testing.T) {
 }
 
 func TestGetConfigurationConditionsMap(t *testing.T) {
-	manager := NewStatusReconciler()
+	manager := NewStatusReconciler(nil)
 	conditionsMap := manager.getConfigurationConditionsMap()
 
 	assert.NotNil(t, conditionsMap)
@@ -602,7 +664,7 @@ func TestGetConfigurationConditionsMap(t *testing.T) {
 }
 
 func TestGetConditionsMapIndex(t *testing.T) {
-	manager := NewStatusReconciler()
+	manager := NewStatusReconciler(nil)
 	conditionsMapIndex := manager.getConditionsMapIndex()
 
 	assert.NotNil(t, conditionsMapIndex)
@@ -671,7 +733,7 @@ func TestHandleTrafficRouting(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			manager.handleTrafficRouting(tt.statusSpec, tt.serviceStatus, tt.revisionTraffic)
 
 			assert.Equal(t, tt.expectedLatest, tt.statusSpec.LatestRolledoutRevision)
@@ -733,7 +795,7 @@ func TestPropagateServiceConditions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			statusSpec := v1beta1.ComponentStatusSpec{}
 
 			manager.propagateServiceConditions(tt.status, tt.component, tt.serviceStatus, &statusSpec)
@@ -755,6 +817,7 @@ func TestCheckContainerStatuses(t *testing.T) {
 		pod           *corev1.Pod
 		totalCopies   int
 		expectedState v1beta1.ModelState
+		expectedError string
 	}{
 		{
 			name:   "storage initializer running",
@@ -775,7 +838,7 @@ func TestCheckContainerStatuses(t *testing.T) {
 			expectedState: v1beta1.Loading,
 		},
 		{
-			name:   "storage initializer terminated with error",
+			name:   "storage initializer terminated with gpu oom error",
 			status: &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}},
 			pod: &corev1.Pod{
 				Status: corev1.PodStatus{
@@ -785,7 +848,7 @@ func TestCheckContainerStatuses(t *testing.T) {
 							State: corev1.ContainerState{
 								Terminated: &corev1.ContainerStateTerminated{
 									Reason:   constants.StateReasonError,
-									Message:  "Failed to download model",
+									Message:  "CUDA error: not enough GPU memory to load model",
 									ExitCode: 1,
 								},
 							},
@@ -795,6 +858,7 @@ func TestCheckContainerStatuses(t *testing.T) {
 			},
 			totalCopies:   1,
 			expectedState: v1beta1.FailedToLoad,
+			expectedError: "Model failed to load: not enough GPU memory",
 		},
 		{
 			name:   "storage initializer crash loop back off",
@@ -912,14 +976,337 @@ func TestCheckContainerStatuses(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
-			manager.checkContainerStatuses(tt.status, tt.pod, tt.totalCopies)
+			manager := NewStatusReconciler(nil)
+			manager.checkContainerStatuses(tt.status, v1beta1.EngineComponent, tt.pod, tt.totalCopies)
 
 			if tt.status.ModelStatus.ModelRevisionStates != nil {
 				assert.Equal(t, tt.expectedState, tt.status.ModelStatus.ModelRevisionStates.TargetModelState)
 			}
+			if tt.expectedError != "" {
+				require.NotNil(t, tt.status.ModelStatus.LastFailureInfo)
+				assert.Equal(t, tt.expectedError, tt.status.ModelStatus.LastFailureInfo.Message)
+				engineReady := tt.status.GetCondition(v1beta1.EngineReady)
+				require.NotNil(t, engineReady)
+				assert.Equal(t, corev1.ConditionFalse, engineReady.Status)
+				assert.Equal(t, constants.InsufficientGPUMemoryReason, engineReady.Reason)
+				assert.Equal(t, constants.InsufficientGPUMemoryMessage, engineReady.Message)
+				ready := tt.status.GetCondition(apis.ConditionReady)
+				require.NotNil(t, ready)
+				assert.Equal(t, corev1.ConditionFalse, ready.Status)
+			}
 		})
 	}
+}
+
+func TestCheckContainerStatusesUsesPodLogsForGPUOOM(t *testing.T) {
+	manager := NewStatusReconciler(nil)
+	manager.podLogFetcher = func(namespace, podName, containerName string, previous bool) (string, error) {
+		assert.Equal(t, "default", namespace)
+		assert.Equal(t, "test-pod", podName)
+		assert.Equal(t, constants.MainContainerName, containerName)
+		assert.True(t, previous)
+		return "\u001b[0;36m(APIServer pid=1)\u001b[0;0m RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}\n" +
+			"\u001b[0;36m(Worker_TP0_EP0 pid=544)\u001b[0;0m ERROR Failed to load model - not enough GPU memory.", nil
+	}
+
+	status := &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: constants.MainContainerName,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: constants.StateReasonCrashLoopBackOff,
+						},
+					},
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Message:  "RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}",
+							ExitCode: 1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	manager.checkContainerStatuses(status, v1beta1.EngineComponent, pod, 1)
+
+	require.NotNil(t, status.ModelStatus.ModelRevisionStates)
+	assert.Equal(t, v1beta1.FailedToLoad, status.ModelStatus.ModelRevisionStates.TargetModelState)
+	require.NotNil(t, status.ModelStatus.LastFailureInfo)
+	assert.Equal(t, constants.ModelLoadGPUOOMFailureMessage, status.ModelStatus.LastFailureInfo.Message)
+	assert.Equal(t, int32(1), status.ModelStatus.LastFailureInfo.ExitCode)
+	engineReady := status.GetCondition(v1beta1.EngineReady)
+	require.NotNil(t, engineReady)
+	assert.Equal(t, corev1.ConditionFalse, engineReady.Status)
+	assert.Equal(t, constants.InsufficientGPUMemoryReason, engineReady.Reason)
+	assert.Equal(t, constants.InsufficientGPUMemoryMessage, engineReady.Message)
+	ready := status.GetCondition(apis.ConditionReady)
+	require.NotNil(t, ready)
+	assert.Equal(t, corev1.ConditionFalse, ready.Status)
+}
+
+func TestCheckContainerStatusesDoesNotUsePodLogsForStorageInitializer(t *testing.T) {
+	manager := NewStatusReconciler(nil)
+	fetcherCalls := 0
+	manager.podLogFetcher = func(namespace, podName, containerName string, previous bool) (string, error) {
+		fetcherCalls++
+		return constants.ModelLoadGPUOOMFailureMessage, nil
+	}
+
+	status := &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: constants.StorageInitializerContainerName,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   constants.StateReasonError,
+							Message:  "failed to download model",
+							ExitCode: 2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	manager.checkContainerStatuses(status, v1beta1.EngineComponent, pod, 1)
+
+	assert.Equal(t, 0, fetcherCalls)
+	require.NotNil(t, status.ModelStatus.ModelRevisionStates)
+	assert.Equal(t, v1beta1.FailedToLoad, status.ModelStatus.ModelRevisionStates.TargetModelState)
+	require.NotNil(t, status.ModelStatus.LastFailureInfo)
+	assert.Equal(t, "failed to download model", status.ModelStatus.LastFailureInfo.Message)
+	engineReady := status.GetCondition(v1beta1.EngineReady)
+	if engineReady != nil {
+		assert.NotEqual(t, constants.InsufficientGPUMemoryReason, engineReady.Reason)
+	}
+}
+
+func TestCheckContainerStatusesDoesNotSetComponentFailureConditionForNonGPUOOM(t *testing.T) {
+	manager := NewStatusReconciler(nil)
+	status := &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}}
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: constants.MainContainerName,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   constants.StateReasonError,
+							Message:  "generic startup failure",
+							ExitCode: 2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	manager.checkContainerStatuses(status, v1beta1.EngineComponent, pod, 1)
+
+	require.NotNil(t, status.ModelStatus.ModelRevisionStates)
+	assert.Equal(t, v1beta1.FailedToLoad, status.ModelStatus.ModelRevisionStates.TargetModelState)
+	require.NotNil(t, status.ModelStatus.LastFailureInfo)
+	assert.Equal(t, "generic startup failure", status.ModelStatus.LastFailureInfo.Message)
+	engineReady := status.GetCondition(v1beta1.EngineReady)
+	if engineReady != nil {
+		assert.NotEqual(t, constants.InsufficientGPUMemoryReason, engineReady.Reason)
+	}
+}
+
+func TestGetContainerFailureMessage(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name                string
+		containerStatus     corev1.ContainerStatus
+		logMessage          string
+		logErr              error
+		expectFetcherCalled bool
+		expectedPrevious    bool
+		expectedMessage     string
+		expectedExitCode    int32
+		expectedFound       bool
+	}{
+		{
+			name: "terminated container uses current pod logs to upgrade generic failure",
+			containerStatus: corev1.ContainerStatus{
+				Name: constants.MainContainerName,
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message:  "RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}",
+						ExitCode: 7,
+					},
+				},
+			},
+			logMessage:          "torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1.31 GiB.",
+			expectFetcherCalled: true,
+			expectedPrevious:    false,
+			expectedMessage:     constants.ModelLoadGPUOOMFailureMessage,
+			expectedExitCode:    7,
+			expectedFound:       true,
+		},
+		{
+			name: "crash loop back off uses previous pod logs to upgrade generic failure",
+			containerStatus: corev1.ContainerStatus{
+				Name: constants.MainContainerName,
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason: constants.StateReasonCrashLoopBackOff,
+					},
+				},
+				LastTerminationState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message:  "WorkerProc failed to start.",
+						ExitCode: 8,
+					},
+				},
+			},
+			logMessage:          "ERROR Failed to load model - not enough GPU memory.",
+			expectFetcherCalled: true,
+			expectedPrevious:    true,
+			expectedMessage:     constants.ModelLoadGPUOOMFailureMessage,
+			expectedExitCode:    8,
+			expectedFound:       true,
+		},
+		{
+			name: "gpu oom from termination message skips log fetch",
+			containerStatus: corev1.ContainerStatus{
+				Name: constants.MainContainerName,
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message:  "torch.OutOfMemoryError: CUDA out of memory.",
+						ExitCode: 9,
+					},
+				},
+			},
+			expectFetcherCalled: false,
+			expectedMessage:     constants.ModelLoadGPUOOMFailureMessage,
+			expectedExitCode:    9,
+			expectedFound:       true,
+		},
+		{
+			name: "non oom logs preserve original termination message",
+			containerStatus: corev1.ContainerStatus{
+				Name: constants.MainContainerName,
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message:  "generic startup failure",
+						ExitCode: 10,
+					},
+				},
+			},
+			logMessage:          "some unrelated log line",
+			expectFetcherCalled: true,
+			expectedPrevious:    false,
+			expectedMessage:     "generic startup failure",
+			expectedExitCode:    10,
+			expectedFound:       true,
+		},
+		{
+			name: "log fetch error preserves original termination message",
+			containerStatus: corev1.ContainerStatus{
+				Name: constants.MainContainerName,
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message:  "generic startup failure",
+						ExitCode: 11,
+					},
+				},
+			},
+			logErr:              fmt.Errorf("log fetch failed"),
+			expectFetcherCalled: true,
+			expectedPrevious:    false,
+			expectedMessage:     "generic startup failure",
+			expectedExitCode:    11,
+			expectedFound:       true,
+		},
+		{
+			name: "no termination info returns no message",
+			containerStatus: corev1.ContainerStatus{
+				Name: constants.MainContainerName,
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+			},
+			logMessage:          "torch.OutOfMemoryError: CUDA out of memory.",
+			expectFetcherCalled: true,
+			expectedPrevious:    false,
+			expectedMessage:     constants.ModelLoadGPUOOMFailureMessage,
+			expectedExitCode:    0,
+			expectedFound:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewStatusReconciler(nil)
+
+			fetcherCalls := 0
+			manager.podLogFetcher = func(namespace, podName, containerName string, previous bool) (string, error) {
+				fetcherCalls++
+				assert.Equal(t, "default", namespace)
+				assert.Equal(t, "test-pod", podName)
+				assert.Equal(t, constants.MainContainerName, containerName)
+				assert.Equal(t, tt.expectedPrevious, previous)
+				return tt.logMessage, tt.logErr
+			}
+
+			message, exitCode, found := manager.getContainerFailureMessage(pod, tt.containerStatus)
+
+			assert.Equal(t, tt.expectedMessage, message)
+			assert.Equal(t, tt.expectedExitCode, exitCode)
+			assert.Equal(t, tt.expectedFound, found)
+			if tt.expectFetcherCalled {
+				assert.Equal(t, 1, fetcherCalls)
+			} else {
+				assert.Equal(t, 0, fetcherCalls)
+			}
+		})
+	}
+}
+
+func TestGetContainerFailureMessageWithoutPodOrFetcher(t *testing.T) {
+	containerStatus := corev1.ContainerStatus{
+		Name: constants.MainContainerName,
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				Message:  "generic startup failure",
+				ExitCode: 12,
+			},
+		},
+	}
+
+	manager := NewStatusReconciler(nil)
+	manager.podLogFetcher = nil
+
+	message, exitCode, found := manager.getContainerFailureMessage(nil, containerStatus)
+	assert.Equal(t, "generic startup failure", message)
+	assert.Equal(t, int32(12), exitCode)
+	assert.True(t, found)
+
+	message, exitCode, found = NewStatusReconciler(nil).getContainerFailureMessage(nil, containerStatus)
+	assert.Equal(t, "generic startup failure", message)
+	assert.Equal(t, int32(12), exitCode)
+	assert.True(t, found)
 }
 
 func TestSafeGetTerminationMessage(t *testing.T) {
@@ -945,6 +1332,34 @@ func TestSafeGetTerminationMessage(t *testing.T) {
 			expectedHasTermination: true,
 		},
 		{
+			name: "terminated container with ansi gpu oom log",
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message:  "\u001b[0;36m(Worker_TP0_EP0 pid=544)\u001b[0;0m ERROR Failed to load model - not enough GPU memory. Tried to allocate 1.31 GiB.",
+						ExitCode: 1,
+					},
+				},
+			},
+			expectedMessage:        "Model failed to load: not enough GPU memory",
+			expectedExitCode:       1,
+			expectedHasTermination: true,
+		},
+		{
+			name: "terminated container with multiline torch out of memory log",
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message:  "\u001b[0;36m(Worker_TP1_EP1 pid=545)\u001b[0;0m ERROR 03-25 22:10:36 [multiproc_executor.py:772] torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1.31 GiB. GPU 1 has a total capacity of 79.32 GiB of which 724.44 MiB is free.",
+						ExitCode: 1,
+					},
+				},
+			},
+			expectedMessage:        "Model failed to load: not enough GPU memory",
+			expectedExitCode:       1,
+			expectedHasTermination: true,
+		},
+		{
 			name: "crash loop back off with last termination",
 			containerStatus: corev1.ContainerStatus{
 				State: corev1.ContainerState{
@@ -960,6 +1375,48 @@ func TestSafeGetTerminationMessage(t *testing.T) {
 				},
 			},
 			expectedMessage:        "Last termination message",
+			expectedExitCode:       2,
+			expectedHasTermination: true,
+		},
+		{
+			name: "crash loop back off with ansi last termination message",
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason: constants.StateReasonCrashLoopBackOff,
+					},
+				},
+				LastTerminationState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message:  "\u001b[0;36m(worker)\u001b[0;0m regular failure message",
+						ExitCode: 2,
+					},
+				},
+			},
+			expectedMessage:        "(worker) regular failure message",
+			expectedExitCode:       2,
+			expectedHasTermination: true,
+		},
+		{
+			name: "crash loop back off with multiline gpu oom worker startup log",
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason: constants.StateReasonCrashLoopBackOff,
+					},
+				},
+				LastTerminationState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message: "\u001b[0;36m(Worker_TP1_EP1 pid=545)\u001b[0;0m ERROR 03-25 22:10:36 [multiproc_executor.py:772] torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1.31 GiB. GPU 1 has a total capacity of 79.32 GiB of which 724.44 MiB is free.\n" +
+							"\u001b[0;36m(Worker_TP1_EP1 pid=545)\u001b[0;0m INFO 03-25 22:10:36 [multiproc_executor.py:730] Parent process exited, terminating worker\n" +
+							"\u001b[0;36m(Worker_TP0_EP0 pid=544)\u001b[0;0m INFO 03-25 22:10:36 [multiproc_executor.py:730] Parent process exited, terminating worker\n" +
+							"\u001b[0;36m(Worker_TP0_EP0 pid=544)\u001b[0;0m ERROR 03-25 22:10:36 [gpu_model_runner.py:4128] Failed to load model - not enough GPU memory. Try lowering --gpu-memory-utilization to free memory for weights, increasing --tensor-parallel-size, or using --quantization.\n" +
+							"\u001b[0;36m(Worker_TP0_EP0 pid=544)\u001b[0;0m ERROR 03-25 22:10:36 [multiproc_executor.py:772] WorkerProc failed to start.",
+						ExitCode: 2,
+					},
+				},
+			},
+			expectedMessage:        "Model failed to load: not enough GPU memory",
 			expectedExitCode:       2,
 			expectedHasTermination: true,
 		},
@@ -991,7 +1448,7 @@ func TestSafeGetTerminationMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := NewStatusReconciler()
+			manager := NewStatusReconciler(nil)
 			message, exitCode, hasTermination := manager.safeGetTerminationMessage(tt.containerStatus)
 
 			assert.Equal(t, tt.expectedMessage, message)


### PR DESCRIPTION
## What this PR does

Polishes InferenceService failure reporting so GPU out-of-memory errors can be surfaced from crashed pod logs instead of only falling back to generic deployment availability conditions.

This PR:
1. Detects GPU OOM by inspecting termination messages and previous pod logs for crashlooping runtime containers
2. Sets a clearer component condition reason/message for GPU memory insufficiency
3. Fixes raw-deployment pod lookup for long InferenceService names by making status pod selection use the same truncated app label as deployment/pod creation
4. Preserves existing non-initializing conditions instead of overwriting them during condition initialization
5. Adds unit tests coverage


## Why we need it

Before this change, GPU OOM failures were easy to miss in InferenceService status.

Two things got in the way:

1. The controller often only surfaced generic deployment-level conditions such as MinimumReplicasUnavailable
2. For long InferenceService names, pod-based status propagation could fail entirely because the controller selected pods with the full component name while the actual pod app label was truncated/hashed
As a result, the controller could miss the crashed pod, skip previous-log inspection, and fail to surface the real runtime failure reason.

Fixes #575

## How to test

1. Deploy an InferenceService with a long name in raw deployment mode.
2. Use a model/runtime combination that causes the runtime container to crash with CUDA OOM.
3. Confirm the runtime pod enters CrashLoopBackOff.
4. Verify the InferenceService now matches the pod and surfaces a clearer condition instead of only generic deployment unavailability.

## Test result
With this change, the isvc status contains: 
```
status:
  conditions:
    - lastTransitionTime: '2026-04-10T00:32:07Z'
      message: Insufficient GPU memory to run the model container
      reason: InsufficientGPUMemory
      status: 'False'
      type: Ready
```

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
