### PR TITLE
ci: add Artifact Hub repository metadata for helm chart publishing

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,10 @@
+# Artifact Hub repository metadata file
+# See https://artifacthub.io/docs/topics/repositories/helm-charts/
+#
+# After registering the repository on Artifact Hub, replace the
+# repositoryID below with the value assigned by Artifact Hub and
+# update the owners list to match Artifact Hub account emails.
+repositoryID: null
+owners:
+  - name: sgl-project
+    email: linsimo.mark@gmail.com


### PR DESCRIPTION
## What's broken?

OME helm charts under `charts/` are not discoverable on [Artifact Hub](https://artifacthub.io/), making it hard for users to find and install them. As noted in #507, even AI assistants don't know the charts exist.

## What this PR does

Adds `artifacthub-repo.yml` at the repository root — the metadata file that Artifact Hub requires to index helm charts from a Git repository.

## Next steps for maintainers

After merging, a maintainer should:
1. Go to https://artifacthub.io/ and register/log in
2. Add this repository as a Helm charts source (pointing to the `charts/` directory)
3. Update `repositoryID` in `artifacthub-repo.yml` with the ID assigned by Artifact Hub
4. Update the `owners` email to match the Artifact Hub account email

## Changes

- Added `artifacthub-repo.yml` at repo root with placeholder `repositoryID` and owner metadata

Fixes #507
