### PR TITLE
[Misc] add Gemma 4 config parser

### DIFF
--- a/config/models/SUPPORTED_MODELS.md
+++ b/config/models/SUPPORTED_MODELS.md
@@ -98,6 +98,10 @@ This document provides a comprehensive reference of all models supported by SGLa
 | Gemma 3 4B IT  | `google/gemma-3-4b-it`  | 4B         | Gemma3ForConditionalGeneration | 8 GB  | 128K    | Yes            | Configured |
 | Gemma 3 12B IT | `google/gemma-3-12b-it` | 12B        | Gemma3ForConditionalGeneration | 24 GB | 128K    | Yes            | Missing    |
 | Gemma 3 27B IT | `google/gemma-3-27b-it` | 27B        | Gemma3ForConditionalGeneration | 54 GB | 128K    | Yes            | Missing    |
+| Gemma 4 E2B IT | `google/gemma-4-E2B-it` | 5.4B       | Gemma4ForConditionalGeneration | 11 GB | 128K    | Yes            | Missing    |
+| Gemma 4 E4B IT | `google/gemma-4-E4B-it` | 8B         | Gemma4ForConditionalGeneration | 16 GB | 128K    | Yes            | Missing    |
+| Gemma 4 26B-A4B IT | `google/gemma-4-26B-A4B-it` | 26B (MoE) | Gemma4ForConditionalGeneration | 52 GB | 256K    | Yes            | Missing    |
+| Gemma 4 31B IT | `google/gemma-4-31B-it` | 31B        | Gemma4ForConditionalGeneration | 62 GB | 256K    | Yes            | Missing    |
 
 ### Microsoft Phi Family
 

--- a/pkg/hfutil/modelconfig/README.md
+++ b/pkg/hfutil/modelconfig/README.md
@@ -27,7 +27,7 @@ This package provides Go utilities for loading, parsing, and analyzing Hugging F
 - **DeepSeek**: DeepSeek V3
 - **Phi Family**: Phi-3, Phi-3 Vision
 - **Qwen Family**: Qwen2, Qwen2.5
-- **Gemma Family**: Gemma, Gemma2
+- **Gemma Family**: Gemma, Gemma2, Gemma4
 - **ChatGLM Family**: ChatGLM3, GLM-4
 - **Other Models**:
   - StableLM (StabilityAI)

--- a/pkg/hfutil/modelconfig/gemma4.go
+++ b/pkg/hfutil/modelconfig/gemma4.go
@@ -1,0 +1,181 @@
+package modelconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+// Gemma4Config defines the configuration for Google Gemma 4 multimodal models.
+type Gemma4Config struct {
+	BaseModelConfig
+
+	// Gemma 4 configs (transformers 5.x) use top-level "dtype" instead of "torch_dtype".
+	Dtype string `json:"dtype"`
+
+	// Special tokens for multimodal support
+	AudioTokenId  int         `json:"audio_token_id"`
+	BoaTokenId    int         `json:"boa_token_id"`
+	BoiTokenId    int         `json:"boi_token_id"`
+	EoaTokenId    int         `json:"eoa_token_id"`
+	EoaTokenIndex int         `json:"eoa_token_index"`
+	EoiTokenId    int         `json:"eoi_token_id"`
+	EosTokenId    interface{} `json:"eos_token_id"`
+	ImageTokenId  int         `json:"image_token_id"`
+	VideoTokenId  int         `json:"video_token_id"`
+
+	InitializerRange         float64 `json:"initializer_range"`
+	TieWordEmbeddings        bool    `json:"tie_word_embeddings"`
+	VisionSoftTokensPerImage int     `json:"vision_soft_tokens_per_image"`
+
+	TextConfig   Gemma4TextConfig   `json:"text_config"`
+	VisionConfig Gemma4VisionConfig `json:"vision_config"`
+
+	// AudioConfig is nil on text/vision-only variants (26B, 31B) and populated on E2B/E4B.
+	AudioConfig *Gemma4AudioConfig `json:"audio_config"`
+
+	QuantizationConfig *struct {
+		QuantMethod string `json:"quant_method"`
+	} `json:"quantization_config,omitempty"`
+}
+
+// Gemma4TextConfig defines the text/language model configuration for Gemma 4.
+type Gemma4TextConfig struct {
+	ModelType string `json:"model_type"`
+	Dtype     string `json:"dtype"`
+
+	HiddenSize            int `json:"hidden_size"`
+	IntermediateSize      int `json:"intermediate_size"`
+	NumHiddenLayers       int `json:"num_hidden_layers"`
+	HeadDim               int `json:"head_dim"`
+	NumAttentionHeads     int `json:"num_attention_heads"`
+	NumKeyValueHeads      int `json:"num_key_value_heads"`
+	MaxPositionEmbeddings int `json:"max_position_embeddings"`
+	VocabSize             int `json:"vocab_size"`
+
+	SlidingWindow           int `json:"sliding_window"`
+	NumKvSharedLayers       int `json:"num_kv_shared_layers"`
+	HiddenSizePerLayerInput int `json:"hidden_size_per_layer_input"`
+
+	// MoE fields: populated on MoE variants (26B-A4B), null on dense variants.
+	EnableMoeBlock      bool `json:"enable_moe_block"`
+	NumExperts          *int `json:"num_experts"`
+	TopKExperts         *int `json:"top_k_experts"`
+	MoeIntermediateSize *int `json:"moe_intermediate_size"`
+}
+
+// Gemma4VisionConfig defines the vision tower configuration for Gemma 4.
+type Gemma4VisionConfig struct {
+	ModelType string `json:"model_type"`
+	Dtype     string `json:"dtype"`
+
+	HiddenSize        int `json:"hidden_size"`
+	IntermediateSize  int `json:"intermediate_size"`
+	NumHiddenLayers   int `json:"num_hidden_layers"`
+	NumAttentionHeads int `json:"num_attention_heads"`
+	PatchSize         int `json:"patch_size"`
+}
+
+// Gemma4AudioConfig defines the audio encoder configuration for Gemma 4.
+type Gemma4AudioConfig struct {
+	ModelType string `json:"model_type"`
+	Dtype     string `json:"dtype"`
+
+	HiddenSize        int `json:"hidden_size"`
+	NumHiddenLayers   int `json:"num_hidden_layers"`
+	NumAttentionHeads int `json:"num_attention_heads"`
+}
+
+// LoadGemma4Config loads a Gemma 4 model configuration from a JSON file.
+func LoadGemma4Config(configPath string) (*Gemma4Config, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Gemma4 config file '%s': %w", configPath, err)
+	}
+
+	// Gemma 4 configs may contain Python-style Infinity/NaN values that stdlib json rejects.
+	data = SanitizeJSONBytes(data)
+
+	var config Gemma4Config
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse Gemma4 config JSON from '%s': %w", configPath, err)
+	}
+
+	// Promote top-level dtype to TorchDtype so size estimation stays correct.
+	if config.TorchDtype == "" && config.Dtype != "" {
+		config.TorchDtype = config.Dtype
+	}
+
+	config.ConfigPath = configPath
+	return &config, nil
+}
+
+// GetParameterCount returns the total number of parameters in the model.
+func (c *Gemma4Config) GetParameterCount() int64 {
+	count, err := FindAndParseSafetensors(c.ConfigPath)
+	if err == nil {
+		return count
+	}
+	log.Printf("Warning: failed to get parameter count from safetensors: %v", err)
+
+	tc := c.TextConfig
+
+	switch {
+	case tc.HiddenSize == 1536 && tc.NumHiddenLayers == 35:
+		return 5_400_000_000 // Gemma 4 E2B (total params including PLE)
+	case tc.HiddenSize == 2560 && tc.NumHiddenLayers == 42:
+		return 8_000_000_000 // Gemma 4 E4B (total params including PLE)
+	case tc.HiddenSize == 2816 && tc.NumHiddenLayers == 30 && tc.EnableMoeBlock:
+		return 26_000_000_000 // Gemma 4 26B-A4B (MoE)
+	case tc.HiddenSize == 5376 && tc.NumHiddenLayers == 60:
+		return 31_000_000_000 // Gemma 4 31B
+	}
+
+	if tc.EnableMoeBlock && tc.NumExperts != nil && tc.TopKExperts != nil {
+		return estimateMoEParamCount(tc.HiddenSize, tc.NumHiddenLayers, tc.IntermediateSize, *tc.NumExperts, *tc.TopKExperts)
+	}
+
+	textParams := estimateTextParams(tc.HiddenSize, tc.NumHiddenLayers, tc.IntermediateSize)
+	visionParams := estimateVisionParams(c.VisionConfig.HiddenSize, c.VisionConfig.NumHiddenLayers, c.VisionConfig.IntermediateSize)
+	return textParams + visionParams
+}
+
+// GetContextLength returns the maximum context length supported by the model.
+func (c *Gemma4Config) GetContextLength() int {
+	return c.TextConfig.MaxPositionEmbeddings
+}
+
+// GetModelSizeBytes returns the estimated size of the model in bytes.
+func (c *Gemma4Config) GetModelSizeBytes() int64 {
+	return EstimateModelSizeBytes(c.GetParameterCount(), c.TorchDtype)
+}
+
+// GetQuantizationType returns the quantization method used (if any).
+func (c *Gemma4Config) GetQuantizationType() string {
+	if c.QuantizationConfig == nil {
+		return ""
+	}
+	if strings.Contains(strings.ToLower(c.QuantizationConfig.QuantMethod), "fp8") {
+		return "fp8"
+	}
+	// Fail safe: any other non-nil quantization_config is treated as int4 so the matcher rejects it from unquantized runtimes.
+	return "int4"
+}
+
+// HasVision returns true since all Gemma 4 variants ship a vision tower.
+func (c *Gemma4Config) HasVision() bool {
+	return true
+}
+
+// IsEmbedding returns false since this is not an embedding model.
+func (c *Gemma4Config) IsEmbedding() bool {
+	return false
+}
+
+func init() {
+	RegisterModelLoader("gemma4", func(configPath string) (HuggingFaceModel, error) {
+		return LoadGemma4Config(configPath)
+	})
+}

--- a/pkg/hfutil/modelconfig/gemma4_test.go
+++ b/pkg/hfutil/modelconfig/gemma4_test.go
@@ -1,0 +1,184 @@
+package modelconfig
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadGemma4Config(t *testing.T) {
+	tests := []struct {
+		name       string
+		configFile string
+	}{
+		{"E2B", "gemma4_e2b.json"},
+		{"E4B", "gemma4_e4b.json"},
+		{"26B-A4B", "gemma4_26b_a4b.json"},
+		{"31B", "gemma4_31b.json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join("testdata", tt.configFile)
+			config, err := LoadGemma4Config(configPath)
+			if err != nil {
+				t.Fatalf("Failed to load Gemma4 config: %v", err)
+			}
+
+			if config.GetModelType() != "gemma4" {
+				t.Errorf("Expected model type 'gemma4', got '%s'", config.GetModelType())
+			}
+			if config.GetArchitecture() != "Gemma4ForConditionalGeneration" {
+				t.Errorf("Expected architecture 'Gemma4ForConditionalGeneration', got '%s'", config.GetArchitecture())
+			}
+			if !config.HasVision() {
+				t.Error("Expected HasVision to be true for all Gemma 4 variants")
+			}
+			if config.IsEmbedding() {
+				t.Error("Expected IsEmbedding to be false")
+			}
+		})
+	}
+}
+
+func TestGemma4ConfigContextLength(t *testing.T) {
+	tests := []struct {
+		name           string
+		configFile     string
+		expectedLength int
+	}{
+		{"E2B", "gemma4_e2b.json", 131072},
+		{"E4B", "gemma4_e4b.json", 131072},
+		{"26B-A4B", "gemma4_26b_a4b.json", 262144},
+		{"31B", "gemma4_31b.json", 262144},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := LoadGemma4Config(filepath.Join("testdata", tt.configFile))
+			if err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+			if got := config.GetContextLength(); got != tt.expectedLength {
+				t.Errorf("Expected context length %d, got %d", tt.expectedLength, got)
+			}
+		})
+	}
+}
+
+func TestGemma4ConfigAudioEncoderPresence(t *testing.T) {
+	tests := []struct {
+		name        string
+		file        string
+		wantPresent bool
+	}{
+		{"E2B ships audio encoder", "gemma4_e2b.json", true},
+		{"E4B ships audio encoder", "gemma4_e4b.json", true},
+		{"26B-A4B has no audio", "gemma4_26b_a4b.json", false},
+		{"31B has no audio", "gemma4_31b.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := LoadGemma4Config(filepath.Join("testdata", tt.file))
+			if err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+			gotPresent := config.AudioConfig != nil
+			if gotPresent != tt.wantPresent {
+				t.Errorf("Expected AudioConfig presence=%v, got %v", tt.wantPresent, gotPresent)
+			}
+		})
+	}
+}
+
+func TestGemma4ConfigMoEFields(t *testing.T) {
+	config, err := LoadGemma4Config(filepath.Join("testdata", "gemma4_26b_a4b.json"))
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if !config.TextConfig.EnableMoeBlock {
+		t.Error("Expected EnableMoeBlock=true for 26B-A4B")
+	}
+	if config.TextConfig.NumExperts == nil || *config.TextConfig.NumExperts != 128 {
+		t.Errorf("Expected NumExperts=128, got %v", config.TextConfig.NumExperts)
+	}
+	if config.TextConfig.TopKExperts == nil || *config.TextConfig.TopKExperts != 8 {
+		t.Errorf("Expected TopKExperts=8, got %v", config.TextConfig.TopKExperts)
+	}
+	if config.TextConfig.MoeIntermediateSize == nil || *config.TextConfig.MoeIntermediateSize != 704 {
+		t.Errorf("Expected MoeIntermediateSize=704, got %v", config.TextConfig.MoeIntermediateSize)
+	}
+}
+
+func TestGemma4ConfigDenseHasNoMoE(t *testing.T) {
+	for _, file := range []string{"gemma4_e2b.json", "gemma4_e4b.json", "gemma4_31b.json"} {
+		t.Run(file, func(t *testing.T) {
+			config, err := LoadGemma4Config(filepath.Join("testdata", file))
+			if err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+			if config.TextConfig.EnableMoeBlock {
+				t.Error("Expected EnableMoeBlock=false on dense variant")
+			}
+			if config.TextConfig.NumExperts != nil {
+				t.Errorf("Expected NumExperts=nil on dense variant, got %v", *config.TextConfig.NumExperts)
+			}
+		})
+	}
+}
+
+func TestGemma4ConfigGetTorchDtype(t *testing.T) {
+	config, err := LoadGemma4Config(filepath.Join("testdata", "gemma4_e2b.json"))
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+	if got := config.GetTorchDtype(); got != "bfloat16" {
+		t.Errorf("Expected torch dtype 'bfloat16' (promoted from top-level dtype), got '%s'", got)
+	}
+}
+
+func TestGemma4ConfigGetParameterCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		file      string
+		minParams int64
+		maxParams int64
+	}{
+		{"E2B", "gemma4_e2b.json", 2_000_000_000, 10_000_000_000},
+		{"E4B", "gemma4_e4b.json", 4_000_000_000, 12_000_000_000},
+		{"26B-A4B", "gemma4_26b_a4b.json", 20_000_000_000, 32_000_000_000},
+		{"31B", "gemma4_31b.json", 25_000_000_000, 40_000_000_000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := LoadGemma4Config(filepath.Join("testdata", tt.file))
+			if err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+			got := config.GetParameterCount()
+			if got < tt.minParams || got > tt.maxParams {
+				t.Errorf("Expected param count in [%d, %d], got %d", tt.minParams, tt.maxParams, got)
+			}
+		})
+	}
+}
+
+func TestGemma4ConfigRegisteredLoader(t *testing.T) {
+	// LoadModelConfig dispatches on model_type; verify "gemma4" resolves to Gemma4Config.
+	config, err := LoadModelConfig(filepath.Join("testdata", "gemma4_e2b.json"))
+	if err != nil {
+		t.Fatalf("LoadModelConfig failed: %v", err)
+	}
+	if _, ok := config.(*Gemma4Config); !ok {
+		t.Errorf("Expected *Gemma4Config from LoadModelConfig, got %T", config)
+	}
+	if !config.HasVision() {
+		t.Error("Expected HasVision=true via interface dispatch for E2B")
+	}
+}
+
+func TestGemma4ConfigInterface(t *testing.T) {
+	var _ HuggingFaceModel = (*Gemma4Config)(nil)
+}

--- a/pkg/hfutil/modelconfig/testdata/gemma4_26b_a4b.json
+++ b/pkg/hfutil/modelconfig/testdata/gemma4_26b_a4b.json
@@ -1,0 +1,52 @@
+{
+  "architectures": [
+    "Gemma4ForConditionalGeneration"
+  ],
+  "audio_config": null,
+  "audio_token_id": 258881,
+  "boa_token_id": 256000,
+  "boi_token_id": 255999,
+  "dtype": "bfloat16",
+  "eoa_token_id": 258883,
+  "eoa_token_index": 258883,
+  "eoi_token_id": 258882,
+  "eos_token_id": [
+    1,
+    106
+  ],
+  "image_token_id": 258880,
+  "initializer_range": 0.02,
+  "model_type": "gemma4",
+  "text_config": {
+    "dtype": "bfloat16",
+    "enable_moe_block": true,
+    "head_dim": 256,
+    "hidden_size": 2816,
+    "hidden_size_per_layer_input": 0,
+    "intermediate_size": 2112,
+    "max_position_embeddings": 262144,
+    "model_type": "gemma4_text",
+    "moe_intermediate_size": 704,
+    "num_attention_heads": 16,
+    "num_experts": 128,
+    "num_hidden_layers": 30,
+    "num_key_value_heads": 8,
+    "num_kv_shared_layers": 0,
+    "sliding_window": 1024,
+    "top_k_experts": 8,
+    "vocab_size": 262144
+  },
+  "tie_word_embeddings": true,
+  "transformers_version": "5.5.0.dev0",
+  "video_token_id": 258884,
+  "vision_config": {
+    "dtype": "bfloat16",
+    "hidden_size": 1152,
+    "intermediate_size": 4304,
+    "model_type": "gemma4_vision",
+    "num_attention_heads": 16,
+    "num_hidden_layers": 27,
+    "patch_size": 16
+  },
+  "vision_soft_tokens_per_image": 280
+}

--- a/pkg/hfutil/modelconfig/testdata/gemma4_31b.json
+++ b/pkg/hfutil/modelconfig/testdata/gemma4_31b.json
@@ -1,0 +1,51 @@
+{
+  "architectures": [
+    "Gemma4ForConditionalGeneration"
+  ],
+  "audio_config": null,
+  "audio_token_id": 258881,
+  "boa_token_id": 256000,
+  "boi_token_id": 255999,
+  "dtype": "bfloat16",
+  "eoa_token_id": 258883,
+  "eoa_token_index": 258883,
+  "eoi_token_id": 258882,
+  "eos_token_id": [
+    1,
+    106
+  ],
+  "image_token_id": 258880,
+  "initializer_range": 0.02,
+  "model_type": "gemma4",
+  "text_config": {
+    "dtype": "bfloat16",
+    "enable_moe_block": false,
+    "head_dim": 256,
+    "hidden_size": 5376,
+    "hidden_size_per_layer_input": 0,
+    "intermediate_size": 21504,
+    "max_position_embeddings": 262144,
+    "model_type": "gemma4_text",
+    "num_attention_heads": 32,
+    "num_experts": null,
+    "num_hidden_layers": 60,
+    "num_key_value_heads": 16,
+    "num_kv_shared_layers": 0,
+    "sliding_window": 1024,
+    "top_k_experts": null,
+    "vocab_size": 262144
+  },
+  "tie_word_embeddings": true,
+  "transformers_version": "5.5.0.dev0",
+  "video_token_id": 258884,
+  "vision_config": {
+    "dtype": "bfloat16",
+    "hidden_size": 1152,
+    "intermediate_size": 4304,
+    "model_type": "gemma4_vision",
+    "num_attention_heads": 16,
+    "num_hidden_layers": 27,
+    "patch_size": 16
+  },
+  "vision_soft_tokens_per_image": 280
+}

--- a/pkg/hfutil/modelconfig/testdata/gemma4_e2b.json
+++ b/pkg/hfutil/modelconfig/testdata/gemma4_e2b.json
@@ -1,0 +1,57 @@
+{
+  "architectures": [
+    "Gemma4ForConditionalGeneration"
+  ],
+  "audio_config": {
+    "dtype": "bfloat16",
+    "hidden_size": 1024,
+    "model_type": "gemma4_audio",
+    "num_attention_heads": 8,
+    "num_hidden_layers": 12
+  },
+  "audio_token_id": 258881,
+  "boa_token_id": 256000,
+  "boi_token_id": 255999,
+  "dtype": "bfloat16",
+  "eoa_token_id": 258883,
+  "eoa_token_index": 258883,
+  "eoi_token_id": 258882,
+  "eos_token_id": [
+    1,
+    106
+  ],
+  "image_token_id": 258880,
+  "initializer_range": 0.02,
+  "model_type": "gemma4",
+  "text_config": {
+    "dtype": "bfloat16",
+    "enable_moe_block": false,
+    "head_dim": 256,
+    "hidden_size": 1536,
+    "hidden_size_per_layer_input": 256,
+    "intermediate_size": 6144,
+    "max_position_embeddings": 131072,
+    "model_type": "gemma4_text",
+    "num_attention_heads": 8,
+    "num_experts": null,
+    "num_hidden_layers": 35,
+    "num_key_value_heads": 1,
+    "num_kv_shared_layers": 20,
+    "sliding_window": 512,
+    "top_k_experts": null,
+    "vocab_size": 262144
+  },
+  "tie_word_embeddings": true,
+  "transformers_version": "5.5.0.dev0",
+  "video_token_id": 258884,
+  "vision_config": {
+    "dtype": "bfloat16",
+    "hidden_size": 768,
+    "intermediate_size": 3072,
+    "model_type": "gemma4_vision",
+    "num_attention_heads": 12,
+    "num_hidden_layers": 16,
+    "patch_size": 16
+  },
+  "vision_soft_tokens_per_image": 280
+}

--- a/pkg/hfutil/modelconfig/testdata/gemma4_e4b.json
+++ b/pkg/hfutil/modelconfig/testdata/gemma4_e4b.json
@@ -1,0 +1,57 @@
+{
+  "architectures": [
+    "Gemma4ForConditionalGeneration"
+  ],
+  "audio_config": {
+    "dtype": "bfloat16",
+    "hidden_size": 1024,
+    "model_type": "gemma4_audio",
+    "num_attention_heads": 8,
+    "num_hidden_layers": 12
+  },
+  "audio_token_id": 258881,
+  "boa_token_id": 256000,
+  "boi_token_id": 255999,
+  "dtype": "bfloat16",
+  "eoa_token_id": 258883,
+  "eoa_token_index": 258883,
+  "eoi_token_id": 258882,
+  "eos_token_id": [
+    1,
+    106
+  ],
+  "image_token_id": 258880,
+  "initializer_range": 0.02,
+  "model_type": "gemma4",
+  "text_config": {
+    "dtype": "bfloat16",
+    "enable_moe_block": false,
+    "head_dim": 256,
+    "hidden_size": 2560,
+    "hidden_size_per_layer_input": 256,
+    "intermediate_size": 10240,
+    "max_position_embeddings": 131072,
+    "model_type": "gemma4_text",
+    "num_attention_heads": 8,
+    "num_experts": null,
+    "num_hidden_layers": 42,
+    "num_key_value_heads": 2,
+    "num_kv_shared_layers": 18,
+    "sliding_window": 512,
+    "top_k_experts": null,
+    "vocab_size": 262144
+  },
+  "tie_word_embeddings": true,
+  "transformers_version": "5.5.0.dev0",
+  "video_token_id": 258884,
+  "vision_config": {
+    "dtype": "bfloat16",
+    "hidden_size": 768,
+    "intermediate_size": 3072,
+    "model_type": "gemma4_vision",
+    "num_attention_heads": 12,
+    "num_hidden_layers": 16,
+    "patch_size": 16
+  },
+  "vision_soft_tokens_per_image": 280
+}


### PR DESCRIPTION
## Motivation

Adds a config parser for Google Gemma 4 multimodal models to `pkg/hfutil/modelconfig`. 

## Modifications

- Add `Gemma4Config` struct implementing the `HuggingFaceModel` interface, with nested `Gemma4TextConfig`, `Gemma4VisionConfig`, and `Gemma4AudioConfig`
- Model Gemma 4's MoE structure via pointer fields (`NumExperts`, `TopKExperts`, `MoeIntermediateSize`) so dense variants (`null` in JSON) round-trip as `nil` and MoE variants (26B-A4B) retain their 128-expert / top-k-8 shape.
- Model the optional audio encoder as `AudioConfig *Gemma4AudioConfig` so `null` on text+vision-only variants (26B, 31B) deserialises to `nil` and populated encoders (E2B, E4B) round-trip correctly.
- Promote the top-level `dtype` field (used by transformers 5.x) to `TorchDtype` during `LoadGemma4Config` so `EstimateModelSizeBytes` and downstream runtime sizing stay accurate
- `GetContextLength()` returns `text_config.max_position_embeddings` directly: 131072 on E2B/E4B, 262144 on 26B-A4B/31B.
- `GetParameterCount()` first reads from co-located safetensors files via `FindAndParseSafetensors`, then falls back to a shape-based lookup table for the four published variants, then to `estimateMoEParamCount` for MoE and `estimateTextParams + estimateVisionParams` for dense unknowns.
- `GetQuantizationType()` inspects the optional `quantization_config.quant_method` and returns `"fp8"` for FP8 checkpoints, `"int4"` for any other non-nil quant config, `""` otherwise so the runtime matcher can reject quantized checkpoints from unquantized runtimes.
- `HasVision()` returns `true` for every variant (all four ship the vision tower); `IsEmbedding()` returns `false`. 
- Register `"gemma4"` in the model loader registry via `init()` so `LoadModelConfig` dispatches correctly.
- Add `gemma4_test.go`
- Add `testdata/gemma4_{e2b,e4b,26b_a4b,31b}.json` 
- Update `pkg/hfutil/modelconfig/README.md` supported-families list and `config/models/SUPPORTED_MODELS.md` Google Gemma table.

## Checklist

- [x] Format your code with [gofumpt](https://github.com/mvdan/gofumpt) and [golines](https://github.com/segmentio/golines) (`make format`).
- [x] Add unit tests as outlined in the [Modifications](#modifications) section.
- [x] Update documentation / examples if applicable.