### PR TITLE
feat: add AUDIO_TO_TEXT capability detection for ASR models

### DIFF
--- a/pkg/modelagent/config_parser.go
+++ b/pkg/modelagent/config_parser.go
@@ -557,6 +557,15 @@ func (p *ModelConfigParser) determineModelCapabilitiesFromHF(hfModel modelconfig
 			string(v1beta1.ModelCapabilityAudioToAudio))
 	}
 
+	// Check for audio-to-text capability (ASR/transcription models e.g. Whisper, Wav2Vec2, HuBERT)
+	if strings.Contains(normalizedArchitecture, "whisper") ||
+		strings.Contains(normalizedArchitecture, "wav2vec2") ||
+		strings.Contains(normalizedArchitecture, "hubert") ||
+		strings.Contains(normalizedArchitecture, "fortc") ||
+		strings.Contains(normalizedArchitecture, "forspeechtotext") {
+		return append(capabilities, string(v1beta1.ModelCapabilityAudioToText))
+	}
+
 	// Check for text embedding capability
 	if hfModel.IsEmbedding() ||
 		strings.Contains(normalizedArchitecture, "embedding") ||

--- a/pkg/modelagent/config_parser_test.go
+++ b/pkg/modelagent/config_parser_test.go
@@ -362,6 +362,42 @@ func TestDetermineModelCapabilitiesFromHF(t *testing.T) {
 				string(v1beta1.ModelCapabilityAudioToAudio),
 			},
 		},
+		{
+			name: "Whisper ASR Model",
+			mockModel: &mockHuggingFaceModel{
+				modelType:    "whisper",
+				architecture: "WhisperForConditionalGeneration",
+				hasVision:    false,
+			},
+			expectedCapabilities: []string{string(v1beta1.ModelCapabilityAudioToText)},
+		},
+		{
+			name: "Wav2Vec2 ASR Model",
+			mockModel: &mockHuggingFaceModel{
+				modelType:    "wav2vec2",
+				architecture: "Wav2Vec2ForCTC",
+				hasVision:    false,
+			},
+			expectedCapabilities: []string{string(v1beta1.ModelCapabilityAudioToText)},
+		},
+		{
+			name: "HuBERT ASR Model",
+			mockModel: &mockHuggingFaceModel{
+				modelType:    "hubert",
+				architecture: "HubertForCTC",
+				hasVision:    false,
+			},
+			expectedCapabilities: []string{string(v1beta1.ModelCapabilityAudioToText)},
+		},
+		{
+			name: "Generic ForSpeechToText Model",
+			mockModel: &mockHuggingFaceModel{
+				modelType:    "seamless_m4t",
+				architecture: "SeamlessM4TForSpeechToText",
+				hasVision:    false,
+			},
+			expectedCapabilities: []string{string(v1beta1.ModelCapabilityAudioToText)},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## What this PR does

The model agent config parser was falling through to `TEXT_TO_TEXT` for all audio transcription models (Whisper, Wav2Vec2, HuBERT, etc.) because `determineModelCapabilitiesFromHF()` had no audio capability check. This PR adds `AUDIO_TO_TEXT` capability detection so ASR models are correctly identified when imported as custom models.

## Changes

Added architecture-string-based detection for `AUDIO_TO_TEXT` in `pkg/modelagent/config_parser.go`, placed after the omni-model check and before the embedding check.

Covers:
- `WhisperForConditionalGeneration` → Whisper family
- `Wav2Vec2ForCTC` and variants → Wav2Vec2 family
- `HubertForCTC` → HuBERT family
- Any architecture with `ForCTC` suffix → generic CTC-based ASR
- Any architecture with `ForSpeechToText` suffix → generic speech-to-text

Added test cases for all four patterns in `config_parser_test.go`.

## Why we need it

`openai/whisper-large-v3-turbo` imported as a custom model was showing capability `TEXT_TO_TEXT` instead of `AUDIO_TO_TEXT`, causing incorrect runtime matching and endpoint behavior.

## How to test

Import openai/whisper-large-v3-turbo (or any Whisper-based model) via the console as a HuggingFace imported model. Once the model status is Ready, run the following command to confirm the capability is correctly detected as AUDIO_TO_TEXT instead of the previous default TEXT_TO_TEXT:

kubectl get basemodel -n default <basemodel-ocid> \
  -o jsonpath='Name: {.metadata.name}{"\n"}Architecture: {.spec.modelArchitecture}{"\n"}Capabilities: {.spec.modelCapabilities}{"\n"}'

Expected output:

Name: amaaaaaabgjpxjqa...
Architecture: WhisperForConditionalGeneration
Capabilities: ["AUDIO_TO_TEXT"]

Also test a standard text model (e.g. Llama) to ensure nothing is broken.

## Checklist
- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally