### PR TITLE
[Helm] Update default image version to v0.1.5

### DIFF
--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -36,7 +36,7 @@ data:
 
   modelInit: |-
     {
-        "image" : "ghcr.io/sgl-project/ome/ome-agent:v1.1-177-2-g029e07e-dirty",
+        "image" : "ghcr.io/moirai-internal/ome-agent:v0.1.5",
         "memoryRequest": "320Gi",
         "memoryLimit": "320Gi",
         "cpuRequest": "15",
@@ -49,7 +49,7 @@ data:
 
   multinodeProber: |-
     {
-      "image" : "ghcr.io/sgl-project/ome/multinode-prober:v1.0-84-3-g5dff59e",
+      "image" : "ghcr.io/moirai-internal/multinode-prober:v0.1.5",
       "memoryRequest": "100Mi",
       "memoryLimit": "100Mi",
       "cpuRequest": "100m",

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: manager
-          image: ghcr.io/moirai-internal/ome-manager:v0.1.4
+          image: ghcr.io/moirai-internal/ome-manager:v0.1.5

--- a/config/default/model_agent_image_patch.yaml
+++ b/config/default/model_agent_image_patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: model-agent
-          image: ghcr.io/moirai-internal/model-agent:v0.1.4
+          image: ghcr.io/moirai-internal/model-agent:v0.1.5

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
           - "--leader-elect"
           - "webhook"
           - "--zap-encoder=console"
-        image: ghcr.io/moirai-internal/ome-manager:v0.1.4
+        image: ghcr.io/moirai-internal/ome-manager:v0.1.5
         imagePullPolicy: Always
         name: manager
         securityContext:


### PR DESCRIPTION
## What this PR does

Bumps default image pins from `v0.1.4` to `v0.1.5` to match the v0.1.5 release:

- `config/default/manager_image_patch.yaml` — `ome-manager` → v0.1.5
- `config/default/model_agent_image_patch.yaml` — `model-agent` → v0.1.5
- `config/manager/manager.yaml` — `ome-manager` → v0.1.5
- `config/configmap/inferenceservice.yaml` — `modelInit` and `multinodeProber` sidecars → `ghcr.io/moirai-internal/ome-agent:v0.1.5` and `ghcr.io/moirai-internal/multinode-prober:v0.1.5`

The ConfigMap sidecar images also correct registry drift: the previous values pointed at `ghcr.io/sgl-project/ome/...` with stale tags, which don't match the v0.1.5 release bundle published at `ghcr.io/moirai-internal/...`.

## Why we need it

After v0.1.5 was released, the default kustomize manifests at the `v0.1.5` tag still pinned `v0.1.4` images. Running `make install` at the release tag therefore installs v0.1.4 controller/agent images. The sidecar references in `inferenceservice-config` also pointed at a retired registry path, so freshly reconciled InferenceService pods would fail to pull their init/prober containers.

Fixes # N/A

## How to test

Validated locally against the moirai-dev cluster:

```bash
export KUBECONFIG=$HOME/.kube/gais-clusters/moirai-dev-config
make install
```

Post-install verification:

- `ome-controller-manager` Deployment → `ghcr.io/moirai-internal/ome-manager:v0.1.5` (3/3 Running)
- `ome-model-agent-daemonset` → `ghcr.io/moirai-internal/model-agent:v0.1.5` (15/15 Running)
- `inferenceservice-config` ConfigMap `modelInit.image` → `ghcr.io/moirai-internal/ome-agent:v0.1.5`
- `inferenceservice-config` ConfigMap `multinodeProber.image` → `ghcr.io/moirai-internal/multinode-prober:v0.1.5`
- All 8 OME CRDs current; 4 existing InferenceServices remained `READY=True`; controller logs show healthy reconcile.

## Checklist

- [ ] Tests added/updated (if applicable) — N/A (config-only change)
- [ ] Docs updated (if applicable) — N/A
- [ ] `make test` passes locally — N/A (config-only change; validated via `make install` on a live cluster)