### PR TITLE
[Misc] add multi modal model fallback in generic model config parse

### DIFF
--- a/pkg/hfutil/modelconfig/deepseek_vl.go
+++ b/pkg/hfutil/modelconfig/deepseek_vl.go
@@ -200,27 +200,6 @@ func (c *DeepSeekVLConfig) GetArchitecture() string {
 	return "DeepseekVLForCausalLM"
 }
 
-// Helper function to estimate MoE model parameters
-func estimateMoEParams(hiddenSize, numLayers, intermediateSize, moeIntermediateSize, nRoutedExperts, nSharedExperts, vocabSize int) int64 {
-	// Embeddings
-	params := int64(hiddenSize * vocabSize)
-
-	// For each layer
-	params += int64(numLayers) * (
-	// Self-attention
-	int64(4*hiddenSize*hiddenSize) +
-		// Shared experts
-		int64(nSharedExperts*2*hiddenSize*intermediateSize) +
-		// Routed experts
-		int64(nRoutedExperts*2*hiddenSize*moeIntermediateSize) +
-		// Router
-		int64(hiddenSize*nRoutedExperts) +
-		// Layer norms
-		int64(2*hiddenSize))
-
-	return params
-}
-
 // Register the DeepSeek VL model handlers
 func init() {
 	RegisterModelLoader("deepseek_vl_v2", func(configPath string) (HuggingFaceModel, error) {

--- a/pkg/hfutil/modelconfig/interface.go
+++ b/pkg/hfutil/modelconfig/interface.go
@@ -228,6 +228,8 @@ var (
 // GenericModelConfig is a fallback configuration for unsupported model types.
 // It provides basic functionality by parsing common fields from the config.json
 // and attempting to get parameter count from safetensors files.
+// For multimodal models with nested configs (text_config, llm_config, language_config),
+// loadGenericModelConfig probes nested sub-configs to fill zero-valued fields.
 type GenericModelConfig struct {
 	BaseModelConfig
 
@@ -237,10 +239,19 @@ type GenericModelConfig struct {
 	NumAttentionHeads     int `json:"num_attention_heads"`
 	IntermediateSize      int `json:"intermediate_size"`
 	MaxPositionEmbeddings int `json:"max_position_embeddings"`
+	MaxSequenceLength     int `json:"max_sequence_length"`
 	VocabSize             int `json:"vocab_size"`
+
+	// MoE fields (populated from top-level or nested config)
+	NRoutedExperts      int `json:"n_routed_experts"`
+	NSharedExperts      int `json:"n_shared_experts"`
+	MoeIntermediateSize int `json:"moe_intermediate_size"`
 
 	// Quantization config (optional)
 	QuantizationConfig *QuantizationConfig `json:"quantization_config,omitempty"`
+
+	// Set during loading when vision sub-config is detected
+	hasVisionConfig bool
 }
 
 // GetParameterCount attempts to get parameter count from safetensors, falls back to estimation
@@ -255,6 +266,10 @@ func (c *GenericModelConfig) GetParameterCount() int64 {
 
 	// Fallback: estimate from architecture if we have the necessary fields
 	if c.HiddenSize > 0 && c.NumHiddenLayers > 0 {
+		if c.NRoutedExperts > 0 {
+			return estimateMoEParams(c.HiddenSize, c.NumHiddenLayers, c.IntermediateSize,
+				c.MoeIntermediateSize, c.NRoutedExperts, c.NSharedExperts, c.VocabSize)
+		}
 		return estimateGenericParams(c.HiddenSize, c.NumHiddenLayers, c.IntermediateSize, c.VocabSize)
 	}
 
@@ -278,6 +293,139 @@ func estimateGenericParams(hiddenSize, numLayers, intermediateSize, vocabSize in
 	return embeddingParams + totalLayerParams
 }
 
+// estimateMoEParams estimates parameter count for Mixture-of-Experts models.
+// It accounts for per-expert FFN weights, shared experts, and the router.
+func estimateMoEParams(hiddenSize, numLayers, intermediateSize, moeIntermediateSize, nRoutedExperts, nSharedExperts, vocabSize int) int64 {
+	if moeIntermediateSize == 0 {
+		moeIntermediateSize = intermediateSize
+	}
+
+	// Embeddings
+	params := int64(hiddenSize * vocabSize)
+
+	// For each layer
+	params += int64(numLayers) * (
+	// Self-attention
+	int64(4*hiddenSize*hiddenSize) +
+		// Shared experts
+		int64(nSharedExperts*2*hiddenSize*intermediateSize) +
+		// Routed experts
+		int64(nRoutedExperts*2*hiddenSize*moeIntermediateSize) +
+		// Router
+		int64(hiddenSize*nRoutedExperts) +
+		// Layer norms
+		int64(2*hiddenSize))
+
+	return params
+}
+
+// nestedLLMConfigKeys lists the JSON keys under which multimodal models
+// commonly store their language/LLM sub-configuration.
+var nestedLLMConfigKeys = []string{"text_config", "llm_config", "language_config"}
+
+// probeNestedConfig attempts to fill zero-valued fields in config from
+// nested sub-configurations commonly found in multimodal model configs.
+// It only fills fields that are zero/empty, so it is safe to call unconditionally.
+func probeNestedConfig(data []byte, config *GenericModelConfig) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return
+	}
+
+	// Probe for nested LLM/text config
+	for _, key := range nestedLLMConfigKeys {
+		sub, ok := raw[key]
+		if !ok {
+			continue
+		}
+		var nested struct {
+			HiddenSize            int    `json:"hidden_size"`
+			NumHiddenLayers       int    `json:"num_hidden_layers"`
+			NumAttentionHeads     int    `json:"num_attention_heads"`
+			IntermediateSize      int    `json:"intermediate_size"`
+			MaxPositionEmbeddings int    `json:"max_position_embeddings"`
+			VocabSize             int    `json:"vocab_size"`
+			TransformersVersion   string `json:"transformers_version"`
+			TorchDtype            string `json:"torch_dtype"`
+			// MoE fields — try all common JSON key names via multiple fields
+			NRoutedExperts      int `json:"n_routed_experts"`
+			NumLocalExperts     int `json:"num_local_experts"`
+			NumExperts          int `json:"num_experts"`
+			NSharedExperts      int `json:"n_shared_experts"`
+			MoeIntermediateSize int `json:"moe_intermediate_size"`
+		}
+		if err := json.Unmarshal(sub, &nested); err != nil {
+			continue
+		}
+
+		// Fill zero-valued fields from nested config
+		if config.HiddenSize == 0 {
+			config.HiddenSize = nested.HiddenSize
+		}
+		if config.NumHiddenLayers == 0 {
+			config.NumHiddenLayers = nested.NumHiddenLayers
+		}
+		if config.NumAttentionHeads == 0 {
+			config.NumAttentionHeads = nested.NumAttentionHeads
+		}
+		if config.IntermediateSize == 0 {
+			config.IntermediateSize = nested.IntermediateSize
+		}
+		if config.MaxPositionEmbeddings == 0 {
+			config.MaxPositionEmbeddings = nested.MaxPositionEmbeddings
+		}
+		if config.VocabSize == 0 {
+			config.VocabSize = nested.VocabSize
+		}
+		if config.TransformerVersion == "" {
+			config.TransformerVersion = nested.TransformersVersion
+		}
+		if config.TorchDtype == "" {
+			config.TorchDtype = nested.TorchDtype
+		}
+
+		// MoE fields — resolve the different JSON key names
+		if config.NRoutedExperts == 0 {
+			if nested.NRoutedExperts > 0 {
+				config.NRoutedExperts = nested.NRoutedExperts
+			} else if nested.NumLocalExperts > 0 {
+				config.NRoutedExperts = nested.NumLocalExperts
+			} else if nested.NumExperts > 0 {
+				config.NRoutedExperts = nested.NumExperts
+			}
+		}
+		if config.NSharedExperts == 0 {
+			config.NSharedExperts = nested.NSharedExperts
+		}
+		if config.MoeIntermediateSize == 0 {
+			config.MoeIntermediateSize = nested.MoeIntermediateSize
+		}
+
+		break // Use the first matching nested config
+	}
+
+	// Resolve top-level MoE field name variants (num_local_experts, num_experts)
+	// that don't match the GenericModelConfig JSON tags
+	if config.NRoutedExperts == 0 {
+		var topLevel struct {
+			NumLocalExperts int `json:"num_local_experts"`
+			NumExperts      int `json:"num_experts"`
+		}
+		if err := json.Unmarshal(data, &topLevel); err == nil {
+			if topLevel.NumLocalExperts > 0 {
+				config.NRoutedExperts = topLevel.NumLocalExperts
+			} else if topLevel.NumExperts > 0 {
+				config.NRoutedExperts = topLevel.NumExperts
+			}
+		}
+	}
+
+	// Detect vision config presence
+	if _, ok := raw["vision_config"]; ok {
+		config.hasVisionConfig = true
+	}
+}
+
 func (c *GenericModelConfig) GetQuantizationType() string {
 	if c.QuantizationConfig != nil && c.QuantizationConfig.QuantMethod != "" {
 		return c.QuantizationConfig.QuantMethod
@@ -286,7 +434,15 @@ func (c *GenericModelConfig) GetQuantizationType() string {
 }
 
 func (c *GenericModelConfig) GetContextLength() int {
-	return c.MaxPositionEmbeddings
+	if c.MaxPositionEmbeddings > 0 {
+		return c.MaxPositionEmbeddings
+	}
+	return c.MaxSequenceLength
+}
+
+// HasVision returns true if a vision sub-config was detected during loading
+func (c *GenericModelConfig) HasVision() bool {
+	return c.hasVisionConfig
 }
 
 func (c *GenericModelConfig) GetModelSizeBytes() int64 {
@@ -462,6 +618,11 @@ func loadGenericModelConfig(configPath string) (HuggingFaceModel, error) {
 	}
 
 	config.ConfigPath = configPath
+
+	// Probe nested sub-configs (text_config, llm_config, language_config)
+	// to fill zero-valued fields for multimodal models
+	probeNestedConfig(data, &config)
+
 	return &config, nil
 }
 

--- a/pkg/hfutil/modelconfig/interface_test.go
+++ b/pkg/hfutil/modelconfig/interface_test.go
@@ -293,3 +293,239 @@ func TestGenericConfigFallback(t *testing.T) {
 	}
 	t.Logf("Estimated model size: %s", FormatSize(modelSize))
 }
+
+func TestGenericMultimodalFallback(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+
+	// Nemotron-style config: top-level model_type with nested llm_config
+	configJSON := `{
+		"architectures": ["Reasoning_V3"],
+		"model_type": "Reasoning_V3",
+		"torch_dtype": "bfloat16",
+		"max_sequence_length": 131072,
+		"llm_config": {
+			"architectures": ["CausalLM"],
+			"model_type": "multi_h",
+			"transformers_version": "4.55.4",
+			"torch_dtype": "bfloat16",
+			"hidden_size": 2688,
+			"num_hidden_layers": 52,
+			"num_attention_heads": 32,
+			"intermediate_size": 1856,
+			"max_position_embeddings": 262144,
+			"vocab_size": 131072,
+			"n_routed_experts": 128,
+			"n_shared_experts": 1,
+			"moe_intermediate_size": 1856
+		},
+		"vision_config": {
+			"architectures": ["RADIOModel"],
+			"max_resolution": 2048
+		},
+		"sound_config": {
+			"model_type": "parakeet",
+			"hidden_size": 1024
+		}
+	}`
+
+	if err := os.WriteFile(configPath, []byte(configJSON), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	config, err := LoadModelConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if config.GetModelType() != "Reasoning_V3" {
+		t.Errorf("Expected model type 'Reasoning_V3', got '%s'", config.GetModelType())
+	}
+
+	if config.GetTransformerVersion() != "4.55.4" {
+		t.Errorf("Expected transformers_version '4.55.4', got '%s'", config.GetTransformerVersion())
+	}
+
+	// Context length should use max_position_embeddings from llm_config (262144)
+	// since it's probed and takes priority over max_sequence_length
+	if config.GetContextLength() != 262144 {
+		t.Errorf("Expected context length 262144, got %d", config.GetContextLength())
+	}
+
+	if !config.HasVision() {
+		t.Error("Expected HasVision() to return true")
+	}
+
+	if config.IsEmbedding() {
+		t.Error("Expected IsEmbedding() to return false")
+	}
+
+	// Parameter count should use MoE estimation (~68.8B), not dense (~4.86B)
+	paramCount := config.GetParameterCount()
+	if paramCount < 60_000_000_000 || paramCount > 80_000_000_000 {
+		t.Errorf("Expected MoE parameter count in range [60B, 80B], got %d (%s)",
+			paramCount, FormatParamCount(paramCount))
+	}
+	t.Logf("Estimated parameter count: %s (%d)", FormatParamCount(paramCount), paramCount)
+}
+
+func TestGenericMultimodalFallback_TextConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+
+	configJSON := `{
+		"architectures": ["SomeVisionModel"],
+		"model_type": "some_vision_model",
+		"text_config": {
+			"hidden_size": 4096,
+			"num_hidden_layers": 32,
+			"intermediate_size": 11008,
+			"max_position_embeddings": 4096,
+			"vocab_size": 32000,
+			"transformers_version": "4.40.0",
+			"torch_dtype": "float16"
+		},
+		"vision_config": {
+			"hidden_size": 1024,
+			"num_hidden_layers": 24
+		}
+	}`
+
+	if err := os.WriteFile(configPath, []byte(configJSON), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	config, err := LoadModelConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if config.GetTransformerVersion() != "4.40.0" {
+		t.Errorf("Expected transformers_version '4.40.0', got '%s'", config.GetTransformerVersion())
+	}
+	if config.GetContextLength() != 4096 {
+		t.Errorf("Expected context length 4096, got %d", config.GetContextLength())
+	}
+	if config.GetTorchDtype() != "float16" {
+		t.Errorf("Expected torch_dtype 'float16', got '%s'", config.GetTorchDtype())
+	}
+	if !config.HasVision() {
+		t.Error("Expected HasVision() to return true")
+	}
+	if config.GetParameterCount() <= 0 {
+		t.Error("Expected positive parameter count")
+	}
+}
+
+func TestGenericMultimodalFallback_LanguageConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+
+	configJSON := `{
+		"architectures": ["SomeVLModel"],
+		"model_type": "some_vl_model",
+		"language_config": {
+			"hidden_size": 2048,
+			"num_hidden_layers": 24,
+			"intermediate_size": 5504,
+			"max_position_embeddings": 4096,
+			"vocab_size": 100000,
+			"transformers_version": "4.38.0"
+		},
+		"vision_config": {
+			"hidden_size": 1152
+		}
+	}`
+
+	if err := os.WriteFile(configPath, []byte(configJSON), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	config, err := LoadModelConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if config.GetTransformerVersion() != "4.38.0" {
+		t.Errorf("Expected transformers_version '4.38.0', got '%s'", config.GetTransformerVersion())
+	}
+	if config.GetContextLength() != 4096 {
+		t.Errorf("Expected context length 4096, got %d", config.GetContextLength())
+	}
+	if !config.HasVision() {
+		t.Error("Expected HasVision() to return true")
+	}
+}
+
+func TestGenericMoEFallback(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+
+	// Flat MoE config (like Mixtral) with num_local_experts variant
+	configJSON := `{
+		"architectures": ["SomeMoEModel"],
+		"model_type": "some_moe",
+		"hidden_size": 4096,
+		"num_hidden_layers": 32,
+		"intermediate_size": 14336,
+		"max_position_embeddings": 32768,
+		"vocab_size": 32000,
+		"torch_dtype": "bfloat16",
+		"transformers_version": "4.36.0",
+		"num_local_experts": 8,
+		"moe_intermediate_size": 14336
+	}`
+
+	if err := os.WriteFile(configPath, []byte(configJSON), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	config, err := LoadModelConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Should use MoE estimation with 8 experts
+	paramCount := config.GetParameterCount()
+	// Dense estimate would be ~12 * 4096^2 * 32 + embeddings ≈ 6.6B
+	// MoE estimate with 8 experts should be much higher
+	if paramCount < 30_000_000_000 {
+		t.Errorf("Expected MoE parameter count > 30B, got %d (%s)",
+			paramCount, FormatParamCount(paramCount))
+	}
+	t.Logf("Estimated MoE parameter count: %s (%d)", FormatParamCount(paramCount), paramCount)
+}
+
+func TestGenericContextLengthMaxSequenceLength(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+
+	// Config with max_sequence_length but no max_position_embeddings at top level
+	configJSON := `{
+		"architectures": ["SomeModel"],
+		"model_type": "some_model",
+		"max_sequence_length": 131072,
+		"hidden_size": 2048,
+		"num_hidden_layers": 24,
+		"vocab_size": 32000,
+		"torch_dtype": "bfloat16",
+		"transformers_version": "4.40.0"
+	}`
+
+	if err := os.WriteFile(configPath, []byte(configJSON), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	config, err := LoadModelConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if config.GetContextLength() != 131072 {
+		t.Errorf("Expected context length 131072 from max_sequence_length, got %d", config.GetContextLength())
+	}
+
+	if config.HasVision() {
+		t.Error("Expected HasVision() to return false for non-multimodal config")
+	}
+}

--- a/pkg/modelagent/config_parser.go
+++ b/pkg/modelagent/config_parser.go
@@ -544,6 +544,12 @@ func (p *ModelConfigParser) determineModelCapabilitiesFromHF(hfModel modelconfig
 		}
 	}
 
+	// For NemotronH_Nano capability
+	if strings.Contains(normalizedModelType, "NemotronH_Nano") {
+		return append(capabilities, string(v1beta1.ModelCapabilityImageTextToText), string(v1beta1.ModelCapabilityTextToText),
+			string(v1beta1.ModelCapabilityAudioToText))
+	}
+
 	// For vision, only support image text capability right now
 	if hfModel.HasVision() {
 		return append(capabilities, string(v1beta1.ModelCapabilityImageTextToText))


### PR DESCRIPTION
## What this PR does

 - Enhance GenericModelConfig fallback to probe nested sub-configs (text_config, llm_config, language_config) commonly found in multimodal models                                                                    
  - Add MoE-aware parameter estimation for unregistered Mixture-of-Experts models                                                                                                                                     
  - Move `estimateMoEParams()` from `deepseek_vl.go` to interface.go as a shared utility   
## Why we need it
 When an unregistered multimodal model (e.g., composite vision-language-audio models) falls back to GenericModelConfig, critical fields like hidden_size, max_position_embeddings, and transformers_version are      
  missed because they are nested under keys like llm_config, text_config, or language_config. This causes:                                                                                                            
  - GetContextLength() → 0                                                                                                                                                                                            
  - GetParameterCount() → 0 (or massively underestimated for MoE models)                                                                                                                                              
  - GetTransformerVersion() → ""                                                                                                                                                                                      
  - HasVision() → false  

## What changes in this PR

 `pkg/hfutil/modelconfig/interface.go`                                                                                                                                                                                 
                                                                                                                                                                                                                      
  - Add MaxSequenceLength, MoE fields (NRoutedExperts, NSharedExperts, MoeIntermediateSize), and hasVisionConfig to GenericModelConfig                                                                                
  - Add probeNestedConfig() helper that extracts fields from nested sub-configs and detects vision_config presence                                                                                                    
  - Override GetContextLength() to fall back to MaxSequenceLength                                                                                                                                                     
  - Override HasVision() to return detected vision config presence                                                                                                                                                    
  - Override GetParameterCount() to use MoE-aware estimation when experts are detected                                                                                                                                
  - Move estimateMoEParams() here from deepseek_vl.go (general-purpose, not DeepSeek-specific)                                                                                                                        
  - Call probeNestedConfig() unconditionally in loadGenericModelConfig() (safe — only fills zero-valued fields)                                                                                                       
                                                                                                                                                                                                                      
  `pkg/hfutil/modelconfig/deepseek_vl.go`                                                                                                                                                                               
                                                                                                                                                                                                                      
  - Remove estimateMoEParams() (moved to interface.go, same package — no behavior change)                                                                                                                             
                                                                                                                                                                                                                      
  `pkg/hfutil/modelconfig/interface_test.go`                                                                                                                                                                            
                                                                                                                                                                                                                      
  - TestGenericMultimodalFallback — nested llm_config + vision_config with MoE fields                                                                                                                                 
  - TestGenericMultimodalFallback_TextConfig — text_config variant                                                                                                                                                    
  - TestGenericMultimodalFallback_LanguageConfig — language_config variant                                                                                                                                            
  - TestGenericMoEFallback — flat MoE config with num_local_experts field name variant                                                                                                                                
  - TestGenericContextLengthMaxSequenceLength — max_sequence_length fallback           

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally