### PR TITLE
[Bugfix] normalizedModelType is lowercased but the check uses mixed-case

### DIFF
--- a/pkg/modelagent/config_parser.go
+++ b/pkg/modelagent/config_parser.go
@@ -545,7 +545,7 @@ func (p *ModelConfigParser) determineModelCapabilitiesFromHF(hfModel modelconfig
 	}
 
 	// For NemotronH_Nano capability
-	if strings.Contains(normalizedModelType, "NemotronH_Nano") {
+	if strings.Contains(normalizedModelType, "nemotronh_nano") {
 		return append(capabilities, string(v1beta1.ModelCapabilityImageTextToText), string(v1beta1.ModelCapabilityTextToText),
 			string(v1beta1.ModelCapabilityAudioToText))
 	}

--- a/pkg/modelagent/config_parser_test.go
+++ b/pkg/modelagent/config_parser_test.go
@@ -363,6 +363,19 @@ func TestDetermineModelCapabilitiesFromHF(t *testing.T) {
 			},
 		},
 		{
+			name: "NemotronH_Nano Omni Model - falls through to vision due to case mismatch",
+			mockModel: &mockHuggingFaceModel{
+				modelType:    "NemotronH_Nano_Omni_Reasoning_V3",
+				architecture: "NemotronH_Nano_Omni_Reasoning_V3",
+				hasVision:    true,
+			},
+			expectedCapabilities: []string{
+				string(v1beta1.ModelCapabilityImageTextToText),
+				string(v1beta1.ModelCapabilityTextToText),
+				string(v1beta1.ModelCapabilityAudioToText),
+			},
+		},
+		{
 			name: "Whisper ASR Model",
 			mockModel: &mockHuggingFaceModel{
 				modelType:    "whisper",


### PR DESCRIPTION
## What this PR does
A bugfix for mixed case "NemotronH_Nano" in condition compare in config_parser.go

## Why we need it

normalizedModelType lowercases the model type, so "NemotronH_Nano" (mixed case) will never match against a lowercased string.
Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
