### PR TITLE
[Helm] Bump remaining v0.1.4 references to v0.1.5

### DIFF
--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -8,7 +8,7 @@ global:
   imagePullSecrets: []
 
 ome:
-  version: &defaultVersion v0.1.4
+  version: &defaultVersion v0.1.5
   metricsaggregator:
     enableMetricAggregation: "false"
     enablePrometheusScraping: "false"

--- a/config/model-agent/daemonset.yaml
+++ b/config/model-agent/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
           type: DirectoryOrCreate
       containers:
       - name: model-agent
-        image: ghcr.io/moirai-internal/model-agent:v0.1.4
+        image: ghcr.io/moirai-internal/model-agent:v0.1.5
         imagePullPolicy: Always
         ports:
         - name: metrics


### PR DESCRIPTION
## Summary
- Follow-up to #582, which bumped the default image version to v0.1.5 but left two stragglers on v0.1.4
- Update `config/model-agent/daemonset.yaml` model-agent image tag to v0.1.5
- Update `charts/ome-resources/values.yaml` `defaultVersion` anchor to v0.1.5

## Test plan
- [ ] `make helm-lint` passes
- [ ] Verify no remaining `v0.1.4` references in OME-owned files (third-party deps in go.sum / package-lock.json excluded)