### PR TITLE
[Core] add serving graph and predictor bridge

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -205,17 +205,27 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Determine which components to reconcile based on the spec
 	var reconcilers []components.Component
 
-	// Migrate predictor spec to new architecture if needed
-	if err := r.migratePredictorToNewArchitecture(isvc); err != nil {
-		r.Log.Error(err, "Failed to migrate predictor spec", "namespace", isvc.Namespace, "inferenceService", isvc.Name)
-		r.Recorder.Eventf(isvc, v1.EventTypeWarning, "PredictorMigrationError", err.Error())
+	servingGraph, err := isvcutils.ResolveServingGraph(isvc)
+	if err != nil {
+		r.Log.Error(err, "Failed to resolve serving graph", "namespace", isvc.Namespace, "inferenceService", isvc.Name)
+		r.Recorder.Eventf(isvc, v1.EventTypeWarning, "ServingGraphError", err.Error())
 		return reconcile.Result{}, err
+	}
+	resolvedISVC := servingGraph.InferenceService
+
+	// Persist compatibility translation for predictor-only services during the rollout.
+	if servingGraph.PredictorCompatibility {
+		if err := r.migratePredictorToNewArchitecture(isvc); err != nil {
+			r.Log.Error(err, "Failed to migrate predictor spec", "namespace", isvc.Namespace, "inferenceService", isvc.Name)
+			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "PredictorMigrationError", err.Error())
+			return reconcile.Result{}, err
+		}
 	}
 
 	var ingressDeploymentMode constants.DeploymentModeType
 
 	// Step 1: Reconcile model first
-	baseModel, baseModelMeta, err := isvcutils.ReconcileBaseModel(r.Client, isvc)
+	baseModel, baseModelMeta, err := isvcutils.ReconcileBaseModel(r.Client, resolvedISVC)
 	if err != nil {
 		r.Log.Error(err, "Failed to reconcile base model", "Name", isvc.Name)
 		r.Recorder.Eventf(isvc, v1.EventTypeWarning, "ModelReconcileError", err.Error())
@@ -227,14 +237,14 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	var rtName string
 	userSpecifiedRuntime := false
 
-	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Name != "" {
+	if servingGraph.Runtime != nil && servingGraph.Runtime.Name != "" {
 		// Validate specified runtime
-		rtName = isvc.Spec.Runtime.Name
+		rtName = servingGraph.Runtime.Name
 		userSpecifiedRuntime = true
-		if err := r.RuntimeSelector.ValidateRuntime(ctx, rtName, baseModel, isvc); err != nil {
-			r.Log.Error(err, "Runtime validation failed", "runtime", rtName, "model", isvc.Spec.Model.Name)
+		if err := r.RuntimeSelector.ValidateRuntime(ctx, rtName, baseModel, resolvedISVC); err != nil {
+			r.Log.Error(err, "Runtime validation failed", "runtime", rtName, "model", resolvedISVC.Spec.Model.Name)
 			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeValidationError",
-				"Runtime %s does not support model %s: %v", rtName, isvc.Spec.Model.Name, err)
+				"Runtime %s does not support model %s: %v", rtName, resolvedISVC.Spec.Model.Name, err)
 			return reconcile.Result{}, err
 		}
 
@@ -248,33 +258,28 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		rt = rtSpec
 	} else {
 		// Auto-select runtime
-		selection, err := r.RuntimeSelector.SelectRuntime(ctx, baseModel, isvc)
+		selection, err := r.RuntimeSelector.SelectRuntime(ctx, baseModel, resolvedISVC)
 		if err != nil {
-			r.Log.Error(err, "Failed to auto-select runtime", "model", isvc.Spec.Model.Name)
+			r.Log.Error(err, "Failed to auto-select runtime", "model", resolvedISVC.Spec.Model.Name)
 			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeSelectionError",
-				"Failed to find runtime for model %s: %v", isvc.Spec.Model.Name, err)
+				"Failed to find runtime for model %s: %v", resolvedISVC.Spec.Model.Name, err)
 			return reconcile.Result{}, err
 		}
 		rt = selection.Spec
 		rtName = selection.Name
-		r.Log.Info("Auto-selected runtime", "runtime", rtName, "model", isvc.Spec.Model.Name)
+		r.Log.Info("Auto-selected runtime", "runtime", rtName, "model", resolvedISVC.Spec.Model.Name)
 	}
 
-	// Step 3: Merge rt and isvc specs to get final engine, decoder, and router specs
-	mergedEngine, mergedDecoder, mergedRouter, err := isvcutils.MergeRuntimeSpecs(isvc, rt, r.Log)
+	servingGraph, err = isvcutils.ResolveServingGraphWithRuntime(servingGraph, rt, r.Log)
 	if err != nil {
-		r.Log.Error(err, "Failed to merge specs", "Name", isvc.Name)
-		r.Recorder.Eventf(isvc, v1.EventTypeWarning, "MergeSpecsError", err.Error())
+		r.Log.Error(err, "Failed to resolve runtime-backed serving graph", "Name", isvc.Name)
+		r.Recorder.Eventf(isvc, v1.EventTypeWarning, "ServingGraphError", err.Error())
 		return reconcile.Result{}, err
 	}
-
-	// Step 4: Determine deployment modes based on merged specs
-	engineDeploymentMode, decoderDeploymentMode, routerDeploymentMode, err := isvcutils.DetermineDeploymentModes(mergedEngine, mergedDecoder, mergedRouter, rt)
-	if err != nil {
-		r.Log.Error(err, "Failed to determine deployment modes", "Name", isvc.Name)
-		r.Recorder.Eventf(isvc, v1.EventTypeWarning, "DeploymentModeError", err.Error())
-		return reconcile.Result{}, err
-	}
+	mergedEngine, mergedDecoder, mergedRouter := servingGraph.Engine, servingGraph.Decoder, servingGraph.Router
+	engineDeploymentMode := servingGraph.EngineDeploymentMode
+	decoderDeploymentMode := servingGraph.DecoderDeploymentMode
+	routerDeploymentMode := servingGraph.RouterDeploymentMode
 
 	// If both engine and decoder exist, it's PD-disaggregated
 	if mergedEngine != nil && mergedDecoder != nil {
@@ -283,7 +288,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Step 5: Create reconcilers based on merged specs
 	if mergedEngine != nil {
-		engineACObj, engineAcName, err := r.AcceleratorClassSelector.GetAcceleratorClass(ctx, isvc, rt, v1beta1.EngineComponent)
+		engineACObj, engineAcName, err := r.AcceleratorClassSelector.GetAcceleratorClass(ctx, resolvedISVC, rt, v1beta1.EngineComponent)
 		if err != nil {
 			r.Log.Error(err, "Failed to get accelerator class for engine component", "Name", isvc.Name)
 			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "AcceleratorClassError", "Failed to get accelerator class for engine: %v", err)
@@ -317,7 +322,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	if mergedDecoder != nil {
-		decoderACObj, decoderAcName, err := r.AcceleratorClassSelector.GetAcceleratorClass(ctx, isvc, rt, v1beta1.DecoderComponent)
+		decoderACObj, decoderAcName, err := r.AcceleratorClassSelector.GetAcceleratorClass(ctx, resolvedISVC, rt, v1beta1.DecoderComponent)
 		if err != nil {
 			r.Log.Error(err, "Failed to get accelerator class for decoder component", "Name", isvc.Name)
 			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "AcceleratorClassError", "Failed to get accelerator class for decoder: %v", err)
@@ -368,17 +373,10 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		reconcilers = append(reconcilers, routerReconciler)
 	}
 
-	// Determine the correct ingress deployment mode using the same logic as ingress reconciler
-	// but with the already-determined deployment modes to avoid inconsistency
-	if mergedRouter != nil {
-		ingressDeploymentMode = routerDeploymentMode
-	} else if mergedDecoder != nil {
-		ingressDeploymentMode = decoderDeploymentMode
-	} else {
-		ingressDeploymentMode = engineDeploymentMode
-	}
+	ingressDeploymentMode = servingGraph.EntrypointDeploymentMode
 
 	r.Log.Info("Determined ingress deployment mode",
+		"entrypointComponent", servingGraph.EntrypointComponent,
 		"ingressDeploymentMode", ingressDeploymentMode,
 		"namespace", isvc.Namespace,
 		"inferenceService", isvc.Name)

--- a/pkg/controller/v1beta1/inferenceservice/utils/migration_util.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/migration_util.go
@@ -15,6 +15,142 @@ import (
 	"github.com/sgl-project/ome/pkg/constants"
 )
 
+func translatePredictorModelRef(predictor *v1beta2.PredictorSpec) *v1beta2.ModelRef {
+	if predictor == nil || predictor.Model == nil || predictor.Model.BaseModel == nil {
+		return nil
+	}
+
+	return &v1beta2.ModelRef{
+		Name:             *predictor.Model.BaseModel,
+		FineTunedWeights: predictor.Model.FineTunedWeights,
+	}
+}
+
+func translatePredictorRuntimeRef(predictor *v1beta2.PredictorSpec) *v1beta2.ServingRuntimeRef {
+	if predictor == nil || predictor.Model == nil || predictor.Model.Runtime == nil {
+		return nil
+	}
+
+	runtimeKind := "ClusterServingRuntime"
+	runtimeAPIGroup := "ome.io"
+	return &v1beta2.ServingRuntimeRef{
+		Name:     *predictor.Model.Runtime,
+		Kind:     &runtimeKind,
+		APIGroup: &runtimeAPIGroup,
+	}
+}
+
+func translatePredictorEngineSpec(predictor *v1beta2.PredictorSpec) *v1beta2.EngineSpec {
+	if predictor == nil {
+		return nil
+	}
+
+	engine := &v1beta2.EngineSpec{
+		PodSpec:                predictor.PodSpec,
+		ComponentExtensionSpec: predictor.ComponentExtensionSpec,
+	}
+
+	// Process containers - look for ome-container or first container as Runner.
+	if len(predictor.Containers) > 0 {
+		runnerFound := false
+		var otherContainers []v1.Container
+
+		for _, container := range predictor.Containers {
+			if !runnerFound && (container.Name == "ome-container" || strings.Contains(strings.ToLower(container.Name), "ome")) {
+				runnerSpec := &v1beta2.RunnerSpec{
+					Container: container,
+				}
+
+				if predictor.Model != nil {
+					if len(predictor.Model.Env) > 0 {
+						runnerSpec.Env = append(runnerSpec.Env, predictor.Model.Env...)
+					}
+
+					if predictor.Model.StorageUri != nil {
+						runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
+							Name:  "STORAGE_URI",
+							Value: *predictor.Model.StorageUri,
+						})
+					}
+
+					if predictor.Model.ProtocolVersion != nil {
+						runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
+							Name:  "PROTOCOL_VERSION",
+							Value: string(*predictor.Model.ProtocolVersion),
+						})
+					}
+				}
+
+				engine.Runner = runnerSpec
+				runnerFound = true
+			} else {
+				otherContainers = append(otherContainers, container)
+			}
+		}
+
+		if !runnerFound {
+			runnerSpec := &v1beta2.RunnerSpec{
+				Container: predictor.Containers[0],
+			}
+
+			if predictor.Model != nil {
+				if len(predictor.Model.Env) > 0 {
+					runnerSpec.Env = append(runnerSpec.Env, predictor.Model.Env...)
+				}
+				if predictor.Model.StorageUri != nil {
+					runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
+						Name:  "STORAGE_URI",
+						Value: *predictor.Model.StorageUri,
+					})
+				}
+				if predictor.Model.ProtocolVersion != nil {
+					runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
+						Name:  "PROTOCOL_VERSION",
+						Value: string(*predictor.Model.ProtocolVersion),
+					})
+				}
+			}
+
+			engine.Runner = runnerSpec
+			if len(predictor.Containers) > 1 {
+				engine.Containers = predictor.Containers[1:]
+			}
+		} else {
+			engine.Containers = otherContainers
+		}
+	} else if predictor.Model != nil {
+		runnerSpec := &v1beta2.RunnerSpec{
+			Container: predictor.Model.Container,
+		}
+
+		if predictor.Model.StorageUri != nil {
+			runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
+				Name:  "STORAGE_URI",
+				Value: *predictor.Model.StorageUri,
+			})
+		}
+
+		if predictor.Model.ProtocolVersion != nil {
+			runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
+				Name:  "PROTOCOL_VERSION",
+				Value: string(*predictor.Model.ProtocolVersion),
+			})
+		}
+
+		if runnerSpec.Container.Name == "" {
+			runnerSpec = nil
+		}
+
+		engine.Runner = runnerSpec
+	}
+
+	if predictor.Worker != nil {
+		engine.Worker = predictor.Worker
+	}
+
+	return engine
+}
+
 // MigratePredictorToNewArchitecture migrates existing predictor resources to new engine/model architecture
 func MigratePredictorToNewArchitecture(ctx context.Context, c client.Client, log logr.Logger, isvc *v1beta2.InferenceService) error {
 	// Check if predictor is being used and migration hasn't happened yet
@@ -80,15 +216,15 @@ func IsPredictorUsed(isvc *v1beta2.InferenceService) bool {
 
 // MigratePredictor performs the actual migration from predictor to engine/model
 func MigratePredictor(ctx context.Context, c client.Client, isvc *v1beta2.InferenceService) error {
-	// Migrate Model
-	if isvc.Spec.Predictor.Model != nil && isvc.Spec.Predictor.Model.BaseModel != nil {
-		isvc.Spec.Model = &v1beta2.ModelRef{
-			Name:             *isvc.Spec.Predictor.Model.BaseModel,
-			FineTunedWeights: isvc.Spec.Predictor.Model.FineTunedWeights,
-		}
+	predictor := &isvc.Spec.Predictor
 
+	isvc.Spec.Model = translatePredictorModelRef(predictor)
+	isvc.Spec.Runtime = translatePredictorRuntimeRef(predictor)
+	isvc.Spec.Engine = translatePredictorEngineSpec(predictor)
+
+	if isvc.Spec.Model != nil {
 		// Determine the model kind dynamically
-		modelName := *isvc.Spec.Predictor.Model.BaseModel
+		modelName := isvc.Spec.Model.Name
 		kind, err := DetermineModelKind(ctx, c, modelName, isvc.Namespace)
 		if err != nil {
 			return err
@@ -98,142 +234,6 @@ func MigratePredictor(ctx context.Context, c client.Client, isvc *v1beta2.Infere
 		apiGroup := "ome.io"
 		isvc.Spec.Model.Kind = &kind
 		isvc.Spec.Model.APIGroup = &apiGroup
-
-		// Migrate Runtime reference
-		if isvc.Spec.Predictor.Model.Runtime != nil {
-			runtimeKind := "ClusterServingRuntime"
-			runtimeAPIGroup := "ome.io"
-			isvc.Spec.Runtime = &v1beta2.ServingRuntimeRef{
-				Name:     *isvc.Spec.Predictor.Model.Runtime,
-				Kind:     &runtimeKind,
-				APIGroup: &runtimeAPIGroup,
-			}
-		}
-	}
-
-	// Migrate Engine
-	isvc.Spec.Engine = &v1beta2.EngineSpec{
-		PodSpec:                isvc.Spec.Predictor.PodSpec,
-		ComponentExtensionSpec: isvc.Spec.Predictor.ComponentExtensionSpec,
-	}
-
-	// Process containers - look for ome-container or first container as Runner
-	if len(isvc.Spec.Predictor.Containers) > 0 {
-		// Look for ome-container first
-		runnerFound := false
-		var otherContainers []v1.Container
-
-		for _, container := range isvc.Spec.Predictor.Containers {
-			if !runnerFound && (container.Name == "ome-container" || strings.Contains(strings.ToLower(container.Name), "ome")) {
-				// Migrate container from PredictorExtensionSpec to Runner
-				runnerSpec := &v1beta2.RunnerSpec{
-					Container: container,
-				}
-
-				// Merge PredictorExtensionSpec container settings if present
-				if isvc.Spec.Predictor.Model != nil {
-					// Merge environment variables
-					if len(isvc.Spec.Predictor.Model.Env) > 0 {
-						runnerSpec.Env = append(runnerSpec.Env, isvc.Spec.Predictor.Model.Env...)
-					}
-
-					// Add storage URI as environment variable if present
-					if isvc.Spec.Predictor.Model.StorageUri != nil {
-						runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
-							Name:  "STORAGE_URI",
-							Value: *isvc.Spec.Predictor.Model.StorageUri,
-						})
-					}
-
-					// Add protocol version as environment variable if present
-					if isvc.Spec.Predictor.Model.ProtocolVersion != nil {
-						runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
-							Name:  "PROTOCOL_VERSION",
-							Value: string(*isvc.Spec.Predictor.Model.ProtocolVersion),
-						})
-					}
-				}
-
-				isvc.Spec.Engine.Runner = runnerSpec
-				runnerFound = true
-			} else {
-				otherContainers = append(otherContainers, container)
-			}
-		}
-
-		// If no ome container found, use first container as Runner
-		if !runnerFound && len(isvc.Spec.Predictor.Containers) > 0 {
-			runnerSpec := &v1beta2.RunnerSpec{
-				Container: isvc.Spec.Predictor.Containers[0],
-			}
-
-			// Apply PredictorExtensionSpec settings
-			if isvc.Spec.Predictor.Model != nil {
-				if len(isvc.Spec.Predictor.Model.Env) > 0 {
-					runnerSpec.Env = append(runnerSpec.Env, isvc.Spec.Predictor.Model.Env...)
-				}
-				if isvc.Spec.Predictor.Model.StorageUri != nil {
-					runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
-						Name:  "STORAGE_URI",
-						Value: *isvc.Spec.Predictor.Model.StorageUri,
-					})
-				}
-				if isvc.Spec.Predictor.Model.ProtocolVersion != nil {
-					runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
-						Name:  "PROTOCOL_VERSION",
-						Value: string(*isvc.Spec.Predictor.Model.ProtocolVersion),
-					})
-				}
-			}
-
-			isvc.Spec.Engine.Runner = runnerSpec
-
-			// Keep remaining containers
-			if len(isvc.Spec.Predictor.Containers) > 1 {
-				isvc.Spec.Engine.Containers = isvc.Spec.Predictor.Containers[1:]
-			}
-		} else {
-			isvc.Spec.Engine.Containers = otherContainers
-		}
-	} else if isvc.Spec.Predictor.Model != nil {
-		// No containers in PodSpec, but we have Model spec with container configuration
-		runnerSpec := &v1beta2.RunnerSpec{
-			Container: isvc.Spec.Predictor.Model.Container,
-		}
-
-		// Add storage URI as environment variable if present
-		if isvc.Spec.Predictor.Model.StorageUri != nil {
-			if runnerSpec.Env == nil {
-				runnerSpec.Env = []v1.EnvVar{}
-			}
-			runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
-				Name:  "STORAGE_URI",
-				Value: *isvc.Spec.Predictor.Model.StorageUri,
-			})
-		}
-
-		// Add protocol version as environment variable if present
-		if isvc.Spec.Predictor.Model.ProtocolVersion != nil {
-			if runnerSpec.Env == nil {
-				runnerSpec.Env = []v1.EnvVar{}
-			}
-			runnerSpec.Env = append(runnerSpec.Env, v1.EnvVar{
-				Name:  "PROTOCOL_VERSION",
-				Value: string(*isvc.Spec.Predictor.Model.ProtocolVersion),
-			})
-		}
-
-		// No containers in Model spec, set runnerSpec as nil
-		if runnerSpec.Container.Name == "" {
-			runnerSpec = nil
-		}
-
-		isvc.Spec.Engine.Runner = runnerSpec
-	}
-
-	// Migrate Worker spec if present
-	if isvc.Spec.Predictor.Worker != nil {
-		isvc.Spec.Engine.Worker = isvc.Spec.Predictor.Worker
 	}
 
 	return nil

--- a/pkg/controller/v1beta1/inferenceservice/utils/serving_graph.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/serving_graph.go
@@ -1,0 +1,154 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/constants"
+)
+
+// ServingGraph captures the serving components that the controller should reconcile.
+// Predictor is only retained as a compatibility marker during rollout.
+type ServingGraph struct {
+	InferenceService         *v1beta1.InferenceService
+	Model                    *v1beta1.ModelRef
+	Runtime                  *v1beta1.ServingRuntimeRef
+	Engine                   *v1beta1.EngineSpec
+	Decoder                  *v1beta1.DecoderSpec
+	Router                   *v1beta1.RouterSpec
+	PredictorCompatibility   bool
+	EntrypointComponent      v1beta1.ComponentType
+	EntrypointDeploymentMode constants.DeploymentModeType
+	EngineDeploymentMode     constants.DeploymentModeType
+	DecoderDeploymentMode    constants.DeploymentModeType
+	RouterDeploymentMode     constants.DeploymentModeType
+}
+
+// IsPredictorCompatibilityMode returns true when the deprecated predictor field is the
+// only serving configuration and needs translation into engine/model/runtime fields.
+func IsPredictorCompatibilityMode(isvc *v1beta1.InferenceService) bool {
+	return isvc != nil && IsPredictorUsed(isvc) && isvc.Spec.Engine == nil && isvc.Spec.Model == nil
+}
+
+// ResolveServingGraph translates predictor compatibility input into the shared engine-first serving graph.
+func ResolveServingGraph(isvc *v1beta1.InferenceService) (*ServingGraph, error) {
+	if isvc == nil {
+		return nil, fmt.Errorf("inference service is required")
+	}
+
+	resolvedISVC := isvc.DeepCopy()
+	predictorCompatibility := IsPredictorCompatibilityMode(resolvedISVC)
+	if predictorCompatibility {
+		resolvedISVC.Spec.Model = translatePredictorModelRef(&resolvedISVC.Spec.Predictor)
+		resolvedISVC.Spec.Runtime = translatePredictorRuntimeRef(&resolvedISVC.Spec.Predictor)
+		resolvedISVC.Spec.Engine = translatePredictorEngineSpec(&resolvedISVC.Spec.Predictor)
+	}
+
+	return newServingGraph(
+		resolvedISVC,
+		resolvedISVC.Spec.Model,
+		resolvedISVC.Spec.Runtime,
+		resolvedISVC.Spec.Engine,
+		resolvedISVC.Spec.Decoder,
+		resolvedISVC.Spec.Router,
+		predictorCompatibility,
+	), nil
+}
+
+// ResolveServingGraphWithRuntime merges runtime defaults into the resolved serving graph
+// and computes deployment-mode and entrypoint selection from the shared component view.
+func ResolveServingGraphWithRuntime(graph *ServingGraph, runtime *v1beta1.ServingRuntimeSpec, log logr.Logger) (*ServingGraph, error) {
+	if graph == nil || graph.InferenceService == nil {
+		return nil, fmt.Errorf("serving graph is required")
+	}
+
+	resolvedISVC := graph.InferenceService.DeepCopy()
+	engine, decoder, router, err := MergeRuntimeSpecs(resolvedISVC, runtime, log)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedGraph := newServingGraph(
+		resolvedISVC,
+		resolvedISVC.Spec.Model,
+		resolvedISVC.Spec.Runtime,
+		engine,
+		decoder,
+		router,
+		graph.PredictorCompatibility,
+	)
+
+	if engine == nil && decoder == nil && router == nil {
+		resolvedGraph.EntrypointDeploymentMode = constants.RawDeployment
+		return resolvedGraph, nil
+	}
+
+	engineMode, decoderMode, routerMode, err := DetermineDeploymentModes(engine, decoder, router, runtime)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedGraph.EngineDeploymentMode = engineMode
+	resolvedGraph.DecoderDeploymentMode = decoderMode
+	resolvedGraph.RouterDeploymentMode = routerMode
+	resolvedGraph.EntrypointDeploymentMode = resolvedGraph.DeploymentModeFor(resolvedGraph.EntrypointComponent)
+	return resolvedGraph, nil
+}
+
+// DeploymentModeFor returns the deployment mode for the requested component.
+func (g *ServingGraph) DeploymentModeFor(component v1beta1.ComponentType) constants.DeploymentModeType {
+	if g == nil {
+		return constants.RawDeployment
+	}
+
+	switch component {
+	case v1beta1.RouterComponent:
+		if g.Router != nil {
+			return g.RouterDeploymentMode
+		}
+	case v1beta1.DecoderComponent:
+		if g.Decoder != nil {
+			return g.DecoderDeploymentMode
+		}
+	case v1beta1.PredictorComponent:
+		fallthrough
+	case v1beta1.EngineComponent:
+		if g.Engine != nil {
+			return g.EngineDeploymentMode
+		}
+	}
+
+	return constants.RawDeployment
+}
+
+func newServingGraph(
+	isvc *v1beta1.InferenceService,
+	model *v1beta1.ModelRef,
+	runtime *v1beta1.ServingRuntimeRef,
+	engine *v1beta1.EngineSpec,
+	decoder *v1beta1.DecoderSpec,
+	router *v1beta1.RouterSpec,
+	predictorCompatibility bool,
+) *ServingGraph {
+	graph := &ServingGraph{
+		InferenceService:       isvc,
+		Model:                  model,
+		Runtime:                runtime,
+		Engine:                 engine,
+		Decoder:                decoder,
+		Router:                 router,
+		PredictorCompatibility: predictorCompatibility,
+	}
+	graph.EntrypointComponent = determineServingGraphEntrypoint(graph)
+	return graph
+}
+
+func determineServingGraphEntrypoint(graph *ServingGraph) v1beta1.ComponentType {
+	if graph != nil && graph.Router != nil {
+		return v1beta1.RouterComponent
+	}
+
+	return v1beta1.EngineComponent
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/serving_graph_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/serving_graph_test.go
@@ -1,0 +1,159 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/sgl-project/ome/pkg/apis/ome/v1beta1"
+	"github.com/sgl-project/ome/pkg/constants"
+)
+
+func TestResolveServingGraphPredictorCompatibility(t *testing.T) {
+	isvc := &v1beta1.InferenceService{
+		Spec: v1beta1.InferenceServiceSpec{
+			Predictor: v1beta1.PredictorSpec{
+				PodSpec: v1beta1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "ome-container",
+							Image: "engine:latest",
+						},
+						{
+							Name:  "sidecar",
+							Image: "sidecar:latest",
+						},
+					},
+				},
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					MinReplicas: servingGraphTestIntPtr(0),
+				},
+				Model: &v1beta1.ModelSpec{
+					BaseModel: servingGraphTestStringPtr("base-model"),
+					Runtime:   servingGraphTestStringPtr("runtime-a"),
+					PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+						StorageUri:      servingGraphTestStringPtr("oci://bucket/model"),
+						ProtocolVersion: servingGraphTestProtocolPtr(constants.OpenInferenceProtocolV2),
+					},
+				},
+			},
+		},
+	}
+
+	graph, err := ResolveServingGraph(isvc)
+	require.NoError(t, err)
+
+	require.NotNil(t, graph.Model)
+	assert.True(t, graph.PredictorCompatibility)
+	assert.Equal(t, "base-model", graph.Model.Name)
+	require.NotNil(t, graph.Runtime)
+	assert.Equal(t, "runtime-a", graph.Runtime.Name)
+	require.NotNil(t, graph.Engine)
+	require.NotNil(t, graph.Engine.Runner)
+	assert.Equal(t, "ome-container", graph.Engine.Runner.Name)
+	assert.Len(t, graph.Engine.Containers, 1)
+	assert.Equal(t, "sidecar", graph.Engine.Containers[0].Name)
+	assert.Equal(t, v1beta1.EngineComponent, graph.EntrypointComponent)
+	assert.Equal(t, v1beta1.EngineComponent, DetermineEntrypointComponent(isvc))
+}
+
+func TestResolveServingGraphWithRuntimeSelectsEntrypointAndModes(t *testing.T) {
+	tests := []struct {
+		name                   string
+		isvc                   *v1beta1.InferenceService
+		expectedEntrypoint     v1beta1.ComponentType
+		expectedEntrypointMode constants.DeploymentModeType
+		expectedEngineMode     constants.DeploymentModeType
+		expectedDecoderMode    constants.DeploymentModeType
+		expectedRouterMode     constants.DeploymentModeType
+	}{
+		{
+			name: "engine only keeps engine as entrypoint",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: servingGraphTestIntPtr(0),
+						},
+					},
+				},
+			},
+			expectedEntrypoint:     v1beta1.EngineComponent,
+			expectedEntrypointMode: constants.Serverless,
+			expectedEngineMode:     constants.Serverless,
+			expectedDecoderMode:    constants.RawDeployment,
+			expectedRouterMode:     constants.RawDeployment,
+		},
+		{
+			name: "decoder does not replace engine as entrypoint",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: servingGraphTestIntPtr(0),
+						},
+					},
+					Decoder: &v1beta1.DecoderSpec{},
+				},
+			},
+			expectedEntrypoint:     v1beta1.EngineComponent,
+			expectedEntrypointMode: constants.RawDeployment,
+			expectedEngineMode:     constants.RawDeployment,
+			expectedDecoderMode:    constants.RawDeployment,
+			expectedRouterMode:     constants.RawDeployment,
+		},
+		{
+			name: "router takes precedence over engine",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: servingGraphTestIntPtr(1),
+						},
+					},
+					Router: &v1beta1.RouterSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: servingGraphTestIntPtr(0),
+						},
+					},
+				},
+			},
+			expectedEntrypoint:     v1beta1.RouterComponent,
+			expectedEntrypointMode: constants.Serverless,
+			expectedEngineMode:     constants.RawDeployment,
+			expectedDecoderMode:    constants.RawDeployment,
+			expectedRouterMode:     constants.Serverless,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			graph, err := ResolveServingGraph(tt.isvc)
+			require.NoError(t, err)
+
+			graph, err = ResolveServingGraphWithRuntime(graph, nil, logr.Discard())
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedEntrypoint, graph.EntrypointComponent)
+			assert.Equal(t, tt.expectedEntrypointMode, graph.EntrypointDeploymentMode)
+			assert.Equal(t, tt.expectedEngineMode, graph.EngineDeploymentMode)
+			assert.Equal(t, tt.expectedDecoderMode, graph.DecoderDeploymentMode)
+			assert.Equal(t, tt.expectedRouterMode, graph.RouterDeploymentMode)
+		})
+	}
+}
+
+func servingGraphTestIntPtr(i int) *int {
+	return &i
+}
+
+func servingGraphTestStringPtr(s string) *string {
+	return &s
+}
+
+func servingGraphTestProtocolPtr(p constants.InferenceServiceProtocol) *constants.InferenceServiceProtocol {
+	return &p
+}


### PR DESCRIPTION
## What this PR does

Adds a small shared serving-graph utility for controller reconciliation so the controller resolves the  active serving components from a single engine-first view.

  This PR:

  - resolves model, runtime, engine, decoder, and router through a shared serving-graph path
  - keeps predictor handling as a compatibility-only translation for predictor-only services during rollout
  - updates the controller to reconcile from the resolved serving graph instead of open-coding predictor-era  handling
  - adds focused tests for predictor compatibility translation, serving-graph resolution, entrypoint selection, and deployment-mode selection

  ## Why we need it

 The controller is moving toward an engine-first serving model where `engine` is the primary serving component, with optional `decoder` and optional `router`. Today, part of that logic is still split between direct controller wiring and predictor-era translation behavior.

This change is needed to make the controller resolve the active serving graph once and then use that shared result consistently for:

  - model/runtime resolution
  - predictor compatibility translation during rollout
  - merged component selection after runtime defaults are applied
  - deployment-mode and entrypoint selection for the resolved serving graph

  Without this, predictor compatibility and component-oriented reconciliation continue to be handled through
  separate paths, which increases controller complexity and makes follow-on work harder to reason about.

  ## How to test

  Run:

  ```bash
  env HOME=/tmp/oss-ome-home \
    KUBEBUILDER_ASSETS=/tmp/oss-ome-envtest-binaries/k8s/1.30.3-darwin-arm64 \
    GOCACHE=/tmp/oss-ome-gocache \
    GOMODCACHE=/tmp/oss-ome-gomodcache \
    GOPATH=/tmp/oss-ome-gopath \
    go test ./pkg/controller/v1beta1/inferenceservice/...

  What this covers:

  - predictor-only services are translated into the shared engine/model/runtime view for compatibility
  - serving-graph resolution identifies the effective engine/decoder/router set the controller should reconcile
  - router is selected as the entrypoint when present; otherwise engine remains the entrypoint
  - deployment modes are computed from the resolved graph after runtime defaults are merged
  - controller package tests continue to pass with the shared serving-graph path in place

  ## Checklist

  - [x] Tests added/updated (if applicable)
  - [ ] Docs updated (if applicable)
  - [X] make test passes locally
