### PR TITLE
[Core] support runtime-owned engine reconcile

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -321,9 +321,9 @@ func MergeResources(b *BaseComponentFields, container *corev1.Container) {
 // resources are respected and not overridden, while providing sensible defaults from the
 // runtime and accelerator class when resources are not specified.
 func MergeEngineResources(b *BaseComponentFields, isvc *v1beta1.InferenceService, container *corev1.Container) {
-	if isvc.Spec.Engine != nil &&
-		(isvc.Spec.Engine.Runner == nil ||
-			isResourcesUnspecified(isvc.Spec.Engine.Runner.Container.Resources)) {
+	if isvc.Spec.Engine == nil ||
+		isvc.Spec.Engine.Runner == nil ||
+		isResourcesUnspecified(isvc.Spec.Engine.Runner.Container.Resources) {
 		b.Log.Info("Merging resources for engine container as user did not specify resources in InferenceService")
 		MergeResources(b, container)
 	}
@@ -346,7 +346,7 @@ func MergeDecoderResources(b *BaseComponentFields, isvc *v1beta1.InferenceServic
 // UpdateEngineAffinity merges affinity from the accelerator class into the pod spec
 // It only merges when customer didn't specify affinity in the inference service
 func UpdateEngineAffinity(b *BaseComponentFields, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec) {
-	if isvc.Spec.Engine != nil &&
+	if isvc.Spec.Engine == nil ||
 		isvc.Spec.Engine.PodSpec.Affinity == nil {
 		if b.AcceleratorClass != nil && b.AcceleratorClass.Discovery.Affinity != nil {
 			b.Log.Info("Merging affinity from accelerator class into engine pod spec as user did not specify affinity in InferenceService")

--- a/pkg/controller/v1beta1/inferenceservice/components/engine_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine_test.go
@@ -1418,7 +1418,147 @@ func TestEngineAffinityMerging(t *testing.T) {
 	}
 }
 
+func TestEngineResourceMergingWithRuntimeOwnedEngine(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-isvc",
+			Namespace: "default",
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Model: &v1beta1.ModelRef{},
+		},
+	}
+
+	runtimeEngine := &v1beta1.EngineSpec{
+		Runner: &v1beta1.RunnerSpec{
+			Container: v1.Container{
+				Name:  "ome-container",
+				Image: "engine:latest",
+			},
+		},
+	}
+	runtimeSpec := &v1beta1.ServingRuntimeSpec{
+		ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "ome-container",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("4"),
+							v1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	g.Expect(v1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	clientset := fake.NewClientset()
+	c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
+
+	engine := NewEngine(
+		c,
+		clientset,
+		scheme,
+		&controllerconfig.InferenceServicesConfig{},
+		constants.RawDeployment,
+		nil,
+		nil,
+		runtimeEngine,
+		runtimeSpec,
+		"test-runtime",
+		nil,
+		nil,
+		"",
+	).(*Engine)
+
+	objectMeta := &metav1.ObjectMeta{Name: "test", Namespace: "default"}
+	podSpec, err := engine.reconcilePodSpec(isvc, objectMeta)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(podSpec.Containers).To(gomega.HaveLen(1))
+
+	cpu := podSpec.Containers[0].Resources.Requests[v1.ResourceCPU]
+	g.Expect(cpu.String()).To(gomega.Equal("4"))
+	memory := podSpec.Containers[0].Resources.Requests[v1.ResourceMemory]
+	g.Expect(memory.String()).To(gomega.Equal("8Gi"))
+}
+
+func TestEngineAffinityMergingWithRuntimeOwnedEngine(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-isvc",
+			Namespace: "default",
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Model: &v1beta1.ModelRef{},
+		},
+	}
+
+	runtimeEngine := &v1beta1.EngineSpec{
+		PodSpec: v1beta1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "ome-container", Image: "engine:latest"},
+			},
+		},
+	}
+	acceleratorClass := &v1beta1.AcceleratorClassSpec{
+		Discovery: v1beta1.AcceleratorDiscovery{
+			Affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      "ac-key",
+										Operator: v1.NodeSelectorOpIn,
+										Values:   []string{"ac-value"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	g.Expect(v1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	clientset := fake.NewClientset()
+	c := ctrlclientfake.NewClientBuilder().WithScheme(scheme).Build()
+
+	engine := NewEngine(
+		c,
+		clientset,
+		scheme,
+		&controllerconfig.InferenceServicesConfig{},
+		constants.RawDeployment,
+		nil,
+		nil,
+		runtimeEngine,
+		nil,
+		"test-runtime",
+		nil,
+		acceleratorClass,
+		"test-accel-class",
+	).(*Engine)
+
+	objectMeta := &metav1.ObjectMeta{Name: "test", Namespace: "default"}
+	podSpec, err := engine.reconcilePodSpec(isvc, objectMeta)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(podSpec.Affinity).NotTo(gomega.BeNil())
+	g.Expect(podSpec.Affinity.NodeAffinity).NotTo(gomega.BeNil())
+	terms := podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	g.Expect(terms[0].MatchExpressions[0].Key).To(gomega.Equal("ac-key"))
+}
+
 // Note: Worker resource and affinity tests are not included because MergeEngineResources and
-// UpdateEngineAffinity check isvc.Spec.Engine.Runner and isvc.Spec.Engine.PodSpec.Affinity,
-// not the worker-specific fields. This means the merging decision is based on the engine/leader
-// spec, not the worker spec. This is the current implementation behavior.
+// UpdateEngineAffinity base their override decision on the engine-level InferenceService fields,
+// not the worker-specific fields.

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -694,6 +694,116 @@ func TestInferenceServiceReconcile(t *testing.T) {
 				g.Expect(lwsList.Items[0].Name).To(gomega.ContainSubstring("test-multinode"))
 			},
 		},
+		{
+			name: "Runtime-driven multi-node engine deployment",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-runtime-multinode",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Model: &v1beta1.ModelRef{
+						Name: "base-model-5",
+						Kind: stringPtr("BaseModel"),
+					},
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name: "runtime-multinode",
+					},
+				},
+			},
+			setupMocks: func(c client.Client, cs *fake.Clientset) {
+				cm := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "inferenceservice-config",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"config": "{}",
+					},
+				}
+				err := c.Create(context.TODO(), cm)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				omeCm := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "inferenceservice-config",
+						Namespace: "ome",
+					},
+					Data: map[string]string{
+						"deploy": `{"defaultDeploymentMode": "RawDeployment"}`,
+					},
+				}
+				_, err = cs.CoreV1().ConfigMaps("ome").Create(context.TODO(), omeCm, metav1.CreateOptions{})
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				baseModel := &v1beta1.BaseModel{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "base-model-5",
+						Namespace: "default",
+					},
+					Spec: v1beta1.BaseModelSpec{
+						ModelFormat: v1beta1.ModelFormat{
+							Name:    "safetensors",
+							Version: stringPtr("1.0.0"),
+						},
+					},
+				}
+				err = c.Create(context.TODO(), baseModel)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+
+				rt := &v1beta1.ServingRuntime{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "runtime-multinode",
+						Namespace: "default",
+					},
+					Spec: v1beta1.ServingRuntimeSpec{
+						SupportedModelFormats: []v1beta1.SupportedModelFormat{
+							{
+								Name:    "safetensors",
+								Version: stringPtr("*"),
+								ModelFormat: &v1beta1.ModelFormat{
+									Name:    "safetensors",
+									Version: stringPtr("1.0.0"),
+									Weight:  int64(1),
+								},
+							},
+						},
+						EngineConfig: &v1beta1.EngineSpec{
+							Leader: &v1beta1.LeaderSpec{
+								PodSpec: v1beta1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "leader",
+											Image: "leader:latest",
+										},
+									},
+								},
+							},
+							Worker: &v1beta1.WorkerSpec{
+								Size: intPtr(2),
+								PodSpec: v1beta1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "worker",
+											Image: "worker:latest",
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				err = c.Create(context.TODO(), rt)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+			},
+			validate: func(t *testing.T, c client.Client, isvc *v1beta1.InferenceService) {
+				lwsList := &lws.LeaderWorkerSetList{}
+				err := c.List(context.TODO(), lwsList, client.InNamespace("default"))
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(lwsList.Items).To(gomega.HaveLen(1))
+				g.Expect(lwsList.Items[0].Name).To(gomega.ContainSubstring("test-runtime-multinode"))
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/external_service/external_service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/external_service/external_service_reconciler.go
@@ -107,7 +107,7 @@ func (r *ExternalServiceReconciler) shouldCreateExternalService(isvc *v1beta1.In
 	}
 
 	// Only create if there are components that can serve traffic
-	return isvc.Spec.Router != nil || isvc.Spec.Engine != nil || isvc.Spec.Predictor.Model != nil
+	return isvc.Spec.Router != nil || hasEngineComponent(isvc) || isvc.Spec.Predictor.Model != nil
 }
 
 // determineTargetSelector determines which component should be the target for the external service
@@ -123,7 +123,7 @@ func (r *ExternalServiceReconciler) determineTargetSelector(isvc *v1beta1.Infere
 			return baseSelector
 		}
 
-		if isvc.Spec.Engine != nil {
+		if hasEngineComponent(isvc) {
 			baseSelector[constants.OMEComponentLabel] = string(v1beta1.EngineComponent)
 			return baseSelector
 		}
@@ -131,6 +131,23 @@ func (r *ExternalServiceReconciler) determineTargetSelector(isvc *v1beta1.Infere
 
 	// When predictor is still used, not attach component label to service selector to make sure no downtime during migration
 	return baseSelector
+}
+
+func hasEngineComponent(isvc *v1beta1.InferenceService) bool {
+	if isvc == nil {
+		return false
+	}
+
+	if isvc.Spec.Engine != nil {
+		return true
+	}
+
+	if isvc.Status.Components == nil {
+		return false
+	}
+
+	_, ok := isvc.Status.Components[v1beta1.EngineComponent]
+	return ok
 }
 
 // buildExternalService builds the external service specification

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/external_service/external_service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/external_service/external_service_reconciler_test.go
@@ -150,6 +150,25 @@ func TestExternalServiceReconciler_shouldCreateExternalService(t *testing.T) {
 			description: "should create external service for multinode deployments when ingress disabled",
 		},
 		{
+			name: "should create when runtime-driven engine status exists",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+						v1beta1.EngineComponent: {},
+					},
+				},
+			},
+			ingressConfig: &controllerconfig.IngressConfig{
+				DisableIngressCreation: true,
+			},
+			expected:    true,
+			description: "should create external service when a runtime-driven engine has already been reconciled",
+		},
+		{
 			name: "should not create when no components",
 			isvc: &v1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{
@@ -249,6 +268,25 @@ func TestExternalServiceReconciler_determineTargetSelector(t *testing.T) {
 				constants.InferenceServicePodLabelKey: "test-service",
 			},
 			description: "predictor component should be selected as fallback",
+		},
+		{
+			name: "runtime-driven engine uses engine selector",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+						v1beta1.EngineComponent: {},
+					},
+				},
+			},
+			expectedSelector: map[string]string{
+				constants.InferenceServicePodLabelKey: "test-service",
+				constants.OMEComponentLabel:           string(v1beta1.EngineComponent),
+			},
+			description: "runtime-driven engine should still target the engine component",
 		},
 	}
 
@@ -353,6 +391,35 @@ func TestExternalServiceReconciler_buildExternalService(t *testing.T) {
 			internalService:    nil, // No internal service
 			expectedTargetPort: constants.CommonISVCPort,
 			description:        "should fallback to default port when internal service not found",
+		},
+		{
+			name: "runtime-driven engine uses internal engine service",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+						v1beta1.EngineComponent: {},
+					},
+				},
+			},
+			internalService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service-engine",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 8083,
+						},
+					},
+				},
+			},
+			expectedTargetPort: 8083,
+			description:        "should resolve target port from the internal engine service for runtime-driven engine deployments",
 		},
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/utils/merging.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/merging.go
@@ -105,8 +105,11 @@ func MergeRouterSpec(isvcRouter, runtimeRouter *v1beta1.RouterSpec) (*v1beta1.Ro
 func MergeEngineSpec(runtimeEngine, isvcEngine *v1beta1.EngineSpec) (*v1beta1.EngineSpec, error) {
 	switch {
 	case isvcEngine == nil:
-		// if engine is not specified in isvc, return nil
-		return nil, nil
+		// if engine is only specified in runtime, use the runtime-owned engine spec
+		if runtimeEngine == nil {
+			return nil, nil
+		}
+		return runtimeEngine.DeepCopy(), nil
 	case runtimeEngine == nil:
 		// if engine is not specified in runtime, return a copy of isvcEngine
 		return isvcEngine.DeepCopy(), nil

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -667,9 +667,22 @@ func TestMergeEngineSpec(t *testing.T) {
 					},
 				},
 			},
-			isvcEngine:     nil,
-			expectedEngine: nil,
-			expectError:    false,
+			isvcEngine: nil,
+			expectedEngine: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					MinReplicas: intPtr(1),
+					MaxReplicas: 3,
+				},
+				PodSpec: v1beta1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "ome-container",
+							Image: "runtime-engine:v1",
+						},
+					},
+				},
+			},
+			expectError: false,
 		},
 		{
 			name: "merge min/max replicas - isvc overrides",


### PR DESCRIPTION
  ## What this PR does

 Enables the existing engine component reconciliation path to work when the engine is defined by the selected runtime rather than directly on the InferenceService.

  This keeps the change minimal and focused:
  - `MergeEngineSpec()` now preserves a runtime-owned engine spec when`isvc.spec.engine` is omitted.
  - Engine resource and affinity merging now treat a missing `isvc.spec.engine` as "no user override", so runtime defaults still flow into the reconciled engine workload.
  - External service selection now recognizes runtime-driven engine deployments and routes traffic to the engine component when appropriate.
  - Adds focused regression coverage for runtime-owned engine reconciliation, external service targeting, and engine resource/affinity merging.

  ## Why we need it

Some serving runtimes define their engine configuration in`runtime.spec.engineConfig` without requiring users to also duplicate that  configuration in `InferenceService.spec.engine`.

Before this change, those runtime-owned engine cases could miss parts of the normal engine reconciliation flow because several code paths assumed the engine only existed when `isvc.spec.engine` was set directly. That made  runtime-driven engine deployments incomplete, especially for multi-node engine reconciliation and external service targeting.

  ## How to test

  1. Run the full repo test suite:
     ```bash
     make test

  2. Focus on the added regression coverage under:

     go test ./pkg/controller/v1beta1/inferenceservice/...
  3. Verify that an InferenceService using a runtime with
     runtime.spec.engineConfig and no explicit isvc.spec.engine still:
      - reconciles an engine component
      - applies runtime/default engine resources and affinity when the user did
        not override them
      - targets the engine component for external service selection when no
        router is present