### PR TITLE
feat: add DeepSeek v4 runtimes

### DIFF
--- a/config/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/config/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: deepseek-v4-flash
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: deepseek-ai
+  displayName: deepseek-ai.deepseek-v4-flash
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://deepseek-ai/DeepSeek-V4-Flash
+    path: /raid/models/deepseek-ai/DeepSeek-V4-Flash

--- a/config/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/config/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -1,0 +1,14 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: deepseek-v4-pro
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: deepseek-ai
+  displayName: deepseek-ai.deepseek-v4-pro
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://deepseek-ai/DeepSeek-V4-Pro
+    path: /raid/models/deepseek-ai/DeepSeek-V4-Pro

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -50,3 +50,5 @@ resources:
 - vllm/llama-4-scout-17b-16e-instruct-rt.yaml
 - vllm/mistral-7b-instruct-rt.yaml
 - vllm/mixtral-8x7b-instruct-rt.yaml
+- vllm/deepseek-ai/deepseek-v4-flash-rt.yaml
+- vllm/deepseek-ai/deepseek-v4-pro-rt.yaml

--- a/config/runtimes/vllm/deepseek-ai/deepseek-v4-flash-rt.yaml
+++ b/config/runtimes/vllm/deepseek-ai/deepseek-v4-flash-rt.yaml
@@ -114,7 +114,7 @@ spec:
           medium: Memory
     runner:
       name: ome-container
-      image: docker.io/vllm/vllm-openai:v0.20.0-cu129
+      image: docker.io/vllm/vllm-openai:v0.20.1-cu129
       ports:
         - containerPort: 8080
           name: http1

--- a/config/runtimes/vllm/deepseek-ai/deepseek-v4-flash-rt.yaml
+++ b/config/runtimes/vllm/deepseek-ai/deepseek-v4-flash-rt.yaml
@@ -1,0 +1,186 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: vllm-deepseek-v4-flash
+spec:
+  disabled: false
+  routerConfig:
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: '29000'
+      prometheus.io/scrape: 'true'
+    labels:
+      logging-forward: enabled
+    runner:
+      name: router
+      image: docker.io/lightseekorg/smg:1.4.1
+      ports:
+        - containerPort: 8080
+          name: http
+      resources:
+        limits:
+          cpu: "8"
+          memory: 16Gi
+      args:
+        - --host
+        - 0.0.0.0
+        - --port
+        - "8080"
+        - --service-discovery
+        - --service-discovery-namespace
+        - $(NAMESPACE)
+        - --service-discovery-port
+        - "8080"
+        - --selector
+        - component=engine ome.io/inferenceservice=$(INFERENCESERVICE_NAME)
+        - --enable-igw
+        - --request-id-headers
+        - opc-request-id
+        - --log-json
+        - --disable-retries
+        - --disable-circuit-breaker
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INFERENCESERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['ome.io/inferenceservice']
+      readinessProbe:
+        httpGet:
+          path: /readiness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /liveness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 20
+        timeoutSeconds: 10
+        initialDelaySeconds: 30
+  supportedModelFormats:
+    - modelFramework:
+        name: transformers
+        version: "4.57.1"
+      modelFormat:
+        name: safetensors
+        version: "1.0.0"
+      modelArchitecture: DeepseekV4ForCausalLM
+      quantization: fp8
+      autoSelect: true
+      priority: 1
+  modelSizeRange:
+    min: 150B
+    max: 200B
+  protocolVersions:
+    - openAI
+  engineConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: "/metrics"
+    labels:
+      logging-forward: enabled
+    tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node.kubernetes.io/instance-type
+                  operator: In
+                  values:
+                    - BM.GPU.H100.8
+                    - BM.GPU.H200.8
+                    - BM.GPU.H200-NC.8
+    volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+    runner:
+      name: ome-container
+      image: docker.io/vllm/vllm-openai:v0.20.0-cu129
+      ports:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+      command:
+        - vllm
+        - serve
+      args:
+        - $(MODEL_PATH)
+        - --trust-remote-code
+        - --tensor-parallel-size=1
+        - --data-parallel-size=4
+        - --enable-expert-parallel
+        - --kv-cache-dtype=fp8
+        - --block-size=256
+        - '--compilation-config={"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'
+        - --tokenizer-mode=deepseek_v4
+        - --tool-call-parser=deepseek_v4
+        - --enable-auto-tool-choice
+        - --reasoning-parser=deepseek_v4
+        - --served-model-name=vllm-model
+        - --max-model-len=-1
+        - --enable-chunked-prefill
+        - --no-scheduler-reserve-full-isl
+        - '--speculative-config={"method":"mtp","num_speculative_tokens":1}'
+        - --enable-log-requests
+        - --port=8080
+      env:
+        - name: VLLM_ENGINE_READY_TIMEOUT_S
+          value: '3600'
+        - name: VLLM_LOGGING_LEVEL
+          value: 'INFO'
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+      resources:
+        requests:
+          cpu: 64
+          memory: 256Gi
+          nvidia.com/gpu: 4
+        limits:
+          cpu: 64
+          memory: 256Gi
+          nvidia.com/gpu: 4
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 3
+        successThreshold: 1
+        periodSeconds: 90
+        timeoutSeconds: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        successThreshold: 1
+        periodSeconds: 60
+        timeoutSeconds: 60
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 190
+        successThreshold: 1
+        periodSeconds: 6
+        initialDelaySeconds: 60
+        timeoutSeconds: 30

--- a/config/runtimes/vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
+++ b/config/runtimes/vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
@@ -105,7 +105,6 @@ spec:
                 - key: node.kubernetes.io/instance-type
                   operator: In
                   values:
-                    - BM.GPU.H100.8
                     - BM.GPU.H200.8
                     - BM.GPU.H200-NC.8
     volumes:

--- a/config/runtimes/vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
+++ b/config/runtimes/vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
@@ -1,0 +1,188 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: vllm-deepseek-v4-pro
+spec:
+  disabled: false
+  routerConfig:
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: '29000'
+      prometheus.io/scrape: 'true'
+    labels:
+      logging-forward: enabled
+    runner:
+      name: router
+      image: docker.io/lightseekorg/smg:1.4.1
+      ports:
+        - containerPort: 8080
+          name: http
+      resources:
+        limits:
+          cpu: "8"
+          memory: 16Gi
+      args:
+        - --host
+        - 0.0.0.0
+        - --port
+        - "8080"
+        - --service-discovery
+        - --service-discovery-namespace
+        - $(NAMESPACE)
+        - --service-discovery-port
+        - "8080"
+        - --selector
+        - component=engine ome.io/inferenceservice=$(INFERENCESERVICE_NAME)
+        - --enable-igw
+        - --request-id-headers
+        - opc-request-id
+        - --log-json
+        - --disable-retries
+        - --disable-circuit-breaker
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INFERENCESERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['ome.io/inferenceservice']
+      readinessProbe:
+        httpGet:
+          path: /readiness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /liveness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 20
+        timeoutSeconds: 10
+        initialDelaySeconds: 30
+  supportedModelFormats:
+    - modelFramework:
+        name: transformers
+        version: "4.57.1"
+      modelFormat:
+        name: safetensors
+        version: "1.0.0"
+      modelArchitecture: DeepseekV4ForCausalLM
+      quantization: fp8
+      autoSelect: true
+      priority: 1
+  modelSizeRange:
+    min: 800B
+    max: 900B
+  protocolVersions:
+    - openAI
+  engineConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: "/metrics"
+    labels:
+      logging-forward: enabled
+    tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node.kubernetes.io/instance-type
+                  operator: In
+                  values:
+                    - BM.GPU.H100.8
+                    - BM.GPU.H200.8
+                    - BM.GPU.H200-NC.8
+    volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+    runner:
+      name: ome-container
+      image: docker.io/vllm/vllm-openai:v0.20.0-cu129
+      ports:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+      command:
+        - vllm
+        - serve
+      args:
+        - $(MODEL_PATH)
+        - --trust-remote-code
+        - --tensor-parallel-size=1
+        - --data-parallel-size=8
+        - --enable-expert-parallel
+        - --kv-cache-dtype=fp8
+        - --block-size=256
+        - '--compilation-config={"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'
+        - --tokenizer-mode=deepseek_v4
+        - --tool-call-parser=deepseek_v4
+        - --enable-auto-tool-choice
+        - --reasoning-parser=deepseek_v4
+        - --served-model-name=vllm-model
+        - --max-model-len=-1
+        - --enable-chunked-prefill
+        - --no-scheduler-reserve-full-isl
+        - '--speculative-config={"method":"mtp","num_speculative_tokens":1}'
+        - --enable-log-requests
+        - --port=8080
+      env:
+        - name: VLLM_ENGINE_READY_TIMEOUT_S
+          value: '3600'
+        - name: VLLM_LOGGING_LEVEL
+          value: 'INFO'
+        - name: VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS
+          value: '0'
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+      resources:
+        requests:
+          cpu: 128
+          memory: 512Gi
+          nvidia.com/gpu: 8
+        limits:
+          cpu: 128
+          memory: 512Gi
+          nvidia.com/gpu: 8
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 3
+        successThreshold: 1
+        periodSeconds: 90
+        timeoutSeconds: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        successThreshold: 1
+        periodSeconds: 60
+        timeoutSeconds: 60
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 190
+        successThreshold: 1
+        periodSeconds: 6
+        initialDelaySeconds: 60
+        timeoutSeconds: 30

--- a/config/runtimes/vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
+++ b/config/runtimes/vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
@@ -124,11 +124,11 @@ spec:
       args:
         - $(MODEL_PATH)
         - --trust-remote-code
-        - --tensor-parallel-size=1
-        - --data-parallel-size=8
+        - --tensor-parallel-size=8
         - --enable-expert-parallel
         - --kv-cache-dtype=fp8
         - --block-size=256
+        - --no-enable-flashinfer-autotune
         - '--compilation-config={"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'
         - --tokenizer-mode=deepseek_v4
         - --tool-call-parser=deepseek_v4

--- a/config/runtimes/vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
+++ b/config/runtimes/vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
@@ -113,7 +113,7 @@ spec:
           medium: Memory
     runner:
       name: ome-container
-      image: docker.io/vllm/vllm-openai:v0.20.0-cu129
+      image: docker.io/vllm/vllm-openai:v0.20.1-cu129
       ports:
         - containerPort: 8080
           name: http1

--- a/config/samples/isvc/deepseek-ai/deepseek-v4-flash.yaml
+++ b/config/samples/isvc/deepseek-ai/deepseek-v4-flash.yaml
@@ -1,0 +1,19 @@
+# apiVersion: v1
+# kind: Namespace
+# metadata:
+#   name: deepseek-v4
+---
+apiVersion: ome.io/v1beta1
+kind: InferenceService
+metadata:
+  name: deepseek-v4-flash
+  namespace: deepseek-v4
+spec:
+  model:
+    name: deepseek-v4-flash
+  engine:
+    minReplicas: 1
+    maxReplicas: 1
+  router:
+    minReplicas: 1
+    maxReplicas: 1


### PR DESCRIPTION
## What this PR does

Adds configurations and runtimes for DeepSeek V4 models. Specifically:
- Adds ClusterBaseModel CRD for DeepSeek V4
- Adds serving runtimes for DeepSeek V4 models (`deepseek-v4-flash-rt` and `deepseek-v4-pro-rt`)
- Adds InferenceService (`isvc`) and updates `kustomization.yaml` for DeepSeek V4
- Adjusts `deepseek-v4-pro-rt` to remove H100 requirements

## Why we need it

To enable serving and deployment of DeepSeek V4 models via our inference services.

Fixes #

## How to test

N/A for config changes

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally