### PR TITLE
[Docs] Update documentation site URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/SUPPORT.md
+++ b/.github/ISSUE_TEMPLATE/SUPPORT.md
@@ -13,7 +13,7 @@ STOP!
 For questions or support, please consider:
 
 1. Searching existing issues: https://github.com/sgl-project/ome/issues
-2. Checking the documentation: https://docs.sglang.ai/ome/docs/
+2. Checking the documentation: https://ome-projects.github.io/ome/docs/
 3. Looking at examples in the /config/samples directory
 
 If you still need help, please provide the following information:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,10 +56,10 @@ jobs:
         working-directory: ./site
         env:
           HUGO_ENVIRONMENT: production
-          HUGO_BASEURL: https://docs.sglang.ai/ome/
+          HUGO_BASEURL: https://ome-projects.github.io/ome/
         run: |
           # Build the site with local node_modules
-          $GITHUB_WORKSPACE/bin/hugo --gc --minify --baseURL https://docs.sglang.ai/ome/
+          $GITHUB_WORKSPACE/bin/hugo --gc --minify --baseURL https://ome-projects.github.io/ome/
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Report](https://goreportcard.com/badge/github.com/sgl-project/ome)](https://goreportcard.com/report/github.com/sgl-project/ome)
 [![Latest Release](https://img.shields.io/github/v/release/sgl-project/ome?include_prereleases)](https://github.com/sgl-project/ome/releases/latest)
-[![API Reference](https://img.shields.io/badge/API-v1beta1-blue)](https://sgl-project.github.io/ome/docs/reference/ome.v1beta1/)
+[![API Reference](https://img.shields.io/badge/API-v1beta1-blue)](https://ome-projects.github.io/ome/docs/reference/ome.v1beta1/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sgl-project/ome)
 
@@ -15,7 +15,7 @@
 ## What is OME?
 OME (Open Model Engine) is a Kubernetes operator for enterprise-grade management and serving of Large Language Models (LLMs). It optimizes the deployment and operation of LLMs by automating model management, intelligent runtime selection, efficient resource utilization, and sophisticated deployment patterns.
 
-Read the [documentation](https://sgl-project.github.io/ome/docs/) to learn more about OME capabilities and features.
+Read the [documentation](https://ome-projects.github.io/ome/docs/) to learn more about OME capabilities and features.
 
 ## Features Overview
 
@@ -40,7 +40,7 @@ Read the [documentation](https://sgl-project.github.io/ome/docs/) to learn more 
 ## Production Readiness Status
 
 - ✅ API version: v1beta1
-- ✅ Comprehensive [documentation](https://sgl-project.github.io/ome/docs/)
+- ✅ Comprehensive [documentation](https://ome-projects.github.io/ome/docs/)
 - ✅ Unit and integration test coverage
 - ✅ Production deployments with large-scale LLM workloads
 - ✅ Monitoring via standard metrics and Kubernetes events
@@ -69,7 +69,7 @@ Install using the traditional Helm repository:
 
 ```bash
 # Add the OME Helm repository
-helm repo add ome https://sgl-project.github.io/ome
+helm repo add ome https://ome-projects.github.io/ome
 helm repo update
 
 # Install OME CRDs first
@@ -93,11 +93,11 @@ helm install ome-crd charts/ome-crd --namespace ome --create-namespace
 helm install ome charts/ome-resources --namespace ome
 ```
 
-Read the [installation guide](https://sgl-project.github.io/ome/docs/installation/) for more options and advanced configurations.
+Read the [installation guide](https://ome-projects.github.io/ome/docs/installation/) for more options and advanced configurations.
 
 Learn more about:
-- OME [concepts](https://sgl-project.github.io/ome/docs/concepts/)
-- Common [tasks](https://sgl-project.github.io/ome/docs/tasks/)
+- OME [concepts](https://ome-projects.github.io/ome/docs/concepts/)
+- Common [tasks](https://ome-projects.github.io/ome/docs/tasks/)
 
 ## Architecture
 
@@ -128,7 +128,7 @@ High-level overview of the main priorities:
 ## Community and Support
 
 - [GitHub Issues](https://github.com/sgl-project/ome/issues) for bug reports and feature requests
-- [Documentation](https://sgl-project.github.io/ome/docs/) for guides and reference
+- [Documentation](https://ome-projects.github.io/ome/docs/) for guides and reference
 
 ## License
 

--- a/site/content/en/docs/developer-guide/contributing.md
+++ b/site/content/en/docs/developer-guide/contributing.md
@@ -433,7 +433,7 @@ kubectl get inferenceservice -A
 
 ### Community Resources
 
-- **Documentation**: [OME Documentation](https://ome.docs.example.com)
+- **Documentation**: [OME Documentation](https://ome-projects.github.io/ome/docs/)
 - **Issue Tracker**: Report bugs and request features
 - **Discussions**: Ask questions and share ideas
 

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://docs.sglang.ai/ome/"
+baseURL = "https://ome-projects.github.io/ome/"
 title = "OME"
 
 enableRobotsTXT = true
@@ -99,7 +99,7 @@ github_project_repo = "https://github.com/sgl-project/ome"
 
   # A link to latest version of the docs. Used in the "version-banner" partial to
   # point people to the main doc site.
-  url_latest_version = "https://docs.sglang.ai/ome/"
+  url_latest_version = "https://ome-projects.github.io/ome/"
 
   # A variable used in various docs to determine URLs for config files etc.
   # To find occurrences, search the repo for 'params "githubbranch"'.

--- a/web-console/frontend/src/app/page.tsx
+++ b/web-console/frontend/src/app/page.tsx
@@ -67,7 +67,7 @@ export default function LandingPage() {
             {/* Links */}
             <div className="mt-8 flex items-center justify-center gap-6 text-sm">
               <a
-                href="https://docs.sglang.io/ome/"
+                href="https://ome-projects.github.io/ome/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
## What this PR does

Updates OME documentation and site configuration URLs to point to `https://ome-projects.github.io/ome/`, including README links, the Hugo base URL, the Pages workflow base URL, the support issue template, the contributing guide, and the web console documentation link.

## Why we need it

The docs site now lives under `ome-projects.github.io/ome/`, while several repository references still pointed at old or placeholder documentation URLs.

Fixes # N/A

## How to test

N/A for docs/config link updates.

## Checklist

- [ ] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [ ] `make test` passes locally