### PR TITLE
[MISC] Add MLE lead to config CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /cmd/ @slin1237 @pallasathena92 @beiguo218
 
 # config
-/config/ @slin1237 @CatherineSue @XinyueZhang369
+/config/ @slin1237 @CatherineSue @XinyueZhang369 @YouNeedCryDear
 
 # dockerfiles
 /dockerfiles/ @slin1237 @pallasathena92 @beiguo218


### PR DESCRIPTION
## Summary

- Add the MLE lead to the CODEOWNERS approval list for the `config/` directory.

## Reason

MLE will push all runtime and model related YAML changes into the `config/` directory. Adding the MLE lead to the config approval list ensures those changes can be reviewed and approved by the right owner as they land.

## Impact

- Config changes for runtime and model YAML updates can include the MLE lead in the required approval path.
- No runtime behavior changes are introduced.

## Validation

- Confirmed the pushed branch `misc/add-code-owner` contains only the `.github/CODEOWNERS` update against `main`.
- No test run was needed for this CODEOWNERS-only metadata change.