### PR TITLE
[Runtime] Add Qwen 3.6 35B A3B 1M context runtime

### DIFF
--- a/config/models/Qwen/Qwen3.6-35B-A3B-FP8.yaml
+++ b/config/models/Qwen/Qwen3.6-35B-A3B-FP8.yaml
@@ -1,0 +1,16 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: qwen3-6-35b-a3b-fp8
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+    - IMAGE_TEXT_TO_TEXT
+    - VIDEO_TEXT_TO_TEXT
+  vendor: Qwen
+  displayName: Qwen.qwen3.6-35b-a3b-fp8
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Qwen/Qwen3.6-35B-A3B-FP8
+    path: /raid/models/Qwen/Qwen3.6-35B-A3B-FP8

--- a/config/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/config/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -1,0 +1,16 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: qwen3-6-35b-a3b
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+    - IMAGE_TEXT_TO_TEXT
+    - VIDEO_TEXT_TO_TEXT
+  vendor: Qwen
+  displayName: Qwen.qwen3.6-35b-a3b
+  disabled: false
+  version: "1.0.0"
+  storage:
+    storageUri: hf://Qwen/Qwen3.6-35B-A3B
+    path: /raid/models/Qwen/Qwen3.6-35B-A3B

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -52,3 +52,4 @@ resources:
 - vllm/mixtral-8x7b-instruct-rt.yaml
 - vllm/deepseek-ai/deepseek-v4-flash-rt.yaml
 - vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
+- vllm/qwen/qwen-3-6-35b-a3b-rt.yaml

--- a/config/runtimes/vllm/qwen/qwen-3-6-35b-a3b-rt.yaml
+++ b/config/runtimes/vllm/qwen/qwen-3-6-35b-a3b-rt.yaml
@@ -112,9 +112,10 @@ spec:
       args:
         - $(MODEL_PATH)
         - --port=8080
-        - --max-log-len=0
+        - --enable-log-requests
         - --served-model-name=vllm-model
         - --tensor-parallel-size=2
+        - --enable-expert-parallel
         - --data-parallel-size=1
         - --gpu-memory-utilization=0.9
         - --max-model-len=1010000
@@ -123,6 +124,7 @@ spec:
         - --reasoning-parser=qwen3
         - --enable-auto-tool-choice
         - --tool-call-parser=qwen3_coder
+        - '--speculative-config={"method":"qwen3_next_mtp","num_speculative_tokens":2}'
         - '--hf-overrides={"text_config": {"rope_parameters": {"mrope_interleaved": true, "mrope_section": [11, 11, 10], "rope_type": "yarn", "rope_theta": 10000000, "partial_rotary_factor": 0.25, "factor": 4.0, "original_max_position_embeddings": 262144}}}'
       env:
         - name: VLLM_RPC_TIMEOUT
@@ -131,6 +133,8 @@ spec:
           value: '120'
         - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
           value: '1'
+        - name: VLLM_LOGGING_LEVEL
+          value: 'INFO'
       volumeMounts:
         - mountPath: /dev/shm
           name: dshm

--- a/config/runtimes/vllm/qwen/qwen-3-6-35b-a3b-rt.yaml
+++ b/config/runtimes/vllm/qwen/qwen-3-6-35b-a3b-rt.yaml
@@ -1,0 +1,158 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: vllm-qwen-3-6-35b-a3b
+spec:
+  disabled: false
+  routerConfig:
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: '29000'
+      prometheus.io/scrape: 'true'
+    labels:
+      logging-forward: enabled
+    runner:
+      name: router
+      image: docker.io/lightseekorg/smg:1.4.1
+      ports:
+        - containerPort: 8080
+          name: http
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+      args:
+        - --host
+        - 0.0.0.0
+        - --port
+        - "8080"
+        - --service-discovery
+        - --service-discovery-namespace
+        - $(NAMESPACE)
+        - --service-discovery-port
+        - "8080"
+        - --selector
+        - component=engine ome.io/inferenceservice=$(INFERENCESERVICE_NAME)
+        - --enable-igw
+        - --request-id-headers
+        - opc-request-id
+        - --log-json
+        - --disable-retries
+        - --disable-circuit-breaker
+        - --disable-tokenizer-autoload
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INFERENCESERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['ome.io/inferenceservice']
+      readinessProbe:
+        httpGet:
+          path: /readiness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /liveness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 10
+        periodSeconds: 20
+        timeoutSeconds: 10
+  supportedModelFormats:
+    - modelFramework:
+        name: transformers
+        version: "4.57.1"
+      modelFormat:
+        name: safetensors
+        version: "1.0.0"
+      autoSelect: true
+      modelArchitecture: Qwen3_5MoeForConditionalGeneration
+      version: "1.0.0"
+      priority: 1
+  modelSizeRange:
+    min: 34B
+    max: 36B
+  protocolVersions:
+    - openAI
+  engineConfig:
+    volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+    runner:
+      name: ome-container
+      image: fra.ocir.io/idqj093njucb/vllm-openai:v0.19.1
+      ports:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+      args:
+        - $(MODEL_PATH)
+        - --port=8080
+        - --max-log-len=0
+        - --served-model-name=vllm-model
+        - --tensor-parallel-size=2
+        - --gpu-memory-utilization=0.9
+        - --max-model-len=1010000
+        - --no-scheduler-reserve-full-isl
+        - --limit-mm-per-prompt={"image":5,"video":1}
+        - --reasoning-parser=qwen3
+        - --enable-auto-tool-choice
+        - --tool-call-parser=qwen3_coder
+        - '--hf-overrides={"text_config": {"rope_parameters": {"mrope_interleaved": true, "mrope_section": [11, 11, 10], "rope_type": "yarn", "rope_theta": 10000000, "partial_rotary_factor": 0.25, "factor": 4.0, "original_max_position_embeddings": 262144}}}'
+      env:
+        - name: VLLM_RPC_TIMEOUT
+          value: '30000'
+        - name: VLLM_ENGINE_ITERATION_TIMEOUT_S
+          value: '120'
+        - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
+          value: '1'
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+      resources:
+        requests:
+          cpu: 10
+          memory: 80Gi
+          nvidia.com/gpu: 2
+        limits:
+          cpu: 10
+          memory: 80Gi
+          nvidia.com/gpu: 2
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 3
+        successThreshold: 1
+        periodSeconds: 90
+        timeoutSeconds: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        successThreshold: 1
+        periodSeconds: 60
+        timeoutSeconds: 60
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 150
+        successThreshold: 1
+        periodSeconds: 6
+        initialDelaySeconds: 60
+        timeoutSeconds: 30

--- a/config/runtimes/vllm/qwen/qwen-3-6-35b-a3b-rt.yaml
+++ b/config/runtimes/vllm/qwen/qwen-3-6-35b-a3b-rt.yaml
@@ -81,6 +81,17 @@ spec:
       modelArchitecture: Qwen3_5MoeForConditionalGeneration
       version: "1.0.0"
       priority: 1
+    - modelFramework:
+        name: transformers
+        version: "4.57.1"
+      modelFormat:
+        name: safetensors
+        version: "1.0.0"
+      autoSelect: true
+      modelArchitecture: Qwen3_5MoeForConditionalGeneration
+      quantization: fp8
+      version: "1.0.0"
+      priority: 1
   modelSizeRange:
     min: 34B
     max: 36B
@@ -104,6 +115,7 @@ spec:
         - --max-log-len=0
         - --served-model-name=vllm-model
         - --tensor-parallel-size=2
+        - --data-parallel-size=1
         - --gpu-memory-utilization=0.9
         - --max-model-len=1010000
         - --no-scheduler-reserve-full-isl

--- a/config/samples/isvc/Qwen/qwen3-6-35b-a3b.yaml
+++ b/config/samples/isvc/Qwen/qwen3-6-35b-a3b.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: qwen
 spec:
   model:
-    name: qwen3-6-35b-a3b
+    name: qwen3-6-35b-a3b-fp8
   engine:
     minReplicas: 1
     maxReplicas: 1

--- a/config/samples/isvc/Qwen/qwen3-6-35b-a3b.yaml
+++ b/config/samples/isvc/Qwen/qwen3-6-35b-a3b.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: qwen
 spec:
   model:
-    name: qwen3-6-35b-a3b-fp8
+    name: qwen3-6-35b-a3b
   engine:
     minReplicas: 1
     maxReplicas: 1

--- a/config/samples/isvc/Qwen/qwen3-6-35b-a3b.yaml
+++ b/config/samples/isvc/Qwen/qwen3-6-35b-a3b.yaml
@@ -1,0 +1,17 @@
+
+---
+
+apiVersion: ome.io/v1beta1
+kind: InferenceService
+metadata:
+  name: qwen-3-6-35b-a3b
+  namespace: qwen
+spec:
+  model:
+    name: qwen3-6-35b-a3b
+  engine:
+    minReplicas: 1
+    maxReplicas: 1
+  router:
+    minReplicas: 1
+    maxReplicas: 1


### PR DESCRIPTION
## What this PR does

Adds OME configuration for serving Qwen 3.6 35B A3B with a 1M context window:

- Adds the `qwen3-6-35b-a3b` `ClusterBaseModel` pointing to `hf://Qwen/Qwen3.6-35B-A3B`.
- Adds the `vllm-qwen-3-6-35b-a3b` `ClusterServingRuntime` with vLLM settings for Qwen3_5Moe, 2-way tensor parallelism, long-context rope overrides, multimodal limits, Qwen reasoning parsing, and tool-call parsing.
- Registers the runtime in `config/runtimes/kustomization.yaml`.
- Adds a sample `InferenceService` for the Qwen namespace.

## Why we need it

This enables OME to select and deploy a dedicated runtime for Qwen 3.6 35B A3B, including the long-context configuration required for 1M-token serving.

Fixes: N/A

## How to test

Not run locally; this PR was created from an already-pushed commit.

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
