### PR TITLE
[Core] Expose container startup failures in InferenceService status

### DIFF
--- a/charts/ome-crd/templates/ome.io_inferenceservices.yaml
+++ b/charts/ome-crd/templates/ome.io_inferenceservices.yaml
@@ -36399,6 +36399,7 @@ spec:
                             - BaseModelNotReady
                             - BaseModelNotFound
                             - ModelLoadFailed
+                            - ContainerStartupFailed
                             - RuntimeUnhealthy
                             - RuntimeDisabled
                             - NoSupportingRuntime

--- a/config/crd/full/ome.io_inferenceservices.yaml
+++ b/config/crd/full/ome.io_inferenceservices.yaml
@@ -36399,6 +36399,7 @@ spec:
                             - BaseModelNotReady
                             - BaseModelNotFound
                             - ModelLoadFailed
+                            - ContainerStartupFailed
                             - RuntimeUnhealthy
                             - RuntimeDisabled
                             - NoSupportingRuntime

--- a/pkg/apis/ome/v1beta1/inference_service_status.go
+++ b/pkg/apis/ome/v1beta1/inference_service_status.go
@@ -202,13 +202,15 @@ const (
 )
 
 // FailureReason enum
-// +kubebuilder:validation:Enum=BaseModelNotReady;BaseModelNotFound;ModelLoadFailed;RuntimeUnhealthy;RuntimeDisabled;NoSupportingRuntime;RuntimeNotRecognized;InvalidPredictorSpec
+// +kubebuilder:validation:Enum=BaseModelNotReady;BaseModelNotFound;ModelLoadFailed;ContainerStartupFailed;RuntimeUnhealthy;RuntimeDisabled;NoSupportingRuntime;RuntimeNotRecognized;InvalidPredictorSpec
 type FailureReason string
 
 // FailureReason enum values
 const (
 	// ModelLoadFailed The model failed to load within a ServingRuntime container
 	ModelLoadFailed FailureReason = "ModelLoadFailed"
+	// ContainerStartupFailed Serving container failed to start before becoming ready
+	ContainerStartupFailed FailureReason = "ContainerStartupFailed"
 	// RuntimeUnhealthy Corresponding ServingRuntime containers failed to start or are unhealthy
 	RuntimeUnhealthy FailureReason = "RuntimeUnhealthy"
 	// RuntimeDisabled The ServingRuntime is disabled

--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -494,7 +494,26 @@ func UpdateComponentStatus(b *BaseComponentFields, isvc *v1beta1.InferenceServic
 	if err != nil {
 		return errors.Wrapf(err, "failed to list %s pods by label", componentType)
 	}
-	b.StatusManager.PropagateModelStatus(&isvc.Status, statusSpec, pods, rawDeployment)
+	reportContainerStartupFailure := shouldReportContainerStartupFailure(b, isvc, componentType)
+	b.StatusManager.PropagateModelStatus(&isvc.Status, statusSpec, pods, rawDeployment, reportContainerStartupFailure)
 
 	return nil
+}
+
+func shouldReportContainerStartupFailure(b *BaseComponentFields, isvc *v1beta1.InferenceService, componentType v1beta1.ComponentType) bool {
+	if componentType != v1beta1.EngineComponent && componentType != v1beta1.DecoderComponent {
+		return false
+	}
+	if b == nil || b.BaseModelMeta == nil || isvc == nil || isvc.Spec.Model == nil {
+		return false
+	}
+	if isvc.Spec.Model.Kind != nil &&
+		*isvc.Spec.Model.Kind != constants.BaseModel &&
+		*isvc.Spec.Model.Kind != constants.ClusterBaseModel {
+		return false
+	}
+	if b.BaseModelMeta.Name != isvc.Spec.Model.Name {
+		return false
+	}
+	return b.BaseModelMeta.Namespace == "" || b.BaseModelMeta.Namespace == isvc.Namespace
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/base_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base_test.go
@@ -218,3 +218,115 @@ func TestProcessBaseLabels(t *testing.T) {
 	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.BaseModelTypeLabelKey, string(constants.ServingBaseModel)))
 	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.BaseModelVendorLabelKey, "meta"))
 }
+
+func TestShouldReportContainerStartupFailure(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseModelMeta *metav1.ObjectMeta
+		modelRef      *v1beta1.ModelRef
+		isvcNamespace string
+		componentType v1beta1.ComponentType
+		expected      bool
+	}{
+		{
+			name:          "engine component with resolved BaseModel",
+			baseModelMeta: &metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+			modelRef:      &v1beta1.ModelRef{Name: "test-model", Kind: stringPtr(constants.BaseModel)},
+			isvcNamespace: "default",
+			componentType: v1beta1.EngineComponent,
+			expected:      true,
+		},
+		{
+			name:          "decoder component with resolved ClusterBaseModel",
+			baseModelMeta: &metav1.ObjectMeta{Name: "test-model"},
+			modelRef:      &v1beta1.ModelRef{Name: "test-model", Kind: stringPtr(constants.ClusterBaseModel)},
+			isvcNamespace: "default",
+			componentType: v1beta1.DecoderComponent,
+			expected:      true,
+		},
+		{
+			name:          "default model kind still reports when resolved model is BaseModel",
+			baseModelMeta: &metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+			modelRef:      &v1beta1.ModelRef{Name: "test-model"},
+			isvcNamespace: "default",
+			componentType: v1beta1.EngineComponent,
+			expected:      true,
+		},
+		{
+			name:          "requested BaseModel kind still reports when resolved model is ClusterBaseModel",
+			baseModelMeta: &metav1.ObjectMeta{Name: "test-model"},
+			modelRef:      &v1beta1.ModelRef{Name: "test-model", Kind: stringPtr(constants.BaseModel)},
+			isvcNamespace: "default",
+			componentType: v1beta1.EngineComponent,
+			expected:      true,
+		},
+		{
+			name:          "requested ClusterBaseModel kind still reports when resolved model is BaseModel",
+			baseModelMeta: &metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+			modelRef:      &v1beta1.ModelRef{Name: "test-model", Kind: stringPtr(constants.ClusterBaseModel)},
+			isvcNamespace: "default",
+			componentType: v1beta1.EngineComponent,
+			expected:      true,
+		},
+		{
+			name:          "router component is not model-serving status",
+			baseModelMeta: &metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+			modelRef:      &v1beta1.ModelRef{Name: "test-model", Kind: stringPtr(constants.ClusterBaseModel)},
+			isvcNamespace: "default",
+			componentType: v1beta1.RouterComponent,
+			expected:      false,
+		},
+		{
+			name:          "mismatched BaseModel",
+			baseModelMeta: &metav1.ObjectMeta{Name: "other-model", Namespace: "default"},
+			modelRef:      &v1beta1.ModelRef{Name: "test-model", Kind: stringPtr(constants.ClusterBaseModel)},
+			isvcNamespace: "default",
+			componentType: v1beta1.EngineComponent,
+			expected:      false,
+		},
+		{
+			name:          "missing BaseModel metadata",
+			baseModelMeta: nil,
+			modelRef:      &v1beta1.ModelRef{Name: "test-model", Kind: stringPtr(constants.ClusterBaseModel)},
+			isvcNamespace: "default",
+			componentType: v1beta1.EngineComponent,
+			expected:      false,
+		},
+		{
+			name:          "missing model ref",
+			baseModelMeta: &metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+			modelRef:      nil,
+			isvcNamespace: "default",
+			componentType: v1beta1.EngineComponent,
+			expected:      false,
+		},
+		{
+			name:          "non-BaseModel model ref still does not report",
+			baseModelMeta: &metav1.ObjectMeta{Name: "test-model", Namespace: "default"},
+			modelRef:      &v1beta1.ModelRef{Name: "test-model", Kind: stringPtr("CustomModel")},
+			isvcNamespace: "default",
+			componentType: v1beta1.EngineComponent,
+			expected:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &BaseComponentFields{BaseModelMeta: tt.baseModelMeta}
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: tt.isvcNamespace,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Model: tt.modelRef,
+				},
+			}
+
+			result := shouldReportContainerStartupFailure(b, isvc, tt.componentType)
+
+			if result != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/status/status_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_reconciler.go
@@ -36,7 +36,11 @@ func (sr *StatusReconciler) PropagateRawStatus(
 
 	statusSpec := sr.initializeComponentStatus(status, component)
 
-	statusSpec.LatestCreatedRevision = deployment.GetObjectMeta().GetAnnotations()["deployment.kubernetes.io/revision"]
+	latestRevision := deployment.GetObjectMeta().GetAnnotations()["deployment.kubernetes.io/revision"]
+	statusSpec.LatestCreatedRevision = latestRevision
+	if latestRevision != "" && sr.isDeploymentRolloutComplete(deployment) {
+		statusSpec.LatestReadyRevision = latestRevision
+	}
 	condition := sr.getDeploymentCondition(deployment, appsv1.DeploymentAvailable)
 	if condition != nil && condition.Status == v1.ConditionTrue {
 		statusSpec.URL = url
@@ -149,7 +153,8 @@ func (sr *StatusReconciler) PropagateModelStatus(
 	status *v1beta1.InferenceServiceStatus,
 	statusSpec v1beta1.ComponentStatusSpec,
 	podList *v1.PodList,
-	rawDeployment bool) {
+	rawDeployment bool,
+	reportContainerStartupFailure bool) {
 
 	// Check at least one pod is running for the latest revision of inferenceservice
 	totalCopies := len(podList.Items)
@@ -165,19 +170,42 @@ func (sr *StatusReconciler) PropagateModelStatus(
 		return
 	}
 
-	// Update model state to 'Loaded' if inferenceservice status is ready.
-	if status.IsReady() {
-		if rawDeployment {
-			sr.UpdateModelRevisionStates(status, v1beta1.Loaded, totalCopies, nil)
-			return
-		} else if statusSpec.LatestCreatedRevision == statusSpec.LatestReadyRevision {
-			sr.UpdateModelRevisionStates(status, v1beta1.Loaded, totalCopies, nil)
-			return
-		}
+	// Update model state to 'Loaded' when the current ready status still matches the latest rollout revision.
+	if status.IsReady() && statusSpec.LatestCreatedRevision == statusSpec.LatestReadyRevision {
+		sr.UpdateModelRevisionStates(status, v1beta1.Loaded, totalCopies, nil)
+		return
 	}
 
 	// Check container statuses
-	sr.checkContainerStatuses(status, firstPod, totalCopies)
+	currentModelRevisionName := statusSpec.LatestCreatedRevision
+	reportContainerStartupFailure = reportContainerStartupFailure &&
+		sr.shouldReportContainerStartupFailure(status, statusSpec, rawDeployment)
+	sr.checkContainerStatuses(status, firstPod, totalCopies, currentModelRevisionName, reportContainerStartupFailure)
+}
+
+func (sr *StatusReconciler) shouldReportContainerStartupFailure(
+	status *v1beta1.InferenceServiceStatus,
+	statusSpec v1beta1.ComponentStatusSpec,
+	rawDeployment bool) bool {
+	if status.ModelStatus.ModelRevisionStates == nil ||
+		status.ModelStatus.ModelRevisionStates.ActiveModelState != v1beta1.Loaded {
+		return true
+	}
+
+	// Raw deployments do not expose a revision-level "latest revision became ready" signal.
+	// Once a raw deployment has previously loaded, a later crash during rollout could happen
+	// either before first ready or after the new pod was already serving. Keep the existing
+	// ModelLoadFailed classification in that case rather than guessing.
+	if rawDeployment {
+		return false
+	}
+
+	// After a model is already loaded, only treat crash loops as startup failures when the
+	// component status clearly shows a new rollout is in progress.
+	if statusSpec.LatestCreatedRevision == "" || statusSpec.LatestReadyRevision == "" {
+		return false
+	}
+	return statusSpec.LatestCreatedRevision != statusSpec.LatestReadyRevision
 }
 
 // UpdateModelRevisionStates updates the model revision states

--- a/pkg/controller/v1beta1/inferenceservice/status/status_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	lwsspec "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
 )
 
 func TestNewStatusReconciler(t *testing.T) {
@@ -66,6 +67,7 @@ func TestPropagateRawStatus(t *testing.T) {
 			},
 			url: &apis.URL{Scheme: "http", Host: "test-service.default.svc.cluster.local"},
 			expectedStatus: v1beta1.ComponentStatusSpec{
+				LatestReadyRevision:   "1",
 				LatestCreatedRevision: "1",
 				URL:                   &apis.URL{Scheme: "http", Host: "test-service.default.svc.cluster.local"},
 			},
@@ -104,6 +106,7 @@ func TestPropagateRawStatus(t *testing.T) {
 			},
 			url: &apis.URL{Scheme: "http", Host: "test-engine-service.default.svc.cluster.local"},
 			expectedStatus: v1beta1.ComponentStatusSpec{
+				LatestReadyRevision:   "2",
 				LatestCreatedRevision: "2",
 				URL:                   &apis.URL{Scheme: "http", Host: "test-engine-service.default.svc.cluster.local"},
 			},
@@ -185,6 +188,103 @@ func TestPropagateRawStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "available rollout preserves previous ready revision until new deployment revision is complete",
+			status: &v1beta1.InferenceServiceStatus{
+				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+					v1beta1.PredictorComponent: {
+						LatestReadyRevision:   "1",
+						LatestCreatedRevision: "1",
+					},
+				},
+			},
+			component: v1beta1.PredictorComponent,
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-deployment",
+					Namespace:  "default",
+					Generation: 2,
+					Annotations: map[string]string{
+						"deployment.kubernetes.io/revision": "2",
+					},
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           4,
+					ReadyReplicas:      3,
+					AvailableReplicas:  3,
+					UpdatedReplicas:    2,
+					ObservedGeneration: 2,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:   appsv1.DeploymentAvailable,
+							Status: corev1.ConditionTrue,
+							Reason: "MinimumReplicasAvailable",
+						},
+						{
+							Type:   appsv1.DeploymentProgressing,
+							Status: corev1.ConditionTrue,
+							Reason: "ReplicaSetUpdated",
+						},
+					},
+				},
+			},
+			url: &apis.URL{Scheme: "http", Host: "test-service.default.svc.cluster.local"},
+			expectedStatus: v1beta1.ComponentStatusSpec{
+				LatestReadyRevision:   "1",
+				LatestCreatedRevision: "2",
+				URL:                   &apis.URL{Scheme: "http", Host: "test-service.default.svc.cluster.local"},
+			},
+		},
+		{
+			name: "scale to zero rollout preserves previous ready revision until a new pod becomes available",
+			status: &v1beta1.InferenceServiceStatus{
+				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+					v1beta1.PredictorComponent: {
+						LatestReadyRevision:   "1",
+						LatestCreatedRevision: "1",
+					},
+				},
+			},
+			component: v1beta1.PredictorComponent,
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-deployment",
+					Namespace:  "default",
+					Generation: 2,
+					Annotations: map[string]string{
+						"deployment.kubernetes.io/revision": "2",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](0),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:           0,
+					ReadyReplicas:      0,
+					AvailableReplicas:  0,
+					UpdatedReplicas:    0,
+					ObservedGeneration: 2,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:   appsv1.DeploymentAvailable,
+							Status: corev1.ConditionTrue,
+							Reason: "MinimumReplicasAvailable",
+						},
+						{
+							Type:   appsv1.DeploymentProgressing,
+							Status: corev1.ConditionTrue,
+							Reason: "NewReplicaSetAvailable",
+						},
+					},
+				},
+			},
+			url: &apis.URL{Scheme: "http", Host: "test-service.default.svc.cluster.local"},
+			expectedStatus: v1beta1.ComponentStatusSpec{
+				LatestReadyRevision:   "1",
+				LatestCreatedRevision: "2",
+				URL:                   &apis.URL{Scheme: "http", Host: "test-service.default.svc.cluster.local"},
+			},
+		},
+		{
 			name:      "deployment with replica failure",
 			status:    &v1beta1.InferenceServiceStatus{},
 			component: v1beta1.PredictorComponent,
@@ -227,6 +327,7 @@ func TestPropagateRawStatus(t *testing.T) {
 			manager.PropagateRawStatus(tt.status, tt.component, tt.deployment, tt.url)
 
 			actualStatus := tt.status.Components[tt.component]
+			assert.Equal(t, tt.expectedStatus.LatestReadyRevision, actualStatus.LatestReadyRevision)
 			assert.Equal(t, tt.expectedStatus.LatestCreatedRevision, actualStatus.LatestCreatedRevision)
 			assert.Equal(t, tt.expectedStatus.URL, actualStatus.URL)
 			assert.Equal(t, tt.deployment.Status.ObservedGeneration, tt.status.ObservedGeneration)
@@ -637,12 +738,15 @@ func TestPropagateStatus(t *testing.T) {
 
 func TestPropagateModelStatus(t *testing.T) {
 	tests := []struct {
-		name          string
-		status        *v1beta1.InferenceServiceStatus
-		statusSpec    v1beta1.ComponentStatusSpec
-		podList       *corev1.PodList
-		rawDeployment bool
-		expectedState v1beta1.ModelState
+		name                  string
+		status                *v1beta1.InferenceServiceStatus
+		statusSpec            v1beta1.ComponentStatusSpec
+		podList               *corev1.PodList
+		rawDeployment         bool
+		reportStartup         bool
+		expectedState         v1beta1.ModelState
+		expectedReason        *v1beta1.FailureReason
+		expectedModelRevision string
 	}{
 		{
 			name:   "no pods available",
@@ -660,7 +764,8 @@ func TestPropagateModelStatus(t *testing.T) {
 			status: &v1beta1.InferenceServiceStatus{
 				Status: duckv1.Status{
 					Conditions: duckv1.Conditions{
-						{Type: v1beta1.PredictorReady, Status: corev1.ConditionTrue},
+						{Type: v1beta1.IngressReady, Status: corev1.ConditionTrue},
+						{Type: v1beta1.EngineReady, Status: corev1.ConditionTrue},
 					},
 				},
 				ModelStatus: v1beta1.ModelStatus{},
@@ -696,7 +801,8 @@ func TestPropagateModelStatus(t *testing.T) {
 			status: &v1beta1.InferenceServiceStatus{
 				Status: duckv1.Status{
 					Conditions: duckv1.Conditions{
-						{Type: v1beta1.PredictorReady, Status: corev1.ConditionTrue},
+						{Type: v1beta1.IngressReady, Status: corev1.ConditionTrue},
+						{Type: v1beta1.EngineReady, Status: corev1.ConditionTrue},
 					},
 				},
 				ModelStatus: v1beta1.ModelStatus{},
@@ -718,16 +824,201 @@ func TestPropagateModelStatus(t *testing.T) {
 			rawDeployment: true,
 			expectedState: v1beta1.Loaded,
 		},
+		{
+			name: "rollout crash loop surfaces startup failure after previous revision was loaded",
+			status: &v1beta1.InferenceServiceStatus{
+				ModelStatus: v1beta1.ModelStatus{
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{
+						ActiveModelState: v1beta1.Loaded,
+					},
+				},
+			},
+			statusSpec: v1beta1.ComponentStatusSpec{
+				LatestReadyRevision:   "rev-1",
+				LatestCreatedRevision: "rev-2",
+			},
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-pod-1"},
+						Status: corev1.PodStatus{
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:         constants.MainContainerName,
+									RestartCount: 4,
+									State: corev1.ContainerState{
+										Waiting: &corev1.ContainerStateWaiting{
+											Reason: constants.StateReasonCrashLoopBackOff,
+										},
+									},
+									LastTerminationState: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											Message:  "container exited during startup",
+											ExitCode: 2,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			rawDeployment:         false,
+			reportStartup:         true,
+			expectedState:         v1beta1.FailedToLoad,
+			expectedReason:        ptr.To(v1beta1.ContainerStartupFailed),
+			expectedModelRevision: "rev-2",
+		},
+		{
+			name: "same ready revision crash loop stays pending after service was previously loaded",
+			status: &v1beta1.InferenceServiceStatus{
+				ModelStatus: v1beta1.ModelStatus{
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{
+						ActiveModelState: v1beta1.Loaded,
+					},
+				},
+			},
+			statusSpec: v1beta1.ComponentStatusSpec{
+				LatestReadyRevision:   "rev-1",
+				LatestCreatedRevision: "rev-1",
+			},
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-pod-1"},
+						Status: corev1.PodStatus{
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:         constants.MainContainerName,
+									RestartCount: 4,
+									State: corev1.ContainerState{
+										Waiting: &corev1.ContainerStateWaiting{
+											Reason: constants.StateReasonCrashLoopBackOff,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			rawDeployment: false,
+			reportStartup: true,
+			expectedState: v1beta1.Pending,
+		},
+		{
+			name: "raw rollout crash loop keeps prior failure behavior after previous revision was loaded",
+			status: &v1beta1.InferenceServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{Type: v1beta1.IngressReady, Status: corev1.ConditionTrue},
+						{Type: v1beta1.EngineReady, Status: corev1.ConditionTrue},
+					},
+				},
+				ModelStatus: v1beta1.ModelStatus{
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{
+						ActiveModelState: v1beta1.Loaded,
+					},
+				},
+			},
+			statusSpec: v1beta1.ComponentStatusSpec{
+				LatestReadyRevision:   "rev-1",
+				LatestCreatedRevision: "rev-2",
+			},
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-pod-1"},
+						Status: corev1.PodStatus{
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:         constants.MainContainerName,
+									RestartCount: 4,
+									State: corev1.ContainerState{
+										Waiting: &corev1.ContainerStateWaiting{
+											Reason: constants.StateReasonCrashLoopBackOff,
+										},
+									},
+									LastTerminationState: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											Message:  "container exited after becoming ready",
+											ExitCode: 2,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			rawDeployment:  true,
+			reportStartup:  true,
+			expectedState:  v1beta1.FailedToLoad,
+			expectedReason: ptr.To(v1beta1.ModelLoadFailed),
+		},
+		{
+			name: "multi-node style status without ready revision keeps prior failure behavior after service was previously loaded",
+			status: &v1beta1.InferenceServiceStatus{
+				ModelStatus: v1beta1.ModelStatus{
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{
+						ActiveModelState: v1beta1.Loaded,
+					},
+				},
+			},
+			statusSpec: v1beta1.ComponentStatusSpec{
+				LatestCreatedRevision: "rev-2",
+			},
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-pod-1"},
+						Status: corev1.PodStatus{
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:         constants.MainContainerName,
+									RestartCount: 4,
+									State: corev1.ContainerState{
+										Waiting: &corev1.ContainerStateWaiting{
+											Reason: constants.StateReasonCrashLoopBackOff,
+										},
+									},
+									LastTerminationState: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											Message:  "container exited after becoming ready",
+											ExitCode: 2,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			rawDeployment:  false,
+			reportStartup:  true,
+			expectedState:  v1beta1.FailedToLoad,
+			expectedReason: ptr.To(v1beta1.ModelLoadFailed),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := NewStatusReconciler()
 
-			manager.PropagateModelStatus(tt.status, tt.statusSpec, tt.podList, tt.rawDeployment)
+			manager.PropagateModelStatus(tt.status, tt.statusSpec, tt.podList, tt.rawDeployment, tt.reportStartup)
 
 			if tt.status.ModelStatus.ModelRevisionStates != nil {
 				assert.Equal(t, tt.expectedState, tt.status.ModelStatus.ModelRevisionStates.TargetModelState)
+			}
+			if tt.expectedReason != nil {
+				if assert.NotNil(t, tt.status.ModelStatus.LastFailureInfo) {
+					assert.Equal(t, *tt.expectedReason, tt.status.ModelStatus.LastFailureInfo.Reason)
+				}
+			}
+			if tt.expectedModelRevision != "" {
+				if assert.NotNil(t, tt.status.ModelStatus.LastFailureInfo) {
+					assert.Equal(t, tt.expectedModelRevision, tt.status.ModelStatus.LastFailureInfo.ModelRevisionName)
+				}
 			}
 		})
 	}

--- a/pkg/controller/v1beta1/inferenceservice/status/status_util.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_util.go
@@ -13,6 +13,8 @@ import (
 	"sigs.k8s.io/ome/pkg/constants"
 )
 
+const containerStartupFailureRestartThreshold int32 = 3
+
 // Helper functions for StatusReconciler
 
 // initializeComponentStatus ensures component status is properly initialized
@@ -59,6 +61,25 @@ func (sr *StatusReconciler) getDeploymentCondition(deployment *appsv1.Deployment
 		}
 	}
 	return &condition
+}
+
+func (sr *StatusReconciler) isDeploymentRolloutComplete(deployment *appsv1.Deployment) bool {
+	if deployment == nil {
+		return false
+	}
+
+	desiredReplicas := deployment.Status.Replicas
+	if deployment.Spec.Replicas != nil {
+		desiredReplicas = *deployment.Spec.Replicas
+	}
+	if desiredReplicas == 0 {
+		return false
+	}
+
+	return deployment.Status.ObservedGeneration >= deployment.Generation &&
+		deployment.Status.UpdatedReplicas == desiredReplicas &&
+		deployment.Status.Replicas == desiredReplicas &&
+		deployment.Status.AvailableReplicas == desiredReplicas
 }
 
 // getLWSConditions extracts condition from LeaderWorkerSet
@@ -259,9 +280,14 @@ func (sr *StatusReconciler) propagateServiceConditions(
 }
 
 // checkContainerStatuses checks the status of containers in a pod
-func (sr *StatusReconciler) checkContainerStatuses(status *v1beta1.InferenceServiceStatus, firstPod *v1.Pod, totalCopies int) {
+func (sr *StatusReconciler) checkContainerStatuses(
+	status *v1beta1.InferenceServiceStatus,
+	firstPod *v1.Pod,
+	totalCopies int,
+	currentModelRevisionName string,
+	reportContainerStartupFailure bool) {
 	// Update model state to 'Loading' if storage initializer is running.
-	// If the storage initializer is terminated due to error or crashloopbackoff, update model
+	// If the storage initializer is terminated due to error, update model
 	// state to 'ModelLoadFailed' with failure info.
 	for _, cs := range firstPod.Status.InitContainerStatuses {
 		if cs.Name == constants.StorageInitializerContainerName {
@@ -285,13 +311,15 @@ func (sr *StatusReconciler) checkContainerStatuses(status *v1beta1.InferenceServ
 						Message:  message,
 						ExitCode: exitCode,
 					})
+				} else {
+					sr.UpdateModelRevisionStates(status, v1beta1.Pending, totalCopies, nil)
 				}
 				return
 			}
 		}
 	}
 
-	// If the ome container is terminated due to error or crashloopbackoff, update model
+	// If the ome container is terminated due to error, update model
 	// state to 'ModelLoadFailed' with failure info.
 	for _, cs := range firstPod.Status.ContainerStatuses {
 		if cs.Name == constants.MainContainerName {
@@ -304,13 +332,32 @@ func (sr *StatusReconciler) checkContainerStatuses(status *v1beta1.InferenceServ
 					ExitCode: exitCode,
 				})
 			case cs.State.Waiting != nil && cs.State.Waiting.Reason == constants.StateReasonCrashLoopBackOff:
+				var startupFailureInfo *v1beta1.FailureInfo
+				if reportContainerStartupFailure {
+					startupFailureInfo = sr.getCrashLoopBackOffStartupFailure(firstPod, cs, currentModelRevisionName)
+				}
+
 				message, exitCode, hasTermination := sr.safeGetTerminationMessage(cs)
 				if hasTermination {
-					sr.UpdateModelRevisionStates(status, v1beta1.FailedToLoad, totalCopies, &v1beta1.FailureInfo{
+					failureInfo := &v1beta1.FailureInfo{
 						Reason:   v1beta1.ModelLoadFailed,
 						Message:  message,
 						ExitCode: exitCode,
-					})
+					}
+					if startupFailureInfo != nil {
+						failureInfo.Reason = startupFailureInfo.Reason
+						failureInfo.Location = startupFailureInfo.Location
+						failureInfo.ModelRevisionName = startupFailureInfo.ModelRevisionName
+						if failureInfo.Message == "" {
+							failureInfo.Message = startupFailureInfo.Message
+						}
+						if failureInfo.ExitCode == 0 {
+							failureInfo.ExitCode = startupFailureInfo.ExitCode
+						}
+					}
+					sr.UpdateModelRevisionStates(status, v1beta1.FailedToLoad, totalCopies, failureInfo)
+				} else if startupFailureInfo != nil {
+					sr.UpdateModelRevisionStates(status, v1beta1.FailedToLoad, totalCopies, startupFailureInfo)
 				} else {
 					sr.UpdateModelRevisionStates(status, v1beta1.Pending, totalCopies, nil)
 				}
@@ -319,6 +366,39 @@ func (sr *StatusReconciler) checkContainerStatuses(status *v1beta1.InferenceServ
 			}
 		}
 	}
+}
+
+func (sr *StatusReconciler) getCrashLoopBackOffStartupFailure(
+	pod *v1.Pod,
+	cs v1.ContainerStatus,
+	currentModelRevisionName string) *v1beta1.FailureInfo {
+	if cs.State.Waiting == nil || cs.State.Waiting.Reason != constants.StateReasonCrashLoopBackOff {
+		return nil
+	}
+	if cs.Ready || cs.RestartCount <= containerStartupFailureRestartThreshold {
+		return nil
+	}
+
+	failureInfo := &v1beta1.FailureInfo{
+		Location: fmt.Sprintf("%s/%s", pod.Name, cs.Name),
+		Reason:   v1beta1.ContainerStartupFailed,
+	}
+	message, exitCode, hasTermination := sr.safeGetTerminationMessage(cs)
+	if hasTermination {
+		failureInfo.Message = message
+		failureInfo.ExitCode = exitCode
+	} else {
+		failureInfo.Message = fmt.Sprintf("Container %q in pod %q never became ready: %s after %d restarts",
+			cs.Name, pod.Name, cs.State.Waiting.Reason, cs.RestartCount)
+		if cs.State.Waiting.Message != "" {
+			failureInfo.Message = fmt.Sprintf("%s: %s", failureInfo.Message, cs.State.Waiting.Message)
+		}
+	}
+	if currentModelRevisionName != "" {
+		failureInfo.ModelRevisionName = currentModelRevisionName
+	}
+
+	return failureInfo
 }
 
 // safeGetTerminationMessage safely extracts termination message from container status

--- a/pkg/controller/v1beta1/inferenceservice/status/status_util_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/status_util_test.go
@@ -750,11 +750,17 @@ func TestPropagateServiceConditions(t *testing.T) {
 
 func TestCheckContainerStatuses(t *testing.T) {
 	tests := []struct {
-		name          string
-		status        *v1beta1.InferenceServiceStatus
-		pod           *corev1.Pod
-		totalCopies   int
-		expectedState v1beta1.ModelState
+		name                  string
+		status                *v1beta1.InferenceServiceStatus
+		pod                   *corev1.Pod
+		totalCopies           int
+		modelRevision         string
+		expectedState         v1beta1.ModelState
+		expectedReason        *v1beta1.FailureReason
+		expectedMsg           string
+		expectedModelRevision string
+		expectedExitCode      *int32
+		reportStartup         bool
 	}{
 		{
 			name:   "storage initializer running",
@@ -797,7 +803,7 @@ func TestCheckContainerStatuses(t *testing.T) {
 			expectedState: v1beta1.FailedToLoad,
 		},
 		{
-			name:   "storage initializer crash loop back off",
+			name:   "storage initializer crash loop back off with termination",
 			status: &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}},
 			pod: &corev1.Pod{
 				Status: corev1.PodStatus{
@@ -819,8 +825,62 @@ func TestCheckContainerStatuses(t *testing.T) {
 					},
 				},
 			},
+			totalCopies:    1,
+			expectedState:  v1beta1.FailedToLoad,
+			expectedReason: ptr.To(v1beta1.ModelLoadFailed),
+			expectedMsg:    "Failed to download model",
+		},
+		{
+			name:   "storage initializer crash loop back off with termination keeps prior failure behavior when startup reporting is enabled",
+			status: &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}},
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: constants.StorageInitializerContainerName,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: constants.StateReasonCrashLoopBackOff,
+								},
+							},
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Message:  "Failed to download model",
+									ExitCode: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+			totalCopies:    1,
+			expectedState:  v1beta1.FailedToLoad,
+			expectedReason: ptr.To(v1beta1.ModelLoadFailed),
+			expectedMsg:    "Failed to download model",
+			reportStartup:  true,
+		},
+		{
+			name:   "storage initializer crash loop back off after restart threshold without termination",
+			status: &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:         constants.StorageInitializerContainerName,
+							RestartCount: 3,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason:  constants.StateReasonCrashLoopBackOff,
+									Message: "back-off restarting failed container",
+								},
+							},
+						},
+					},
+				},
+			},
 			totalCopies:   1,
-			expectedState: v1beta1.FailedToLoad,
+			expectedState: v1beta1.Pending,
 		},
 		{
 			name:   "main container terminated with error",
@@ -845,7 +905,102 @@ func TestCheckContainerStatuses(t *testing.T) {
 			expectedState: v1beta1.FailedToLoad,
 		},
 		{
-			name:   "main container crash loop back off with termination",
+			name:   "main container crash loop back off with termination keeps original failure below startup threshold when startup reporting is enabled",
+			status: &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}},
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:         constants.MainContainerName,
+							RestartCount: 2,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: constants.StateReasonCrashLoopBackOff,
+								},
+							},
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Message:  "Model loading failed",
+									ExitCode: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+			totalCopies:      1,
+			expectedState:    v1beta1.FailedToLoad,
+			expectedReason:   ptr.To(v1beta1.ModelLoadFailed),
+			expectedMsg:      "Model loading failed",
+			expectedExitCode: ptr.To(int32(1)),
+			reportStartup:    true,
+		},
+		{
+			name:   "main container crash loop back off at startup threshold keeps original failure when startup reporting is enabled",
+			status: &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}},
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:         constants.MainContainerName,
+							RestartCount: containerStartupFailureRestartThreshold,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: constants.StateReasonCrashLoopBackOff,
+								},
+							},
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Message:  "Model loading failed at threshold",
+									ExitCode: 2,
+								},
+							},
+						},
+					},
+				},
+			},
+			totalCopies:      1,
+			expectedState:    v1beta1.FailedToLoad,
+			expectedReason:   ptr.To(v1beta1.ModelLoadFailed),
+			expectedMsg:      "Model loading failed at threshold",
+			expectedExitCode: ptr.To(int32(2)),
+			reportStartup:    true,
+		},
+		{
+			name:   "main container crash loop back off with termination reports container startup failure when startup reporting is enabled",
+			status: &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}},
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:         constants.MainContainerName,
+							RestartCount: 4,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: constants.StateReasonCrashLoopBackOff,
+								},
+							},
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Message:  "Model loading failed",
+									ExitCode: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+			totalCopies:           1,
+			modelRevision:         "rev-2",
+			expectedState:         v1beta1.FailedToLoad,
+			expectedReason:        ptr.To(v1beta1.ContainerStartupFailed),
+			expectedMsg:           "Model loading failed",
+			expectedModelRevision: "rev-2",
+			expectedExitCode:      ptr.To(int32(1)),
+			reportStartup:         true,
+		},
+		{
+			name:   "main container crash loop back off with termination keeps prior failure behavior when startup reporting disabled",
 			status: &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}},
 			pod: &corev1.Pod{
 				Status: corev1.PodStatus{
@@ -867,8 +1022,59 @@ func TestCheckContainerStatuses(t *testing.T) {
 					},
 				},
 			},
+			totalCopies:    1,
+			expectedState:  v1beta1.FailedToLoad,
+			expectedReason: ptr.To(v1beta1.ModelLoadFailed),
+			expectedMsg:    "Model loading failed",
+		},
+		{
+			name:   "main container crash loop back off after restart threshold",
+			status: &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:         constants.MainContainerName,
+							RestartCount: 4,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: constants.StateReasonCrashLoopBackOff,
+								},
+							},
+						},
+					},
+				},
+			},
+			totalCopies:           1,
+			modelRevision:         "rev-2",
+			expectedState:         v1beta1.FailedToLoad,
+			expectedReason:        ptr.To(v1beta1.ContainerStartupFailed),
+			expectedMsg:           constants.StateReasonCrashLoopBackOff,
+			expectedModelRevision: "rev-2",
+			reportStartup:         true,
+		},
+		{
+			name:   "main container crash loop back off after restart threshold with startup reporting disabled",
+			status: &v1beta1.InferenceServiceStatus{ModelStatus: v1beta1.ModelStatus{}},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:         constants.MainContainerName,
+							RestartCount: 4,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: constants.StateReasonCrashLoopBackOff,
+								},
+							},
+						},
+					},
+				},
+			},
 			totalCopies:   1,
-			expectedState: v1beta1.FailedToLoad,
+			expectedState: v1beta1.Pending,
 		},
 		{
 			name:   "main container crash loop back off without termination",
@@ -913,10 +1119,30 @@ func TestCheckContainerStatuses(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := NewStatusReconciler()
-			manager.checkContainerStatuses(tt.status, tt.pod, tt.totalCopies)
+			manager.checkContainerStatuses(tt.status, tt.pod, tt.totalCopies, tt.modelRevision, tt.reportStartup)
 
 			if tt.status.ModelStatus.ModelRevisionStates != nil {
 				assert.Equal(t, tt.expectedState, tt.status.ModelStatus.ModelRevisionStates.TargetModelState)
+			}
+			if tt.expectedReason != nil {
+				if assert.NotNil(t, tt.status.ModelStatus.LastFailureInfo) {
+					assert.Equal(t, *tt.expectedReason, tt.status.ModelStatus.LastFailureInfo.Reason)
+				}
+			}
+			if tt.expectedMsg != "" {
+				if assert.NotNil(t, tt.status.ModelStatus.LastFailureInfo) {
+					assert.Contains(t, tt.status.ModelStatus.LastFailureInfo.Message, tt.expectedMsg)
+				}
+			}
+			if tt.expectedModelRevision != "" {
+				if assert.NotNil(t, tt.status.ModelStatus.LastFailureInfo) {
+					assert.Equal(t, tt.expectedModelRevision, tt.status.ModelStatus.LastFailureInfo.ModelRevisionName)
+				}
+			}
+			if tt.expectedExitCode != nil {
+				if assert.NotNil(t, tt.status.ModelStatus.LastFailureInfo) {
+					assert.Equal(t, *tt.expectedExitCode, tt.status.ModelStatus.LastFailureInfo.ExitCode)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## What this PR does

Adds `ContainerStartupFailed` to InferenceService status for serving containers that are unready in `CrashLoopBackOff` past the restart threshold.

### More details 
1. Why this approach?
This PR uses pod status instead of fetching container logs during reconciliation. `CrashLoopBackOff` is a bounded, actionable signal for the most common serving-container startup failure pattern. Detailed debugging stays in pod events, pod logs, and controller logs.

2. Behavior

- `ModelLoadFailed` remains for model download, model load, and init-container failures.
- `ContainerStartupFailed` applies only to Engine/Decoder serving containers backed by a `BaseModel` or `ClusterBaseModel`.
- No new condition is added; model state remains `FailedToLoad` and transition status remains `BlockedByFailedLoad`.
- Raw deployment handling stays conservative after a model has already loaded, because it cannot reliably prove whether a crash happened before readiness or after serving.

## Why we need it

When a serving container keeps restarting, we need to distinguish startup failures from runtime failures.

If the container never becomes ready, the rollout is blocked and higher-level automation can remove the failed deployment to avoid wasting resources.

This PR makes startup failures visible in InferenceService status instead of letting them remain pending or appear as generic model load failures.

## How to test
Check isvc status when container cannot start due to OOM. 

Sample container status: 
```
status:
initContainerStatuses:
- name: ome-container
      state:
        waiting:
          reason: CrashLoopBackOff
          message: >-
            back-off 5m0s restarting failed container=ome-container
```
Sample isvc status: 
```
status:
modelStatus:
    lastFailureInfo:
      location: >-
        <model-name>/ome-container
      modelRevisionName: '1'
      reason: ContainerStartupFailed
    modelRevisionStates:
      activeModelState: ''
      targetModelState: FailedToLoad
    transitionStatus: BlockedByFailedLoad
```

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
