### PR TITLE
[Bugfix] Fix InferenceService pod status lookup for long raw deployment names

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -477,7 +477,7 @@ func ProcessBaseLabels(b *BaseComponentFields, isvc *v1beta1.InferenceService, c
 
 // UpdateComponentStatus updates component status based on deployment mode
 // This method provides a systematic way to handle status updates across all components
-func UpdateComponentStatus(b *BaseComponentFields, isvc *v1beta1.InferenceService, componentType v1beta1.ComponentType, objectMeta metav1.ObjectMeta, getPodLabelInfo func(bool, metav1.ObjectMeta, v1beta1.ComponentStatusSpec) (string, string)) error {
+func UpdateComponentStatus(b *BaseComponentFields, isvc *v1beta1.InferenceService, componentType v1beta1.ComponentType, objectMeta metav1.ObjectMeta) error {
 	// Always initialize the component ready condition to ensure it's visible from the start
 	// The deployment reconciler will update the condition based on the actual deployment status:
 	// - MultiNode: Updates when LWS becomes available
@@ -498,6 +498,14 @@ func UpdateComponentStatus(b *BaseComponentFields, isvc *v1beta1.InferenceServic
 	b.StatusManager.PropagateModelStatus(&isvc.Status, statusSpec, pods, rawDeployment, reportContainerStartupFailure)
 
 	return nil
+}
+
+// getPodLabelInfo returns the pod label key and value based on the deployment mode.
+func getPodLabelInfo(rawDeployment bool, objectMeta metav1.ObjectMeta, statusSpec v1beta1.ComponentStatusSpec) (string, string) {
+	if rawDeployment {
+		return constants.RawDeploymentAppLabel, constants.TruncateNameWithMaxLength(objectMeta.Name, 63)
+	}
+	return constants.RevisionLabel, statusSpec.LatestCreatedRevision
 }
 
 func shouldReportContainerStartupFailure(b *BaseComponentFields, isvc *v1beta1.InferenceService, componentType v1beta1.ComponentType) bool {

--- a/pkg/controller/v1beta1/inferenceservice/components/decoder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder.go
@@ -165,15 +165,7 @@ func (d *Decoder) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta
 
 // updateDecoderStatus updates the status of the decoder
 func (d *Decoder) updateDecoderStatus(isvc *v1beta1.InferenceService, objectMeta metav1.ObjectMeta) error {
-	return UpdateComponentStatus(&d.BaseComponentFields, isvc, v1beta1.DecoderComponent, objectMeta, d.getPodLabelInfo)
-}
-
-// getPodLabelInfo returns the pod label key and value based on the deployment mode
-func (d *Decoder) getPodLabelInfo(rawDeployment bool, objectMeta metav1.ObjectMeta, statusSpec v1beta1.ComponentStatusSpec) (string, string) {
-	if rawDeployment {
-		return constants.RawDeploymentAppLabel, constants.GetRawServiceLabel(objectMeta.Name)
-	}
-	return constants.RevisionLabel, statusSpec.LatestCreatedRevision
+	return UpdateComponentStatus(&d.BaseComponentFields, isvc, v1beta1.DecoderComponent, objectMeta)
 }
 
 // reconcileObjectMeta creates the object metadata for the decoder component

--- a/pkg/controller/v1beta1/inferenceservice/components/engine.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine.go
@@ -166,15 +166,7 @@ func (e *Engine) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta 
 
 // updateEngineStatus updates the status of the engine
 func (e *Engine) updateEngineStatus(isvc *v1beta1.InferenceService, objectMeta metav1.ObjectMeta) error {
-	return UpdateComponentStatus(&e.BaseComponentFields, isvc, v1beta1.EngineComponent, objectMeta, e.getPodLabelInfo)
-}
-
-// getPodLabelInfo returns the pod label key and value based on the deployment mode
-func (e *Engine) getPodLabelInfo(rawDeployment bool, objectMeta metav1.ObjectMeta, statusSpec v1beta1.ComponentStatusSpec) (string, string) {
-	if rawDeployment {
-		return constants.RawDeploymentAppLabel, constants.GetRawServiceLabel(objectMeta.Name)
-	}
-	return constants.RevisionLabel, statusSpec.LatestCreatedRevision
+	return UpdateComponentStatus(&e.BaseComponentFields, isvc, v1beta1.EngineComponent, objectMeta)
 }
 
 // reconcileObjectMeta creates the object metadata for the engine component

--- a/pkg/controller/v1beta1/inferenceservice/components/router.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/router.go
@@ -140,15 +140,7 @@ func (r *Router) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta 
 
 // updateRouterStatus updates the status of the router component
 func (r *Router) updateRouterStatus(isvc *v1beta1.InferenceService, objectMeta metav1.ObjectMeta) error {
-	return UpdateComponentStatus(&r.BaseComponentFields, isvc, v1beta1.RouterComponent, objectMeta, r.getPodLabelInfo)
-}
-
-// getPodLabelInfo returns the pod label key and value based on the deployment mode
-func (r *Router) getPodLabelInfo(rawDeployment bool, objectMeta metav1.ObjectMeta, statusSpec v1beta1.ComponentStatusSpec) (string, string) {
-	if rawDeployment {
-		return constants.RawDeploymentAppLabel, constants.GetRawServiceLabel(objectMeta.Name)
-	}
-	return constants.RevisionLabel, statusSpec.LatestCreatedRevision
+	return UpdateComponentStatus(&r.BaseComponentFields, isvc, v1beta1.RouterComponent, objectMeta)
 }
 
 // reconcileObjectMeta creates the object metadata for the router component

--- a/pkg/controller/v1beta1/inferenceservice/components/status_pod_label_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/status_pod_label_test.go
@@ -1,0 +1,37 @@
+package components
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestRawDeploymentPodLabelInfoUsesTruncatedComponentName(t *testing.T) {
+	componentName := "amaaaaaabgjpxjqah52sm262rjisgzw3sfp2f4lukfkinrwwoj2v7yy73jrq-engine"
+	objectMeta := metav1.ObjectMeta{Name: componentName}
+	statusSpec := v1beta1.ComponentStatusSpec{LatestCreatedRevision: "revision-name"}
+	expectedValue := constants.TruncateNameWithMaxLength(componentName, 63)
+
+	key, value := getPodLabelInfo(true, objectMeta, statusSpec)
+	if key != constants.RawDeploymentAppLabel {
+		t.Fatalf("label key = %q, want %q", key, constants.RawDeploymentAppLabel)
+	}
+	if value != expectedValue {
+		t.Fatalf("label value = %q, want %q", value, expectedValue)
+	}
+}
+
+func TestNonRawPodLabelInfoUsesRevision(t *testing.T) {
+	statusSpec := v1beta1.ComponentStatusSpec{LatestCreatedRevision: "revision-name"}
+
+	key, value := getPodLabelInfo(false, metav1.ObjectMeta{Name: "component-name"}, statusSpec)
+	if key != constants.RevisionLabel {
+		t.Fatalf("label key = %q, want %q", key, constants.RevisionLabel)
+	}
+	if value != statusSpec.LatestCreatedRevision {
+		t.Fatalf("label value = %q, want %q", value, statusSpec.LatestCreatedRevision)
+	}
+}


### PR DESCRIPTION
## What this PR does

Fixes raw InferenceService component pod lookup for long component names.

This PR moves raw/non-raw pod label selection into the shared InferenceService component status path and ensures raw deployments look up pods using the same truncated Kubernetes-safe `app` label used on the pod template.

## Why we need it

For long InferenceService names, raw deployment pods are labeled with a truncated component name, but component status propagation was looking up pods with the full component name. That caused pod listing to return zero pods and hid pod-level model status/runtime failure details.

Fixes #575

## How to test

```bash
go test ./pkg/controller/v1beta1/inferenceservice/components -count=1

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
