### PR TITLE
[Bugfix] Return pod webhook errors instead of panics

### DIFF
--- a/pkg/webhook/admission/pod/fine_tuned_adapter_injector.go
+++ b/pkg/webhook/admission/pod/fine_tuned_adapter_injector.go
@@ -71,7 +71,10 @@ func (fa *FineTunedAdapterInjector) injectFineTunedAdapter(pod *v1.Pod) error {
 
 	modelInitMounts := fa.getVolumeMounts(pod)
 
-	fineTunedWeightUri, _ := fa.getFineTunedWeightUri(pod)
+	fineTunedWeightUri, err := fa.getFineTunedWeightUri(pod)
+	if err != nil {
+		return err
+	}
 
 	initEnvs, err := fa.getModelInitEnvs(pod, fineTunedWeightUri)
 	if err != nil {
@@ -136,6 +139,10 @@ func (fa *FineTunedAdapterInjector) getFineTunedWeightUri(pod *v1.Pod) (*storage
 	fineTunedWeight, err := isvcutils.GetFineTunedWeight(fa.client, fa.fineTunedWeightName)
 	if err != nil {
 		return nil, err
+	}
+
+	if fineTunedWeight.Spec.Storage == nil || fineTunedWeight.Spec.Storage.StorageUri == nil || *fineTunedWeight.Spec.Storage.StorageUri == "" {
+		return nil, fmt.Errorf("fine-tuned weight %q storage.storageUri is required", fa.fineTunedWeightName)
 	}
 
 	osUri, err := storage.ParseOCIStorageURI(*fineTunedWeight.Spec.Storage.StorageUri)

--- a/pkg/webhook/admission/pod/fine_tuned_adapter_injector.go
+++ b/pkg/webhook/admission/pod/fine_tuned_adapter_injector.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/ome/pkg/constants"
@@ -33,15 +32,15 @@ type FineTunedAdapterInjector struct {
 }
 
 // newFineTunedAdapterInjector initializes a FineTunedAdapterInjector from a ConfigMap.
-func newFineTunedAdapterInjector(configMap *v1.ConfigMap, client client.Client) *FineTunedAdapterInjector {
+func newFineTunedAdapterInjector(configMap *v1.ConfigMap, client client.Client) (*FineTunedAdapterInjector, error) {
 	fineTunedAdapterInjector := &FineTunedAdapterInjector{}
 	if fineTunedAdapterConfigVal, ok := configMap.Data[fineTunedAdapterConfigMapKeyName]; ok {
 		if err := json.Unmarshal([]byte(fineTunedAdapterConfigVal), fineTunedAdapterInjector); err != nil {
-			panic(fmt.Errorf("unable to unmarshal %v json string: %w", fineTunedAdapterConfigMapKeyName, err))
+			return nil, fmt.Errorf("unable to unmarshal %v json string: %w", fineTunedAdapterConfigMapKeyName, err)
 		}
 	}
 	fineTunedAdapterInjector.client = client
-	return fineTunedAdapterInjector
+	return fineTunedAdapterInjector, nil
 }
 
 // InjectFineTunedAdapter injects the fine-tuned weight initialization container into the pod if necessary.
@@ -84,7 +83,10 @@ func (fa *FineTunedAdapterInjector) injectFineTunedAdapter(pod *v1.Pod) error {
 		return err
 	}
 
-	initContainer := fa.createInitContainer(initEnvs, modelInitMounts, securityContext)
+	initContainer, err := fa.createInitContainer(initEnvs, modelInitMounts, securityContext)
+	if err != nil {
+		return err
+	}
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *initContainer)
 	return nil
 }
@@ -111,7 +113,12 @@ func (fa *FineTunedAdapterInjector) getVolumeMounts(pod *v1.Pod) []v1.VolumeMoun
 }
 
 // createInitContainer constructs the init container configuration.
-func (fa *FineTunedAdapterInjector) createInitContainer(envs []v1.EnvVar, mounts []v1.VolumeMount, securityContext *v1.SecurityContext) *v1.Container {
+func (fa *FineTunedAdapterInjector) createInitContainer(envs []v1.EnvVar, mounts []v1.VolumeMount, securityContext *v1.SecurityContext) (*v1.Container, error) {
+	resources, err := newResourceRequirements(fa.CpuLimit, fa.MemoryLimit, fa.CpuRequest, fa.MemoryRequest)
+	if err != nil {
+		return nil, err
+	}
+
 	return &v1.Container{
 		Name:                     constants.FineTunedAdapterContainerName,
 		Image:                    fa.Image,
@@ -119,18 +126,9 @@ func (fa *FineTunedAdapterInjector) createInitContainer(envs []v1.EnvVar, mounts
 		Env:                      envs,
 		VolumeMounts:             mounts,
 		Args:                     []string{"fine-tuned-adapter", "--config", "/ome-agent.yaml", "--debug"},
-		Resources: v1.ResourceRequirements{
-			Limits: map[v1.ResourceName]resource.Quantity{
-				v1.ResourceCPU:    resource.MustParse(fa.CpuLimit),
-				v1.ResourceMemory: resource.MustParse(fa.MemoryLimit),
-			},
-			Requests: map[v1.ResourceName]resource.Quantity{
-				v1.ResourceCPU:    resource.MustParse(fa.CpuRequest),
-				v1.ResourceMemory: resource.MustParse(fa.MemoryRequest),
-			},
-		},
-		SecurityContext: securityContext,
-	}
+		Resources:                resources,
+		SecurityContext:          securityContext,
+	}, nil
 }
 
 // getFineTunedWeightUri retrieves the fine-tuned weight uri from the fine-tuned weight CR

--- a/pkg/webhook/admission/pod/injector_error_test.go
+++ b/pkg/webhook/admission/pod/injector_error_test.go
@@ -1,0 +1,91 @@
+package pod
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInjectorConstructorsReturnJSONErrors(t *testing.T) {
+	tests := map[string]struct {
+		configKey string
+		new       func(*v1.ConfigMap) error
+	}{
+		"model init": {
+			configKey: modelInitConfigMapKeyName,
+			new: func(configMap *v1.ConfigMap) error {
+				_, err := newModelInitInjector(configMap)
+				return err
+			},
+		},
+		"fine-tuned adapter": {
+			configKey: fineTunedAdapterConfigMapKeyName,
+			new: func(configMap *v1.ConfigMap) error {
+				_, err := newFineTunedAdapterInjector(configMap, nil)
+				return err
+			},
+		},
+		"serving sidecar": {
+			configKey: servingSidecarConfigMapKeyName,
+			new: func(configMap *v1.ConfigMap) error {
+				_, err := newServingSidecarInjector(configMap)
+				return err
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-configmap"},
+				Data: map[string]string{
+					tt.configKey: `{"image":`,
+				},
+			}
+			if err := tt.new(configMap); err == nil {
+				t.Fatalf("expected invalid JSON error")
+			}
+		})
+	}
+}
+
+func TestInjectorContainerBuildersReturnResourceErrors(t *testing.T) {
+	tests := map[string]func() error{
+		"model init": func() error {
+			_, err := (&ModelInitInjector{
+				CpuLimit:      "bad-cpu",
+				MemoryLimit:   "1Gi",
+				CpuRequest:    "1",
+				MemoryRequest: "1Gi",
+			}).createInitContainer(nil, nil, nil)
+			return err
+		},
+		"fine-tuned adapter": func() error {
+			_, err := (&FineTunedAdapterInjector{
+				CpuLimit:      "bad-cpu",
+				MemoryLimit:   "1Gi",
+				CpuRequest:    "1",
+				MemoryRequest: "1Gi",
+			}).createInitContainer(nil, nil, nil)
+			return err
+		},
+		"serving sidecar": func() error {
+			_, err := (&ServingSidecarInjector{
+				CpuLimit:      "bad-cpu",
+				MemoryLimit:   "1Gi",
+				CpuRequest:    "1",
+				MemoryRequest: "1Gi",
+			}).createServingSidecarContainer(nil, nil, nil)
+			return err
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := test(); err == nil {
+				t.Fatalf("expected invalid resource quantity error")
+			}
+		})
+	}
+}

--- a/pkg/webhook/admission/pod/injector_error_test.go
+++ b/pkg/webhook/admission/pod/injector_error_test.go
@@ -1,10 +1,16 @@
 package pod
 
 import (
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
 )
 
 func TestInjectorConstructorsReturnJSONErrors(t *testing.T) {
@@ -88,4 +94,79 @@ func TestInjectorContainerBuildersReturnResourceErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFineTunedAdapterReturnsWeightLookupError(t *testing.T) {
+	injector := newTestFineTunedAdapterInjector(t, nil)
+	pod := newFineTunedAdapterPod("missing-weight")
+
+	err := injector.InjectFineTunedAdapter(pod)
+	if err == nil {
+		t.Fatalf("expected fine-tuned weight lookup error")
+	}
+}
+
+func TestFineTunedAdapterRequiresStorageURI(t *testing.T) {
+	tests := map[string]*v1beta1.StorageSpec{
+		"missing storage": nil,
+		"missing uri":     {},
+		"empty uri":       {StorageUri: stringPtr("")},
+	}
+
+	for name, storageSpec := range tests {
+		t.Run(name, func(t *testing.T) {
+			injector := newTestFineTunedAdapterInjector(t, &v1beta1.FineTunedWeight{
+				ObjectMeta: metav1.ObjectMeta{Name: "ft-weight"},
+				Spec: v1beta1.FineTunedWeightSpec{
+					Storage: storageSpec,
+				},
+			})
+			pod := newFineTunedAdapterPod("ft-weight")
+
+			err := injector.InjectFineTunedAdapter(pod)
+			if err == nil {
+				t.Fatalf("expected storage URI validation error")
+			}
+			if !strings.Contains(err.Error(), "storage.storageUri is required") {
+				t.Fatalf("expected storage URI validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func newTestFineTunedAdapterInjector(t *testing.T, objects ...*v1beta1.FineTunedWeight) *FineTunedAdapterInjector {
+	t.Helper()
+
+	s := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add v1beta1 to scheme: %v", err)
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(s)
+	for _, obj := range objects {
+		if obj != nil {
+			builder.WithObjects(obj)
+		}
+	}
+
+	return &FineTunedAdapterInjector{
+		Image:         "fine-tuned-adapter:latest",
+		CompartmentId: "ocid1.compartment.oc1..test",
+		AuthType:      "InstancePrincipal",
+		client:        builder.Build(),
+	}
+}
+
+func newFineTunedAdapterPod(weightName string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.FineTunedAdapterInjectionKey: weightName,
+			},
+		},
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/pkg/webhook/admission/pod/model_init_injector.go
+++ b/pkg/webhook/admission/pod/model_init_injector.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"sigs.k8s.io/ome/pkg/constants"
 	isvcutils "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils"
@@ -33,14 +32,14 @@ type ModelInitInjector struct {
 }
 
 // newModelInitInjector initializes a ModelInitInjector from a ConfigMap.
-func newModelInitInjector(configMap *v1.ConfigMap) *ModelInitInjector {
+func newModelInitInjector(configMap *v1.ConfigMap) (*ModelInitInjector, error) {
 	modelInitInjector := &ModelInitInjector{}
 	if modelInitConfigVal, ok := configMap.Data[modelInitConfigMapKeyName]; ok {
 		if err := json.Unmarshal([]byte(modelInitConfigVal), modelInitInjector); err != nil {
-			panic(fmt.Errorf("unable to unmarshal %v json string: %w", modelInitConfigMapKeyName, err))
+			return nil, fmt.Errorf("unable to unmarshal %v json string: %w", modelInitConfigMapKeyName, err)
 		}
 	}
-	return modelInitInjector
+	return modelInitInjector, nil
 }
 
 // InjectModelInit injects the model initialization container into the pod if necessary.
@@ -78,7 +77,10 @@ func (mi *ModelInitInjector) injectModelInit(pod *v1.Pod) error {
 		return err
 	}
 
-	initContainer := mi.createInitContainer(initEnvs, modelInitMounts, securityContext)
+	initContainer, err := mi.createInitContainer(initEnvs, modelInitMounts, securityContext)
+	if err != nil {
+		return err
+	}
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *initContainer)
 	return nil
 }
@@ -148,7 +150,12 @@ func (mi *ModelInitInjector) getMainContainerSecurityContext(pod *v1.Pod) (*v1.S
 }
 
 // createInitContainer constructs the init container configuration.
-func (mi *ModelInitInjector) createInitContainer(envs []v1.EnvVar, mounts []v1.VolumeMount, securityContext *v1.SecurityContext) *v1.Container {
+func (mi *ModelInitInjector) createInitContainer(envs []v1.EnvVar, mounts []v1.VolumeMount, securityContext *v1.SecurityContext) (*v1.Container, error) {
+	resources, err := newResourceRequirements(mi.CpuLimit, mi.MemoryLimit, mi.CpuRequest, mi.MemoryRequest)
+	if err != nil {
+		return nil, err
+	}
+
 	return &v1.Container{
 		Name:                     constants.ModelInitContainerName,
 		Image:                    mi.Image,
@@ -156,18 +163,9 @@ func (mi *ModelInitInjector) createInitContainer(envs []v1.EnvVar, mounts []v1.V
 		Env:                      envs,
 		VolumeMounts:             mounts,
 		Args:                     []string{"enigma", "--config", "/ome-agent.yaml", "--debug"},
-		Resources: v1.ResourceRequirements{
-			Limits: map[v1.ResourceName]resource.Quantity{
-				v1.ResourceCPU:    resource.MustParse(mi.CpuLimit),
-				v1.ResourceMemory: resource.MustParse(mi.MemoryLimit),
-			},
-			Requests: map[v1.ResourceName]resource.Quantity{
-				v1.ResourceCPU:    resource.MustParse(mi.CpuRequest),
-				v1.ResourceMemory: resource.MustParse(mi.MemoryRequest),
-			},
-		},
-		SecurityContext: securityContext,
-	}
+		Resources:                resources,
+		SecurityContext:          securityContext,
+	}, nil
 }
 
 // getModelInitEnvs generates environment variables for the Model Init container.
@@ -188,9 +186,13 @@ func (mi *ModelInitInjector) getModelInitEnvs(pod *v1.Pod) ([]v1.EnvVar, error) 
 
 	modelFormat := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(pod.ObjectMeta.Annotations[constants.BaseModelFormat], "_", ""), "-", ""))
 	if modelFormat == strings.ToLower(strings.ReplaceAll(constants.TensorRTLLM, "_", "")) {
+		gpuCount, err := mi.getGPUCount(pod)
+		if err != nil {
+			return nil, err
+		}
 		envVars = append(envVars, v1.EnvVar{Name: constants.AgentModelFrameworkEnvVarKey, Value: constants.TensorRTLLM})
 		envVars = append(envVars, v1.EnvVar{Name: constants.AgentTensorRTLLMVersionsEnvVarKey, Value: pod.ObjectMeta.Annotations[constants.BaseModelFormatVersion]})
-		envVars = append(envVars, v1.EnvVar{Name: constants.AgentNumOfGPUEnvVarKey, Value: mi.getGPUCount(pod)})
+		envVars = append(envVars, v1.EnvVar{Name: constants.AgentNumOfGPUEnvVarKey, Value: gpuCount})
 	} else {
 		envVars = append(envVars, v1.EnvVar{Name: constants.AgentModelFrameworkEnvVarKey, Value: modelFormat})
 	}
@@ -204,15 +206,16 @@ func (mi *ModelInitInjector) getModelInitEnvs(pod *v1.Pod) ([]v1.EnvVar, error) 
 }
 
 // getGPUCount retrieves the GPU count for the main container.
-func (mi *ModelInitInjector) getGPUCount(pod *v1.Pod) string {
+func (mi *ModelInitInjector) getGPUCount(pod *v1.Pod) (string, error) {
 	for _, container := range pod.Spec.Containers {
 		if container.Name == constants.MainContainerName {
 			if gpus, exists := container.Resources.Limits[constants.NvidiaGPUResourceType]; exists {
-				return gpus.String()
+				return gpus.String(), nil
 			}
+			return "", fmt.Errorf("%s resource not set for main container %s", constants.NvidiaGPUResourceType, constants.MainContainerName)
 		}
 	}
-	panic("NVIDIA GPU resource not set for main container")
+	return "", fmt.Errorf("main container %s not found while reading %s resource", constants.MainContainerName, constants.NvidiaGPUResourceType)
 }
 
 // getAnnotationOrDefault retrieves the value from the pod's annotations if it exists;

--- a/pkg/webhook/admission/pod/model_init_injector_test.go
+++ b/pkg/webhook/admission/pod/model_init_injector_test.go
@@ -35,11 +35,30 @@ func TestNewModelInitInjector(t *testing.T) {
 				"VaultId":       "test-vault-id",
 			},
 		},
+		{
+			name: "invalid config map json",
+			configMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-configmap",
+				},
+				Data: map[string]string{
+					modelInitConfigMapKeyName: `{"image":`,
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			modelInitInjector := newModelInitInjector(tt.configMap)
+			modelInitInjector, err := newModelInitInjector(tt.configMap)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newModelInitInjector() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
 
 			if modelInitInjector.Image != tt.wantImage {
 				t.Errorf("expected image to be '%s', but got '%s'", tt.wantImage, modelInitInjector.Image)
@@ -544,6 +563,31 @@ func TestModelInitInjector_getModelInitEnvs(t *testing.T) {
 					Value: "extra-env-var-value",
 				},
 			},
+		},
+		{
+			name: "test getModelInitEnvs with TensorRTLLM model format and missing GPU",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.BaseModelName:          "test-base-model-name",
+						constants.BaseModelFormat:        constants.TensorRTLLM,
+						constants.BaseModelFormatVersion: "test-format-version",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: constants.MainContainerName,
+						},
+					},
+				},
+			},
+			mi: &ModelInitInjector{
+				CompartmentId: "test-compartment-id",
+				AuthType:      "test-auth-type",
+				VaultId:       "test-vault-id",
+			},
+			wantErr: true,
 		},
 	}
 

--- a/pkg/webhook/admission/pod/mutator.go
+++ b/pkg/webhook/admission/pod/mutator.go
@@ -79,11 +79,20 @@ func (mutator *Mutator) mutate(pod *v1.Pod, configMap *v1.ConfigMap) error {
 		return err
 	}
 
-	modelInitInjector := newModelInitInjector(configMap)
+	modelInitInjector, err := newModelInitInjector(configMap)
+	if err != nil {
+		return err
+	}
 
-	fineTunedAdapterInjector := newFineTunedAdapterInjector(configMap, mutator.Client)
+	fineTunedAdapterInjector, err := newFineTunedAdapterInjector(configMap, mutator.Client)
+	if err != nil {
+		return err
+	}
 
-	servingSidecarInjector := newServingSidecarInjector(configMap)
+	servingSidecarInjector, err := newServingSidecarInjector(configMap)
+	if err != nil {
+		return err
+	}
 
 	rdmaInjector := NewRDMAInjector()
 

--- a/pkg/webhook/admission/pod/resource_requirements.go
+++ b/pkg/webhook/admission/pod/resource_requirements.go
@@ -1,0 +1,49 @@
+package pod
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func newResourceRequirements(cpuLimit, memoryLimit, cpuRequest, memoryRequest string) (v1.ResourceRequirements, error) {
+	parsedCPULimit, err := parseResourceQuantity("cpuLimit", cpuLimit)
+	if err != nil {
+		return v1.ResourceRequirements{}, err
+	}
+	parsedMemoryLimit, err := parseResourceQuantity("memoryLimit", memoryLimit)
+	if err != nil {
+		return v1.ResourceRequirements{}, err
+	}
+	parsedCPURequest, err := parseResourceQuantity("cpuRequest", cpuRequest)
+	if err != nil {
+		return v1.ResourceRequirements{}, err
+	}
+	parsedMemoryRequest, err := parseResourceQuantity("memoryRequest", memoryRequest)
+	if err != nil {
+		return v1.ResourceRequirements{}, err
+	}
+
+	return v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    parsedCPULimit,
+			v1.ResourceMemory: parsedMemoryLimit,
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    parsedCPURequest,
+			v1.ResourceMemory: parsedMemoryRequest,
+		},
+	}, nil
+}
+
+func parseResourceQuantity(fieldName, value string) (resource.Quantity, error) {
+	if value == "" {
+		return resource.Quantity{}, fmt.Errorf("%s is required", fieldName)
+	}
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("invalid %s %q: %w", fieldName, value, err)
+	}
+	return quantity, nil
+}

--- a/pkg/webhook/admission/pod/serving_sidecar_injector.go
+++ b/pkg/webhook/admission/pod/serving_sidecar_injector.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"sigs.k8s.io/ome/pkg/constants"
 )
@@ -30,14 +29,14 @@ type ServingSidecarInjector struct {
 }
 
 // newServingSidecarInjector initializes a ServingSidecarInjector from a ConfigMap.
-func newServingSidecarInjector(configMap *v1.ConfigMap) *ServingSidecarInjector {
+func newServingSidecarInjector(configMap *v1.ConfigMap) (*ServingSidecarInjector, error) {
 	servingSidecarInjector := &ServingSidecarInjector{}
 	if servingSidecarConfigVal, ok := configMap.Data[servingSidecarConfigMapKeyName]; ok {
 		if err := json.Unmarshal([]byte(servingSidecarConfigVal), servingSidecarInjector); err != nil {
-			panic(fmt.Errorf("unable to unmarshal %v json string: %w", servingSidecarConfigMapKeyName, err))
+			return nil, fmt.Errorf("unable to unmarshal %v json string: %w", servingSidecarConfigMapKeyName, err)
 		}
 	}
-	return servingSidecarInjector
+	return servingSidecarInjector, nil
 }
 
 // InjectServingSidecar injects the serving sidecar container into the pod if necessary.
@@ -77,7 +76,10 @@ func (ss *ServingSidecarInjector) injectServingSidecar(pod *v1.Pod) error {
 		return err
 	}
 
-	sidecarContainer := ss.createServingSidecarContainer(initEnvs, servingSidecarMounts, securityContext)
+	sidecarContainer, err := ss.createServingSidecarContainer(initEnvs, servingSidecarMounts, securityContext)
+	if err != nil {
+		return err
+	}
 	pod.Spec.Containers = append(pod.Spec.Containers, *sidecarContainer)
 	return nil
 }
@@ -159,7 +161,12 @@ func (ss *ServingSidecarInjector) getServingSidecarEnvs(fineTunedWeightFTStrateg
 }
 
 // createServingSidecarContainer constructs the serving sidecar configuration.
-func (ss *ServingSidecarInjector) createServingSidecarContainer(envs []v1.EnvVar, mounts []v1.VolumeMount, securityContext *v1.SecurityContext) *v1.Container {
+func (ss *ServingSidecarInjector) createServingSidecarContainer(envs []v1.EnvVar, mounts []v1.VolumeMount, securityContext *v1.SecurityContext) (*v1.Container, error) {
+	resources, err := newResourceRequirements(ss.CpuLimit, ss.MemoryLimit, ss.CpuRequest, ss.MemoryRequest)
+	if err != nil {
+		return nil, err
+	}
+
 	return &v1.Container{
 		Name:                     constants.ServingSidecarContainerName,
 		Image:                    ss.Image,
@@ -167,18 +174,9 @@ func (ss *ServingSidecarInjector) createServingSidecarContainer(envs []v1.EnvVar
 		Env:                      envs,
 		VolumeMounts:             mounts,
 		Args:                     []string{"serving-agent", "--config", "/ome-agent.yaml", "--debug"},
-		Resources: v1.ResourceRequirements{
-			Limits: map[v1.ResourceName]resource.Quantity{
-				v1.ResourceCPU:    resource.MustParse(ss.CpuLimit),
-				v1.ResourceMemory: resource.MustParse(ss.MemoryLimit),
-			},
-			Requests: map[v1.ResourceName]resource.Quantity{
-				v1.ResourceCPU:    resource.MustParse(ss.CpuRequest),
-				v1.ResourceMemory: resource.MustParse(ss.MemoryRequest),
-			},
-		},
-		SecurityContext: securityContext,
-	}
+		Resources:                resources,
+		SecurityContext:          securityContext,
+	}, nil
 }
 
 // getMainContainerSecurityContext finds and returns the security context of the main container.


### PR DESCRIPTION
## What this PR does

Handle malformed pod injector config and invalid resource quantities as
admission errors instead of panicking in the webhook process.

Also return an explicit error when TensorRT model init cannot determine the
main container GPU limit, and add regression tests for those failure paths.
## Why we need it

Fixes pod webhook panic issue. The error should be properly handled.

## How to test

make test

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
