### PR TITLE
[Core] Add data parallelism override support

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -281,6 +281,12 @@ func MergeRuntimeArgumentsOverride(b *BaseComponentFields, container *corev1.Con
 				if tensorParallelismConfig.PipelineParallelSize != nil && *tensorParallelismConfig.PipelineParallelSize > 0 {
 					overrideParam(container, []string{"--pp-size", "--pp", "--pipeline-parallel-size"}, *tensorParallelismConfig.PipelineParallelSize)
 				}
+				// Override data parallel size if specified
+				// --dp-size and --dp are parameters used in sglang
+				// --data-parallel-size is parameter used in vllm
+				if tensorParallelismConfig.DataParallelSize != nil && *tensorParallelismConfig.DataParallelSize > 0 {
+					overrideParam(container, []string{"--dp-size", "--dp", "--data-parallel-size"}, *tensorParallelismConfig.DataParallelSize)
+				}
 			}
 		}
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/base_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base_test.go
@@ -171,6 +171,65 @@ func TestUpdatePodSpecNodeSelector(t *testing.T) {
 	}
 }
 
+func TestMergeRuntimeArgumentsOverrideDataParallelSize(t *testing.T) {
+	tests := []struct {
+		name            string
+		container       v1.Container
+		expectedArgs    []string
+		expectedCommand []string
+	}{
+		{
+			name: "overrides data parallel size in args with sglang alias",
+			container: v1.Container{
+				Args: []string{"--dp-size", "1", "--enable-expert-parallel"},
+			},
+			expectedArgs: []string{"--dp-size", "4", "--enable-expert-parallel"},
+		},
+		{
+			name: "overrides data parallel size in command with vllm alias",
+			container: v1.Container{
+				Command: []string{
+					"python3",
+					"-m",
+					"vllm.entrypoints.openai.api_server",
+					"--data-parallel-size",
+					"1",
+				},
+			},
+			expectedCommand: []string{
+				"python3",
+				"-m",
+				"vllm.entrypoints.openai.api_server",
+				"--data-parallel-size",
+				"4",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			b := &BaseComponentFields{
+				AcceleratorClassName: "nvidia-h100",
+				SupportedModelFormat: &v1beta1.SupportedModelFormat{
+					AcceleratorConfig: map[string]*v1beta1.AcceleratorModelConfig{
+						"nvidia-h100": {
+							TensorParallelismOverride: &v1beta1.TensorParallelismConfig{
+								DataParallelSize: int64Ptr(4),
+							},
+						},
+					},
+				},
+			}
+
+			MergeRuntimeArgumentsOverride(b, &tt.container)
+
+			g.Expect(tt.container.Args).To(gomega.Equal(tt.expectedArgs))
+			g.Expect(tt.container.Command).To(gomega.Equal(tt.expectedCommand))
+		})
+	}
+}
+
 func TestProcessBaseLabels(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
@@ -217,4 +276,8 @@ func TestProcessBaseLabels(t *testing.T) {
 	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.InferenceServiceBaseModelSizeLabelKey, "LARGE"))
 	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.BaseModelTypeLabelKey, string(constants.ServingBaseModel)))
 	g.Expect(labels).To(gomega.HaveKeyWithValue(constants.BaseModelVendorLabelKey, "meta"))
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
 }


### PR DESCRIPTION
## What this PR does

Adds explicit data parallelism override support for accelerator-specific runtime configuration.

When `tensorParallelismOverride.dataParallelSize` is set for a selected accelerator class, OME now updates matching runtime arguments using the supported SGLang and vLLM aliases:

- `--dp-size`
- `--dp`
- `--data-parallel-size`

This mirrors the existing tensor and pipeline parallelism override behavior.

## Why we need it

The API already exposes `dataParallelSize`, but the reconciler only applied tensor parallel and pipeline parallel sizing. This meant accelerator-specific data parallel sizing could be configured but would not be reflected in generated runtime command or args.

Data parallel sizing is needed for MoE deployments where effective parallelism depends on TP x DP.

Fixes #

## How to test

```bash
go test ./pkg/controller/v1beta1/inferenceservice/components
git diff --check
```

## Checklist

- [X] Tests added/updated (if applicable)
- [X] Docs updated (if applicable)
- [X] `make test` passes locally
