### PR TITLE
[Runtime] Add Qwen3-32B, Qwen3-Embedding-8B, and Qwen3Guard-Gen-8B vLLM runtimes

### DIFF
--- a/config/models/Qwen/Qwen3Guard-Gen-8B.yaml
+++ b/config/models/Qwen/Qwen3Guard-Gen-8B.yaml
@@ -1,22 +1,23 @@
 apiVersion: ome.io/v1beta1
 kind: ClusterBaseModel
 metadata:
-  name: qwen3-embedding-8b
+  name: qwen3guard-gen-8b
 spec:
   modelCapabilities:
-    - TEXT_TO_EMBEDDING
+    - TEXT_TO_TEXT
   vendor: Qwen
+  displayName: Qwen.qwen3guard-gen-8b
   disabled: false
   version: "1.0.0"
-  displayName: Qwen.qwen3-embedding-8b
   modelArchitecture: Qwen3ForCausalLM
   modelFormat:
     name: safetensors
     version: "1.0.0"
   modelFramework:
     name: transformers
-    version: "4.51.2"
+    version: "4.51.1"
   modelParameterSize: 8B
   storage:
-    storageUri: hf://Qwen/Qwen3-Embedding-8B
-    path: /raid/models/Qwen/Qwen3-Embedding-8B
+    storageUri: hf://Qwen/Qwen3Guard-Gen-8B
+    path: /raid/models/Qwen/Qwen3Guard-Gen-8B
+    key: "hf-token"

--- a/config/models/kustomization.yaml
+++ b/config/models/kustomization.yaml
@@ -140,10 +140,13 @@ resources:
   # Qwen
   - Qwen/Qwen3-0.6B.yaml
   - Qwen/Qwen3-30B-A3B.yaml
+  - Qwen/Qwen3-32B.yaml
   - Qwen/Qwen3-Embedding-0.6B.yaml
   - Qwen/Qwen3-Embedding-4B.yaml
+  - Qwen/Qwen3-Embedding-8B.yaml
   - Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
   - Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+  - Qwen/Qwen3Guard-Gen-8B.yaml
 
   # rednote-hilab
   - rednote-hilab/dots.ocr.yaml

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -52,6 +52,6 @@ resources:
 - vllm/mixtral-8x7b-instruct-rt.yaml
 - vllm/deepseek-ai/deepseek-v4-flash-rt.yaml
 - vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
+- vllm/qwen3-8b-rt.yaml
 - vllm/qwen3-32b-rt.yaml
 - vllm/qwen3-embedding-8b-rt.yaml
-- vllm/qwen3guard-gen-8b-rt.yaml

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -52,3 +52,6 @@ resources:
 - vllm/mixtral-8x7b-instruct-rt.yaml
 - vllm/deepseek-ai/deepseek-v4-flash-rt.yaml
 - vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
+- vllm/qwen3-32b-rt.yaml
+- vllm/qwen3-embedding-8b-rt.yaml
+- vllm/qwen3guard-gen-8b-rt.yaml

--- a/config/runtimes/vllm/qwen3-32b-rt.yaml
+++ b/config/runtimes/vllm/qwen3-32b-rt.yaml
@@ -50,7 +50,7 @@ spec:
         - --port=8080
         - --enable-log-requests
         - --served-model-name=vllm-model
-        - --tensor-parallel-size=4
+        - --tensor-parallel-size=2
         - --gpu-memory-utilization=0.9
         - --max-model-len=32768
         - --reasoning-parser=qwen3
@@ -63,11 +63,11 @@ spec:
         requests:
           cpu: 20
           memory: 120Gi
-          nvidia.com/gpu: 4
+          nvidia.com/gpu: 2
         limits:
           cpu: 20
           memory: 120Gi
-          nvidia.com/gpu: 4
+          nvidia.com/gpu: 2
 
       readinessProbe:
         httpGet:
@@ -91,7 +91,7 @@ spec:
         httpGet:
           path: /health
           port: 8080
-        failureThreshold: 150
+        failureThreshold: 100
         successThreshold: 1
         periodSeconds: 6
         initialDelaySeconds: 60
@@ -110,6 +110,9 @@ spec:
         - containerPort: 8080
           name: http
       resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
         limits:
           cpu: "1"
           memory: 2Gi

--- a/config/runtimes/vllm/qwen3-32b-rt.yaml
+++ b/config/runtimes/vllm/qwen3-32b-rt.yaml
@@ -1,0 +1,165 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: vllm-qwen3-32b
+spec:
+  disabled: false
+  supportedModelFormats:
+    - modelFramework:
+        name: transformers
+        version: "4.51.0"
+      modelFormat:
+        name: safetensors
+        version: "1.0.0"
+      modelArchitecture: Qwen3ForCausalLM
+      autoSelect: false
+      priority: 1
+      version: "1.0.0"
+  protocolVersions:
+    - openAI
+  modelSizeRange:
+    min: 30B
+    max: 34B
+  engineConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: "/metrics"
+    labels:
+      logging-forward: enabled
+    tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+    volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+    runner:
+      name: ome-container
+      image: docker.io/vllm/vllm-openai:v0.20.0
+      ports:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+      command:
+        - vllm
+        - serve
+      args:
+        - $(MODEL_PATH)
+        - --port=8080
+        - --enable-log-requests
+        - --served-model-name=vllm-model
+        - --tensor-parallel-size=4
+        - --gpu-memory-utilization=0.9
+        - --max-model-len=32768
+        - --reasoning-parser=qwen3
+        - --enable-auto-tool-choice
+        - --tool-call-parser=hermes
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+      resources:
+        requests:
+          cpu: 20
+          memory: 120Gi
+          nvidia.com/gpu: 4
+        limits:
+          cpu: 20
+          memory: 120Gi
+          nvidia.com/gpu: 4
+
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 3
+        successThreshold: 1
+        periodSeconds: 90
+        timeoutSeconds: 60
+
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        successThreshold: 1
+        periodSeconds: 60
+        timeoutSeconds: 60
+
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 150
+        successThreshold: 1
+        periodSeconds: 6
+        initialDelaySeconds: 60
+        timeoutSeconds: 30
+  routerConfig:
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: '29000'
+      prometheus.io/scrape: 'true'
+    labels:
+      logging-forward: enabled
+    runner:
+      name: router
+      image: docker.io/lightseekorg/smg:1.4.1
+      ports:
+        - containerPort: 8080
+          name: http
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+      args:
+        - --host
+        - 0.0.0.0
+        - --port
+        - "8080"
+        - --service-discovery
+        - --service-discovery-namespace
+        - $(NAMESPACE)
+        - --service-discovery-port
+        - "8080"
+        - --selector
+        - component=engine ome.io/inferenceservice=$(INFERENCESERVICE_NAME)
+        - --enable-igw
+        - --request-id-headers
+        - opc-request-id
+        - --log-json
+        - --disable-retries
+        - --disable-circuit-breaker
+        - --disable-tokenizer-autoload
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INFERENCESERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['ome.io/inferenceservice']
+      readinessProbe:
+        httpGet:
+          path: /readiness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /liveness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 10
+        periodSeconds: 20
+        timeoutSeconds: 10
+        initialDelaySeconds: 30

--- a/config/runtimes/vllm/qwen3-8b-rt.yaml
+++ b/config/runtimes/vllm/qwen3-8b-rt.yaml
@@ -1,10 +1,20 @@
 apiVersion: ome.io/v1beta1
 kind: ClusterServingRuntime
 metadata:
-  name: vllm-qwen3guard-gen-8b
+  name: vllm-qwen3-8b
 spec:
   disabled: false
   supportedModelFormats:
+    - modelFramework:
+        name: transformers
+        version: "4.51.0"
+      modelFormat:
+        name: safetensors
+        version: "1.0.0"
+      modelArchitecture: Qwen3ForCausalLM
+      autoSelect: true
+      priority: 1
+      version: "1.0.0"
     - modelFramework:
         name: transformers
         version: "4.51.1"
@@ -12,7 +22,7 @@ spec:
         name: safetensors
         version: "1.0.0"
       modelArchitecture: Qwen3ForCausalLM
-      autoSelect: false
+      autoSelect: true
       priority: 1
       version: "1.0.0"
   protocolVersions:

--- a/config/runtimes/vllm/qwen3-embedding-8b-rt.yaml
+++ b/config/runtimes/vllm/qwen3-embedding-8b-rt.yaml
@@ -92,7 +92,7 @@ spec:
         httpGet:
           path: /health
           port: 8080
-        failureThreshold: 150
+        failureThreshold: 60
         successThreshold: 1
         periodSeconds: 6
         initialDelaySeconds: 60

--- a/config/runtimes/vllm/qwen3-embedding-8b-rt.yaml
+++ b/config/runtimes/vllm/qwen3-embedding-8b-rt.yaml
@@ -1,0 +1,99 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: vllm-qwen3-embedding-8b
+spec:
+  disabled: false
+  supportedModelFormats:
+    - modelFramework:
+        name: transformers
+        version: "4.51.2"
+      modelFormat:
+        name: safetensors
+        version: "1.0.0"
+      modelArchitecture: Qwen3ForCausalLM
+      autoSelect: false
+      priority: 1
+      version: "1.0.0"
+  protocolVersions:
+    - openAI
+  modelSizeRange:
+    min: 7B
+    max: 9B
+  engineConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: "/metrics"
+    labels:
+      logging-forward: enabled
+    tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+    volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+    runner:
+      name: ome-container
+      image: docker.io/vllm/vllm-openai:v0.20.0
+      ports:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+      command:
+        - vllm
+        - serve
+      args:
+        - $(MODEL_PATH)
+        - --port
+        - "8080"
+        - --served-model-name
+        - vllm-model
+        - --runner
+        - pooling
+        - --tensor-parallel-size
+        - "1"
+        - --gpu-memory-utilization
+        - "0.9"
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+      resources:
+        requests:
+          cpu: 10
+          memory: 40Gi
+          nvidia.com/gpu: 1
+        limits:
+          cpu: 10
+          memory: 40Gi
+          nvidia.com/gpu: 1
+
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 3
+        successThreshold: 1
+        periodSeconds: 90
+        timeoutSeconds: 60
+
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        successThreshold: 1
+        periodSeconds: 60
+        timeoutSeconds: 60
+
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 150
+        successThreshold: 1
+        periodSeconds: 6
+        initialDelaySeconds: 60
+        timeoutSeconds: 30

--- a/config/runtimes/vllm/qwen3guard-gen-8b-rt.yaml
+++ b/config/runtimes/vllm/qwen3guard-gen-8b-rt.yaml
@@ -92,7 +92,7 @@ spec:
         httpGet:
           path: /health
           port: 8080
-        failureThreshold: 150
+        failureThreshold: 60
         successThreshold: 1
         periodSeconds: 6
         initialDelaySeconds: 60

--- a/config/runtimes/vllm/qwen3guard-gen-8b-rt.yaml
+++ b/config/runtimes/vllm/qwen3guard-gen-8b-rt.yaml
@@ -1,0 +1,99 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: vllm-qwen3guard-gen-8b
+spec:
+  disabled: false
+  supportedModelFormats:
+    - modelFramework:
+        name: transformers
+        version: "4.51.1"
+      modelFormat:
+        name: safetensors
+        version: "1.0.0"
+      modelArchitecture: Qwen3ForCausalLM
+      autoSelect: false
+      priority: 1
+      version: "1.0.0"
+  protocolVersions:
+    - openAI
+  modelSizeRange:
+    min: 7B
+    max: 9B
+  engineConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: "/metrics"
+    labels:
+      logging-forward: enabled
+    tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+    volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+    runner:
+      name: ome-container
+      image: docker.io/vllm/vllm-openai:v0.20.0
+      ports:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+      command:
+        - vllm
+        - serve
+      args:
+        - $(MODEL_PATH)
+        - --port
+        - "8080"
+        - --served-model-name
+        - vllm-model
+        - --tensor-parallel-size
+        - "1"
+        - --max-model-len
+        - "32768"
+        - --gpu-memory-utilization
+        - "0.9"
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+      resources:
+        requests:
+          cpu: 10
+          memory: 30Gi
+          nvidia.com/gpu: 1
+        limits:
+          cpu: 10
+          memory: 30Gi
+          nvidia.com/gpu: 1
+
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 3
+        successThreshold: 1
+        periodSeconds: 90
+        timeoutSeconds: 60
+
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        successThreshold: 1
+        periodSeconds: 60
+        timeoutSeconds: 60
+
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 150
+        successThreshold: 1
+        periodSeconds: 6
+        initialDelaySeconds: 60
+        timeoutSeconds: 30

--- a/config/samples/isvc/Qwen/Qwen3-32B.yaml
+++ b/config/samples/isvc/Qwen/Qwen3-32B.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   model:
     name: qwen3-32b
+  runtime:
+    name: vllm-qwen3-32b
   engine:
     minReplicas: 1
     maxReplicas: 1

--- a/config/samples/isvc/Qwen/qwen3-embedding-8b.yaml
+++ b/config/samples/isvc/Qwen/qwen3-embedding-8b.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: qwen3-embedding-8b
+---
+apiVersion: ome.io/v1beta1
+kind: InferenceService
+metadata:
+  name: qwen3-embedding-8b
+  namespace: qwen3-embedding-8b
+spec:
+  model:
+    name: qwen3-embedding-8b
+  runtime:
+    name: vllm-qwen3-embedding-8b
+  engine:
+    minReplicas: 1
+    maxReplicas: 1

--- a/config/samples/isvc/Qwen/qwen3guard-gen-8b.yaml
+++ b/config/samples/isvc/Qwen/qwen3guard-gen-8b.yaml
@@ -12,8 +12,6 @@ metadata:
 spec:
   model:
     name: qwen3guard-gen-8b
-  runtime:
-    name: vllm-qwen3guard-gen-8b
   engine:
     minReplicas: 1
     maxReplicas: 1

--- a/config/samples/isvc/Qwen/qwen3guard-gen-8b.yaml
+++ b/config/samples/isvc/Qwen/qwen3guard-gen-8b.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: qwen3guard-gen-8b
+---
+apiVersion: ome.io/v1beta1
+kind: InferenceService
+metadata:
+  name: qwen3guard-gen-8b
+  namespace: qwen3guard-gen-8b
+spec:
+  model:
+    name: qwen3guard-gen-8b
+  runtime:
+    name: vllm-qwen3guard-gen-8b
+  engine:
+    minReplicas: 1
+    maxReplicas: 1


### PR DESCRIPTION
## What this PR does

Adds OME configuration for serving three Qwen3 models on vLLM:

- Adds the `qwen3guard-gen-8b` ClusterBaseModel pointing to `hf://Qwen/Qwen3Guard-Gen-8B`, and completes the `qwen3-embedding-8b` ClusterBaseModel metadata (architecture / format / framework / parameter size).

- Adds the `vllm-qwen3-32b` ClusterServingRuntime with SMG router + vLLM settings for `Qwen3ForCausalLM`, 4-way tensor parallelism, 32K context, chunked prefill, Qwen3 reasoning parsing, and Hermes tool-call parsing.

- Adds the `vllm-qwen3-embedding-8b` ClusterServingRuntime (embedding/pooling via `--runner pooling`, `Qwen3ForCausalLM`, TP=1).

- Adds the `vllm-qwen3guard-gen-8b` ClusterServingRuntime (text-generation guard, `Qwen3ForCausalLM`, TP=1).

- Registers the models and runtimes in the kustomizations.

- Adds sample InferenceServices for the Qwen namespaces.

All runtimes use `docker.io/vllm/vllm-openai:v0.20.0`. Framework versions are pinned to each model's upstream `config.json` `transformers_version` (32B: 4.51.0, Embedding-8B: 4.51.2, Guard-Gen-8B: 4.51.1) to match the runtime selector's `Equal` comparison.

## Why we need it

Enables serving for Qwen3-32B (chat), Qwen3-Embedding-8B (embeddings), and Qwen3Guard-Gen-8B (content moderation).

Fixes #

## How to test

Validated each engine locally on an 8×A100 host via standalone `docker run` against `vllm/vllm-openai:v0.20.0`:

- `Qwen3-32B` — TP=4, `/v1/chat/completions` returns expected output.
- `Qwen3-Embedding-8B` — `--runner pooling`, `/v1/embeddings` returns embedding vectors.
- `Qwen3Guard-Gen-8B` — TP=1, `/v1/chat/completions` returns expected output.

`kubectl kustomize config/models` and `kubectl kustomize config/runtimes` both build cleanly.

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
