### PR TITLE
[Feat] Skip model download when model size > node GPU VRAM

### DIFF
--- a/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
@@ -33,3 +33,23 @@ data:
       "gpu-b200-sxm": "B200",
       "gpu-l40s": "L40S"
     }
+  # Total node VRAM in GiB keyed by short shape alias from instance-type-map.
+  # Each value is the aggregate VRAM across all GPUs on a typical node of that
+  # shape (e.g. H100 = 8 × 80 GiB SXM).
+  # Unknown shapes fail open (precheck disabled for that node).
+  gpu-shape-memory-gb-map: |-
+    {
+      "A10": 96,
+      "A100-40G": 320,
+      "A100-80G": 640,
+      "H100": 640,
+      "H200": 1128,
+      "B200": 1536,
+      "L40": 384,
+      "L40S": 384
+    }
+  # Safety multiplier applied to the estimated weight bytes before comparing
+  # against per-node VRAM. Leaves headroom for activations / KV cache / CUDA
+  # workspace. Clamped to [1.0, 4.0]; values outside the range fall back to
+  # the built-in default of 1.2.
+  model-download-vram-safety-factor: "1.2"

--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -68,6 +68,16 @@ spec:
             configMapKeyRef:
               name: model-agent-config-map
               key: instance-type-map
+        - name: GPU_SHAPE_MEMORY_GB_MAP
+          valueFrom:
+            configMapKeyRef:
+              name: model-agent-config-map
+              key: gpu-shape-memory-gb-map
+        - name: MODEL_DOWNLOAD_VRAM_SAFETY_FACTOR
+          valueFrom:
+            configMapKeyRef:
+              name: model-agent-config-map
+              key: model-download-vram-safety-factor
         {{- range $key, $value := .Values.modelAgent.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/config/model-agent/configmap.yaml
+++ b/config/model-agent/configmap.yaml
@@ -33,3 +33,19 @@ data:
       "gpu-b200-sxm": "B200",
       "gpu-l40s": "L40S"
     }
+  # Total node VRAM (GiB) keyed by the short shape alias above. The precheck
+  # looks up this aggregate directly; tune values when running non-standard
+  # GPU counts under the same alias. Unknown shapes fail open.
+  gpu-shape-memory-gb-map: |-
+    {
+      "A10": 96,
+      "A100-40G": 320,
+      "A100-80G": 640,
+      "H100": 640,
+      "H200": 1128,
+      "B200": 1536,
+      "L40": 384,
+      "L40S": 384
+    }
+  # Safety factor applied to estimated weight bytes; clamped to [1.0, 4.0].
+  model-download-vram-safety-factor: "1.2"

--- a/config/model-agent/daemonset.yaml
+++ b/config/model-agent/daemonset.yaml
@@ -61,6 +61,16 @@ spec:
             configMapKeyRef:
               name: model-agent-config-map
               key: instance-type-map
+        - name: GPU_SHAPE_MEMORY_GB_MAP
+          valueFrom:
+            configMapKeyRef:
+              name: model-agent-config-map
+              key: gpu-shape-memory-gb-map
+        - name: MODEL_DOWNLOAD_VRAM_SAFETY_FACTOR
+          valueFrom:
+            configMapKeyRef:
+              name: model-agent-config-map
+              key: model-download-vram-safety-factor
         volumeMounts:
         - name: host-models
           readOnly: false

--- a/pkg/modelagent/configmap_reconciler.go
+++ b/pkg/modelagent/configmap_reconciler.go
@@ -35,6 +35,7 @@ type CacheEntry struct {
 	ModelName     string         // Name of the model
 	ModelStatus   ModelStatus    // Current status of the model
 	ModelMetadata *ModelMetadata // Model metadata if available
+	StatusDetail  *StatusDetail  // Optional structured detail for the current status
 }
 
 // ConfigMapReconciler handles all ConfigMap operations for storing model state and metadata.
@@ -58,6 +59,7 @@ type ConfigMapStatusOp struct {
 	ModelStatus      ModelStatus               // The updated status of the model
 	BaseModel        *v1beta1.BaseModel        // Reference to a namespace-scoped BaseModel (nil if using ClusterBaseModel)
 	ClusterBaseModel *v1beta1.ClusterBaseModel // Reference to a cluster-scoped BaseModel (nil if using BaseModel)
+	StatusDetail     *StatusDetail             // Optional structured detail to persist alongside the status (omitted when nil)
 }
 
 // ConfigMapMetadataOp represents an operation to update model metadata in ConfigMap.
@@ -224,8 +226,9 @@ func (c *ConfigMapReconciler) recreateConfigMap(ctx context.Context) {
 	for modelID, cacheEntry := range c.modelCache {
 		// Create model entry from cache data
 		modelEntry := &ModelEntry{
-			Name:   cacheEntry.ModelName,
-			Status: cacheEntry.ModelStatus,
+			Name:         cacheEntry.ModelName,
+			Status:       cacheEntry.ModelStatus,
+			StatusDetail: cacheEntry.StatusDetail,
 		}
 
 		// Convert metadata to ModelConfig if available
@@ -278,8 +281,9 @@ func (c *ConfigMapReconciler) recreateConfigMap(ctx context.Context) {
 func (c *ConfigMapReconciler) restoreModelInConfigMap(modelID string, cacheEntry *CacheEntry) {
 	// Construct model entry from cache data
 	modelEntry := &ModelEntry{
-		Name:   cacheEntry.ModelName,
-		Status: cacheEntry.ModelStatus,
+		Name:         cacheEntry.ModelName,
+		Status:       cacheEntry.ModelStatus,
+		StatusDetail: cacheEntry.StatusDetail,
 	}
 
 	// Convert metadata to ModelConfig if available
@@ -414,13 +418,23 @@ func (c *ConfigMapReconciler) ReconcileModelStatus(ctx context.Context, statusOp
 		}
 
 		cacheEntry = &CacheEntry{
-			ModelName:   modelName,
-			ModelStatus: statusOp.ModelStatus,
+			ModelName:    modelName,
+			ModelStatus:  statusOp.ModelStatus,
+			StatusDetail: statusOp.StatusDetail,
 		}
 		c.modelCache[modelID] = cacheEntry
 	} else {
-		// Just update the status in existing entry
+		// Just update the status in existing entry.
+		// StatusDetail follows the same rule as Progress: clear it on a
+		// successful Ready transition; otherwise overwrite when the caller
+		// supplied a new detail, or preserve when they did not.
 		cacheEntry.ModelStatus = statusOp.ModelStatus
+		switch {
+		case statusOp.ModelStatus == ModelStatusReady:
+			cacheEntry.StatusDetail = nil
+		case statusOp.StatusDetail != nil:
+			cacheEntry.StatusDetail = statusOp.StatusDetail
+		}
 	}
 	c.cacheMutex.Unlock()
 
@@ -783,6 +797,17 @@ func (c *ConfigMapReconciler) updateModelStatusInConfigMap(ctx context.Context, 
 			Status: op.ModelStatus,
 			Config: nil,
 		}
+	}
+
+	// StatusDetail: overwrite when the caller supplied one; clear on Ready so
+	// a previously-skipped model that later succeeds does not carry stale
+	// reasoning. On Failed we leave any preserved detail in place unless the
+	// caller overwrites it (the new detail typically describes the new failure).
+	switch {
+	case op.StatusDetail != nil:
+		modelEntry.StatusDetail = op.StatusDetail
+	case op.ModelStatus == ModelStatusReady:
+		modelEntry.StatusDetail = nil
 	}
 
 	// For 'ModelStatusDeleted' status, we might want to entirely remove the entry

--- a/pkg/modelagent/gopher.go
+++ b/pkg/modelagent/gopher.go
@@ -41,6 +41,19 @@ type GopherTask struct {
 	BaseModel              *v1beta1.BaseModel
 	ClusterBaseModel       *v1beta1.ClusterBaseModel
 	TensorRTLLMShapeFilter *TensorRTLLMShapeFilter
+
+	// AvailableVRAMBytes is the aggregate per-node VRAM available to the
+	// gopher's host (sum across all GPUs), stamped by Scout when the task
+	// is created. 0 means "unknown" — Gopher's VRAM precheck fails open in
+	// that case.
+	AvailableVRAMBytes int64
+
+	// MultiNodeSharded is true when the BaseModel/ClusterBaseModel declared
+	// itself as multi-node-sharded via the MultiNodeShardedAnnotation. When
+	// true, Gopher skips the VRAM precheck entirely (the model is intended
+	// to be split across nodes at serve time, so no single node needs to fit
+	// the whole thing).
+	MultiNodeSharded bool
 }
 
 type Gopher struct {
@@ -193,6 +206,7 @@ func (s *Gopher) safeNodeLabelReconciliation(op *NodeLabelOp) error {
 			ModelStatus:      status,
 			BaseModel:        op.BaseModel,
 			ClusterBaseModel: op.ClusterBaseModel,
+			StatusDetail:     op.StatusDetail,
 		}
 
 		// Update the ConfigMap with model status
@@ -306,6 +320,16 @@ func (s *Gopher) processTask(task *GopherTask) error {
 		return err
 	}
 
+	// VRAM precheck — runs only for Download / DownloadOverride. For HF / Local
+	// this fetches a size estimate from the URI alone; for OCI / S3 the gate
+	// runs inline after the per-storage ListObjects step (see downloadModel).
+	if task.TaskType == Download || task.TaskType == DownloadOverride {
+		skipped, _ := s.vramPrecheck(ctx, task, storageType, *baseModelSpec.Storage.StorageUri)
+		if skipped {
+			return nil
+		}
+	}
+
 	switch task.TaskType {
 	case Download:
 		// we might implement a "delete/cleanup and then download" logic to update a model in the future
@@ -324,6 +348,39 @@ func (s *Gopher) processTask(task *GopherTask) error {
 				s.logger.Errorf("Failed to get target directory path for model %s: %v", modelInfo, err)
 				return err
 			}
+
+			// Inline VRAM gate for OCI: do a single ListObjects to sum bytes,
+			// then apply the gate. Done outside the Retry loop so a "skipped"
+			// outcome does not trigger retry. The downstream BulkDownload path
+			// will list again — acceptable extra round-trip for v1 (a list is
+			// cheap relative to the avoided bulk download).
+			//
+			// TODO(modelagent/gopher.go): plumb the listing into downloadModel
+			// so the bulk-download path reuses it and we save one ListObjects.
+			if !task.MultiNodeSharded && task.AvailableVRAMBytes > 0 {
+				if dsForList, derr := s.createOCIOSDataStore(baseModelSpec); derr != nil {
+					s.logger.Warnf("OCI VRAM precheck: data store creation failed (%v); continuing", derr)
+				} else if objects, lerr := dsForList.ListObjects(*osUri); lerr != nil {
+					s.logger.Warnf("OCI VRAM precheck: list objects failed (%v); continuing", lerr)
+				} else {
+					// Apply the same TensorRTLLM shape filter the download path
+					// uses, so we sum only the bytes this node will actually
+					// pull
+					if shouldFilterByTensorRTLLMShape(task) {
+						objects = filterObjectsByTensorRTLLMShape(objects, task.TensorRTLLMShapeFilter)
+					}
+					var size int64
+					for _, o := range objects {
+						if o.Size != nil {
+							size += *o.Size
+						}
+					}
+					if s.applyVRAMGate(task, size, ociListSumDetail()) {
+						return nil
+					}
+				}
+			}
+
 			err = utils.Retry(s.downloadRetry, 100*time.Millisecond, func() error {
 				downloadErr := s.downloadModel(ctx, osUri, destPath, task)
 				if downloadErr != nil {
@@ -585,6 +642,32 @@ func getModelUID(task *GopherTask) string {
 	return ""
 }
 
+// shouldFilterByTensorRTLLMShape reports whether the OCI listing for this task
+// should be narrowed to a single TensorRTLLM shape subdir. TensorRTLLM buckets
+// often contain per-shape kernel directories (/H100/, /A100/, …); only one is
+// downloaded on a given node, and the same filter must be applied during the
+// VRAM precheck so we don't over-count by the number of shape subdirs.
+func shouldFilterByTensorRTLLMShape(task *GopherTask) bool {
+	return task != nil &&
+		task.TensorRTLLMShapeFilter != nil &&
+		task.TensorRTLLMShapeFilter.IsTensorrtLLMModel &&
+		task.TensorRTLLMShapeFilter.ModelType == string(constants.ServingBaseModel)
+}
+
+// filterObjectsByTensorRTLLMShape returns only the objects whose names contain
+// "/<shapeAlias>/". Caller must check shouldFilterByTensorRTLLMShape(task)
+// first so the filter is only applied to TRT-LLM serving models.
+func filterObjectsByTensorRTLLMShape(objects []objectstorage.ObjectSummary, filter *TensorRTLLMShapeFilter) []objectstorage.ObjectSummary {
+	needle := fmt.Sprintf("/%s/", filter.ShapeAlias)
+	out := make([]objectstorage.ObjectSummary, 0, len(objects))
+	for _, o := range objects {
+		if o.Name != nil && strings.Contains(*o.Name, needle) {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
 func (s *Gopher) markModelOnNodeFailed(task *GopherTask) {
 	modelInfo := getModelInfoForLogging(task)
 	s.logger.Infof("Marking model %s as Failed on node", modelInfo)
@@ -602,6 +685,111 @@ func (s *Gopher) markModelOnNodeFailed(task *GopherTask) {
 	} else {
 		s.logger.Infof("Successfully marked model %s as Failed on node", modelInfo)
 	}
+}
+
+// markModelOnNodeSkipped marks the model as Failed on this node with a
+// structured StatusDetail explaining the reason. Used by the VRAM precheck so
+// a downstream controller / operator can tell "this node intentionally did not
+// download" apart from "downloads have not been attempted yet".
+func (s *Gopher) markModelOnNodeSkipped(task *GopherTask, detail *StatusDetail) error {
+	modelInfo := getModelInfoForLogging(task)
+	s.logger.Infof("Marking model %s as Failed on node (skipped: %s)", modelInfo, detail.Reason)
+
+	nodeLabelOp := &NodeLabelOp{
+		ModelStateOnNode: Failed,
+		BaseModel:        task.BaseModel,
+		ClusterBaseModel: task.ClusterBaseModel,
+		StatusDetail:     detail,
+	}
+	return s.safeNodeLabelReconciliation(nodeLabelOp)
+}
+
+// applyVRAMGate compares the estimated weight bytes against the per-node
+// AvailableVRAMBytes (with the configured safety factor) and, when the model
+// is too large, persists a skip status, records a metric, and returns true to
+// signal the caller it should "return nil" to processTask.
+//
+// Returns false when the gate is inapplicable (size or availableVRAM is 0) or
+// when the model fits. Callers must call vramPrecheckBypassedFor first when
+// MultiNodeSharded is set so the bypass is logged once.
+func (s *Gopher) applyVRAMGate(task *GopherTask, size int64, detail *EstimateDetail) bool {
+	if task.MultiNodeSharded {
+		// vramPrecheck already logged/recorded the bypass; inline OCI/S3
+		// callers also reach this point and must not gate when sharded.
+		return false
+	}
+	if task.AvailableVRAMBytes <= 0 || size <= 0 || detail == nil {
+		return false
+	}
+	safety := vramSafetyFactor()
+	required := int64(float64(size) * safety)
+	if required <= task.AvailableVRAMBytes {
+		return false
+	}
+
+	modelInfo := getModelInfoForLogging(task)
+	modelType, namespace, name := GetModelTypeNamespaceAndName(task)
+	s.logger.Infof(
+		"Skipping download for %s: required=%d bytes > available VRAM=%d bytes "+
+			"(estimated_weights=%d, safety=%.2f, format=%s, method=%s, strategy=%s)",
+		modelInfo, required, task.AvailableVRAMBytes,
+		size, safety, detail.Format, detail.Method, detail.Strategy,
+	)
+	s.metrics.RecordSkippedDownload(modelType, namespace, name, "vram_insufficient")
+	if err := s.markModelOnNodeSkipped(task, &StatusDetail{
+		Reason: "VRAMInsufficient",
+		Message: fmt.Sprintf(
+			"estimated weight bytes %d (with safety factor %.2f → required %d) exceed available VRAM %d on this node",
+			size, safety, required, task.AvailableVRAMBytes,
+		),
+		RequiredBytes:        required,
+		AvailableVRAMBytes:   task.AvailableVRAMBytes,
+		EstimatedWeightBytes: size,
+		SafetyFactor:         safety,
+		Format:               detail.Format,
+		Method:               detail.Method,
+		Strategy:             detail.Strategy,
+	}); err != nil {
+		s.logger.Errorf("VRAM precheck: failed to persist skip status for %s: %v", modelInfo, err)
+	}
+	return true
+}
+
+// vramPrecheck handles the storage-URI-based precheck path (HuggingFace,
+// Local). For OCI/S3/Vendor/PVC this returns (false, false) and the caller
+// is expected to gate inline using the existing listing step (OCI today, S3
+// when wired).
+//
+// Returns (skipped, bypassed). skipped means the caller should "return nil"
+// to processTask; bypassed means the precheck was intentionally skipped (e.g.
+// multi-node-sharded annotation, no estimator for storage type) and the
+// download should continue.
+func (s *Gopher) vramPrecheck(ctx context.Context, task *GopherTask, storageType storage.StorageType, uri string) (skipped, bypassed bool) {
+	modelInfo := getModelInfoForLogging(task)
+	modelType, namespace, name := GetModelTypeNamespaceAndName(task)
+
+	if task.MultiNodeSharded {
+		s.logger.Infof("VRAM precheck skipped for %s: %s annotation set; multi-node sharding active",
+			modelInfo, MultiNodeShardedAnnotation)
+		s.metrics.RecordPrecheckBypass(modelType, namespace, name, "multi_node_sharded")
+		return false, true
+	}
+
+	estimator := s.estimatorFor(storageType)
+	if estimator == nil {
+		// OCI/S3 gate inline; other storage types have no estimator.
+		return false, false
+	}
+	size, detail, err := estimator.EstimateRemoteSize(ctx, uri)
+	if err != nil {
+		s.logger.Warnf("VRAM precheck for %s: size estimate failed (%v); continuing", modelInfo, err)
+		return false, false
+	}
+	if size <= 0 {
+		s.metrics.RecordPrecheckBypass(modelType, namespace, name, "size_unknown")
+		return false, true
+	}
+	return s.applyVRAMGate(task, size, detail), false
 }
 
 // getHuggingFaceToken retrieves authentication token for Hugging Face models.
@@ -779,17 +967,9 @@ func (s *Gopher) downloadModel(ctx context.Context, uri *ociobjectstore.ObjectUR
 	s.logger.Infof("Done with list all %d objects in model bucket folder", len(objects))
 
 	// Shape filtering for TensorRTLLM
-	if task.TensorRTLLMShapeFilter != nil && task.TensorRTLLMShapeFilter.IsTensorrtLLMModel && task.TensorRTLLMShapeFilter.ModelType == string(constants.ServingBaseModel) {
+	if shouldFilterByTensorRTLLMShape(task) {
 		s.logger.Infof("TensorRTLLM Serving model detected. Start filtering model files that doesn't belong to the node shape %s in model bucket folder", task.TensorRTLLMShapeFilter.ShapeAlias)
-		shapeFilteredObjects := make([]objectstorage.ObjectSummary, 0)
-		for _, object := range objects {
-			if object.Name != nil {
-				if strings.Contains(*object.Name, fmt.Sprintf("/%s/", task.TensorRTLLMShapeFilter.ShapeAlias)) {
-					shapeFilteredObjects = append(shapeFilteredObjects, object)
-				}
-			}
-		}
-		objects = shapeFilteredObjects
+		objects = filterObjectsByTensorRTLLMShape(objects, task.TensorRTLLMShapeFilter)
 
 		if len(objects) == 0 {
 			return fmt.Errorf("no suitable objects found for shape %s", task.TensorRTLLMShapeFilter.ShapeAlias)

--- a/pkg/modelagent/gpu_memory.go
+++ b/pkg/modelagent/gpu_memory.go
@@ -1,0 +1,118 @@
+package modelagent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+)
+
+// Environment variable names. Values are typically provided by the Helm chart's
+// model-agent ConfigMap, mirroring how INSTANCE_TYPE_MAP is wired.
+const (
+	GPUShapeMemoryGBEnvVar = "GPU_SHAPE_MEMORY_GB_MAP"
+	VRAMSafetyFactorEnvVar = "MODEL_DOWNLOAD_VRAM_SAFETY_FACTOR"
+
+	defaultVRAMSafetyFactor = 1.2
+	minVRAMSafetyFactor     = 1.0
+	maxVRAMSafetyFactor     = 4.0
+)
+
+// defaultGPUShapeMemoryGB is the fallback total node VRAM (GiB) map keyed by
+// the short shape alias (matches values in pkg/utils/instance_type_util.go).
+// Each value is the aggregate VRAM across all GPUs on a typical node of that
+// shape (e.g. H100 = 8 × 80 GiB SXM). Override via the GPU_SHAPE_MEMORY_GB_MAP
+// env var (Helm ConfigMap) when running non-standard GPU counts.
+var defaultGPUShapeMemoryGB = map[string]int64{
+	"A10":      96,   // BM.GPU.A10.4 — 4 × 24 GiB
+	"A100-40G": 320,  // 8 × 40 GiB SXM4
+	"A100-80G": 640,  // 8 × 80 GiB SXM4
+	"H100":     640,  // 8 × 80 GiB SXM5
+	"H200":     1128, // 8 × 141 GiB HBM3e
+	"B200":     1536, // 8 × 192 GiB
+	"L40":      384,  // 8 × 48 GiB
+	"L40S":     384,  // 8 × 48 GiB
+}
+
+var (
+	gpuShapeMemoryGBMap     map[string]int64
+	gpuShapeMemoryGBMapErr  error
+	gpuShapeMemoryGBMapOnce sync.Once
+
+	vramSafetyFactorVal  float64
+	vramSafetyFactorOnce sync.Once
+)
+
+// loadGPUShapeMemoryGBFromEnv parses GPU_SHAPE_MEMORY_GB_MAP. Values are GiB
+// per single GPU. Falls back to defaults on unset/empty/parse-error.
+func loadGPUShapeMemoryGBFromEnv() (map[string]int64, error) {
+	envValue := os.Getenv(GPUShapeMemoryGBEnvVar)
+	if envValue == "" {
+		return defaultGPUShapeMemoryGB, nil
+	}
+
+	var configMap map[string]int64
+	if err := json.Unmarshal([]byte(envValue), &configMap); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", GPUShapeMemoryGBEnvVar, err)
+	}
+	if len(configMap) == 0 {
+		return defaultGPUShapeMemoryGB, nil
+	}
+	return configMap, nil
+}
+
+// gpuShapeMemoryGB returns the total node VRAM in GiB for the given shape
+// alias (e.g. "H100", "A10"). Second return is false when the shape is
+// unknown.
+func gpuShapeMemoryGB(shape string) (int64, bool) {
+	gpuShapeMemoryGBMapOnce.Do(func() {
+		gpuShapeMemoryGBMap, gpuShapeMemoryGBMapErr = loadGPUShapeMemoryGBFromEnv()
+	})
+	if gpuShapeMemoryGBMapErr != nil || gpuShapeMemoryGBMap == nil {
+		return 0, false
+	}
+	gb, ok := gpuShapeMemoryGBMap[shape]
+	if !ok {
+		return 0, false
+	}
+	return gb, true
+}
+
+// AvailableNodeVRAMBytes returns the aggregate VRAM in bytes for a node of
+// the given shape. Tune the map values in the Helm ConfigMap when running non-
+// standard GPU counts under the same alias.
+//
+// Returns 0 ("unknown") when the shape is not in the map; the caller (Gopher
+// VRAM precheck) treats 0 as "skip the gate".
+func AvailableNodeVRAMBytes(shape string) int64 {
+	gb, ok := gpuShapeMemoryGB(shape)
+	if !ok || gb <= 0 {
+		return 0
+	}
+	return gb * (1 << 30)
+}
+
+// vramSafetyFactor parses MODEL_DOWNLOAD_VRAM_SAFETY_FACTOR once. The factor is
+// multiplied into the estimated weight bytes to leave headroom for activations,
+// KV cache, and CUDA workspace.
+//
+// Invalid values (non-numeric, < 1.0, > 4.0) silently fall back to the default
+// (1.2). The clamp prevents foot-guns: a value < 1.0 would over-permit, and a
+// huge value would block every model.
+func vramSafetyFactor() float64 {
+	vramSafetyFactorOnce.Do(func() {
+		raw := os.Getenv(VRAMSafetyFactorEnvVar)
+		if raw == "" {
+			vramSafetyFactorVal = defaultVRAMSafetyFactor
+			return
+		}
+		v, err := strconv.ParseFloat(raw, 64)
+		if err != nil || v < minVRAMSafetyFactor || v > maxVRAMSafetyFactor {
+			vramSafetyFactorVal = defaultVRAMSafetyFactor
+			return
+		}
+		vramSafetyFactorVal = v
+	})
+	return vramSafetyFactorVal
+}

--- a/pkg/modelagent/gpu_memory_test.go
+++ b/pkg/modelagent/gpu_memory_test.go
@@ -1,0 +1,74 @@
+package modelagent
+
+import (
+	"testing"
+)
+
+func TestLoadGPUShapeMemoryGBFromEnv_Unset(t *testing.T) {
+	t.Setenv(GPUShapeMemoryGBEnvVar, "")
+	m, err := loadGPUShapeMemoryGBFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// H100 default is the node-total (8 × 80 GiB).
+	if got, want := m["H100"], int64(640); got != want {
+		t.Errorf("H100 default = %d, want %d", got, want)
+	}
+}
+
+func TestLoadGPUShapeMemoryGBFromEnv_OverrideRoundtrip(t *testing.T) {
+	t.Setenv(GPUShapeMemoryGBEnvVar, `{"H100":1128,"A10":192}`)
+	m, err := loadGPUShapeMemoryGBFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := m["H100"], int64(1128); got != want {
+		t.Errorf("H100 override = %d, want %d", got, want)
+	}
+	// Default values are dropped when env var is set (we trust the operator's map).
+	if _, present := m["B200"]; present {
+		t.Errorf("expected B200 absent when override map provided")
+	}
+}
+
+func TestLoadGPUShapeMemoryGBFromEnv_EmptyMapFallsBack(t *testing.T) {
+	t.Setenv(GPUShapeMemoryGBEnvVar, `{}`)
+	m, err := loadGPUShapeMemoryGBFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := m["H100"]; !ok {
+		t.Errorf("empty override should fall back to defaults")
+	}
+}
+
+func TestLoadGPUShapeMemoryGBFromEnv_BadJSON(t *testing.T) {
+	t.Setenv(GPUShapeMemoryGBEnvVar, `{`)
+	_, err := loadGPUShapeMemoryGBFromEnv()
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+func TestAvailableNodeVRAMBytes(t *testing.T) {
+	cases := []struct {
+		name  string
+		shape string
+		want  int64
+	}{
+		{"H100 node (8×80)", "H100", 640 * (1 << 30)},
+		{"A10 node (4×24)", "A10", 96 * (1 << 30)},
+		{"H200 node (8×141)", "H200", 1128 * (1 << 30)},
+		{"unknown shape fails open", "unknown-shape", 0},
+		{"empty shape fails open", "", 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AvailableNodeVRAMBytes(tc.shape)
+			if got != tc.want {
+				t.Errorf("AvailableNodeVRAMBytes(%q) = %d, want %d", tc.shape, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/modelagent/metrics.go
+++ b/pkg/modelagent/metrics.go
@@ -17,6 +17,8 @@ type Metrics struct {
 	// Counter metrics
 	modelDownloadsSuccessTotal *prometheus.CounterVec
 	modelDownloadsFailedTotal  *prometheus.CounterVec
+	modelDownloadsSkippedTotal *prometheus.CounterVec
+	modelPrecheckBypassTotal   *prometheus.CounterVec
 	modelVerificationsTotal    *prometheus.CounterVec
 	mdChecksumsFailedTotal     *prometheus.CounterVec
 	rateLimitCounter           *prometheus.CounterVec
@@ -151,6 +153,20 @@ func NewMetrics(registerer prometheus.Registerer) *Metrics {
 			},
 			[]string{"model_type", "namespace", "name"},
 		),
+		modelDownloadsSkippedTotal: promauto.With(registerer).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "model_agent_downloads_skipped_total",
+				Help: "The total number of model downloads skipped by a precheck (e.g. VRAM insufficient on this node)",
+			},
+			[]string{"model_type", "namespace", "name", "reason"},
+		),
+		modelPrecheckBypassTotal: promauto.With(registerer).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "model_agent_precheck_bypass_total",
+				Help: "The total number of times the VRAM precheck was intentionally bypassed (e.g. multi-node sharded annotation)",
+			},
+			[]string{"model_type", "namespace", "name", "reason"},
+		),
 		modelVerificationsTotal: promauto.With(registerer).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "model_agent_verifications_total",
@@ -221,6 +237,22 @@ func (m *Metrics) RecordSuccessfulDownload(modelType, namespace, name string) {
 // RecordFailedDownload records a failed model download
 func (m *Metrics) RecordFailedDownload(modelType, namespace, name, errorType string) {
 	m.modelDownloadsFailedTotal.WithLabelValues(modelType, namespace, name).Inc()
+}
+
+// RecordSkippedDownload records a model download that the agent refused to
+// perform on this node because a precheck rejected it (e.g. estimated weight
+// bytes exceeded available VRAM). reason is a short stable token for the
+// rejection cause; the initial taxonomy is "vram_insufficient".
+func (m *Metrics) RecordSkippedDownload(modelType, namespace, name, reason string) {
+	m.modelDownloadsSkippedTotal.WithLabelValues(modelType, namespace, name, reason).Inc()
+}
+
+// RecordPrecheckBypass records a model download for which the VRAM precheck
+// was deliberately skipped (the model declared itself multi-node-sharded, the
+// estimator returned 0, etc.). Distinct from RecordSkippedDownload so dashboards
+// can distinguish "gate ran and let it through" from "gate ran and refused".
+func (m *Metrics) RecordPrecheckBypass(modelType, namespace, name, reason string) {
+	m.modelPrecheckBypassTotal.WithLabelValues(modelType, namespace, name, reason).Inc()
 }
 
 // RecordVerification records a model verification

--- a/pkg/modelagent/model_data.go
+++ b/pkg/modelagent/model_data.go
@@ -3,6 +3,7 @@ package modelagent
 
 import (
 	"encoding/json"
+	"strconv"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 )
@@ -24,6 +25,38 @@ const (
 
 // ConfigParsingAnnotation is the annotation key to skip config parsing
 const ConfigParsingAnnotation = "ome.oracle.com/skip-config-parsing"
+
+// MultiNodeShardedAnnotation, when set to a truthy value on a BaseModel or
+// ClusterBaseModel, tells the model agent that the model will be split across
+// multiple nodes at serve time (tensor / pipeline parallel sharding). In that
+// case the VRAM precheck in Gopher is skipped (fail-open) so a model that is
+// larger than any single node's VRAM still gets downloaded to every selected
+// node.
+const MultiNodeShardedAnnotation = "ome.io/multi-node-sharded"
+
+// isMultiNodeSharded reports whether the BaseModel / ClusterBaseModel carries
+// the MultiNodeShardedAnnotation with a truthy value. Exactly one of the two
+// pointers is non-nil at every call site; nil checks keep this safe.
+func isMultiNodeSharded(baseModel *v1beta1.BaseModel, clusterBaseModel *v1beta1.ClusterBaseModel) bool {
+	var annotations map[string]string
+	switch {
+	case baseModel != nil:
+		annotations = baseModel.GetAnnotations()
+	case clusterBaseModel != nil:
+		annotations = clusterBaseModel.GetAnnotations()
+	default:
+		return false
+	}
+	raw, ok := annotations[MultiNodeShardedAnnotation]
+	if !ok {
+		return false
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false
+	}
+	return v
+}
 
 // ModelMetadata contains the extracted metadata about a model
 type ModelMetadata struct {
@@ -99,10 +132,35 @@ func (p *DownloadProgress) Percentage() float64 {
 // ModelEntry represents an entry in the node model ConfigMap
 // This is the top-level structure stored for each model in the ConfigMap
 type ModelEntry struct {
-	Name     string            `json:"name"`               // Name of the model
-	Status   ModelStatus       `json:"status"`             // Current status of the model on this node
-	Config   *ModelConfig      `json:"config,omitempty"`   // Model configuration, may be nil if just tracking status
-	Progress *DownloadProgress `json:"progress,omitempty"` // Download progress, nil when not downloading
+	Name         string            `json:"name"`                   // Name of the model
+	Status       ModelStatus       `json:"status"`                 // Current status of the model on this node
+	Config       *ModelConfig      `json:"config,omitempty"`       // Model configuration, may be nil if just tracking status
+	Progress     *DownloadProgress `json:"progress,omitempty"`     // Download progress, nil when not downloading
+	StatusDetail *StatusDetail     `json:"statusDetail,omitempty"` // Optional context for the current Status (e.g. why a download was skipped)
+}
+
+// StatusDetail is optional context that accompanies a model's Status entry on
+// a node. It is written by the model agent when a status transition carries
+// extra reasoning the controller / operator will want to see (e.g. the VRAM
+// precheck refused to download).
+//
+// The Reason field is the discriminator; consumers should switch on it to
+// decide which optional fields are meaningful for the given record.
+type StatusDetail struct {
+	Reason  string `json:"reason"`  // Machine-readable reason, e.g. "VRAMInsufficient"
+	Message string `json:"message"` // Human-readable explanation
+
+	// VRAM precheck context. Populated when Reason == "VRAMInsufficient".
+	RequiredBytes        int64   `json:"requiredBytes,omitempty"`
+	AvailableVRAMBytes   int64   `json:"availableVRAMBytes,omitempty"`
+	EstimatedWeightBytes int64   `json:"estimatedWeightBytes,omitempty"`
+	SafetyFactor         float64 `json:"safetyFactor,omitempty"`
+
+	// Estimator observability (so dashboards / debug logs can show *why* the
+	// estimate came out where it did, independent of Reason).
+	Format   string `json:"format,omitempty"`
+	Method   string `json:"method,omitempty"`
+	Strategy string `json:"strategy,omitempty"`
 }
 
 // ConvertMetadataToModelConfig converts internal ModelMetadata to a client-facing ModelConfig

--- a/pkg/modelagent/node_label_reconciler.go
+++ b/pkg/modelagent/node_label_reconciler.go
@@ -24,6 +24,11 @@ type NodeLabelOp struct {
 	ModelStateOnNode ModelStateOnNode
 	BaseModel        *v1beta1.BaseModel
 	ClusterBaseModel *v1beta1.ClusterBaseModel
+
+	// StatusDetail, when non-nil, is written into the node-scoped ConfigMap
+	// entry alongside the Status. Used to record machine-readable context
+	// for the current state transition (e.g. why a download was skipped).
+	StatusDetail *StatusDetail
 }
 
 // NodeLabelReconciler handles updating node labels œwith model status information

--- a/pkg/modelagent/remote_size.go
+++ b/pkg/modelagent/remote_size.go
@@ -1,0 +1,613 @@
+package modelagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+// EstimateDetail accompanies every remote-size estimate. It captures the
+// reasoning behind a number so logs / metrics make it obvious why the gate
+// decided what it did. Always non-nil on a successful call.
+type EstimateDetail struct {
+	Format string // "safetensors" | "gguf" | "diffusion" | "bin" | "unknown"
+	Method string // "fp16" | "bf16" | "fp32" | "fp8" | "awq" | "gptq" | "bitsandbytes" |
+	//        "hqq" | "compressed-tensors" | "gguf-q4" | "none" | "unknown"
+	Strategy string // "diffusion_component_sum" | "safetensors_dtype_count" |
+	//        "gguf_variant_max" | "siblings_byte_sum" | "oci_list_sum" |
+	//        "s3_list_sum" | "local_walk_sum" | "noop"
+	UsedFallback bool // true when caps/fallbacks tripped (e.g. min capped naive)
+}
+
+// RemoteSizeEstimator computes a conservative byte estimate of the model's
+// downloaded weight footprint for a given storage URI. Returns (0, detail, nil)
+// when the size is genuinely unknown so the caller can fail open.
+type RemoteSizeEstimator interface {
+	EstimateRemoteSize(ctx context.Context, uri string) (int64, *EstimateDetail, error)
+}
+
+// bytesPerDtype maps safetensors dtype tags to bytes per parameter. Validated
+// against a survey of the HF top-300 models + 12 quantization families.
+// Notes:
+//   - U8 is 1 byte: BitsAndBytes and MXFP4 pre-pack two int4 into a uint8 and
+//     report the count of those bytes, not of the underlying int4s.
+//   - I32 is always 4 bytes: AWQ over-reports packed-int4 weights as I32, but
+//     min(naive, usedStorage) absorbs that without needing AWQ-specific math;
+//     HQQ stores genuine fp32 metadata as I32 (4 bytes is correct there too).
+var bytesPerDtype = map[string]float64{
+	"F64":     8,
+	"I64":     8,
+	"F32":     4,
+	"I32":     4,
+	"U32":     4,
+	"BF16":    2,
+	"F16":     2,
+	"F8_E4M3": 1,
+	"F8_E5M2": 1,
+	"F8_E8M0": 1,
+	"I8":      1,
+	"U8":      1,
+	"BOOL":    1,
+}
+
+var diffusionLibraries = map[string]bool{
+	"diffusers":        true,
+	"stable-diffusion": true,
+	"flux":             true,
+}
+
+// shardRe matches sharded weight file names of any digit width:
+//
+//	model-00001-of-00007.safetensors, model-1-of-3.gguf, etc.
+var shardRe = regexp.MustCompile(`-(\d+)-of-(\d+)\.(safetensors|bin|pt|pth|gguf|ckpt)$`)
+
+// ggufQuantRe extracts a GGUF quantization tag from a filename, e.g.
+//
+//	Llama-3.1-8B.Q4_K_M.gguf  -> "Q4_K_M"
+//	tinyllama-1.1b-Q8_0.gguf  -> "Q8_0"
+var ggufQuantRe = regexp.MustCompile(`(?i)[-.](Q\d+_K(?:_[SML])?|Q\d+(?:_\d+)?|BF16|F16|FP16|IQ\d+\w*|F32)`)
+
+// estimatorFor dispatches to the URI-only estimator for the given storage
+// type. Returns nil for OCI / S3 / Vendor / PVC / Azure / GCS / GitHub: those
+// either gate inline using their existing listing step (OCI, future S3) or
+// have no useful size signal (Vendor / PVC). Caller treats nil as "no
+// estimator-based precheck for this URI".
+func (s *Gopher) estimatorFor(storageType storage.StorageType) RemoteSizeEstimator {
+	switch storageType {
+	case storage.StorageTypeHuggingFace:
+		return &hfRemoteSizeEstimator{}
+	case storage.StorageTypeLocal:
+		return &localRemoteSizeEstimator{}
+	default:
+		return nil
+	}
+}
+
+// ociListSumDetail is the EstimateDetail used by the inline OCI VRAM gate
+// (see gopher.go) when the size is the sum of OCI ListObjects results.
+func ociListSumDetail() *EstimateDetail {
+	return &EstimateDetail{
+		Format:   "unknown",
+		Method:   "none",
+		Strategy: "oci_list_sum",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Local
+// ---------------------------------------------------------------------------
+
+type localRemoteSizeEstimator struct{}
+
+func (e *localRemoteSizeEstimator) EstimateRemoteSize(_ context.Context, uri string) (int64, *EstimateDetail, error) {
+	detail := &EstimateDetail{Format: "unknown", Method: "none", Strategy: "local_walk_sum"}
+	root := strings.TrimPrefix(uri, "local://")
+	if root == "" {
+		return 0, detail, fmt.Errorf("local precheck: empty path")
+	}
+
+	var total int64
+	err := filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, detail, nil
+		}
+		return 0, detail, fmt.Errorf("local precheck: walk %s: %w", root, err)
+	}
+	return total, detail, nil
+}
+
+// ---------------------------------------------------------------------------
+// HuggingFace
+// ---------------------------------------------------------------------------
+
+type hfRemoteSizeEstimator struct{}
+
+// hfModelInfo is the subset of /api/models/{id}?blobs=true we read.
+type hfModelInfo struct {
+	ID          string         `json:"id"`
+	LibraryName string         `json:"library_name"`
+	Tags        []string       `json:"tags"`
+	UsedStorage int64          `json:"usedStorage"`
+	Siblings    []hfSibling    `json:"siblings"`
+	Safetensors *hfSafetensors `json:"safetensors"`
+	GGUF        *hfGGUFSummary `json:"gguf"`
+	Config      *hfConfig      `json:"config"`
+}
+
+type hfSibling struct {
+	RFilename string `json:"rfilename"`
+	Size      int64  `json:"size"`
+}
+
+type hfSafetensors struct {
+	// raw is the unparsed parameters payload so we can decide flat-vs-nested.
+	Raw json.RawMessage `json:"parameters"`
+	// Total is the helper "total" field HF often reports.
+	Total int64 `json:"total"`
+}
+
+type hfGGUFSummary struct {
+	TotalFileSize int64 `json:"total_file_size"`
+}
+
+type hfConfig struct {
+	QuantizationConfig *hfQuantConfig `json:"quantization_config"`
+}
+
+type hfQuantConfig struct {
+	QuantMethod string `json:"quant_method"`
+	// Format is the compressed-tensors sub-format ("nvfp4-pack-quantized",
+	// "float-quantized", "pack-quantized", "naive-quantized", ...). Empty for
+	// other quant methods.
+	Format     string `json:"format"`
+	LoadIn4Bit bool   `json:"load_in_4bit"`
+	LoadIn8Bit bool   `json:"load_in_8bit"`
+}
+
+func (e *hfRemoteSizeEstimator) EstimateRemoteSize(ctx context.Context, uri string) (int64, *EstimateDetail, error) {
+	detail := &EstimateDetail{Format: "unknown", Method: "unknown", Strategy: "noop"}
+	modelID := strings.TrimPrefix(uri, "hf://")
+	modelID = strings.TrimPrefix(modelID, "huggingface://")
+	if modelID == "" {
+		return 0, detail, fmt.Errorf("hf precheck: empty model id in uri %q", uri)
+	}
+
+	info, err := fetchHFModelInfo(ctx, modelID, DefaultEndpoint)
+	if err != nil {
+		return 0, detail, err
+	}
+	bytes, d := estimateHuggingFaceWeightBytes(info)
+	return bytes, d, nil
+}
+
+// fetchHFModelInfo issues one GET /api/models/{id}?blobs=true and decodes
+// the subset we need. The blobs=true param is required so siblings carry
+// per-file sizes; without it the diffusion and tree-walk paths degrade to
+// zero (silent fail-open).
+func fetchHFModelInfo(ctx context.Context, modelID, endpoint string) (*hfModelInfo, error) {
+	base, err := hfModelMetaDataUrlWithEndpoint(modelID, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	url := base + "?blobs=true"
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("hf precheck: build request: %w", err)
+	}
+	resp, err := NewHTTPClientWithTimeout(DefaultRequestTimeout).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("hf precheck: get %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("hf precheck: %s: status %d", url, resp.StatusCode)
+	}
+
+	var info hfModelInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("hf precheck: decode %s: %w", url, err)
+	}
+	return &info, nil
+}
+
+// estimateHuggingFaceWeightBytes is the pure-data classifier+strategy. Split
+// out so it is trivially testable with fixtures captured from the HF API.
+func estimateHuggingFaceWeightBytes(info *hfModelInfo) (int64, *EstimateDetail) {
+	format := classifyFormat(info)
+	method := classifyMethod(info, format)
+	detail := &EstimateDetail{Format: format, Method: method}
+
+	switch format {
+	case "diffusion":
+		detail.Strategy = "diffusion_component_sum"
+		return diffusionComponentSum(info), detail
+	case "safetensors":
+		detail.Strategy = "safetensors_dtype_count"
+		size, fallback := safetensorsDtypeCount(info)
+		detail.UsedFallback = fallback
+		return size, detail
+	case "gguf":
+		detail.Strategy = "gguf_variant_max"
+		return ggufVariantMax(info), detail
+	case "bin", "unknown":
+		detail.Strategy = "siblings_byte_sum"
+		return siblingsByteSum(info), detail
+	}
+	return 0, detail
+}
+
+func classifyFormat(info *hfModelInfo) string {
+	if diffusionLibraries[strings.ToLower(info.LibraryName)] {
+		return "diffusion"
+	}
+	if info.Safetensors != nil && len(info.Safetensors.Raw) > 0 {
+		return "safetensors"
+	}
+	hasSafetensors := false
+	hasGGUF := false
+	hasBin := false
+	for _, s := range info.Siblings {
+		name := strings.ToLower(s.RFilename)
+		switch {
+		case strings.HasSuffix(name, ".safetensors"):
+			hasSafetensors = true
+		case strings.HasSuffix(name, ".gguf"):
+			hasGGUF = true
+		case strings.HasSuffix(name, ".bin"),
+			strings.HasSuffix(name, ".pt"),
+			strings.HasSuffix(name, ".pth"):
+			hasBin = true
+		}
+	}
+	if hasGGUF {
+		return "gguf"
+	}
+	// gguf summary present but no .gguf siblings (e.g. blobs=true elided them):
+	// still classify as gguf so the variant-max strategy can fall back to
+	// total_file_size.
+	if info.GGUF != nil && info.GGUF.TotalFileSize > 0 {
+		return "gguf"
+	}
+	if hasSafetensors {
+		return "safetensors"
+	}
+	if hasBin {
+		return "bin"
+	}
+	return "unknown"
+}
+
+func classifyMethod(info *hfModelInfo, format string) string {
+	// GGUF first: a GGUF repo's filenames carry the canonical quant tag
+	// (Q4_K_M, Q8_0, …). Doing this before the fuzzy ID/tag regex prevents
+	// false positives when a GGUF repo's name happens to contain "int4",
+	// "fp8", "gptq", etc.
+	if format == "gguf" {
+		return extractGGUFQuant(info.Siblings)
+	}
+
+	if info.Config != nil && info.Config.QuantizationConfig != nil {
+		qc := info.Config.QuantizationConfig
+		switch strings.ToLower(qc.QuantMethod) {
+		case "awq":
+			return "awq"
+		case "gptq":
+			return "gptq"
+		case "bitsandbytes":
+			return "bitsandbytes"
+		case "hqq":
+			return "hqq"
+		case "compressed-tensors":
+			// compressed-tensors is a wrapper; the actual scheme is in `format`.
+			switch strings.ToLower(qc.Format) {
+			case "nvfp4-pack-quantized":
+				return "nvfp4"
+			case "float-quantized":
+				return "fp8"
+			}
+			return "compressed-tensors"
+		case "aqlm":
+			return "aqlm"
+		}
+		if qc.LoadIn4Bit || qc.LoadIn8Bit {
+			return "bitsandbytes"
+		}
+	}
+
+	hayLower := strings.ToLower(info.ID + " " + strings.Join(info.Tags, " "))
+	for _, m := range []string{
+		"awq", "gptq", "hqq", "aqlm", "exl2",
+		"nvfp4", "mxfp4", "fp4",
+		"bnb", "nf4",
+		"int8", "int4", "fp8",
+	} {
+		if strings.Contains(hayLower, m) {
+			// Collapse BnB variants into one label.
+			if m == "bnb" || m == "nf4" {
+				return "bitsandbytes"
+			}
+			return m
+		}
+	}
+
+	if info.Safetensors != nil {
+		params, _, _ := parseSafetensorsParams(info.Safetensors.Raw)
+		// Order matters: prefer the quantization-indicator dtype over the
+		// metadata / dense-precision dtype, otherwise a quantized model with
+		// BF16 norms or F32 RoPE buffers would be mislabeled "bf16"/"fp32".
+		// MXFP4 / NVFP4 (U8 weights + F8_E8M0 scales) get caught before plain FP8.
+		switch {
+		case hasAnyDtype(params, "F8_E8M0") && hasAnyDtype(params, "U8"):
+			return "mxfp4"
+		case hasAnyDtype(params, "F8_E4M3", "F8_E5M2", "F8_E8M0"):
+			return "fp8"
+		case hasAnyDtype(params, "U8", "I8"):
+			return "uint8_or_int8_storage"
+		case hasAnyDtype(params, "I32", "U32"):
+			return "packed_or_metadata_32"
+		case hasAnyDtype(params, "BF16", "F16"):
+			return "bf16"
+		case hasAnyDtype(params, "F32"):
+			return "fp32"
+		}
+		return "none"
+	}
+	return "unknown"
+}
+
+func extractGGUFQuant(siblings []hfSibling) string {
+	var largest hfSibling
+	for _, s := range siblings {
+		if strings.HasSuffix(strings.ToLower(s.RFilename), ".gguf") && s.Size > largest.Size {
+			largest = s
+		}
+	}
+	if largest.RFilename == "" {
+		return "unknown"
+	}
+	m := ggufQuantRe.FindStringSubmatch(largest.RFilename)
+	if len(m) < 2 {
+		return "gguf-unknown"
+	}
+	return "gguf-" + strings.ToLower(m[1])
+}
+
+func hasAnyDtype(params map[string]int64, dts ...string) bool {
+	for _, d := range dts {
+		if params[d] > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// parseSafetensorsParams handles both flat and nested HF parameters payloads:
+//
+//	flat:   {"BF16": 7000000000, "F32": 1024}
+//	nested: {"variant1": {"BF16": ...}, "variant2": {"F16": ...}}
+//
+// Returns the flattened {dtype: count} sum, the number of groups detected,
+// and whether the payload was nested.
+func parseSafetensorsParams(raw json.RawMessage) (map[string]int64, int, bool) {
+	if len(raw) == 0 {
+		return nil, 0, false
+	}
+	var flat map[string]int64
+	if err := json.Unmarshal(raw, &flat); err == nil {
+		return flat, 1, false
+	}
+	var nested map[string]map[string]int64
+	if err := json.Unmarshal(raw, &nested); err == nil {
+		out := make(map[string]int64)
+		for _, group := range nested {
+			for d, c := range group {
+				out[d] += c
+			}
+		}
+		return out, len(nested), true
+	}
+	return nil, 0, false
+}
+
+func safetensorsDtypeCount(info *hfModelInfo) (int64, bool) {
+	// If the safetensors field or parameters payload is missing, fall back to
+	// a sibling-byte sum. Some repos host *.safetensors but omit the structured
+	// API field (private mirrors, very new uploads, etc.).
+	if info.Safetensors == nil || len(info.Safetensors.Raw) == 0 {
+		return siblingsByteSum(info), true
+	}
+	params, _, _ := parseSafetensorsParams(info.Safetensors.Raw)
+	if len(params) == 0 {
+		return siblingsByteSum(info), true
+	}
+	var naive float64
+	for dtype, count := range params {
+		bpp, ok := bytesPerDtype[strings.ToUpper(dtype)]
+		if !ok {
+			continue
+		}
+		naive += float64(count) * bpp
+	}
+	naiveBytes := int64(naive)
+	if info.UsedStorage > 0 && naiveBytes > info.UsedStorage {
+		return info.UsedStorage, true
+	}
+	return naiveBytes, false
+}
+
+var diffusionComponentDirs = []string{
+	"transformer/",
+	"unet/",
+	"vae/",
+	"text_encoder/",
+	"text_encoder_2/",
+	"text_encoder_3/",
+	"image_encoder/",
+}
+
+func diffusionComponentSum(info *hfModelInfo) int64 {
+	var total int64
+	for _, dir := range diffusionComponentDirs {
+		var inDir []hfSibling
+		for _, s := range info.Siblings {
+			if strings.HasPrefix(s.RFilename, dir) {
+				inDir = append(inDir, s)
+			}
+		}
+		total += pickBestWeightFile(inDir)
+	}
+	if total > 0 {
+		return total
+	}
+	// No recognized component dirs — fall back to a tree-walk sum to remain useful
+	// for older diffusion pipelines without the standard layout.
+	return siblingsByteSum(info)
+}
+
+// pickBestWeightFile returns the byte size of the preferred weight artifact in
+// a single component directory. Preference (lower index = better):
+//  1. fp16/bf16 variant of safetensors
+//  2. regular safetensors
+//  3. anything else with a weight extension
+//
+// Sharded weights are summed across the shard family.
+func pickBestWeightFile(files []hfSibling) int64 {
+	if len(files) == 0 {
+		return 0
+	}
+	type group struct {
+		key      string
+		priority int
+		total    int64
+	}
+	groups := make(map[string]*group)
+	for _, f := range files {
+		nameLower := strings.ToLower(f.RFilename)
+		var pri int
+		switch {
+		case strings.HasSuffix(nameLower, ".onnx"),
+			strings.HasSuffix(nameLower, ".msgpack"),
+			strings.HasSuffix(nameLower, ".h5"):
+			continue
+		case strings.HasSuffix(nameLower, ".safetensors") && (strings.Contains(nameLower, ".fp16.") || strings.Contains(nameLower, ".bf16.")):
+			pri = 0
+		case strings.HasSuffix(nameLower, ".safetensors"):
+			pri = 1
+		case strings.HasSuffix(nameLower, ".bin"),
+			strings.HasSuffix(nameLower, ".pt"),
+			strings.HasSuffix(nameLower, ".pth"),
+			strings.HasSuffix(nameLower, ".ckpt"):
+			pri = 2
+		default:
+			continue
+		}
+		key := shardFamilyKey(f.RFilename, pri)
+		g, ok := groups[key]
+		if !ok {
+			g = &group{key: key, priority: pri}
+			groups[key] = g
+		}
+		g.total += f.Size
+	}
+	if len(groups) == 0 {
+		return 0
+	}
+	var best *group
+	for _, g := range groups {
+		switch {
+		case best == nil:
+			best = g
+		case g.priority < best.priority:
+			best = g
+		case g.priority == best.priority && g.total > best.total:
+			best = g
+		}
+	}
+	if best == nil {
+		return 0
+	}
+	return best.total
+}
+
+// shardFamilyKey returns a stable key that groups shards belonging to the same
+// logical weight file (so they sum together) but separates distinct families
+// like ".fp16.safetensors" vs ".safetensors".
+func shardFamilyKey(name string, priority int) string {
+	base := shardRe.ReplaceAllString(name, ".$3")
+	return fmt.Sprintf("%d:%s", priority, base)
+}
+
+func ggufVariantMax(info *hfModelInfo) int64 {
+	variants := make(map[string]int64)
+	for _, s := range info.Siblings {
+		if !strings.HasSuffix(strings.ToLower(s.RFilename), ".gguf") {
+			continue
+		}
+		m := ggufQuantRe.FindStringSubmatch(s.RFilename)
+		key := "default"
+		if len(m) >= 2 {
+			key = strings.ToUpper(m[1])
+		}
+		variants[key] += s.Size
+	}
+	if len(variants) == 0 {
+		if info.GGUF != nil && info.GGUF.TotalFileSize > 0 {
+			return info.GGUF.TotalFileSize
+		}
+		return 0
+	}
+	var max int64
+	for _, v := range variants {
+		if v > max {
+			max = v
+		}
+	}
+	return max
+}
+
+var weightExtensions = map[string]bool{
+	".safetensors": true,
+	".bin":         true,
+	".pt":          true,
+	".pth":         true,
+	".gguf":        true,
+	".ckpt":        true,
+}
+
+func siblingsByteSum(info *hfModelInfo) int64 {
+	var total int64
+	for _, s := range info.Siblings {
+		ext := strings.ToLower(filepath.Ext(s.RFilename))
+		if !weightExtensions[ext] {
+			continue
+		}
+		if s.Size <= 0 {
+			continue
+		}
+		total += s.Size
+	}
+	return total
+}

--- a/pkg/modelagent/remote_size_test.go
+++ b/pkg/modelagent/remote_size_test.go
@@ -1,0 +1,403 @@
+package modelagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeHFInfo is a small helper for constructing hfModelInfo fixtures inline.
+func makeHFInfo(t *testing.T, body string) *hfModelInfo {
+	t.Helper()
+	var info hfModelInfo
+	if err := json.Unmarshal([]byte(body), &info); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	return &info
+}
+
+func TestEstimateHF_SafetensorsBF16(t *testing.T) {
+	// meta-llama/Llama-3.1-8B-Instruct shape: single BF16 group, no quantization.
+	body := `{
+        "id": "meta-llama/Llama-3.1-8B-Instruct",
+        "safetensors": {"parameters": {"BF16": 8030261248}, "total": 8030261248},
+        "usedStorage": 32121044992
+    }`
+	info := makeHFInfo(t, body)
+	bytes, detail := estimateHuggingFaceWeightBytes(info)
+	want := int64(8030261248 * 2)
+	if bytes != want {
+		t.Errorf("BF16 size = %d, want %d", bytes, want)
+	}
+	if detail.Format != "safetensors" || detail.Method != "bf16" || detail.Strategy != "safetensors_dtype_count" {
+		t.Errorf("classifier detail = %+v", detail)
+	}
+}
+
+func TestEstimateHF_SafetensorsAWQUsedStorageCap(t *testing.T) {
+	// AWQ-style: I32 over-count would inflate naive; min(naive, usedStorage)
+	// caps to usedStorage which matches the real file size.
+	// Synthetic numbers: 1 B I32 entries (naive = 4 GB) but real usedStorage = 1 GB.
+	body := `{
+        "id": "Qwen/Qwen2.5-7B-Instruct-AWQ",
+        "tags": ["awq"],
+        "safetensors": {"parameters": {"I32": 1000000000, "BF16": 100000000}, "total": 1100000000},
+        "usedStorage": 1000000000
+    }`
+	info := makeHFInfo(t, body)
+	bytes, detail := estimateHuggingFaceWeightBytes(info)
+	if bytes != 1000000000 {
+		t.Errorf("AWQ cap size = %d, want %d", bytes, 1000000000)
+	}
+	if detail.Method != "awq" {
+		t.Errorf("expected method awq, got %q", detail.Method)
+	}
+	if !detail.UsedFallback {
+		t.Errorf("expected UsedFallback=true when usedStorage caps naive")
+	}
+}
+
+func TestEstimateHF_GGUFMultiVariantMax(t *testing.T) {
+	// Three .gguf variants: Q4_K_M, Q5_K_M, Q8_0. We expect the largest (Q8_0).
+	body := `{
+        "id": "bartowski/Qwen2.5-7B-Instruct-GGUF",
+        "gguf": {"total_file_size": 5000000000},
+        "siblings": [
+            {"rfilename": "model-Q4_K_M.gguf", "size": 4000000000},
+            {"rfilename": "model-Q5_K_M.gguf", "size": 5000000000},
+            {"rfilename": "model-Q8_0.gguf",   "size": 7000000000}
+        ]
+    }`
+	info := makeHFInfo(t, body)
+	bytes, detail := estimateHuggingFaceWeightBytes(info)
+	if bytes != 7000000000 {
+		t.Errorf("GGUF size = %d, want %d (largest variant)", bytes, 7000000000)
+	}
+	if detail.Format != "gguf" || detail.Strategy != "gguf_variant_max" {
+		t.Errorf("classifier detail = %+v", detail)
+	}
+}
+
+func TestEstimateHF_GGUFFallbackToTotal(t *testing.T) {
+	// No siblings carry sizes → fall back to gguf.total_file_size.
+	body := `{
+        "id": "foo/bar",
+        "gguf": {"total_file_size": 2500000000},
+        "siblings": [
+            {"rfilename": "config.json", "size": 1024}
+        ]
+    }`
+	info := makeHFInfo(t, body)
+	bytes, _ := estimateHuggingFaceWeightBytes(info)
+	if bytes != 2500000000 {
+		t.Errorf("GGUF fallback = %d, want %d", bytes, 2500000000)
+	}
+}
+
+func TestEstimateHF_DiffusionComponentSum(t *testing.T) {
+	// Stable Diffusion-style layout: prefer .fp16.safetensors and sum across
+	// components.
+	body := `{
+        "id": "stabilityai/stable-diffusion-3-medium",
+        "library_name": "diffusers",
+        "siblings": [
+            {"rfilename": "transformer/diffusion_pytorch_model.fp16.safetensors", "size": 10000000000},
+            {"rfilename": "transformer/diffusion_pytorch_model.safetensors",      "size": 20000000000},
+            {"rfilename": "vae/diffusion_pytorch_model.fp16.safetensors",          "size": 250000000},
+            {"rfilename": "vae/diffusion_pytorch_model.safetensors",               "size": 500000000},
+            {"rfilename": "text_encoder/model.fp16.safetensors",                   "size": 250000000},
+            {"rfilename": "text_encoder/model.safetensors",                        "size": 500000000}
+        ]
+    }`
+	info := makeHFInfo(t, body)
+	bytes, detail := estimateHuggingFaceWeightBytes(info)
+	want := int64(10000000000 + 250000000 + 250000000)
+	if bytes != want {
+		t.Errorf("diffusion sum = %d, want %d (fp16 preferred)", bytes, want)
+	}
+	if detail.Format != "diffusion" || detail.Strategy != "diffusion_component_sum" {
+		t.Errorf("classifier detail = %+v", detail)
+	}
+}
+
+func TestEstimateHF_FP8Detection(t *testing.T) {
+	body := `{
+        "id": "neuralmagic/Llama-3-8B-FP8",
+        "safetensors": {"parameters": {"F8_E4M3": 8000000000, "BF16": 30000000}}
+    }`
+	info := makeHFInfo(t, body)
+	_, detail := estimateHuggingFaceWeightBytes(info)
+	if detail.Method != "fp8" {
+		t.Errorf("FP8 method = %q, want %q", detail.Method, "fp8")
+	}
+}
+
+func TestEstimateHF_UnknownFallsbackToSiblings(t *testing.T) {
+	body := `{
+        "id": "private/repo",
+        "siblings": [
+            {"rfilename": "pytorch_model.bin",  "size": 1000000000},
+            {"rfilename": "model.safetensors",  "size": 2000000000},
+            {"rfilename": "extra-file.txt",     "size": 1024}
+        ]
+    }`
+	info := makeHFInfo(t, body)
+	bytes, detail := estimateHuggingFaceWeightBytes(info)
+	// safetensors should win the format vote since at least one is present.
+	if detail.Format != "safetensors" {
+		t.Errorf("expected safetensors format, got %q", detail.Format)
+	}
+	if bytes <= 0 {
+		t.Errorf("expected positive size, got %d", bytes)
+	}
+}
+
+func TestParseSafetensorsParams_FlatAndNested(t *testing.T) {
+	flat := json.RawMessage(`{"BF16": 100, "F32": 4}`)
+	out, groups, nested := parseSafetensorsParams(flat)
+	if nested || groups != 1 || out["BF16"] != 100 || out["F32"] != 4 {
+		t.Errorf("flat parse = %v (groups=%d nested=%v)", out, groups, nested)
+	}
+
+	nestedRaw := json.RawMessage(`{"variant1": {"BF16": 50}, "variant2": {"F16": 25}}`)
+	out, groups, nested = parseSafetensorsParams(nestedRaw)
+	if !nested || groups != 2 || out["BF16"] != 50 || out["F16"] != 25 {
+		t.Errorf("nested parse = %v (groups=%d nested=%v)", out, groups, nested)
+	}
+}
+
+func TestHFEstimator_BlobsTrueQueryParam(t *testing.T) {
+	// Asserts the estimator hits /api/models/{id}?blobs=true. Without it,
+	// siblings sizes are zero and the diffusion / sibling-sum paths fail open
+	// silently.
+	var seenRawQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenRawQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{
+            "id": "foo/bar",
+            "safetensors": {"parameters": {"BF16": 1000}}
+        }`))
+	}))
+	defer srv.Close()
+
+	info, err := fetchHFModelInfo(context.Background(), "foo/bar", srv.URL)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if seenRawQuery != "blobs=true" {
+		t.Errorf("expected ?blobs=true; got %q", seenRawQuery)
+	}
+	if info.ID != "foo/bar" {
+		t.Errorf("decoded id = %q", info.ID)
+	}
+}
+
+func TestLocalEstimator(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]int{
+		"weights.bin":               4000,
+		"sub/dir/model.safetensors": 6000,
+		"sub/dir/config.json":       100,
+	}
+	for name, size := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		buf := make([]byte, size)
+		if err := os.WriteFile(p, buf, 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	e := &localRemoteSizeEstimator{}
+	got, detail, err := e.EstimateRemoteSize(context.Background(), "local://"+dir)
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+	var want int64
+	for _, s := range files {
+		want += int64(s)
+	}
+	if got != want {
+		t.Errorf("local sum = %d, want %d", got, want)
+	}
+	if detail.Strategy != "local_walk_sum" {
+		t.Errorf("strategy = %q", detail.Strategy)
+	}
+}
+
+func TestLocalEstimator_Missing(t *testing.T) {
+	e := &localRemoteSizeEstimator{}
+	got, _, err := e.EstimateRemoteSize(context.Background(), "local:///path/that/does/not/exist")
+	if err != nil {
+		t.Fatalf("missing path should not error, got %v", err)
+	}
+	if got != 0 {
+		t.Errorf("missing path size = %d, want 0", got)
+	}
+}
+
+// Sanity-check that bytesPerDtype covers the dtypes we expect from the
+// quantization survey (regression guard).
+func TestBytesPerDtype_KeyCoverage(t *testing.T) {
+	for _, d := range []string{"F32", "BF16", "F16", "F8_E4M3", "F8_E5M2", "I8", "U8", "I32", "U32", "I64", "BOOL"} {
+		if _, ok := bytesPerDtype[d]; !ok {
+			t.Errorf("bytesPerDtype missing %q", d)
+		}
+	}
+	// Critical invariants from the survey:
+	if bytesPerDtype["U8"] != 1 {
+		t.Errorf("U8 must be 1 byte (BnB pre-packs); got %v", bytesPerDtype["U8"])
+	}
+	if bytesPerDtype["I32"] != 4 {
+		t.Errorf("I32 must be 4 bytes (HQQ uses real I32; AWQ over-count caught by min(naive,usedStorage)); got %v", bytesPerDtype["I32"])
+	}
+}
+
+// Sanity-check shard regex matches the survey-observed forms.
+func TestShardRegex(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"model-00001-of-00007.safetensors", true},
+		{"model-1-of-3.gguf", true},
+		{"model-Q4_K_M-00001-of-00003.gguf", true},
+		{"pytorch_model.bin", false},
+		{"config.json", false},
+	}
+	for _, tc := range cases {
+		got := shardRe.MatchString(tc.name)
+		if got != tc.want {
+			t.Errorf("shardRe.MatchString(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func ExampleEstimateDetail() {
+	d := &EstimateDetail{Format: "safetensors", Method: "bf16", Strategy: "safetensors_dtype_count"}
+	fmt.Printf("%s/%s/%s\n", d.Format, d.Method, d.Strategy)
+	// Output: safetensors/bf16/safetensors_dtype_count
+}
+
+func TestClassifyMethod_GGUFBeatsFuzzyTagMatch(t *testing.T) {
+	// A GGUF repo whose name contains "fp8" must not be mislabeled as "fp8";
+	// extractGGUFQuant should be hit first.
+	body := `{
+        "id": "user/SomeModel-fp8-variant-GGUF",
+        "tags": ["gguf", "fp8"],
+        "gguf": {"total_file_size": 4000000000},
+        "siblings": [
+            {"rfilename": "model-Q4_K_M.gguf", "size": 4000000000}
+        ]
+    }`
+	info := makeHFInfo(t, body)
+	_, detail := estimateHuggingFaceWeightBytes(info)
+	if detail.Format != "gguf" {
+		t.Fatalf("format = %q, want gguf", detail.Format)
+	}
+	if detail.Method != "gguf-q4_k_m" {
+		t.Errorf("method = %q, want gguf-q4_k_m (GGUF must win over the fp8 tag)", detail.Method)
+	}
+}
+
+func TestClassifyMethod_CompressedTensorsNVFP4(t *testing.T) {
+	body := `{
+        "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
+        "config": {"quantization_config": {"quant_method": "compressed-tensors", "format": "nvfp4-pack-quantized"}},
+        "safetensors": {"parameters": {"U8": 18000000000, "F8_E8M0": 50000000, "BF16": 200000000}}
+    }`
+	info := makeHFInfo(t, body)
+	_, detail := estimateHuggingFaceWeightBytes(info)
+	if detail.Method != "nvfp4" {
+		t.Errorf("method = %q, want nvfp4", detail.Method)
+	}
+}
+
+func TestClassifyMethod_CompressedTensorsFloatQuantized(t *testing.T) {
+	body := `{
+        "id": "RedHatAI/Llama-3.2-1B-Instruct-FP8-dynamic",
+        "config": {"quantization_config": {"quant_method": "compressed-tensors", "format": "float-quantized"}},
+        "safetensors": {"parameters": {"F8_E4M3": 1000000000, "BF16": 200000}}
+    }`
+	info := makeHFInfo(t, body)
+	_, detail := estimateHuggingFaceWeightBytes(info)
+	if detail.Method != "fp8" {
+		t.Errorf("method = %q, want fp8 (compressed-tensors float-quantized → fp8)", detail.Method)
+	}
+}
+
+func TestClassifyMethod_NF4MapsToBitsandbytes(t *testing.T) {
+	body := `{
+        "id": "unsloth/Llama-3.1-8B-Instruct-bnb-4bit",
+        "tags": ["nf4"],
+        "safetensors": {"parameters": {"U8": 4000000000, "BF16": 50000000}}
+    }`
+	info := makeHFInfo(t, body)
+	_, detail := estimateHuggingFaceWeightBytes(info)
+	if detail.Method != "bitsandbytes" {
+		t.Errorf("method = %q, want bitsandbytes (nf4 should collapse to bitsandbytes)", detail.Method)
+	}
+}
+
+func TestClassifyMethod_NVFP4ViaTagRegex(t *testing.T) {
+	body := `{
+        "id": "nvidia/Gemma-4-31B-IT-NVFP4",
+        "tags": ["nvfp4"],
+        "safetensors": {"parameters": {"BF16": 1000000, "U8": 30000000000, "F8_E8M0": 60000000}}
+    }`
+	info := makeHFInfo(t, body)
+	_, detail := estimateHuggingFaceWeightBytes(info)
+	if detail.Method != "nvfp4" {
+		t.Errorf("method = %q, want nvfp4 (via tag regex when no quant_method present)", detail.Method)
+	}
+}
+
+func TestClassifyMethod_DtypeFallback_OrderingForQuantStorage(t *testing.T) {
+	// Survey case: openai/gpt-oss-style — BF16 norms + U8 packed weights but
+	// no quantization_config and no recognized tag. Should label as int-storage
+	// (the U8 wins over BF16), not "bf16".
+	body := `{
+        "id": "some/private-quantized",
+        "safetensors": {"parameters": {"BF16": 1000000, "U8": 5000000000, "F32": 2048}}
+    }`
+	info := makeHFInfo(t, body)
+	_, detail := estimateHuggingFaceWeightBytes(info)
+	if detail.Method != "uint8_or_int8_storage" {
+		t.Errorf("method = %q, want uint8_or_int8_storage (U8 must win over BF16)", detail.Method)
+	}
+}
+
+func TestClassifyMethod_DtypeFallback_MXFP4Heuristic(t *testing.T) {
+	// U8 weights + F8_E8M0 scales without compressed-tensors metadata
+	// (e.g. some openai/gpt-oss variants) → "mxfp4", not "fp8".
+	body := `{
+        "id": "some/mxfp4-no-config",
+        "safetensors": {"parameters": {"U8": 30000000000, "F8_E8M0": 60000000, "BF16": 100000}}
+    }`
+	info := makeHFInfo(t, body)
+	_, detail := estimateHuggingFaceWeightBytes(info)
+	if detail.Method != "mxfp4" {
+		t.Errorf("method = %q, want mxfp4 (U8 + F8_E8M0 must beat plain fp8)", detail.Method)
+	}
+}
+
+func TestClassifyMethod_PureBF16StillWorks(t *testing.T) {
+	// Regression guard: a real BF16 model (Llama-3.1 style) must still come
+	// out as "bf16" after the reorder.
+	body := `{
+        "id": "meta-llama/Llama-3.1-8B-Instruct",
+        "safetensors": {"parameters": {"BF16": 8000000000, "F32": 1024}}
+    }`
+	info := makeHFInfo(t, body)
+	_, detail := estimateHuggingFaceWeightBytes(info)
+	if detail.Method != "bf16" {
+		t.Errorf("method = %q, want bf16 (pure half-precision model)", detail.Method)
+	}
+}

--- a/pkg/modelagent/scout.go
+++ b/pkg/modelagent/scout.go
@@ -37,8 +37,12 @@ type Scout struct {
 	nodeName               string
 	nodeInfo               *v1.Node
 	nodeShapeAlias         string
-	kubeClient             *kubernetes.Clientset
-	logger                 *zap.SugaredLogger
+	// availableVRAMBytes is the aggregate node VRAM looked up from
+	// nodeShapeAlias via the gpu-shape-memory-gb-map (total per-node GiB,
+	// not per-GPU). 0 means unknown (fail-open in Gopher's VRAM precheck).
+	availableVRAMBytes int64
+	kubeClient         *kubernetes.Clientset
+	logger             *zap.SugaredLogger
 }
 
 type TensorRTLLMShapeFilter struct {
@@ -76,6 +80,7 @@ func NewScout(ctx context.Context, nodeName string,
 		ctx:                    ctx,
 		nodeShapeAlias:         nodeShapeAlias,
 		nodeInfo:               nodeInfo,
+		availableVRAMBytes:     AvailableNodeVRAMBytes(nodeShapeAlias),
 		baseModelLister:        baseModelInformer.Lister(),
 		baseModelSynced:        baseModelInformer.Informer().HasSynced,
 		clusterBaseModelLister: clusterBaseModelInformer.Lister(),
@@ -250,6 +255,7 @@ func (w *Scout) downloadBaseModel(obj interface{}) {
 			w.logger.Errorf("Error getting the node info: %s, skipping download", err.Error())
 			return
 		}
+		w.availableVRAMBytes = AvailableNodeVRAMBytes(w.nodeShapeAlias)
 
 		w.logger.Infof("Downloading BaseModel: %s in namespace %s", baseModel.Name, baseModel.Namespace)
 
@@ -268,6 +274,8 @@ func (w *Scout) downloadBaseModel(obj interface{}) {
 				ShapeAlias:         w.nodeShapeAlias,
 				ModelType:          modelType,
 			},
+			AvailableVRAMBytes: w.availableVRAMBytes,
+			MultiNodeSharded:   isMultiNodeSharded(baseModel, nil),
 		}
 
 		w.gopherChan <- gopherTask
@@ -295,6 +303,7 @@ func (w *Scout) downloadClusterBaseModel(obj interface{}) {
 			w.logger.Errorf("Error getting the node info: %s, skipping download", err.Error())
 			return
 		}
+		w.availableVRAMBytes = AvailableNodeVRAMBytes(w.nodeShapeAlias)
 
 		w.logger.Infof("Downloading ClusterBaseModel: %s", clusterBaseModel.Name)
 
@@ -306,8 +315,10 @@ func (w *Scout) downloadClusterBaseModel(obj interface{}) {
 		}
 
 		gopherTask := &GopherTask{
-			TaskType:         Download,
-			ClusterBaseModel: clusterBaseModel,
+			TaskType:           Download,
+			ClusterBaseModel:   clusterBaseModel,
+			AvailableVRAMBytes: w.availableVRAMBytes,
+			MultiNodeSharded:   isMultiNodeSharded(nil, clusterBaseModel),
 			TensorRTLLMShapeFilter: &TensorRTLLMShapeFilter{
 				IsTensorrtLLMModel: IsTensorrtLLMModel,
 				ShapeAlias:         w.nodeShapeAlias,
@@ -709,8 +720,10 @@ func (w *Scout) generateDownloadOverrideTaskBasedOnClusterBaseModel(clusterBaseM
 	}
 
 	gopherTask := &GopherTask{
-		TaskType:         DownloadOverride,
-		ClusterBaseModel: clusterBaseModel,
+		TaskType:           DownloadOverride,
+		ClusterBaseModel:   clusterBaseModel,
+		AvailableVRAMBytes: w.availableVRAMBytes,
+		MultiNodeSharded:   isMultiNodeSharded(nil, clusterBaseModel),
 		TensorRTLLMShapeFilter: &TensorRTLLMShapeFilter{
 			IsTensorrtLLMModel: IsTensorrtLLMModel,
 			ShapeAlias:         w.nodeShapeAlias,
@@ -730,8 +743,10 @@ func (w *Scout) generateDownloadOverrideTaskBasedOnBaseModel(baseModel *v1beta1.
 		modelType = modelTypeFromMetadata
 	}
 	gopherTask := &GopherTask{
-		TaskType:  DownloadOverride,
-		BaseModel: baseModel,
+		TaskType:           DownloadOverride,
+		BaseModel:          baseModel,
+		AvailableVRAMBytes: w.availableVRAMBytes,
+		MultiNodeSharded:   isMultiNodeSharded(baseModel, nil),
 		TensorRTLLMShapeFilter: &TensorRTLLMShapeFilter{
 			IsTensorrtLLMModel: IsTensorrtLLMModel,
 			ShapeAlias:         w.nodeShapeAlias,


### PR DESCRIPTION
## What this PR does

The model-agent currently downloads any `BaseModel`/`ClusterBaseModel` that
satisfies its existing PVC / `NodeSelector` / `NodeAffinity` gates, even when
the model will never fit in the node's GPU VRAM. This wastes disk and
bandwidth and guarantees a pod-load failure later.

## Why we need it

This PR adds a VRAM precheck in Gopher that runs **between** the storage
listing step and the bulk download. When the estimated weight bytes (with a
configurable safety factor) exceed the node's aggregate VRAM, the download is
skipped, the metric `model_agent_downloads_skipped_total{reason="vram_insufficient"}`
fires, and a structured `StatusDetail` is persisted to the per-node ConfigMap
so the skip is observable end-to-end.

The gate is opt-out via the annotation `ome.oracle.com/multi-node-sharded: "true"`
for models that are intentionally split across nodes at serve time.

## How the size estimate works

Per-backend `RemoteSizeEstimator` interface, dispatched by storage type:

| Backend | Strategy |
|---|---|
| **OCI** | Inline: sum sizes returned by the existing `ListObjects` call, applying the same TensorRTLLM shape filter the bulk-download path uses (so per-shape subdirs don't over-count by N). |
| **HuggingFace** | One `/api/models/{id}?blobs=true` call → two-stage classifier (`format × method → strategy`) → byte estimate. See below. |
| **Local** | `filepath.WalkDir` + sum `info.Size()`. |
| **S3** | Stub (fail-open) with TODO; activated when bulk S3 downloads land. |
| **Vendor / PVC** | `(0, nil)` — no useful size signal, fail open. |

### HF classifier (Format × Method → Strategy)

`Format` is one of `diffusion / safetensors / gguf / bin / unknown`, picked
from `library_name`, `safetensors`, `gguf`, and sibling extensions. `Method`
is one of `awq / gptq / bitsandbytes / hqq / compressed-tensors / nvfp4 /
mxfp4 / fp8 / bf16 / fp32 / …`, picked from `config.quantization_config.{quant_method,format}`,
tags/name regex, GGUF filename quant tag, or dtype dominance.

Strategies:

- **`safetensors_dtype_count`** — `Σ count × bytes_per_dtype(d)` over the
  flat `safetensors.parameters` map, capped by `usedStorage` so AWQ's
  packed-int4-as-I32 over-count is absorbed without method-specific math.
- **`diffusion_component_sum`** — sum the best weight file per component
  subdir (`transformer/`, `unet/`, `vae/`, `text_encoder*/`,
  `image_encoder/`), preferring `.fp16.safetensors` so we estimate
  serve-time VRAM rather than disk.
- **`gguf_variant_max`** — group `.gguf` siblings by quant variant
  (Q4_K_M, Q8_0, …) and return the largest variant's total, so the gate
  doesn't under-block a user who picks the heaviest quant. Falls back to
  `gguf.total_file_size`.
- **`siblings_byte_sum`** — last-resort sum of weight-extension siblings.

Dtype byte table is validated against a top-300 + top-1000 HF survey:

| dtype | bytes/param | Notes |
|---|---|---|
| `F32`, `I32`, `U32` | 4 | I32 is always 4 (AWQ packed-int4-as-I32 caught by min cap; HQQ stores real fp32 metadata as I32). |
| `BF16`, `F16` | 2 | |
| `F8_E4M3`, `F8_E5M2`, `F8_E8M0` | 1 | |
| `I8`, `U8` | 1 | U8 is 1, not 0.5 — BnB / MXFP4 pre-pack two int4 into a uint8 and report the byte count. |
| `I64`, `F64` | 8 | |
| `BOOL` | 1 | |

`EstimateDetail{Format, Method, Strategy, UsedFallback}` is logged on every
gate decision and persisted in the skip `StatusDetail` so operators can see
exactly **why** a number came out where it did.

## Multi-node sharded models
A model annotated ome.oracle.com/multi-node-sharded: "true" bypasses the
VRAM gate entirely (Gopher logs the bypass and increments
model_agent_precheck_bypass_total{reason="multi_node_sharded"}). This is
the documented opt-out for models that are split across nodes at serve time
(e.g. a 405 B FP8 deployed 1/N across N nodes).

## Observability
New Prometheus counters:

model_agent_downloads_skipped_total{model_type, namespace, name, reason} — gate refused the download.
model_agent_precheck_bypass_total{model_type, namespace, name, reason} — gate intentionally skipped (multi_node_sharded, size_unknown).
Per-node StatusDetail written to the model-agent ConfigMap on skip:

```
{
  "name": "llama-3-1-70b-instruct",
  "status": "Failed",
  "statusDetail": {
    "reason": "VRAMInsufficient",
    "message": "estimated weight bytes 141G (× safety 1.20 → required 169G) exceed available VRAM 96G on this node",
    "requiredBytes": 169000000000,
    "availableVRAMBytes": 96000000000,
    "estimatedWeightBytes": 141000000000,
    "safetyFactor": 1.2,
    "format": "safetensors",
    "method": "bf16",
    "strategy": "safetensors_dtype_count"
  }
}
```

Top-level CR-status aggregation of these per-node reasons is out of scope
for this PR — it's a model-controller change tracked separately. This PR
only writes the detail.

##  Changes

- New `pkg/modelagent/gpu_memory.go` + test — env-var loader, AvailableNodeVRAMBytes, vramSafetyFactor.
- New `pkg/modelagent/remote_size.go` + test — RemoteSizeEstimator interface, HF classifier, per-backend implementations.
- Modified `pkg/modelagent/scout.go` — caches availableVRAMBytes, stamps AvailableVRAMBytes + MultiNodeSharded on every download/override task.
- Modified `pkg/modelagent/gopher.go` — GopherTask fields, vramPrecheck / applyVRAMGate / markModelOnNodeSkipped helpers; inline OCI gate after ListObjects; TRT-LLM shape filter extracted into a helper.
- Modified `pkg/modelagent/model_data.go` — MultiNodeShardedAnnotation, isMultiNodeSharded, StatusDetail type, ModelEntry.StatusDetail field.
- Modified `pkg/modelagent/node_label_reconciler.go` + configmap_reconciler.go — StatusDetail plumbed through NodeLabelOp → ConfigMapStatusOp → cache → ConfigMap writes.
- Modified `pkg/modelagent/metrics.go` — RecordSkippedDownload, RecordPrecheckBypass.
- Modified `Helm` + `config/model-agent` ConfigMap and DaemonSet manifests.

Fixes #

## How to test

### Test On A100-40G node with large model llama-4-maverick-17b-128e-instruct-fp8 download from oci object storage:
```
Skipping download for ClusterBaseModel llama-4-maverick-17b-128e-instruct-fp8: required=500147599614 bytes > available VRAM=343597383680 bytes (estimated_weights=416789666345, safety=1.20, format=unknown, method=none, strategy=oci_list_sum)
```

### Test on A100-40G node with large model llama-4-maverick-17b-128e-instruct-fp8 download from HF:
```
Skipping download for ClusterBaseModel llama-4-maverick-17b-128e-instruct-fp8: required=500103152025 bytes > available VRAM=343597383680 bytes (estimated_weights=416752626688, safety=1.20, format=safetensors, method=fp8, strategy=safetensors_dtype_count)
```
Different estimated_weights caused by the different estimate function above.

### Test On A100-40G node with large model llama-4-maverick-17b-128e-instruct-fp8 download from oci object storage with "ome.io/multi-node-sharded" annotation:
```
VRAM precheck skipped for ClusterBaseModel llama-4-maverick-17b-128e-instruct-fp8: ome.io/multi-node-sharded annotation set; multi-node sharding active
```

### Test On A100-40G node with large model llama-4-maverick-17b-128e-instruct-fp8 download from HF with "ome.io/multi-node-sharded" annotation:
```
VRAM precheck skipped for ClusterBaseModel llama-4-maverick-17b-128e-instruct-fp8: ome.io/multi-node-sharded annotation set; multi-node sharding active
```

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
