### PR TITLE
[Core] Recognize compressed-tensors as a quantization method

### DIFF
--- a/pkg/apis/ome/v1beta1/model.go
+++ b/pkg/apis/ome/v1beta1/model.go
@@ -274,6 +274,13 @@ const (
 	// the OpenAI gpt-oss family; declared via quant_method=mxfp4 in
 	// quantization_config inside config.json.
 	ModelQuantizationMXFP4 ModelQuantization = "mxfp4"
+	// ModelQuantizationCompressedTensors is the compressed-tensors
+	// container format (vLLM / llm-compressor). Unlike the values above it
+	// names a FORMAT, not a precision: the actual bit-width (FP8 / INT8 /
+	// INT4 / ...) is declared per-group in
+	// quantization_config.config_groups. Declared via
+	// quant_method="compressed-tensors" in config.json.
+	ModelQuantizationCompressedTensors ModelQuantization = "compressed-tensors"
 )
 
 // ModelCapability enum

--- a/pkg/modelparser/config_parser_test.go
+++ b/pkg/modelparser/config_parser_test.go
@@ -162,6 +162,26 @@ func TestExtractModelMetadataFromHF(t *testing.T) {
 			expectedQuantization: v1beta1.ModelQuantizationFP8,
 		},
 		{
+			name: "Compressed-Tensors Model",
+			mockModel: &mockHuggingFaceModel{
+				modelType:          "llama",
+				architecture:       "LlamaForCausalLM",
+				parameterCount:     8000000000, // 8B
+				contextLength:      131072,
+				transformerVersion: "4.44.0",
+				quantizationType:   "compressed-tensors",
+				torchDtype:         "bfloat16",
+				modelSizeBytes:     8000000000,
+				hasVision:          false,
+			},
+			expectedMetadata: func(metadata ModelMetadata) bool {
+				return metadata.ModelType == "llama" &&
+					metadata.ModelArchitecture == "LlamaForCausalLM"
+			},
+			expectedCapability:   string(v1beta1.ModelCapabilityTextToText),
+			expectedQuantization: v1beta1.ModelQuantizationCompressedTensors,
+		},
+		{
 			name: "Vision Model",
 			mockModel: &mockHuggingFaceModel{
 				modelType:          "clip",

--- a/pkg/modelparser/quant.go
+++ b/pkg/modelparser/quant.go
@@ -33,6 +33,10 @@ func QuantAlgoToOMEEnum(s string) v1beta1.ModelQuantization {
 		// fbgemm_fp8 is matched above; this is the catch-all for plain
 		// fp8, fp8_per_tensor, fp8_e4m3, etc.
 		return v1beta1.ModelQuantizationFP8
+	case v == "compressed-tensors" || v == "compressed_tensors":
+		// Container format (vLLM / llm-compressor); names the format, not
+		// the precision (which lives in config_groups, currently unparsed).
+		return v1beta1.ModelQuantizationCompressedTensors
 	}
 	return ""
 }

--- a/pkg/modelparser/quant_test.go
+++ b/pkg/modelparser/quant_test.go
@@ -33,11 +33,16 @@ func TestQuantAlgoToOMEEnum(t *testing.T) {
 		{name: "OCP MXFP4", in: "MXFP4", want: v1beta1.ModelQuantizationMXFP4},
 		{name: "lowercase mxfp4", in: "mxfp4", want: v1beta1.ModelQuantizationMXFP4},
 
+		// compressed-tensors container format (vLLM / llm-compressor) —
+		// label only; the precision lives in config_groups, not the name.
+		{name: "compressed-tensors hyphen", in: "compressed-tensors", want: v1beta1.ModelQuantizationCompressedTensors},
+		{name: "compressed_tensors underscore", in: "compressed_tensors", want: v1beta1.ModelQuantizationCompressedTensors},
+		{name: "compressed-tensors mixed case", in: "Compressed-Tensors", want: v1beta1.ModelQuantizationCompressedTensors},
+
 		// Negatives
 		{name: "empty string", in: "", want: ""},
 		{name: "whitespace only", in: "   ", want: ""},
 		{name: "unknown algorithm", in: "some-future-quant-format", want: ""},
-		{name: "unrelated string", in: "compressed-tensors", want: ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What this PR does

Maps the compressed-tensors quant method to a new ModelQuantization enum value so models quantized with vLLM / llm-compressor (e.g. meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8) surface spec.quantization: compressed-tensors instead of being left empty. Small, additive follow-up to the model-parser refactor (#635).

## Why we need it

#635  already taught modelconfig to recognize quant_method: "compressed-tensors" (it surfaces QuantAlgo = "compressed-tensors" and counts FP8 params correctly), and shipped a fixture for it (testdata/quant/compressed-tensors-llama-3-1-8b). But the final hop was missing: QuantAlgoToOMEEnum("compressed-tensors") returned "", so the parser left spec.quantization unset and logged "unrecognized quant_algo" for every compressed-tensors model. This completes that chain.

## What changed
`model.go` — new enum value ModelQuantizationCompressedTensors = "compressed-tensors". The doc comment is explicit that this names a container format, not a precision — the actual bit-width (FP8 / INT8 / INT4) lives per-group in quantization_config.config_groups.
`quant.go` — QuantAlgoToOMEEnum now maps compressed-tensors / compressed_tensors (case-insensitive) → the new enum.
`quant_test.go` flips the old negative case into three positives (hyphen / underscore / mixed-case.
`config_parser_test.go` adds an end-to-end row asserting a compressed-tensors model resolves the enum through applyQuantizationFromConfig.

## Known limitation (unchanged, called out for reviewers)
Packed int4 compressed-tensors models still under-count, because config_groups isn't parsed, so the packing factor can't be derived from num_bits. That gap predates this PR and is orthogonal to the label; closing it (read config_groups[*].weights.num_bits into QuantPackingFactor) is a separate change.

## Compatibility
Additive enum value only. ModelQuantization has no kubebuilder validation enum, so no CRD regeneration, and no code switches exhaustively on the enum.

Fixes #

## How to test

- go build ./... — clean
- go test ./pkg/modelparser/... ./pkg/apis/ome/v1beta1/... ./pkg/modelconfig/... — all pass
- go vet — clean

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
