### PR TITLE
[Core] add runtime revision support in isvc

### DIFF
--- a/charts/ome-resources/templates/ome-controller/webhooks/controllerrevisionvalidator.yaml
+++ b/charts/ome-resources/templates/ome-controller/webhooks/controllerrevisionvalidator.yaml
@@ -1,0 +1,39 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: controllerrevision-immutability.ome.io
+  annotations:
+    cert-manager.io/inject-ca-from: ome/serving-cert
+webhooks:
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: ome-webhook-server-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-apps-v1-controllerrevision
+    failurePolicy: Ignore
+    name: controllerrevision-immutability.ome-webhook-server.validator
+    # Scope to OME's own namespace: every OME-written runtime-revision lives
+    # here, so this covers 100% of them while leaving StatefulSet/DaemonSet
+    # ControllerRevisions in every other namespace untouched (the apiserver
+    # filters them out before ever calling the webhook).
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace }}
+    sideEffects: None
+    # Fail-open (Ignore) + a short timeout: a wedged webhook server adds at
+    # most 5s to an in-namespace ControllerRevision UPDATE, then admits it.
+    # The webhook is defense-in-depth (K8s already enforces .data/.revision
+    # immutability natively), so a brief gap only skips the .labels check.
+    timeoutSeconds: 5
+    admissionReviewVersions: ["v1"]
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - controllerrevisions

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	kedav1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	ray "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -44,12 +45,14 @@ import (
 	v1beta1benchmarkjobcontroller "sigs.k8s.io/ome/pkg/controller/v1beta1/benchmark"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
 	v1beta1isvccontroller "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice"
+	v1beta1runtimerevisioncontroller "sigs.k8s.io/ome/pkg/controller/v1beta1/runtimerevision"
 	"sigs.k8s.io/ome/pkg/runtimeselector"
 	"sigs.k8s.io/ome/pkg/utils"
 	"sigs.k8s.io/ome/pkg/version"
 	"sigs.k8s.io/ome/pkg/webhook/admission/benchmark"
 	"sigs.k8s.io/ome/pkg/webhook/admission/isvc"
 	"sigs.k8s.io/ome/pkg/webhook/admission/pod"
+	runtimerevisionwebhook "sigs.k8s.io/ome/pkg/webhook/admission/runtimerevision"
 	"sigs.k8s.io/ome/pkg/webhook/admission/servingruntime"
 )
 
@@ -92,28 +95,32 @@ func init() {
 
 // Options defines the program-configurable options that may be passed on the command line.
 type Options struct {
-	metricsAddr             string
-	secureMetrics           bool
-	enableHTTP2             bool
-	webhookPort             int
-	enableLeaderElection    bool
-	enableWebhook           bool
-	probeAddr               string
-	leaderElectionNamespace string
-	zapOpts                 zap.Options
+	metricsAddr                string
+	secureMetrics              bool
+	enableHTTP2                bool
+	webhookPort                int
+	enableLeaderElection       bool
+	enableWebhook              bool
+	probeAddr                  string
+	leaderElectionNamespace    string
+	runtimeRevisionRetention   int
+	runtimeRevisionGracePeriod time.Duration
+	zapOpts                    zap.Options
 }
 
 // DefaultOptions returns the default values for the program options.
 func DefaultOptions() Options {
 	return Options{
-		metricsAddr:             ":8080",
-		webhookPort:             9443,
-		enableLeaderElection:    false,
-		enableWebhook:           false,
-		enableHTTP2:             false,
-		secureMetrics:           false,
-		probeAddr:               ":8081",
-		leaderElectionNamespace: LeaderElectionNamespace,
+		metricsAddr:                ":8080",
+		webhookPort:                9443,
+		enableLeaderElection:       false,
+		enableWebhook:              false,
+		enableHTTP2:                false,
+		secureMetrics:              false,
+		probeAddr:                  ":8081",
+		leaderElectionNamespace:    LeaderElectionNamespace,
+		runtimeRevisionRetention:   10,
+		runtimeRevisionGracePeriod: 24 * time.Hour,
 		zapOpts: zap.Options{
 			TimeEncoder: zapcore.RFC3339TimeEncoder,
 			ZapOpts:     []zaplog.Option{zaplog.AddCaller()},
@@ -137,6 +144,10 @@ func GetOptions() Options {
 	flag.StringVar(&opts.leaderElectionNamespace, "leader-election-namespace", opts.leaderElectionNamespace, "The namespace in which the leader election configmap will be created.")
 	flag.BoolVar(&opts.enableWebhook, "webhook", opts.enableWebhook, "Enable the webhook server.")
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
+	flag.IntVar(&opts.runtimeRevisionRetention, "runtime-revision-retention", opts.runtimeRevisionRetention,
+		"Number of ControllerRevision snapshots to retain per source runtime before garbage collection.")
+	flag.DurationVar(&opts.runtimeRevisionGracePeriod, "runtime-revision-grace-period", opts.runtimeRevisionGracePeriod,
+		"How long a runtime-revision snapshot must stay unreferenced and over-retention before GC deletes it.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 	return opts
@@ -306,6 +317,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	setupLog.Info("Setting up runtime-revision GC controller",
+		"retention", options.runtimeRevisionRetention,
+		"gracePeriod", options.runtimeRevisionGracePeriod)
+	if err = (&v1beta1runtimerevisioncontroller.GCReconciler{
+		Client:              mgr.GetClient(),
+		Log:                 ctrl.Log.WithName("RuntimeRevisionGC"),
+		Scheme:              mgr.GetScheme(),
+		OMENamespace:        constants.OMENamespace,
+		RetentionPerRuntime: options.runtimeRevisionRetention,
+		GracePeriod:         options.runtimeRevisionGracePeriod,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Failed to create runtime-revision GC controller")
+		os.Exit(1)
+	}
+
 	if options.enableWebhook {
 		setupLog.Info("Configuring webhook server", "port", options.webhookPort)
 		hookServer := mgr.GetWebhookServer()
@@ -328,6 +354,11 @@ func main() {
 		setupLog.Info("Registering benchmark job validator webhook to the webhook server")
 		hookServer.Register("/validate-ome-io-v1beta1-benchmarkjob", &webhook.Admission{
 			Handler: &benchmark.BenchmarkJobValidator{Client: mgr.GetClient(), Decoder: admission.NewDecoder(mgr.GetScheme())},
+		})
+
+		setupLog.Info("Registering ControllerRevision immutability validator webhook to the webhook server")
+		hookServer.Register("/validate-apps-v1-controllerrevision", &webhook.Admission{
+			Handler: &runtimerevisionwebhook.ImmutabilityValidator{Decoder: admission.NewDecoder(mgr.GetScheme())},
 		})
 
 		if err = ctrl.NewWebhookManagedBy(mgr).

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -113,6 +113,36 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
+  name: controllerrevision-immutability.ome.io
+webhooks:
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: $(webhookServiceName)
+        namespace: $(omeNamespace)
+        path: /validate-apps-v1-controllerrevision
+    failurePolicy: Ignore
+    name: controllerrevision-immutability.ome-webhook-server.validator
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: $(omeNamespace)
+    sideEffects: None
+    timeoutSeconds: 5
+    admissionReviewVersions: ["v1"]
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - controllerrevisions
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
   name: capacityreservation.ome.io
 webhooks:
   - clientConfig:

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -231,21 +231,40 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// Validate specified runtime
 		rtName = isvc.Spec.Runtime.Name
 		userSpecifiedRuntime = true
-		if err := r.RuntimeSelector.ValidateRuntime(ctx, rtName, baseModel, isvc); err != nil {
-			r.Log.Error(err, "Runtime validation failed", "runtime", rtName, "model", isvc.Spec.Model.Name)
-			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeValidationError",
-				"Runtime %s does not support model %s: %v", rtName, isvc.Spec.Model.Name, err)
-			return reconcile.Result{}, err
-		}
 
-		// Get the runtime spec using selector
-		rtSpec, _, err := r.RuntimeSelector.GetRuntime(ctx, rtName, isvc.Namespace)
-		if err != nil {
-			r.Log.Error(err, "Failed to get runtime spec", "runtime", rtName)
-			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeFetchError", err.Error())
-			return reconcile.Result{}, err
+		if isvc.Spec.Runtime.AutoSync != nil && !*isvc.Spec.Runtime.AutoSync {
+			// Pinning opt-in (autoSync=false): resolve the runtime spec from the
+			// pinned ControllerRevision snapshot instead of the live runtime. The
+			// pin helper handles first-reconcile create, drift detection, and the
+			// ome.io/runtime-sync ack, and persists status itself when children
+			// must be skipped.
+			pin, perr := r.resolvePinnedRuntime(ctx, isvc)
+			if perr != nil {
+				r.Log.Error(perr, "Pin resolution failed", "runtime", rtName)
+				r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimePinError", perr.Error())
+				return reconcile.Result{}, perr
+			}
+			if pin.skipChildren {
+				return reconcile.Result{}, nil
+			}
+			rt = pin.spec
+		} else {
+			if err := r.RuntimeSelector.ValidateRuntime(ctx, rtName, baseModel, isvc); err != nil {
+				r.Log.Error(err, "Runtime validation failed", "runtime", rtName, "model", isvc.Spec.Model.Name)
+				r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeValidationError",
+					"Runtime %s does not support model %s: %v", rtName, isvc.Spec.Model.Name, err)
+				return reconcile.Result{}, err
+			}
+
+			// Get the runtime spec using selector
+			rtSpec, _, err := r.RuntimeSelector.GetRuntime(ctx, rtName, isvc.Namespace)
+			if err != nil {
+				r.Log.Error(err, "Failed to get runtime spec", "runtime", rtName)
+				r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeFetchError", err.Error())
+				return reconcile.Result{}, err
+			}
+			rt = rtSpec
 		}
-		rt = rtSpec
 	} else {
 		// Auto-select runtime
 		selection, err := r.RuntimeSelector.SelectRuntime(ctx, baseModel, isvc)

--- a/pkg/controller/v1beta1/inferenceservice/pinning.go
+++ b/pkg/controller/v1beta1/inferenceservice/pinning.go
@@ -1,0 +1,215 @@
+package inferenceservice
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	knapis "knative.dev/pkg/apis"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimerevision"
+)
+
+// pinResult tells the caller how to proceed after the pinning helper
+// runs. When skipChildren is true, the helper has already mutated +
+// persisted the ISVC status; the caller returns without reconciling
+// engine/decoder/router/etc.
+type pinResult struct {
+	spec         *v1beta1.ServingRuntimeSpec
+	skipChildren bool
+}
+
+// resolvePinnedRuntime fetches the runtime spec via the
+// ControllerRevision pin. Called only when spec.runtime.autoSync is
+// false.
+//
+//   - First reconcile (no PinnedRevisionName yet) → resolve live
+//     spec, find-or-create a revision, save the pin.
+//   - Subsequent reconcile, matching hash → fetch the pinned
+//     revision, use as-is.
+//   - Subsequent reconcile, mismatched hash:
+//   - ome.io/runtime-sync annotation bumped → advance the pin to a
+//     fresh revision of the live spec, clear drift.
+//   - Otherwise → set RuntimeDrifted=True, skip children.
+//   - Explicit spec.runtime.revision set → fetch that revision; if
+//     missing, RuntimeDrifted=True (Reason=RevisionMissing) + skip.
+func (r *InferenceServiceReconciler) resolvePinnedRuntime(
+	ctx context.Context,
+	isvc *v1beta1.InferenceService,
+) (pinResult, error) {
+	runtimeName := isvc.Spec.Runtime.Name
+	kind := sourceKindFor(isvc.Spec.Runtime)
+	sourceNS := sourceNamespaceFor(isvc, kind)
+	omeNS := constants.OMENamespace
+
+	// Resolve the LIVE spec once — needed for hash compare, and to
+	// seed the first-reconcile pin / advance on ack.
+	liveSpec, _, err := r.RuntimeSelector.GetRuntime(ctx, runtimeName, isvc.Namespace)
+	if err != nil {
+		return pinResult{}, fmt.Errorf("resolve live runtime %s: %w", runtimeName, err)
+	}
+	_, liveHash, err := runtimerevision.Hash(liveSpec)
+	if err != nil {
+		return pinResult{}, err
+	}
+
+	// Explicit revision pin overrides everything else.
+	if isvc.Spec.Runtime.Revision != nil && *isvc.Spec.Runtime.Revision != "" {
+		pinName := *isvc.Spec.Runtime.Revision
+		rev, err := runtimerevision.FetchRevision(ctx, r.Client, omeNS, pinName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return r.driftAndSkip(ctx, isvc, "RevisionMissing",
+					fmt.Sprintf("explicit pin %s not found in namespace %s", pinName, omeNS))
+			}
+			return pinResult{}, err
+		}
+		// Defense in depth: the webhook should have caught a wrong-runtime
+		// pin at admission, but if a revision was renamed or relabeled,
+		// surface it here instead of silently using another runtime's spec.
+		if got := rev.Labels[constants.RuntimeRevisionOfLabelKey]; got != runtimeName {
+			return r.driftAndSkip(ctx, isvc, "RuntimeMismatch",
+				fmt.Sprintf("revision %s belongs to runtime %q but ISVC references %q",
+					pinName, got, runtimeName))
+		}
+		pinned, err := runtimerevision.DecodeSpec(rev)
+		if err != nil {
+			return pinResult{}, err
+		}
+		isvc.Status.PinnedRevisionName = pinName
+		clearRuntimeDriftedCondition(isvc)
+		return pinResult{spec: pinned}, nil
+	}
+
+	// First reconcile: nothing pinned yet → create-or-find from live.
+	if isvc.Status.PinnedRevisionName == "" {
+		revName, err := runtimerevision.FindOrCreate(ctx, r.Client, omeNS, kind, sourceNS, runtimeName, liveSpec)
+		if err != nil {
+			return pinResult{}, fmt.Errorf("create initial pin for %s: %w", runtimeName, err)
+		}
+		isvc.Status.PinnedRevisionName = revName
+		isvc.Status.LastRuntimeSyncToken = isvc.Annotations[constants.RuntimeSyncAnnotationKey]
+		clearRuntimeDriftedCondition(isvc)
+		return pinResult{spec: liveSpec}, nil
+	}
+
+	// Already pinned: fetch the pinned revision; missing → drift.
+	pinned, err := runtimerevision.Fetch(ctx, r.Client, omeNS, isvc.Status.PinnedRevisionName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return r.driftAndSkip(ctx, isvc, "RevisionMissing",
+				fmt.Sprintf("pinned revision %s missing from %s", isvc.Status.PinnedRevisionName, omeNS))
+		}
+		return pinResult{}, err
+	}
+	_, pinnedHash, err := runtimerevision.Hash(pinned)
+	if err != nil {
+		return pinResult{}, err
+	}
+
+	if liveHash == pinnedHash {
+		clearRuntimeDriftedCondition(isvc)
+		return pinResult{spec: pinned}, nil
+	}
+
+	// Hashes differ → drift. Check if user acked.
+	currentToken := isvc.Annotations[constants.RuntimeSyncAnnotationKey]
+	if currentToken != "" && currentToken != isvc.Status.LastRuntimeSyncToken {
+		revName, err := runtimerevision.FindOrCreate(ctx, r.Client, omeNS, kind, sourceNS, runtimeName, liveSpec)
+		if err != nil {
+			return pinResult{}, fmt.Errorf("advance pin for %s: %w", runtimeName, err)
+		}
+		isvc.Status.PinnedRevisionName = revName
+		isvc.Status.LastRuntimeSyncToken = currentToken
+		clearRuntimeDriftedCondition(isvc)
+		return pinResult{spec: liveSpec}, nil
+	}
+
+	return r.driftAndSkip(ctx, isvc, "RevisionMismatch",
+		fmt.Sprintf("pinned %s, live spec differs; bump %s annotation to advance",
+			isvc.Status.PinnedRevisionName, constants.RuntimeSyncAnnotationKey))
+}
+
+// driftAndSkip sets RuntimeDrifted=True, persists the status, and
+// returns a pinResult that tells the caller to skip children
+// reconciliation. Persists immediately because the caller bails out
+// before the normal end-of-reconcile status update path runs.
+func (r *InferenceServiceReconciler) driftAndSkip(
+	ctx context.Context,
+	isvc *v1beta1.InferenceService,
+	reason, message string,
+) (pinResult, error) {
+	setRuntimeDriftedCondition(isvc, v1.ConditionTrue, reason, message)
+	if err := r.Status().Update(ctx, isvc); err != nil {
+		if apierrors.IsConflict(err) {
+			// Next reconcile will retry; safe to swallow.
+			return pinResult{skipChildren: true}, nil
+		}
+		return pinResult{}, fmt.Errorf("persist RuntimeDrifted: %w", err)
+	}
+	return pinResult{skipChildren: true}, nil
+}
+
+// sourceKindFor returns the SourceKind based on the runtime ref's
+// Kind field. Defaults to ClusterServingRuntime to match the field's
+// kubebuilder default.
+func sourceKindFor(ref *v1beta1.ServingRuntimeRef) runtimerevision.SourceKind {
+	if ref == nil || ref.Kind == nil || *ref.Kind == string(runtimerevision.KindClusterServingRuntime) {
+		return runtimerevision.KindClusterServingRuntime
+	}
+	return runtimerevision.KindServingRuntime
+}
+
+// sourceNamespaceFor returns the source-runtime namespace for revision
+// naming. Empty when cluster-scoped; the ISVC's own namespace when
+// namespaced (ServingRuntimes only live alongside ISVCs that reference
+// them).
+func sourceNamespaceFor(isvc *v1beta1.InferenceService, kind runtimerevision.SourceKind) string {
+	if kind == runtimerevision.KindClusterServingRuntime {
+		return ""
+	}
+	return isvc.Namespace
+}
+
+// setRuntimeDriftedCondition upserts the RuntimeDrifted condition in
+// the ISVC's knative-style conditions slice without disturbing other
+// conditions (EngineReady, DecoderReady, Ready, …).
+func setRuntimeDriftedCondition(isvc *v1beta1.InferenceService, status v1.ConditionStatus, reason, message string) {
+	now := knapis.VolatileTime{Inner: metav1.Now()}
+	conds := isvc.Status.Conditions
+	for i, c := range conds {
+		if string(c.Type) == constants.RuntimeDriftedConditionType {
+			if c.Status != status || c.Reason != reason || c.Message != message {
+				conds[i].Status = status
+				conds[i].Reason = reason
+				conds[i].Message = message
+				conds[i].LastTransitionTime = now
+			}
+			isvc.Status.Conditions = conds
+			return
+		}
+	}
+	isvc.Status.Conditions = append(conds, knapis.Condition{
+		Type:               knapis.ConditionType(constants.RuntimeDriftedConditionType),
+		Status:             status,
+		LastTransitionTime: now,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+// clearRuntimeDriftedCondition removes RuntimeDrifted entirely.
+func clearRuntimeDriftedCondition(isvc *v1beta1.InferenceService) {
+	conds := isvc.Status.Conditions
+	out := conds[:0]
+	for _, c := range conds {
+		if string(c.Type) != constants.RuntimeDriftedConditionType {
+			out = append(out, c)
+		}
+	}
+	isvc.Status.Conditions = out
+}

--- a/pkg/runtimerevision/store.go
+++ b/pkg/runtimerevision/store.go
@@ -60,7 +60,7 @@ func FindOrCreate(
 			},
 		},
 		Data:     runtime.RawExtension{Raw: specBytes},
-		Revision: 1, // Phase 3 GC will set this to a monotonic counter; Phase 1 doesn't rely on it.
+		Revision: 1, // Unused: OME identifies revisions by content hash (name + revision-hashlabel) and orders GC by CreationTimestamp. Kept as a valid non-zero value the ControllerRevision API requires.
 	}
 	if err := c.Create(ctx, rev); err != nil {
 		// A concurrent writer raced us; resolve to the existing name.

--- a/pkg/webhook/admission/isvc/inference_service_validation.go
+++ b/pkg/webhook/admission/isvc/inference_service_validation.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
 	isvcutils "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils"
+	"sigs.k8s.io/ome/pkg/runtimerevision"
 	"sigs.k8s.io/ome/pkg/runtimeselector"
 )
 
@@ -104,6 +105,11 @@ func (v *InferenceServiceValidator) validateInferenceService(ctx context.Context
 
 	// New validation logic for Engine/Decoder architecture
 	if err := validateEngineDecoderConfiguration(isvc); err != nil {
+		return allWarnings, err
+	}
+
+	// Reject malformed explicit runtime-revision pins early.
+	if err := validateRuntimePin(isvc); err != nil {
 		return allWarnings, err
 	}
 
@@ -358,6 +364,53 @@ func (v *InferenceServiceValidator) validateModelExists(ctx context.Context, isv
 	}
 
 	return nil
+}
+
+// validateRuntimePin rejects malformed explicit ControllerRevision pins
+// at admission. The full existence check is left to reconcile (the
+// webhook can't reliably reach across cluster scope), but the cheap
+// shape checks happen here:
+//
+//   - spec.runtime.revision is meaningful only when autoSync is false;
+//     setting it with autoSync=true (default) is a confused-user
+//     signal worth surfacing immediately.
+//   - The revision name must conform to the convention for the named
+//     runtime's kind + scope; an obviously-wrong name (e.g., pinning
+//     to runtime A but naming a revision of runtime B) is rejected
+//     before the controller ever sees it.
+func validateRuntimePin(isvc *v1beta1.InferenceService) error {
+	if isvc.Spec.Runtime == nil || isvc.Spec.Runtime.Revision == nil || *isvc.Spec.Runtime.Revision == "" {
+		return nil
+	}
+	if isvc.Spec.Runtime.AutoSync == nil || *isvc.Spec.Runtime.AutoSync {
+		return fmt.Errorf(
+			"spec.runtime.revision requires spec.runtime.autoSync=false; AutoSync=true would silently ignore the pin")
+	}
+	kind := runtimerevision.KindClusterServingRuntime
+	sourceNS := ""
+	if isvc.Spec.Runtime.Kind != nil && *isvc.Spec.Runtime.Kind == string(runtimerevision.KindServingRuntime) {
+		kind = runtimerevision.KindServingRuntime
+		sourceNS = isvc.Namespace
+	}
+	revName := *isvc.Spec.Runtime.Revision
+	if !runtimerevision.MatchesRuntime(revName, kind, sourceNS, isvc.Spec.Runtime.Name) {
+		return fmt.Errorf(
+			"spec.runtime.revision %q does not match the expected naming convention for runtime %q (%s); "+
+				"expected the form %s",
+			revName, isvc.Spec.Runtime.Name, kind, expectedPinPattern(kind, sourceNS, isvc.Spec.Runtime.Name))
+	}
+	return nil
+}
+
+func expectedPinPattern(kind runtimerevision.SourceKind, sourceNS, runtimeName string) string {
+	switch kind {
+	case runtimerevision.KindClusterServingRuntime:
+		return fmt.Sprintf("cr-%s-<8 lowercase hex chars>", runtimeName)
+	case runtimerevision.KindServingRuntime:
+		return fmt.Sprintf("r-%s-%s-<8 lowercase hex chars>", sourceNS, runtimeName)
+	default:
+		return "<unknown kind>"
+	}
 }
 
 // validateRuntimeAndModelResolution validates runtime and model resolution for new architecture


### PR DESCRIPTION
## What this PR does

Activates the **runtime-revision snapshot** feature whose machinery landed dormant in #639. With `spec.runtime.autoSync=false`, an `InferenceService` now pins to an immutable `ControllerRevision` snapshot of its `ServingRuntime` spec and reconciles against that — instead of re-rendering from the live runtime every loop — with drift detection and an `ome.io/runtime-sync` ack to roll forward.

## Changes

**Reconciler**
- New `pinning.go`: `resolvePinnedRuntime` + `RuntimeDrifted` condition helpers — first-reconcile create-or-find, explicit `spec.runtime.revision` pin, hash-based drift detection, sync-token ack.
- `controller.go`: in the runtime-resolution step, call `resolvePinnedRuntime` when `autoSync=false`. The live-runtime path is untouched for the default.

**Admission**
- `validateRuntimePin` in the ISVC validating webhook rejects malformed explicit pins early (revision with `autoSync=true`, or a revision name that can't belong to the named runtime).

**Manager**
- Runs the runtime-revision GC controller (retention **10/runtime**, **24h** grace — flag-configurable via `--runtime-revision-retention` / `--runtime-revision-grace-period`).
- Registers the `ControllerRevision` immutability webhook handler.

**Webhook manifest** (Helm + kustomize)
- `ValidatingWebhookConfiguration` scoped to the OME namespace (`namespaceSelector`), `failurePolicy: Ignore`, `timeoutSeconds: 5`. Defense-in-depth — K8s already enforces `.data`/`.revision` immutability, so this only adds the `.labels` check, with no cluster-wide blast radius if the webhook server is down.

## Scope / safety
- **Opt-in:** default `autoSync=true` preserves today's behavior.
- **Mode-agnostic:** pinning resolves before deployment-mode branching.
- **Auto-selected runtimes never pin** (no named runtime = no anchor).

Fixes #

## How to test

- [x] `go build ./cmd/manager/... ./pkg/...`
- [x] `go vet` (manager, inferenceservice, isvc webhook)
- [x] inferenceservice + all subpackages (envtest) — pass
- [x] isvc webhook — pass (no regression from `validateRuntimePin`)
- [x] `helm lint charts/ome-resources` — pass; template renders with namespace scoping
- [x] `kubectl kustomize config/default` — parses clean

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
