### PR TITLE
[Misc] Harden xet cargo build against transient network failures

### DIFF
--- a/dockerfiles/model-agent.Dockerfile
+++ b/dockerfiles/model-agent.Dockerfile
@@ -37,8 +37,13 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-# Build the XET library first
-RUN cd pkg/xet && make build
+# Build the XET library first.
+# Cache the cargo registry and git checkouts across builds so crates and the
+# huggingface/xet-core git deps aren't re-downloaded on every rebuild — faster
+# and resilient to transient network failures (e.g. curl [18] partial file).
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    cd pkg/xet && make build
 
 # Verify static library exists and remove dynamic library to force static linking
 RUN ls -lh /workspace/pkg/xet/target/release/libxet.* && \

--- a/pkg/xet/.cargo/config.toml
+++ b/pkg/xet/.cargo/config.toml
@@ -1,0 +1,12 @@
+# Network resilience for cargo in CI / Docker builds.
+#
+# Fixes transient "curl [18] Transferred a partial file" failures when
+# downloading crates: HTTP/2 multiplexing is the common trigger, so force
+# HTTP/1.1, retry transient drops a few times, and fetch the huggingface/xet-core git
+# dependencies via the system git client (more robust than libgit2).
+[net]
+retry = 4
+git-fetch-with-cli = true
+
+[http]
+multiplexing = false


### PR DESCRIPTION
## What this PR does
The `model-agent` image build intermittently fails while compiling the
`pkg/xet` Rust library because a crate download gets cut off mid-transfer.
This hardens the cargo build against transient network failures and speeds
up rebuilds by caching downloads.
## Why we need it

`make model-agent-image` fails non-deterministically at the XET build step:

```
error: failed to get async-trait as a dependency of package ome-xet-binding
Caused by: download of as/yn/async-trait failed
Caused by: curl failed
Caused by: [18] Transferred a partial file
```



curl error 18 (`CURLE_PARTIAL_FILE`) means the connection delivered fewer
bytes than expected. It succeeds on retry, so it's transport-level — not a
bad dependency.

## Root cause

- cargo downloads crates over **HTTP/2 with multiplexing** by default; on
  flaky networks / proxies / Docker bridges, a dropped multiplexed stream
  truncates a download → curl-18.
- The build had **no retry tuning** (cargo default `net.retry = 2`) and
  **no fetch caching**, so a single blip aborts the whole image build and
  every rebuild re-downloads everything.

## Changes

**`pkg/xet/.cargo/config.toml`** (new)

| Setting | Why |
|---|---|
| `http.multiplexing = false` | Force HTTP/1.1 — removes the curl-18 trigger (primary fix) |
| `net.retry = 4` | Tolerate transient blips; 2× cargo's default, low enough to surface real infra issues |
| `net.git-fetch-with-cli = true` | Use system git for the `huggingface/xet-core` git deps (more robust than libgit2) |

**`dockerfiles/model-agent.Dockerfile`**

- Cache-mount `/root/.cargo/registry` and `/root/.cargo/git` for the XET
  build step, so crates and git deps aren't re-downloaded on rebuild
  (faster + resilient). `target/` is intentionally **not** cached so the
  subsequent `ls … target/release/libxet.*` step still sees the artifacts.

## Testing

- `make model-agent-image` builds successfully

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
