### PR TITLE
[Core] Make explicit-runtime compat error to advisory event

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -250,10 +250,32 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			rt = pin.spec
 		} else {
 			if err := r.RuntimeSelector.ValidateRuntime(ctx, rtName, baseModel, isvc); err != nil {
-				r.Log.Error(err, "Runtime validation failed", "runtime", rtName, "model", isvc.Spec.Model.Name)
-				r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeValidationError",
-					"Runtime %s does not support model %s: %v", rtName, isvc.Spec.Model.Name, err)
-				return reconcile.Result{}, err
+				// The operator named this runtime explicitly, so OME should not
+				// block on the runtime's *declared* supportedModelFormats: a
+				// generic runtime (e.g. sglang) can serve many architectures it
+				// never enumerates. Downgrade a pure compatibility mismatch
+				// (format / architecture / framework) to an advisory event and
+				// proceed — the deliberate choice wins over the declaration.
+				//
+				// This mirrors the admission webhook (explicit-runtime compat
+				// is advisory). Without the same downgrade here, the webhook
+				// admits the ISVC but this reconcile hard-fails, so it never
+				// gets pods.
+				//
+				// Everything else stays a hard error: a not-found / disabled
+				// runtime or a malformed model genuinely cannot run.
+				if runtimeselector.IsRuntimeCompatibilityError(err) {
+					r.Log.Info("Runtime named explicitly; proceeding despite declared-format mismatch",
+						"runtime", rtName, "model", isvc.Spec.Model.Name, "details", err.Error())
+					r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeCompatibilityAdvisory",
+						"Runtime %s does not declare support for model %s (%v); proceeding because the runtime was named explicitly",
+						rtName, isvc.Spec.Model.Name, err)
+				} else {
+					r.Log.Error(err, "Runtime validation failed", "runtime", rtName, "model", isvc.Spec.Model.Name)
+					r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeValidationError",
+						"Runtime %s does not support model %s: %v", rtName, isvc.Spec.Model.Name, err)
+					return reconcile.Result{}, err
+				}
 			}
 
 			// Get the runtime spec using selector

--- a/pkg/webhook/admission/isvc/inference_service_validation.go
+++ b/pkg/webhook/admission/isvc/inference_service_validation.go
@@ -455,6 +455,22 @@ func (v *InferenceServiceValidator) resolveModelAndRuntime(ctx context.Context, 
 	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Name != "" {
 		// Validate specified runtime
 		if err := v.RuntimeSelector.ValidateRuntime(ctx, isvc.Spec.Runtime.Name, baseModel, isvc); err != nil {
+			// The operator named this runtime explicitly, so OME should not
+			// block on the runtime's *declared* supportedModelFormats: a
+			// generic runtime (e.g. sglang) can serve many architectures it
+			// never enumerates. Downgrade a pure compatibility mismatch
+			// (format / architecture / framework) to an advisory warning and
+			// admit — the deliberate choice wins over the declaration.
+			//
+			// Everything else stays a hard error: a not-found / disabled
+			// runtime or a malformed model genuinely cannot run, so admitting
+			// would only produce a broken ISVC.
+			if runtimeselector.IsRuntimeCompatibilityError(err) {
+				warnings = append(warnings, fmt.Sprintf(
+					"runtime %q does not declare support for model %q (%v); proceeding because the runtime was named explicitly",
+					isvc.Spec.Runtime.Name, isvc.Spec.Model.Name, err))
+				return warnings, nil
+			}
 			return warnings, fmt.Errorf("runtime %s does not support model %s: %w",
 				isvc.Spec.Runtime.Name, isvc.Spec.Model.Name, err)
 		}


### PR DESCRIPTION
## What this PR does

When an InferenceService names a ServingRuntime explicitly, a pure
runtime/model *compatibility* mismatch (declared supported model format /
architecture / framework) is now downgraded from a hard failure to an
advisory signal, and the ISVC proceeds. This is applied on both layers
that gate on runtime compatibility:

- **Admission webhook** (`resolveModelAndRuntime`) — emits an admission
  **warning** and admits, instead of returning an error.
- **Reconciler** (Step 2 of `Reconcile`) — emits a
  `RuntimeCompatibilityAdvisory` event and continues to fetch/merge the
  runtime, instead of failing the reconcile.
Both paths gate the downgrade on `runtimeselector.IsRuntimeCompatibilityError(err)`
only. Every other failure — runtime not found, disabled, or a malformed
model — stays a hard error on both layers, since those genuinely cannot run.


## Why we need it

Generic runtimes (e.g. sglang) can serve many model architectures they
never enumerate in `supportedModelFormats`. Today, naming such a runtime
explicitly is rejected the moment the model's architecture isn't in the
runtime's declared list — even though the operator deliberately chose it
and it can serve the model. The declared-format list is meant to drive
*auto-selection*, not to veto a deliberate, explicit choice.

The change must land on both layers together: the webhook is the admission
gate that fires first, and the reconciler is the runtime-resolution path.
If only one were changed, an explicitly-named generic runtime would still
be blocked at admission, or the ISVC would admit but then fail to get pods.
The auto-select path (no explicit runtime) is unchanged and still requires
a declared match.

## What changes
- **Webhook** (`resolveModelAndRuntime`) — appends an admission **warning**
  and admits, instead of returning an error.
- **Reconciler** (Step 2 of `Reconcile`) — records a
  `RuntimeCompatibilityAdvisory` event and proceeds to fetch/merge the
  runtime, instead of failing the reconcile (which left the ISVC with no
  pods).

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
