### PR TITLE
[Core] Add HuggingFace download timeout for replica agent

### DIFF
--- a/cmd/ome-agent/README.md
+++ b/cmd/ome-agent/README.md
@@ -68,6 +68,8 @@ profile: "DEFAULT"
 
 download_size_limit_gb: 650
 enable_size_limit_check: true
+hf_download_timeout: "72h"
+hf_download_stale_progress_timeout: "30m"
 
 source:
   bucket_name: "model-store"
@@ -104,6 +106,8 @@ All environment variables ***must*** start the prefix `OME_AGENT_` to be recogni
 | `num_connections`                             | `OME_AGENT_NUM_CONNECTIONS`                             | 10                        | no                                                                                   |
 | `download_size_limit_gb`                      | `OME_AGENT_DOWNLOAD_SIZE_LIMIT_GB`                      | 650                       | no                                                                                   |
 | `enable_size_limit_check`                     | `OME_AGENT_ENABLE_SIZE_LIMIT_CHECK`                     | true                      | no                                                                                   |
+| `hf_download_timeout`                         | `OME_AGENT_HF_DOWNLOAD_TIMEOUT`                         | 72h                       | no                                                                                   |
+| `hf_download_stale_progress_timeout`          | `OME_AGENT_HF_DOWNLOAD_STALE_PROGRESS_TIMEOUT`          | 30m                       | no                                                                                   |
 | `source.bucket_name`                          | `OME_AGENT_SOURCE_BUCKET_NAME`                          |                           | yes                                                                                  |
 | `source.prefix`                               | `OME_AGENT_SOURCE_PREFIX`                               |                           | no                                                                                   |
 | `source.region`                               | `OME_AGENT_SOURCE_REGION`                               |                           | yes                                                                                  |

--- a/config/ome-agent/ome-agent.yaml
+++ b/config/ome-agent/ome-agent.yaml
@@ -31,6 +31,8 @@ num_connections: 100
 
 download_size_limit_gb: 650
 enable_size_limit_check: true
+hf_download_timeout: "72h"
+hf_download_stale_progress_timeout: "30m"
 
 source:
   storage_uri: "oci://n/<namespace>/b/<bucket-name>/o/<object-name>"

--- a/internal/ome-agent/replica/config.go
+++ b/internal/ome-agent/replica/config.go
@@ -2,6 +2,7 @@ package replica
 
 import (
 	"fmt"
+	"time"
 
 	"sigs.k8s.io/ome/pkg/xet"
 
@@ -20,10 +21,12 @@ import (
 type Config struct {
 	AnotherLogger logging.Interface
 
-	LocalPath            string `mapstructure:"local_path" validate:"required"`
-	DownloadSizeLimitGB  int    `mapstructure:"download_size_limit_gb"`
-	EnableSizeLimitCheck bool   `mapstructure:"enable_size_limit_check"`
-	NumConnections       int    `mapstructure:"num_connections"`
+	LocalPath                      string        `mapstructure:"local_path" validate:"required"`
+	DownloadSizeLimitGB            int           `mapstructure:"download_size_limit_gb"`
+	EnableSizeLimitCheck           bool          `mapstructure:"enable_size_limit_check"`
+	NumConnections                 int           `mapstructure:"num_connections"`
+	HFDownloadTimeout              time.Duration `mapstructure:"hf_download_timeout"`
+	HFDownloadStaleProgressTimeout time.Duration `mapstructure:"hf_download_stale_progress_timeout"`
 
 	Source struct {
 		StorageURIStr  string `mapstructure:"storage_uri" validate:"required"`
@@ -59,9 +62,11 @@ func (c *Config) Apply(opts ...Option) error {
 // defaultConfig returns a new configuration with default values.
 func defaultConfig() *Config {
 	return &Config{
-		NumConnections:       10,
-		DownloadSizeLimitGB:  650,
-		EnableSizeLimitCheck: true,
+		NumConnections:                 10,
+		DownloadSizeLimitGB:            650,
+		EnableSizeLimitCheck:           true,
+		HFDownloadTimeout:              72 * time.Hour,
+		HFDownloadStaleProgressTimeout: 30 * time.Minute,
 	}
 }
 

--- a/internal/ome-agent/replica/config_test.go
+++ b/internal/ome-agent/replica/config_test.go
@@ -3,6 +3,7 @@ package replica
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/ome/pkg/xet"
 
@@ -161,6 +162,8 @@ func TestWithViper(t *testing.T) {
 				v.Set("num_connections", 5)
 				v.Set("download_size_limit_gb", 100)
 				v.Set("enable_size_limit_check", true)
+				v.Set("hf_download_timeout", "2h")
+				v.Set("hf_download_stale_progress_timeout", "15m")
 				v.Set("source.storage_uri", "oci://n/test-src-namespace/b/test-src-bucket/o/models")
 				v.Set("target.storage_uri", "oci://n/test-tgt-namespace/b/test-tgt-bucket/o/models")
 				return v
@@ -171,6 +174,8 @@ func TestWithViper(t *testing.T) {
 				assert.Equal(t, 5, c.NumConnections)
 				assert.Equal(t, 100, c.DownloadSizeLimitGB)
 				assert.Equal(t, true, c.EnableSizeLimitCheck)
+				assert.Equal(t, 2*time.Hour, c.HFDownloadTimeout)
+				assert.Equal(t, 15*time.Minute, c.HFDownloadStaleProgressTimeout)
 				assert.Equal(t, "oci://n/test-src-namespace/b/test-src-bucket/o/models", c.Source.StorageURIStr)
 				assert.Equal(t, "oci://n/test-tgt-namespace/b/test-tgt-bucket/o/models", c.Target.StorageURIStr)
 			},
@@ -186,6 +191,8 @@ func TestWithViper(t *testing.T) {
 				assert.Equal(t, 10, c.NumConnections)
 				assert.Equal(t, 650, c.DownloadSizeLimitGB)
 				assert.Equal(t, true, c.EnableSizeLimitCheck)
+				assert.Equal(t, 72*time.Hour, c.HFDownloadTimeout)
+				assert.Equal(t, 30*time.Minute, c.HFDownloadStaleProgressTimeout)
 			},
 		},
 		{

--- a/internal/ome-agent/replica/factory.go
+++ b/internal/ome-agent/replica/factory.go
@@ -15,11 +15,13 @@ func NewReplicator(r *ReplicaAgent) (replicator.Replicator, error) {
 		return &replicator.HFToOCIReplicator{
 			Logger: r.Logger,
 			Config: replicator.HFToOCIReplicatorConfig{
-				LocalPath:      r.Config.LocalPath,
-				NumConnections: r.Config.NumConnections,
-				ChecksumConfig: r.Config.Target.ChecksumConfig,
-				HubClient:      r.Config.Source.HubClient,
-				OCIOSDataStore: r.Config.Target.OCIOSDataStore,
+				LocalPath:                      r.Config.LocalPath,
+				NumConnections:                 r.Config.NumConnections,
+				ChecksumConfig:                 r.Config.Target.ChecksumConfig,
+				HubClient:                      r.Config.Source.HubClient,
+				OCIOSDataStore:                 r.Config.Target.OCIOSDataStore,
+				HFDownloadTimeout:              r.Config.HFDownloadTimeout,
+				HFDownloadStaleProgressTimeout: r.Config.HFDownloadStaleProgressTimeout,
 			},
 			ReplicationInput: r.ReplicationInput,
 		}, nil
@@ -50,8 +52,10 @@ func NewReplicator(r *ReplicaAgent) (replicator.Replicator, error) {
 		return &replicator.HFToPVCReplicator{
 			Logger: r.Logger,
 			Config: replicator.HFToPVCReplicatorConfig{
-				LocalPath: r.Config.LocalPath,
-				HubClient: r.Config.Source.HubClient,
+				LocalPath:                      r.Config.LocalPath,
+				HubClient:                      r.Config.Source.HubClient,
+				HFDownloadTimeout:              r.Config.HFDownloadTimeout,
+				HFDownloadStaleProgressTimeout: r.Config.HFDownloadStaleProgressTimeout,
 			},
 			ReplicationInput: r.ReplicationInput,
 		}, nil

--- a/internal/ome-agent/replica/replicator/helper.go
+++ b/internal/ome-agent/replica/replicator/helper.go
@@ -1,6 +1,7 @@
 package replicator
 
 import (
+	"context"
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/base64"
@@ -8,6 +9,7 @@ import (
 	"hash"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"sigs.k8s.io/ome/pkg/xet"
@@ -32,11 +34,170 @@ const (
 )
 
 var (
-	downloadSnapHook                      = func(c *xet.Client, req *xet.SnapshotRequest) (string, error) { return c.DownloadSnapshot(req) }
+	downloadSnapHook = func(ctx context.Context, c *xet.Client, req *xet.SnapshotRequest) (string, error) {
+		return c.DownloadSnapshotWithContext(ctx, req)
+	}
+	setProgressHandlerHook = func(c *xet.Client, handler xet.ProgressHandler, throttle time.Duration) error {
+		return c.SetProgressHandler(handler, throttle)
+	}
+	disableProgressHook                   = func(c *xet.Client) error { return c.DisableProgress() }
 	downloadFromHFFunc                    = downloadFromHF
 	uploadDirectoryToOCIOSDataStoreFunc   = uploadDirectoryToOCIOSDataStore
 	downloadObjectsFromOCIOSDataStoreFunc = downloadObjectsFromOCIOSDataStore
 )
+
+type hfDownloadOptions struct {
+	DownloadTimeout              time.Duration
+	StaleProgressTimeout         time.Duration
+	ProgressCallbackThrottleTime time.Duration
+}
+
+type hfSnapshotDownloadResult struct {
+	path string
+	err  error
+}
+
+type hfDownloadProgressSnapshot struct {
+	completedBytes            uint64
+	completedFiles            uint32
+	currentFileCompletedBytes uint64
+}
+
+func downloadSnapshotWithTimeouts(
+	hubClient *xet.Client,
+	req *xet.SnapshotRequest,
+	opts hfDownloadOptions,
+	logger logging.Interface,
+) (string, error) {
+	ctx := context.Background()
+	cancel := func() {}
+	if opts.DownloadTimeout > 0 {
+		var timeoutCancel context.CancelFunc
+		ctx, timeoutCancel = context.WithTimeout(ctx, opts.DownloadTimeout)
+		cancel = timeoutCancel
+	}
+	defer cancel()
+
+	progressed := make(chan struct{}, 1)
+	staleTimedOut := make(chan struct{})
+	var closeStaleOnce sync.Once
+	var lastProgress hfDownloadProgressSnapshot
+	var lastProgressMu sync.Mutex
+	progressHandlerInstalled := false
+	downloadFinished := false
+
+	if opts.StaleProgressTimeout > 0 {
+		if opts.ProgressCallbackThrottleTime <= 0 {
+			opts.ProgressCallbackThrottleTime = 250 * time.Millisecond
+		}
+		if err := setProgressHandlerHook(hubClient, func(update xet.ProgressUpdate) {
+			current := hfDownloadProgressSnapshot{
+				completedBytes:            update.CompletedBytes,
+				completedFiles:            update.CompletedFiles,
+				currentFileCompletedBytes: update.CurrentFileCompletedBytes,
+			}
+			lastProgressMu.Lock()
+			defer lastProgressMu.Unlock()
+			if current == lastProgress {
+				return
+			}
+			lastProgress = current
+			select {
+			case progressed <- struct{}{}:
+			default:
+			}
+		}, opts.ProgressCallbackThrottleTime); err != nil {
+			logger.Warnf("Unable to install HuggingFace/Xet progress watchdog: %v", err)
+		} else {
+			progressHandlerInstalled = true
+			// Only disable the progress handler once the download goroutine has
+			// actually returned (downloadFinished). On the timeout/cancellation path
+			// the goroutine is still running inside DownloadSnapshotWithContext and the
+			// native side may invoke the progress callback concurrently; disabling it
+			// here would race with that in-flight callback. The handler is left in place
+			// and torn down when the process exits shortly after the non-zero return.
+			defer func() {
+				if !downloadFinished {
+					return
+				}
+				if err := disableProgressHook(hubClient); err != nil {
+					logger.Warnf("Unable to disable HuggingFace/Xet progress watchdog: %v", err)
+				}
+			}()
+		}
+	}
+
+	if progressHandlerInstalled {
+		staleCtx, staleCancel := context.WithCancel(ctx)
+		ctx = staleCtx
+		defer staleCancel()
+
+		go func() {
+			timer := time.NewTimer(opts.StaleProgressTimeout)
+			defer timer.Stop()
+			for {
+				select {
+				case <-staleCtx.Done():
+					return
+				case <-progressed:
+					if !timer.Stop() {
+						select {
+						case <-timer.C:
+						default:
+						}
+					}
+					timer.Reset(opts.StaleProgressTimeout)
+				case <-timer.C:
+					closeStaleOnce.Do(func() { close(staleTimedOut) })
+					staleCancel()
+					return
+				}
+			}
+		}()
+	}
+
+	start := time.Now()
+	logger.Infof("Starting HuggingFace/Xet snapshot download for repo %s revision %s with timeout %v and stale-progress timeout %v",
+		req.RepoID, req.Revision, opts.DownloadTimeout, opts.StaleProgressTimeout)
+
+	resultCh := make(chan hfSnapshotDownloadResult, 1)
+	go func() {
+		path, err := downloadSnapHook(ctx, hubClient, req)
+		resultCh <- hfSnapshotDownloadResult{path: path, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		downloadFinished = true
+		duration := time.Since(start)
+		if result.err != nil {
+			if isStaleProgressTimeout(staleTimedOut) {
+				return "", fmt.Errorf("HuggingFace/Xet snapshot download made no bytes/files progress for %s after %s: %w", opts.StaleProgressTimeout, duration, result.err)
+			}
+			if ctx.Err() == context.DeadlineExceeded {
+				return "", fmt.Errorf("HuggingFace/Xet snapshot download exceeded timeout %s after %s: %w", opts.DownloadTimeout, duration, result.err)
+			}
+			return "", result.err
+		}
+		logger.Infof("HuggingFace/Xet snapshot download completed in %v", duration)
+		return result.path, nil
+	case <-ctx.Done():
+		duration := time.Since(start)
+		if isStaleProgressTimeout(staleTimedOut) {
+			return "", fmt.Errorf("HuggingFace/Xet snapshot download made no bytes/files progress for %s after %s", opts.StaleProgressTimeout, duration)
+		}
+		return "", fmt.Errorf("HuggingFace/Xet snapshot download exceeded timeout %s after %s", opts.DownloadTimeout, duration)
+	}
+}
+
+func isStaleProgressTimeout(staleTimedOut <-chan struct{}) bool {
+	select {
+	case <-staleTimedOut:
+		return true
+	default:
+		return false
+	}
+}
 
 func UploadObjectToOCIOSDataStore(ociOSDataStore *ociobjectstore.OCIOSDataStore, object ociobjectstore.ObjectURI, filePath string) error {
 	if ociOSDataStore == nil {

--- a/internal/ome-agent/replica/replicator/helper_timeout_test.go
+++ b/internal/ome-agent/replica/replicator/helper_timeout_test.go
@@ -1,0 +1,115 @@
+package replicator
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/xet"
+
+	testingPkg "sigs.k8s.io/ome/pkg/testing"
+)
+
+func TestDownloadSnapshotWithTimeouts_EndToEndTimeout(t *testing.T) {
+	origDownloadSnapHook := downloadSnapHook
+	t.Cleanup(func() {
+		downloadSnapHook = origDownloadSnapHook
+	})
+
+	downloadSnapHook = func(ctx context.Context, client *xet.Client, req *xet.SnapshotRequest) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	_, err := downloadSnapshotWithTimeouts(nil, &xet.SnapshotRequest{
+		RepoID:   "org/model",
+		Revision: "main",
+	}, hfDownloadOptions{
+		DownloadTimeout: 10 * time.Millisecond,
+	}, testingPkg.SetupMockLogger())
+
+	if err == nil || !strings.Contains(err.Error(), "exceeded timeout") {
+		t.Fatalf("expected end-to-end timeout, got %v", err)
+	}
+}
+
+func TestDownloadSnapshotWithTimeouts_StaleProgressTimeout(t *testing.T) {
+	origDownloadSnapHook := downloadSnapHook
+	origSetProgressHandlerHook := setProgressHandlerHook
+	origDisableProgressHook := disableProgressHook
+	t.Cleanup(func() {
+		downloadSnapHook = origDownloadSnapHook
+		setProgressHandlerHook = origSetProgressHandlerHook
+		disableProgressHook = origDisableProgressHook
+	})
+
+	setProgressHandlerHook = func(client *xet.Client, handler xet.ProgressHandler, throttle time.Duration) error {
+		return nil
+	}
+	disableProgressHook = func(client *xet.Client) error {
+		return nil
+	}
+	downloadSnapHook = func(ctx context.Context, client *xet.Client, req *xet.SnapshotRequest) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	_, err := downloadSnapshotWithTimeouts(nil, &xet.SnapshotRequest{
+		RepoID:   "org/model",
+		Revision: "main",
+	}, hfDownloadOptions{
+		DownloadTimeout:      time.Second,
+		StaleProgressTimeout: 10 * time.Millisecond,
+	}, testingPkg.SetupMockLogger())
+
+	if err == nil || !strings.Contains(err.Error(), "no bytes/files progress") {
+		t.Fatalf("expected stale-progress timeout, got %v", err)
+	}
+}
+
+func TestDownloadSnapshotWithTimeouts_ProgressPreventsStaleTimeout(t *testing.T) {
+	origDownloadSnapHook := downloadSnapHook
+	origSetProgressHandlerHook := setProgressHandlerHook
+	origDisableProgressHook := disableProgressHook
+	t.Cleanup(func() {
+		downloadSnapHook = origDownloadSnapHook
+		setProgressHandlerHook = origSetProgressHandlerHook
+		disableProgressHook = origDisableProgressHook
+	})
+
+	var progressHandler xet.ProgressHandler
+	setProgressHandlerHook = func(client *xet.Client, handler xet.ProgressHandler, throttle time.Duration) error {
+		progressHandler = handler
+		return nil
+	}
+	disableProgressHook = func(client *xet.Client) error {
+		return nil
+	}
+	downloadSnapHook = func(ctx context.Context, client *xet.Client, req *xet.SnapshotRequest) (string, error) {
+		for i := uint64(1); i <= 5; i++ {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(15 * time.Millisecond):
+				progressHandler(xet.ProgressUpdate{CompletedBytes: i})
+			}
+		}
+		return "/tmp/model", nil
+	}
+
+	path, err := downloadSnapshotWithTimeouts(nil, &xet.SnapshotRequest{
+		RepoID:   "org/model",
+		Revision: "main",
+	}, hfDownloadOptions{
+		DownloadTimeout:      time.Second,
+		StaleProgressTimeout: 50 * time.Millisecond,
+	}, testingPkg.SetupMockLogger())
+
+	if err != nil {
+		t.Fatalf("expected progress to prevent stale timeout, got %v", err)
+	}
+	if path != "/tmp/model" {
+		t.Fatalf("unexpected path: got %s", path)
+	}
+}

--- a/internal/ome-agent/replica/replicator/hf_to_oci.go
+++ b/internal/ome-agent/replica/replicator/hf_to_oci.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"sigs.k8s.io/ome/pkg/xet"
 
@@ -23,18 +24,23 @@ type HFToOCIReplicator struct {
 }
 
 type HFToOCIReplicatorConfig struct {
-	LocalPath      string
-	NumConnections int
-	ChecksumConfig *common.ChecksumConfig
-	HubClient      *xet.Client
-	OCIOSDataStore *ociobjectstore.OCIOSDataStore
+	LocalPath                      string
+	NumConnections                 int
+	ChecksumConfig                 *common.ChecksumConfig
+	HubClient                      *xet.Client
+	OCIOSDataStore                 *ociobjectstore.OCIOSDataStore
+	HFDownloadTimeout              time.Duration
+	HFDownloadStaleProgressTimeout time.Duration
 }
 
 func (r *HFToOCIReplicator) Replicate(objects []common.ReplicationObject) error {
 	r.Logger.Info("Starting replication to target")
 	// Download
 	tempDirPath := filepath.Join(r.Config.LocalPath, ReplicaWorkspacePath)
-	downloadPath, err := downloadFromHFFunc(r.ReplicationInput, r.Config.HubClient, tempDirPath, r.Logger)
+	downloadPath, err := downloadFromHFFunc(r.ReplicationInput, r.Config.HubClient, tempDirPath, hfDownloadOptions{
+		DownloadTimeout:      r.Config.HFDownloadTimeout,
+		StaleProgressTimeout: r.Config.HFDownloadStaleProgressTimeout,
+	}, r.Logger)
 	if err != nil {
 		r.Logger.Errorf("Failed to download model %s from HuggingFace: %v", r.ReplicationInput.Source.BucketName, err)
 		return err
@@ -63,7 +69,7 @@ func (r *HFToOCIReplicator) Replicate(objects []common.ReplicationObject) error 
 	return nil
 }
 
-func downloadFromHF(input common.ReplicationInput, hubClient *xet.Client, downloadDir string, logger logging.Interface) (string, error) {
+func downloadFromHF(input common.ReplicationInput, hubClient *xet.Client, downloadDir string, opts hfDownloadOptions, logger logging.Interface) (string, error) {
 	req := &xet.SnapshotRequest{
 		RepoID:   input.Source.BucketName,
 		RepoType: hub.RepoTypeModel,
@@ -71,7 +77,7 @@ func downloadFromHF(input common.ReplicationInput, hubClient *xet.Client, downlo
 		LocalDir: downloadDir,
 	}
 
-	path, err := downloadSnapHook(hubClient, req)
+	path, err := downloadSnapshotWithTimeouts(hubClient, req, opts, logger)
 	if err != nil {
 		logger.Errorf("Failed to download snapshot: %v", err)
 	}

--- a/internal/ome-agent/replica/replicator/hf_to_oci_test.go
+++ b/internal/ome-agent/replica/replicator/hf_to_oci_test.go
@@ -28,7 +28,7 @@ func TestHFToOCIReplicator_Replicate_Success(t *testing.T) {
 
 	downloadCalled := false
 	uploadCalled := false
-	downloadFromHFFunc = func(input common.ReplicationInput, hubClient *xet.Client, downloadDir string, logger logging.Interface) (string, error) {
+	downloadFromHFFunc = func(input common.ReplicationInput, hubClient *xet.Client, downloadDir string, opts hfDownloadOptions, logger logging.Interface) (string, error) {
 		downloadCalled = true
 		return "/tmp/model", nil
 	}
@@ -85,7 +85,7 @@ func TestHFToOCIReplicator_Replicate_Failure(t *testing.T) {
 	objs := CreateCommonMockReplicationObjects(1)
 
 	// Test download error
-	downloadFromHFFunc = func(input common.ReplicationInput, hubClient *xet.Client, downloadDir string, logger logging.Interface) (string, error) {
+	downloadFromHFFunc = func(input common.ReplicationInput, hubClient *xet.Client, downloadDir string, opts hfDownloadOptions, logger logging.Interface) (string, error) {
 		return "", errors.New("download error")
 	}
 	uploadCalled := false
@@ -99,7 +99,7 @@ func TestHFToOCIReplicator_Replicate_Failure(t *testing.T) {
 	assert.ErrorContains(t, err, "download error")
 
 	// Test upload error
-	downloadFromHFFunc = func(input common.ReplicationInput, hubClient *xet.Client, downloadDir string, logger logging.Interface) (string, error) {
+	downloadFromHFFunc = func(input common.ReplicationInput, hubClient *xet.Client, downloadDir string, opts hfDownloadOptions, logger logging.Interface) (string, error) {
 		return "/tmp/model", nil
 	}
 	uploadDirectoryToOCIOSDataStoreFunc = func(ds *ociobjectstore.OCIOSDataStore, target ociobjectstore.ObjectURI, localPath string, checksumConfig *common.ChecksumConfig, numObjects int, numConnections int) error {

--- a/internal/ome-agent/replica/replicator/hf_to_pvc.go
+++ b/internal/ome-agent/replica/replicator/hf_to_pvc.go
@@ -2,6 +2,7 @@ package replicator
 
 import (
 	"path/filepath"
+	"time"
 
 	"sigs.k8s.io/ome/pkg/xet"
 
@@ -16,15 +17,20 @@ type HFToPVCReplicator struct {
 }
 
 type HFToPVCReplicatorConfig struct {
-	LocalPath string
-	HubClient *xet.Client
+	LocalPath                      string
+	HubClient                      *xet.Client
+	HFDownloadTimeout              time.Duration
+	HFDownloadStaleProgressTimeout time.Duration
 }
 
 func (r *HFToPVCReplicator) Replicate(objects []common.ReplicationObject) error {
 	r.Logger.Info("Starting replication to target")
 
 	targetDirPath := filepath.Join(r.Config.LocalPath, r.ReplicationInput.Target.Prefix)
-	downloadPath, err := downloadFromHFFunc(r.ReplicationInput, r.Config.HubClient, targetDirPath, r.Logger)
+	downloadPath, err := downloadFromHFFunc(r.ReplicationInput, r.Config.HubClient, targetDirPath, hfDownloadOptions{
+		DownloadTimeout:      r.Config.HFDownloadTimeout,
+		StaleProgressTimeout: r.Config.HFDownloadStaleProgressTimeout,
+	}, r.Logger)
 	if err != nil {
 		r.Logger.Errorf("Failed to download model %s from HuggingFace: %v", r.ReplicationInput.Source.BucketName, err)
 		return err

--- a/internal/ome-agent/replica/replicator/hf_to_pvc_test.go
+++ b/internal/ome-agent/replica/replicator/hf_to_pvc_test.go
@@ -22,7 +22,7 @@ func TestHFToPVCReplicator_Replicate_Success(t *testing.T) {
 	}()
 
 	// Replace downloadFromHFFunc with a mock version
-	downloadFromHFFunc = func(input common.ReplicationInput, client *xet.Client, path string, logger logging.Interface) (string, error) {
+	downloadFromHFFunc = func(input common.ReplicationInput, client *xet.Client, path string, opts hfDownloadOptions, logger logging.Interface) (string, error) {
 		if path != "/mnt/data/meta/lama-Guard-4-12B" {
 			t.Errorf("unexpected path: got %s, want /mnt/data/meta/lama-Guard-4-12B", path)
 		}
@@ -61,7 +61,7 @@ func TestHFToPVCReplicator_Replicate_Failure(t *testing.T) {
 		downloadFromHFFunc = originalDownloadFunc
 	}()
 
-	downloadFromHFFunc = func(input common.ReplicationInput, client *xet.Client, path string, logger logging.Interface) (string, error) {
+	downloadFromHFFunc = func(input common.ReplicationInput, client *xet.Client, path string, opts hfDownloadOptions, logger logging.Interface) (string, error) {
 		return "", fmt.Errorf("mock error")
 	}
 


### PR DESCRIPTION
## Summary

Adds bounded timeout handling around HuggingFace/Xet snapshot downloads in the OME replica agent. This lets a stalled model import fail with a clear timeout error instead of leaving the replica process blocked indefinitely.

## Changes

- Add replica-agent config fields and env vars for:
  - `hf_download_timeout`
  - `hf_download_stale_progress_timeout`
- Wrap `DownloadSnapshotWithContext` with an end-to-end context deadline.
- Install an Xet progress watchdog that cancels the download if bytes/files stop progressing for the configured stale-progress window.
- Thread the timeout options through HF-to-OCI and HF-to-PVC replication paths.
- Document the new options in the agent README and sample config.
- Add unit coverage for end-to-end timeout, stale-progress timeout, and progress preventing the stale timeout.

## Testing

```bash
GOROOT=/usr/local/go go test ./internal/ome-agent/replica/...
```
