### PR TITLE
Skip same-path OCI reuse for download override

### DIFF
--- a/pkg/modelagent/gopher.go
+++ b/pkg/modelagent/gopher.go
@@ -326,9 +326,7 @@ func (s *Gopher) processTask(task *GopherTask) error {
 				s.logger.Errorf("Failed to get target directory path for model %s: %v", modelInfo, err)
 				return err
 			}
-			if matchedKey, reused := s.findReadyObjectStorageModelWithSamePath(ctx, task, baseModelSpec, destPath); reused {
-				s.logger.Infof("Reusing Ready same-path model artifact for %s/%s from %s at %s", namespace, name, matchedKey, destPath)
-			} else {
+			downloadObjectStorageModel := func() error {
 				err = utils.Retry(s.downloadRetry, 100*time.Millisecond, func() error {
 					downloadErr := s.downloadModel(ctx, osUri, destPath, task)
 					if downloadErr != nil {
@@ -355,6 +353,17 @@ func (s *Gopher) processTask(task *GopherTask) error {
 					s.markModelOnNodeFailed(task)
 					return err
 				}
+				return nil
+			}
+
+			if shouldUseSamePathObjectStorageReuse(task) {
+				if matchedKey, reused := s.findReadyObjectStorageModelWithSamePath(ctx, task, baseModelSpec, destPath); reused {
+					s.logger.Infof("Reusing Ready same-path model artifact for %s/%s from %s at %s", namespace, name, matchedKey, destPath)
+				} else if err := downloadObjectStorageModel(); err != nil {
+					return err
+				}
+			} else if err := downloadObjectStorageModel(); err != nil {
+				return err
 			}
 			// Parse model config and update ConfigMap
 			// We can pass either BaseModel or ClusterBaseModel based on the task's model type
@@ -526,6 +535,10 @@ func (s *Gopher) processTask(task *GopherTask) error {
 	}
 
 	return nil
+}
+
+func shouldUseSamePathObjectStorageReuse(task *GopherTask) bool {
+	return task != nil && task.TaskType == Download
 }
 
 // isPathReferencedByOtherModels checks if the given path is still referenced by other BaseModel or ClusterBaseModel resources
@@ -744,9 +757,9 @@ func (s *Gopher) createOCIOSDataStore(baseModelSpec v1beta1.BaseModelSpec) (*oci
 
 // findReadyObjectStorageModelWithSamePath looks for a Ready OCI Object Storage
 // model entry on this node that resolves to the same local destination path.
-// This is intentionally independent of downloadPolicy: copied model CRs with
-// the same source and destination can reuse Ready local files, while normal
-// downloadPolicy behavior still applies when no same-path Ready artifact exists.
+// This is intentionally independent of downloadPolicy for normal Download tasks:
+// copied model CRs with the same source and destination can reuse Ready local
+// files. DownloadOverride keeps the existing download/validation path.
 func (s *Gopher) findReadyObjectStorageModelWithSamePath(ctx context.Context, task *GopherTask, baseModelSpec v1beta1.BaseModelSpec, destPath string) (string, bool) {
 	if task == nil || (task.BaseModel == nil && task.ClusterBaseModel == nil) {
 		return "", false

--- a/pkg/modelagent/gopher_test.go
+++ b/pkg/modelagent/gopher_test.go
@@ -758,6 +758,37 @@ func TestFindReadyObjectStorageModelWithSamePath(t *testing.T) {
 	}
 }
 
+func TestShouldUseSamePathObjectStorageReuse(t *testing.T) {
+	tests := []struct {
+		name string
+		task *GopherTask
+		want bool
+	}{
+		{
+			name: "normal download can reuse same-path object storage artifact",
+			task: &GopherTask{TaskType: Download},
+			want: true,
+		},
+		{
+			name: "download override must redownload and validate",
+			task: &GopherTask{TaskType: DownloadOverride},
+		},
+		{
+			name: "delete never reuses same-path object storage artifact",
+			task: &GopherTask{TaskType: Delete},
+		},
+		{
+			name: "nil task never reuses same-path object storage artifact",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldUseSamePathObjectStorageReuse(tt.task))
+		})
+	}
+}
+
 func TestHandelReuseArtifactIfNecessary_NoReusePolicy(t *testing.T) {
 	nodeName := "node-1"
 	// Even if CM has content, when policy is AlwaysDownload we should not reuse.


### PR DESCRIPTION
## What this PR does

Scopes OCI Object Storage same-path reuse to normal Download tasks only.
`DownloadOverride` now keeps the existing download/validation path, even when another Ready model entry has the same OCI storage identity and resolved local destination path.

## Why we need it

Same-path reuse is intended to reduce latency for copied model CRs. It should not apply to refresh/update flows.
`DownloadOverride` can be generated when model spec, labels, or annotations change. If same-path reuse runs there, model-agent may skip an intended refresh/revalidation when two model CRs point to the same OCI source and local path.
This keeps copied-CR fast reuse while preserving refresh behavior for override tasks.

Fixes #

## How to test

```
go test -count=1 ./pkg/modelagent
```

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
