### PR TITLE
[Bugfix] Grant controller-manager create on controllerrevisions

### DIFF
--- a/charts/ome-resources/templates/ome-controller/rbac/role.yaml
+++ b/charts/ome-resources/templates/ome-controller/rbac/role.yaml
@@ -58,16 +58,6 @@ rules:
   - apps
   resources:
   - controllerrevisions
-  verbs:
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - deployments
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,16 +58,6 @@ rules:
   - apps
   resources:
   - controllerrevisions
-  verbs:
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - deployments
   verbs:
   - create

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -60,6 +60,7 @@ import (
 // +kubebuilder:rbac:groups=ome.io,resources=clusterbasemodels/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ome.io,resources=clusterbasemodels;basemodels/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ome.io,resources=inferenceservices/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=serving.knative.dev,resources=services,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
## What this PR does

Grant controller-manager create on controllerrevisions
## Why we need it

The runtime-revision pinning path (spec.runtime.autoSync=false) calls
runtimerevision.FindOrCreate on the first reconcile, which needs create
on apps/controllerrevisions. The only RBAC marker for that resource
lived on the GC controller and omitted create, so the manager
ServiceAccount hit "controllerrevisions.apps is forbidden" when writing
the initial pin.

Add a +kubebuilder:rbac marker with the full verb set on the
InferenceService reconciler (where FindOrCreate runs) and regenerate
RBAC. controller-gen merges controllerrevisions into the existing apps
full-CRUD rule, so both config/rbac/role.yaml and the Helm chart role
now grant create.

Fixes #

## How to test

Test in cluster region, without this change. controllerrevisions.apps is forbidden: User "system:serviceaccount:ome:opensource-ome-controller-manager" cannot create resource "controllerrevisions" in API group "apps" in the namespace "ome"
## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
