### PR TITLE
Add support to compare deploymentMode in runtime auto-selection logic

### DIFF
--- a/pkg/runtimeselector/errors.go
+++ b/pkg/runtimeselector/errors.go
@@ -29,17 +29,6 @@ func (e *RuntimeCompatibilityError) Unwrap() error {
 	return e.DetailedError
 }
 
-// RuntimeComponentMismatchError indicates that a runtime does not provide the components required by an InferenceService.
-type RuntimeComponentMismatchError struct {
-	RuntimeName string
-	Reason      string
-}
-
-// Error implements the error interface.
-func (e *RuntimeComponentMismatchError) Error() string {
-	return fmt.Sprintf("runtime %s component configuration mismatch: %s", e.RuntimeName, e.Reason)
-}
-
 // NoRuntimeFoundError indicates that no compatible runtime was found for a model.
 type NoRuntimeFoundError struct {
 	ModelName          string
@@ -127,12 +116,6 @@ func (e *ConfigurationError) Error() string {
 // IsRuntimeCompatibilityError checks if an error is a RuntimeCompatibilityError.
 func IsRuntimeCompatibilityError(err error) bool {
 	_, ok := err.(*RuntimeCompatibilityError)
-	return ok
-}
-
-// IsRuntimeComponentMismatchError checks if an error is a RuntimeComponentMismatchError.
-func IsRuntimeComponentMismatchError(err error) bool {
-	_, ok := err.(*RuntimeComponentMismatchError)
 	return ok
 }
 

--- a/pkg/runtimeselector/errors.go
+++ b/pkg/runtimeselector/errors.go
@@ -29,6 +29,17 @@ func (e *RuntimeCompatibilityError) Unwrap() error {
 	return e.DetailedError
 }
 
+// RuntimeComponentMismatchError indicates that a runtime does not provide the components required by an InferenceService.
+type RuntimeComponentMismatchError struct {
+	RuntimeName string
+	Reason      string
+}
+
+// Error implements the error interface.
+func (e *RuntimeComponentMismatchError) Error() string {
+	return fmt.Sprintf("runtime %s component configuration mismatch: %s", e.RuntimeName, e.Reason)
+}
+
 // NoRuntimeFoundError indicates that no compatible runtime was found for a model.
 type NoRuntimeFoundError struct {
 	ModelName          string
@@ -116,6 +127,12 @@ func (e *ConfigurationError) Error() string {
 // IsRuntimeCompatibilityError checks if an error is a RuntimeCompatibilityError.
 func IsRuntimeCompatibilityError(err error) bool {
 	_, ok := err.(*RuntimeCompatibilityError)
+	return ok
+}
+
+// IsRuntimeComponentMismatchError checks if an error is a RuntimeComponentMismatchError.
+func IsRuntimeComponentMismatchError(err error) bool {
+	_, ok := err.(*RuntimeComponentMismatchError)
 	return ok
 }
 

--- a/pkg/runtimeselector/matcher.go
+++ b/pkg/runtimeselector/matcher.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
@@ -32,14 +31,6 @@ func (m *DefaultRuntimeMatcher) IsCompatible(runtime *v1beta1.ServingRuntimeSpec
 	// Quick checks first
 	if runtime.IsDisabled() {
 		return false, &RuntimeDisabledError{RuntimeName: runtimeName}
-	}
-
-	// Check the runtime provides configs for all non-empty ISVC components.
-	if ok, reason := m.compareRequiredComponents(runtime, isvc); !ok {
-		return false, &RuntimeComponentMismatchError{
-			RuntimeName: runtimeName,
-			Reason:      reason,
-		}
 	}
 
 	// Check accelerator class compatibility
@@ -90,12 +81,6 @@ func (m *DefaultRuntimeMatcher) GetCompatibilityDetails(runtime *v1beta1.Serving
 	// Check if runtime is disabled
 	if runtime.IsDisabled() {
 		report.IncompatibilityReasons = append(report.IncompatibilityReasons, "runtime is disabled")
-		return report, nil
-	}
-
-	// Check that the runtime provides configs for all non-empty ISVC components.
-	if ok, reason := m.compareRequiredComponents(runtime, isvc); !ok {
-		report.IncompatibilityReasons = append(report.IncompatibilityReasons, reason)
 		return report, nil
 	}
 
@@ -327,33 +312,6 @@ func (m *DefaultRuntimeMatcher) compareAcceleratorClass(runtime *v1beta1.Serving
 	}
 
 	return true
-}
-
-// compareRequiredComponents rejects runtimes that do not provide configs for
-// components explicitly configured by the InferenceService. Empty component
-// specs in InferenceService are treated as not required.
-func (m *DefaultRuntimeMatcher) compareRequiredComponents(runtime *v1beta1.ServingRuntimeSpec, isvc *v1beta1.InferenceService) (bool, string) {
-	if isvc == nil || runtime == nil {
-		return true, ""
-	}
-
-	if isEngineSpecConfigured(isvc.Spec.Engine) && runtime.EngineConfig == nil {
-		return false, "inference service defines engine but runtime does not define engineConfig"
-	}
-
-	if isDecoderSpecConfigured(isvc.Spec.Decoder) && runtime.DecoderConfig == nil {
-		return false, "inference service defines decoder but runtime does not define decoderConfig"
-	}
-
-	return true, ""
-}
-
-func isEngineSpecConfigured(engine *v1beta1.EngineSpec) bool {
-	return engine != nil && !equality.Semantic.DeepEqual(engine, &v1beta1.EngineSpec{})
-}
-
-func isDecoderSpecConfigured(decoder *v1beta1.DecoderSpec) bool {
-	return decoder != nil && !equality.Semantic.DeepEqual(decoder, &v1beta1.DecoderSpec{})
 }
 
 // compareDeploymentMode rejects a runtime only when both the InferenceService

--- a/pkg/runtimeselector/matcher.go
+++ b/pkg/runtimeselector/matcher.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
@@ -31,6 +32,14 @@ func (m *DefaultRuntimeMatcher) IsCompatible(runtime *v1beta1.ServingRuntimeSpec
 	// Quick checks first
 	if runtime.IsDisabled() {
 		return false, &RuntimeDisabledError{RuntimeName: runtimeName}
+	}
+
+	// Check the runtime provides configs for all non-empty ISVC components.
+	if ok, reason := m.compareRequiredComponents(runtime, isvc); !ok {
+		return false, &RuntimeComponentMismatchError{
+			RuntimeName: runtimeName,
+			Reason:      reason,
+		}
 	}
 
 	// Check accelerator class compatibility
@@ -81,6 +90,12 @@ func (m *DefaultRuntimeMatcher) GetCompatibilityDetails(runtime *v1beta1.Serving
 	// Check if runtime is disabled
 	if runtime.IsDisabled() {
 		report.IncompatibilityReasons = append(report.IncompatibilityReasons, "runtime is disabled")
+		return report, nil
+	}
+
+	// Check that the runtime provides configs for all non-empty ISVC components.
+	if ok, reason := m.compareRequiredComponents(runtime, isvc); !ok {
+		report.IncompatibilityReasons = append(report.IncompatibilityReasons, reason)
 		return report, nil
 	}
 
@@ -312,6 +327,33 @@ func (m *DefaultRuntimeMatcher) compareAcceleratorClass(runtime *v1beta1.Serving
 	}
 
 	return true
+}
+
+// compareRequiredComponents rejects runtimes that do not provide configs for
+// components explicitly configured by the InferenceService. Empty component
+// specs in InferenceService are treated as not required.
+func (m *DefaultRuntimeMatcher) compareRequiredComponents(runtime *v1beta1.ServingRuntimeSpec, isvc *v1beta1.InferenceService) (bool, string) {
+	if isvc == nil || runtime == nil {
+		return true, ""
+	}
+
+	if isEngineSpecConfigured(isvc.Spec.Engine) && runtime.EngineConfig == nil {
+		return false, "inference service defines engine but runtime does not define engineConfig"
+	}
+
+	if isDecoderSpecConfigured(isvc.Spec.Decoder) && runtime.DecoderConfig == nil {
+		return false, "inference service defines decoder but runtime does not define decoderConfig"
+	}
+
+	return true, ""
+}
+
+func isEngineSpecConfigured(engine *v1beta1.EngineSpec) bool {
+	return engine != nil && !equality.Semantic.DeepEqual(engine, &v1beta1.EngineSpec{})
+}
+
+func isDecoderSpecConfigured(decoder *v1beta1.DecoderSpec) bool {
+	return decoder != nil && !equality.Semantic.DeepEqual(decoder, &v1beta1.DecoderSpec{})
 }
 
 // compareDeploymentMode rejects a runtime only when both the InferenceService

--- a/pkg/runtimeselector/matcher.go
+++ b/pkg/runtimeselector/matcher.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
 	modelVer "sigs.k8s.io/ome/pkg/modelver"
 )
 
@@ -39,6 +40,15 @@ func (m *DefaultRuntimeMatcher) IsCompatible(runtime *v1beta1.ServingRuntimeSpec
 			ModelName:   "", // Will be filled by caller if available
 			ModelFormat: model.ModelFormat.Name,
 			Reason:      "runtime does not support the required accelerator class",
+		}
+	}
+	// Apply component-level deployment mode constraints
+	if ok, reason := m.compareDeploymentMode(runtime, isvc); !ok {
+		return false, &RuntimeCompatibilityError{
+			RuntimeName: runtimeName,
+			ModelName:   "", // Will be filled by caller if available
+			ModelFormat: model.ModelFormat.Name,
+			Reason:      reason,
 		}
 	}
 	// Check if any supported format matches
@@ -78,6 +88,12 @@ func (m *DefaultRuntimeMatcher) GetCompatibilityDetails(runtime *v1beta1.Serving
 	if !m.compareAcceleratorClass(runtime, isvc) {
 		report.IncompatibilityReasons = append(report.IncompatibilityReasons,
 			"runtime does not support the required accelerator class")
+		return report, nil
+	}
+
+	// Apply component-level deployment mode constraints
+	if ok, reason := m.compareDeploymentMode(runtime, isvc); !ok {
+		report.IncompatibilityReasons = append(report.IncompatibilityReasons, reason)
 		return report, nil
 	}
 
@@ -296,6 +312,96 @@ func (m *DefaultRuntimeMatcher) compareAcceleratorClass(runtime *v1beta1.Serving
 	}
 
 	return true
+}
+
+// compareDeploymentMode rejects a runtime only when both the InferenceService
+// component and the matching runtime component explicitly declare different deployment modes.
+func (m *DefaultRuntimeMatcher) compareDeploymentMode(runtime *v1beta1.ServingRuntimeSpec, isvc *v1beta1.InferenceService) (bool, string) {
+	isvcEngineDeploymentMode, hasIsvcEngineDeploymentMode := inferenceServiceEngineDeploymentMode(isvc)
+	runtimeEngineDeploymentMode, hasRuntimeEngineDeploymentMode := getRuntimeEngineDeploymentMode(runtime)
+	if ok, reason := compareComponentDeploymentMode(
+		"engine",
+		isvcEngineDeploymentMode,
+		hasIsvcEngineDeploymentMode,
+		runtimeEngineDeploymentMode,
+		hasRuntimeEngineDeploymentMode,
+	); !ok {
+		return false, reason
+	}
+
+	isvcDecoderDeploymentMode, hasIsvcDecoderDeploymentMode := inferenceServiceDecoderDeploymentMode(isvc)
+	runtimeDecoderDeploymentMode, hasRuntimeDecoderDeploymentMode := getRuntimeDecoderDeploymentMode(runtime)
+	if ok, reason := compareComponentDeploymentMode(
+		"decoder",
+		isvcDecoderDeploymentMode,
+		hasIsvcDecoderDeploymentMode,
+		runtimeDecoderDeploymentMode,
+		hasRuntimeDecoderDeploymentMode,
+	); !ok {
+		return false, reason
+	}
+
+	return true, ""
+}
+
+func compareComponentDeploymentMode(
+	componentName string,
+	isvcDeploymentMode constants.DeploymentModeType,
+	hasIsvcDeploymentMode bool,
+	runtimeDeploymentMode constants.DeploymentModeType,
+	hasRuntimeDeploymentMode bool) (bool, string) {
+	// Keep the runtime unless both sides explicitly declare deployment modes and those values differ.
+	if !hasIsvcDeploymentMode || !hasRuntimeDeploymentMode || isvcDeploymentMode == runtimeDeploymentMode {
+		return true, ""
+	}
+
+	return false, fmt.Sprintf("runtime %s deployment mode %s does not match requested %s deployment mode %s",
+		componentName, runtimeDeploymentMode, componentName, isvcDeploymentMode)
+}
+
+func inferenceServiceEngineDeploymentMode(isvc *v1beta1.InferenceService) (constants.DeploymentModeType, bool) {
+	if isvc == nil || isvc.Spec.Engine == nil {
+		return "", false
+	}
+
+	return deploymentModeFromAnnotations(isvc.Spec.Engine.Annotations)
+}
+
+func inferenceServiceDecoderDeploymentMode(isvc *v1beta1.InferenceService) (constants.DeploymentModeType, bool) {
+	if isvc == nil || isvc.Spec.Decoder == nil {
+		return "", false
+	}
+
+	return deploymentModeFromAnnotations(isvc.Spec.Decoder.Annotations)
+}
+
+func getRuntimeEngineDeploymentMode(runtime *v1beta1.ServingRuntimeSpec) (constants.DeploymentModeType, bool) {
+	if runtime == nil || runtime.EngineConfig == nil {
+		return "", false
+	}
+
+	return deploymentModeFromAnnotations(runtime.EngineConfig.Annotations)
+}
+
+func getRuntimeDecoderDeploymentMode(runtime *v1beta1.ServingRuntimeSpec) (constants.DeploymentModeType, bool) {
+	if runtime == nil || runtime.DecoderConfig == nil {
+		return "", false
+	}
+
+	return deploymentModeFromAnnotations(runtime.DecoderConfig.Annotations)
+}
+
+func deploymentModeFromAnnotations(annotations map[string]string) (constants.DeploymentModeType, bool) {
+	if annotations == nil {
+		return "", false
+	}
+	if mode, exists := annotations[constants.DeploymentMode]; exists {
+		deploymentMode := constants.DeploymentModeType(mode)
+		if deploymentMode.IsValid() {
+			return deploymentMode, true
+		}
+	}
+	return "", false
 }
 
 // compareSupportedModelFormats checks if a model matches a supported format.

--- a/pkg/runtimeselector/matcher.go
+++ b/pkg/runtimeselector/matcher.go
@@ -360,7 +360,7 @@ func isDecoderSpecConfigured(decoder *v1beta1.DecoderSpec) bool {
 // component and the matching runtime component explicitly declare different deployment modes.
 func (m *DefaultRuntimeMatcher) compareDeploymentMode(runtime *v1beta1.ServingRuntimeSpec, isvc *v1beta1.InferenceService) (bool, string) {
 	isvcEngineDeploymentMode, hasIsvcEngineDeploymentMode := inferenceServiceEngineDeploymentMode(isvc)
-	runtimeEngineDeploymentMode, hasRuntimeEngineDeploymentMode := getRuntimeEngineDeploymentMode(runtime)
+	runtimeEngineDeploymentMode, hasRuntimeEngineDeploymentMode := getRuntimeComponentDeploymentMode(runtime, v1beta1.EngineComponent)
 	if ok, reason := compareComponentDeploymentMode(
 		"engine",
 		isvcEngineDeploymentMode,
@@ -372,7 +372,7 @@ func (m *DefaultRuntimeMatcher) compareDeploymentMode(runtime *v1beta1.ServingRu
 	}
 
 	isvcDecoderDeploymentMode, hasIsvcDecoderDeploymentMode := inferenceServiceDecoderDeploymentMode(isvc)
-	runtimeDecoderDeploymentMode, hasRuntimeDecoderDeploymentMode := getRuntimeDecoderDeploymentMode(runtime)
+	runtimeDecoderDeploymentMode, hasRuntimeDecoderDeploymentMode := getRuntimeComponentDeploymentMode(runtime, v1beta1.DecoderComponent)
 	if ok, reason := compareComponentDeploymentMode(
 		"decoder",
 		isvcDecoderDeploymentMode,
@@ -417,20 +417,25 @@ func inferenceServiceDecoderDeploymentMode(isvc *v1beta1.InferenceService) (cons
 	return deploymentModeFromAnnotations(isvc.Spec.Decoder.Annotations)
 }
 
-func getRuntimeEngineDeploymentMode(runtime *v1beta1.ServingRuntimeSpec) (constants.DeploymentModeType, bool) {
-	if runtime == nil || runtime.EngineConfig == nil {
+func getRuntimeComponentDeploymentMode(runtime *v1beta1.ServingRuntimeSpec, componentType v1beta1.ComponentType) (constants.DeploymentModeType, bool) {
+	if runtime == nil {
 		return "", false
 	}
 
-	return deploymentModeFromAnnotations(runtime.EngineConfig.Annotations)
-}
-
-func getRuntimeDecoderDeploymentMode(runtime *v1beta1.ServingRuntimeSpec) (constants.DeploymentModeType, bool) {
-	if runtime == nil || runtime.DecoderConfig == nil {
+	switch componentType {
+	case v1beta1.EngineComponent:
+		if runtime.EngineConfig == nil {
+			return "", false
+		}
+		return deploymentModeFromAnnotations(runtime.EngineConfig.Annotations)
+	case v1beta1.DecoderComponent:
+		if runtime.DecoderConfig == nil {
+			return "", false
+		}
+		return deploymentModeFromAnnotations(runtime.DecoderConfig.Annotations)
+	default:
 		return "", false
 	}
-
-	return deploymentModeFromAnnotations(runtime.DecoderConfig.Annotations)
 }
 
 func deploymentModeFromAnnotations(annotations map[string]string) (constants.DeploymentModeType, bool) {

--- a/pkg/runtimeselector/matcher_test.go
+++ b/pkg/runtimeselector/matcher_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
 )
 
 func TestRuntimeSupportsModel(t *testing.T) {
@@ -884,6 +886,180 @@ func TestGetCompatibilityDetails_AcceleratorClasses(t *testing.T) {
 		report, err := matcher.GetCompatibilityDetails(rt, baseModel, isvc, "rt")
 		assert.NoError(t, err)
 		assert.True(t, report.IsCompatible)
+	})
+}
+
+func TestGetCompatibilityDetails_DeploymentMode(t *testing.T) {
+	matcher := NewDefaultRuntimeMatcher(NewConfig(nil))
+
+	baseModel := &v1beta1.BaseModelSpec{
+		ModelFormat: v1beta1.ModelFormat{Name: "pytorch"},
+	}
+
+	makeRuntime := func(engine *v1beta1.EngineSpec, decoder *v1beta1.DecoderSpec) *v1beta1.ServingRuntimeSpec {
+		return &v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFormat: &v1beta1.ModelFormat{
+						Name:   "pytorch",
+						Weight: 10,
+					},
+					AutoSelect: ptr(true),
+				},
+			},
+			EngineConfig:  engine,
+			DecoderConfig: decoder,
+		}
+	}
+
+	engineWithDeploymentMode := func(deploymentMode constants.DeploymentModeType) *v1beta1.EngineSpec {
+		return &v1beta1.EngineSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+				Annotations: map[string]string{
+					constants.DeploymentMode: string(deploymentMode),
+				},
+			},
+		}
+	}
+
+	decoderWithDeploymentMode := func(deploymentMode constants.DeploymentModeType) *v1beta1.DecoderSpec {
+		return &v1beta1.DecoderSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+				Annotations: map[string]string{
+					constants.DeploymentMode: string(deploymentMode),
+				},
+			},
+		}
+	}
+
+	isvcWithEngineDeploymentMode := func(deploymentMode string) *v1beta1.InferenceService {
+		return &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						Annotations: map[string]string{
+							constants.DeploymentMode: deploymentMode,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	isvcWithDecoderDeploymentMode := func(deploymentMode string) *v1beta1.InferenceService {
+		return &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Decoder: &v1beta1.DecoderSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						Annotations: map[string]string{
+							constants.DeploymentMode: deploymentMode,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("top-level isvc deployment mode is ignored", func(t *testing.T) {
+		servingRuntime := makeRuntime(engineWithDeploymentMode(constants.RawDeployment), nil)
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					constants.DeploymentMode: string(constants.MultiNode),
+				},
+			},
+		}
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvc, "rt")
+		assert.NoError(t, err)
+		assert.True(t, report.IsCompatible)
+	})
+
+	t.Run("empty isvc engine deployment mode is not used for filtering", func(t *testing.T) {
+		servingRuntime := makeRuntime(engineWithDeploymentMode(constants.MultiNode), nil)
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvcWithEngineDeploymentMode(""), "rt")
+		assert.NoError(t, err)
+		assert.True(t, report.IsCompatible)
+	})
+
+	t.Run("isvc engine deployment mode matches runtime engine annotation", func(t *testing.T) {
+		servingRuntime := makeRuntime(engineWithDeploymentMode(constants.MultiNode), nil)
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvcWithEngineDeploymentMode(string(constants.MultiNode)), "rt")
+		assert.NoError(t, err)
+		assert.True(t, report.IsCompatible)
+	})
+
+	t.Run("runtime engine without deployment mode annotation is not used for filtering", func(t *testing.T) {
+		servingRuntime := makeRuntime(&v1beta1.EngineSpec{
+			Leader: &v1beta1.LeaderSpec{},
+			Worker: &v1beta1.WorkerSpec{Size: ptr(1)},
+		}, nil)
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvcWithEngineDeploymentMode(string(constants.MultiNode)), "rt")
+		assert.NoError(t, err)
+		assert.True(t, report.IsCompatible)
+	})
+
+	t.Run("invalid isvc engine deployment mode is not used for filtering", func(t *testing.T) {
+		servingRuntime := makeRuntime(engineWithDeploymentMode(constants.MultiNode), nil)
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvcWithEngineDeploymentMode("InvalidMode"), "rt")
+		assert.NoError(t, err)
+		assert.True(t, report.IsCompatible)
+	})
+
+	t.Run("isvc engine deployment mode rejects runtime engine with different deployment mode", func(t *testing.T) {
+		servingRuntime := makeRuntime(engineWithDeploymentMode(constants.MultiNode), nil)
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvcWithEngineDeploymentMode(string(constants.RawDeployment)), "rt")
+		assert.NoError(t, err)
+		assert.False(t, report.IsCompatible)
+		assert.Contains(t, report.IncompatibilityReasons[0], "engine deployment mode")
+	})
+
+	t.Run("isvc decoder deployment mode matches runtime decoder annotation", func(t *testing.T) {
+		servingRuntime := makeRuntime(nil, decoderWithDeploymentMode(constants.MultiNode))
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvcWithDecoderDeploymentMode(string(constants.MultiNode)), "rt")
+		assert.NoError(t, err)
+		assert.True(t, report.IsCompatible)
+	})
+
+	t.Run("runtime decoder without deployment mode annotation is not used for filtering", func(t *testing.T) {
+		servingRuntime := makeRuntime(nil, &v1beta1.DecoderSpec{
+			Leader: &v1beta1.LeaderSpec{},
+			Worker: &v1beta1.WorkerSpec{Size: ptr(1)},
+		})
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvcWithDecoderDeploymentMode(string(constants.MultiNode)), "rt")
+		assert.NoError(t, err)
+		assert.True(t, report.IsCompatible)
+	})
+
+	t.Run("isvc decoder deployment mode rejects runtime decoder with different deployment mode", func(t *testing.T) {
+		servingRuntime := makeRuntime(nil, decoderWithDeploymentMode(constants.RawDeployment))
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvcWithDecoderDeploymentMode(string(constants.MultiNode)), "rt")
+		assert.NoError(t, err)
+		assert.False(t, report.IsCompatible)
+		assert.Contains(t, report.IncompatibilityReasons[0], "decoder deployment mode")
+	})
+
+	t.Run("runtime is rejected when decoder mismatches even if engine matches", func(t *testing.T) {
+		servingRuntime := makeRuntime(engineWithDeploymentMode(constants.MultiNode), decoderWithDeploymentMode(constants.RawDeployment))
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Engine:  engineWithDeploymentMode(constants.MultiNode),
+				Decoder: decoderWithDeploymentMode(constants.MultiNode),
+			},
+		}
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvc, "rt")
+		assert.NoError(t, err)
+		assert.False(t, report.IsCompatible)
+		assert.Contains(t, report.IncompatibilityReasons[0], "decoder deployment mode")
 	})
 }
 

--- a/pkg/runtimeselector/matcher_test.go
+++ b/pkg/runtimeselector/matcher_test.go
@@ -862,7 +862,6 @@ func TestGetCompatibilityDetails_AcceleratorClasses(t *testing.T) {
 
 	t.Run("engine override matches class", func(t *testing.T) {
 		rt := mkRuntime([]string{"H100"})
-		rt.EngineConfig = &v1beta1.EngineSpec{}
 		cls := "H100"
 		isvc := &v1beta1.InferenceService{Spec: v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{AcceleratorOverride: &v1beta1.AcceleratorSelector{AcceleratorClass: &cls}}}}
 
@@ -873,7 +872,6 @@ func TestGetCompatibilityDetails_AcceleratorClasses(t *testing.T) {
 
 	t.Run("decoder override mismatches class", func(t *testing.T) {
 		rt := mkRuntime([]string{"nvidia-a100"})
-		rt.DecoderConfig = &v1beta1.DecoderSpec{}
 		cls := "H100"
 		isvc := &v1beta1.InferenceService{Spec: v1beta1.InferenceServiceSpec{Decoder: &v1beta1.DecoderSpec{AcceleratorOverride: &v1beta1.AcceleratorSelector{AcceleratorClass: &cls}}}}
 
@@ -888,99 +886,6 @@ func TestGetCompatibilityDetails_AcceleratorClasses(t *testing.T) {
 		report, err := matcher.GetCompatibilityDetails(rt, baseModel, isvc, "rt")
 		assert.NoError(t, err)
 		assert.True(t, report.IsCompatible)
-	})
-}
-
-func TestGetCompatibilityDetails_RequiredComponents(t *testing.T) {
-	matcher := NewDefaultRuntimeMatcher(NewConfig(nil))
-
-	baseModel := &v1beta1.BaseModelSpec{
-		ModelFormat: v1beta1.ModelFormat{Name: "pytorch"},
-	}
-
-	makeRuntime := func(engine *v1beta1.EngineSpec, decoder *v1beta1.DecoderSpec) *v1beta1.ServingRuntimeSpec {
-		return &v1beta1.ServingRuntimeSpec{
-			SupportedModelFormats: []v1beta1.SupportedModelFormat{
-				{
-					ModelFormat: &v1beta1.ModelFormat{
-						Name:   "pytorch",
-						Weight: 10,
-					},
-					AutoSelect: ptr(true),
-				},
-			},
-			EngineConfig:  engine,
-			DecoderConfig: decoder,
-		}
-	}
-
-	t.Run("empty isvc engine does not require runtime engine config", func(t *testing.T) {
-		servingRuntime := makeRuntime(nil, nil)
-		isvc := &v1beta1.InferenceService{
-			Spec: v1beta1.InferenceServiceSpec{
-				Engine: &v1beta1.EngineSpec{},
-			},
-		}
-
-		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvc, "rt")
-		assert.NoError(t, err)
-		assert.True(t, report.IsCompatible)
-	})
-
-	t.Run("configured isvc engine requires runtime engine config", func(t *testing.T) {
-		servingRuntime := makeRuntime(nil, nil)
-		isvc := &v1beta1.InferenceService{
-			Spec: v1beta1.InferenceServiceSpec{
-				Engine: &v1beta1.EngineSpec{
-					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
-						MinReplicas: ptr(1),
-					},
-				},
-			},
-		}
-
-		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvc, "rt")
-		assert.NoError(t, err)
-		assert.False(t, report.IsCompatible)
-		assert.Contains(t, report.IncompatibilityReasons[0], "engineConfig")
-
-		ok, err := matcher.IsCompatible(servingRuntime, baseModel, isvc, "rt")
-		assert.False(t, ok)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "engineConfig")
-		assert.True(t, IsRuntimeComponentMismatchError(err))
-	})
-
-	t.Run("empty isvc decoder does not require runtime decoder config", func(t *testing.T) {
-		servingRuntime := makeRuntime(nil, nil)
-		isvc := &v1beta1.InferenceService{
-			Spec: v1beta1.InferenceServiceSpec{
-				Decoder: &v1beta1.DecoderSpec{},
-			},
-		}
-
-		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvc, "rt")
-		assert.NoError(t, err)
-		assert.True(t, report.IsCompatible)
-	})
-
-	t.Run("configured isvc decoder requires runtime decoder config", func(t *testing.T) {
-		servingRuntime := makeRuntime(&v1beta1.EngineSpec{}, nil)
-		isvc := &v1beta1.InferenceService{
-			Spec: v1beta1.InferenceServiceSpec{
-				Engine: &v1beta1.EngineSpec{},
-				Decoder: &v1beta1.DecoderSpec{
-					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
-						MinReplicas: ptr(1),
-					},
-				},
-			},
-		}
-
-		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvc, "rt")
-		assert.NoError(t, err)
-		assert.False(t, report.IsCompatible)
-		assert.Contains(t, report.IncompatibilityReasons[0], "decoderConfig")
 	})
 }
 

--- a/pkg/runtimeselector/matcher_test.go
+++ b/pkg/runtimeselector/matcher_test.go
@@ -862,6 +862,7 @@ func TestGetCompatibilityDetails_AcceleratorClasses(t *testing.T) {
 
 	t.Run("engine override matches class", func(t *testing.T) {
 		rt := mkRuntime([]string{"H100"})
+		rt.EngineConfig = &v1beta1.EngineSpec{}
 		cls := "H100"
 		isvc := &v1beta1.InferenceService{Spec: v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{AcceleratorOverride: &v1beta1.AcceleratorSelector{AcceleratorClass: &cls}}}}
 
@@ -872,6 +873,7 @@ func TestGetCompatibilityDetails_AcceleratorClasses(t *testing.T) {
 
 	t.Run("decoder override mismatches class", func(t *testing.T) {
 		rt := mkRuntime([]string{"nvidia-a100"})
+		rt.DecoderConfig = &v1beta1.DecoderSpec{}
 		cls := "H100"
 		isvc := &v1beta1.InferenceService{Spec: v1beta1.InferenceServiceSpec{Decoder: &v1beta1.DecoderSpec{AcceleratorOverride: &v1beta1.AcceleratorSelector{AcceleratorClass: &cls}}}}
 
@@ -886,6 +888,99 @@ func TestGetCompatibilityDetails_AcceleratorClasses(t *testing.T) {
 		report, err := matcher.GetCompatibilityDetails(rt, baseModel, isvc, "rt")
 		assert.NoError(t, err)
 		assert.True(t, report.IsCompatible)
+	})
+}
+
+func TestGetCompatibilityDetails_RequiredComponents(t *testing.T) {
+	matcher := NewDefaultRuntimeMatcher(NewConfig(nil))
+
+	baseModel := &v1beta1.BaseModelSpec{
+		ModelFormat: v1beta1.ModelFormat{Name: "pytorch"},
+	}
+
+	makeRuntime := func(engine *v1beta1.EngineSpec, decoder *v1beta1.DecoderSpec) *v1beta1.ServingRuntimeSpec {
+		return &v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFormat: &v1beta1.ModelFormat{
+						Name:   "pytorch",
+						Weight: 10,
+					},
+					AutoSelect: ptr(true),
+				},
+			},
+			EngineConfig:  engine,
+			DecoderConfig: decoder,
+		}
+	}
+
+	t.Run("empty isvc engine does not require runtime engine config", func(t *testing.T) {
+		servingRuntime := makeRuntime(nil, nil)
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{},
+			},
+		}
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvc, "rt")
+		assert.NoError(t, err)
+		assert.True(t, report.IsCompatible)
+	})
+
+	t.Run("configured isvc engine requires runtime engine config", func(t *testing.T) {
+		servingRuntime := makeRuntime(nil, nil)
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: ptr(1),
+					},
+				},
+			},
+		}
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvc, "rt")
+		assert.NoError(t, err)
+		assert.False(t, report.IsCompatible)
+		assert.Contains(t, report.IncompatibilityReasons[0], "engineConfig")
+
+		ok, err := matcher.IsCompatible(servingRuntime, baseModel, isvc, "rt")
+		assert.False(t, ok)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "engineConfig")
+		assert.True(t, IsRuntimeComponentMismatchError(err))
+	})
+
+	t.Run("empty isvc decoder does not require runtime decoder config", func(t *testing.T) {
+		servingRuntime := makeRuntime(nil, nil)
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Decoder: &v1beta1.DecoderSpec{},
+			},
+		}
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvc, "rt")
+		assert.NoError(t, err)
+		assert.True(t, report.IsCompatible)
+	})
+
+	t.Run("configured isvc decoder requires runtime decoder config", func(t *testing.T) {
+		servingRuntime := makeRuntime(&v1beta1.EngineSpec{}, nil)
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{},
+				Decoder: &v1beta1.DecoderSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						MinReplicas: ptr(1),
+					},
+				},
+			},
+		}
+
+		report, err := matcher.GetCompatibilityDetails(servingRuntime, baseModel, isvc, "rt")
+		assert.NoError(t, err)
+		assert.False(t, report.IsCompatible)
+		assert.Contains(t, report.IncompatibilityReasons[0], "decoderConfig")
 	})
 }
 

--- a/pkg/runtimeselector/selector_test.go
+++ b/pkg/runtimeselector/selector_test.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
 )
 
 // Helper functions
@@ -866,6 +867,105 @@ func TestGetCompatibleRuntimes_ExcludeNoAutoSelect(t *testing.T) {
 	// Only the auto-select runtime should appear
 	assert.Len(t, matches, 1)
 	assert.Equal(t, "rt-auto", matches[0].Name)
+}
+
+func TestSelectRuntime_FiltersByDeploymentModeAnnotation(t *testing.T) {
+	fakeClient := createFakeClient()
+	selector := New(fakeClient)
+
+	rawRuntime := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "raw-rt", Namespace: "default"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFormat: &v1beta1.ModelFormat{Name: "pytorch", Weight: 20},
+					AutoSelect:  ptr(true),
+				},
+			},
+			EngineConfig: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					Annotations: map[string]string{
+						constants.DeploymentMode: string(constants.RawDeployment),
+					},
+				},
+			},
+		},
+	}
+	multiRuntime := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "multi-rt", Namespace: "default"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFormat: &v1beta1.ModelFormat{Name: "pytorch", Weight: 10},
+					AutoSelect:  ptr(true),
+				},
+			},
+			EngineConfig: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					Annotations: map[string]string{
+						constants.DeploymentMode: string(constants.MultiNode),
+					},
+				},
+				Leader: &v1beta1.LeaderSpec{},
+				Worker: &v1beta1.WorkerSpec{Size: ptr(1)},
+			},
+		},
+	}
+	noAnnotationRuntime := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-annotation-rt", Namespace: "default"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFormat: &v1beta1.ModelFormat{Name: "pytorch", Weight: 5},
+					AutoSelect:  ptr(true),
+				},
+			},
+			EngineConfig: &v1beta1.EngineSpec{
+				Leader: &v1beta1.LeaderSpec{},
+				Worker: &v1beta1.WorkerSpec{Size: ptr(1)},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	assert.NoError(t, fakeClient.Create(ctx, rawRuntime))
+	assert.NoError(t, fakeClient.Create(ctx, multiRuntime))
+	assert.NoError(t, fakeClient.Create(ctx, noAnnotationRuntime))
+
+	model := &v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: "pytorch"}}
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "isvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.DeploymentMode: string(constants.RawDeployment),
+			},
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Engine: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					Annotations: map[string]string{
+						constants.DeploymentMode: string(constants.MultiNode),
+					},
+				},
+			},
+		},
+	}
+
+	matches, err := selector.GetCompatibleRuntimes(ctx, model, isvc, "default")
+	assert.NoError(t, err)
+	assert.Len(t, matches, 2)
+	assert.Equal(t, "multi-rt", matches[0].Name)
+	assert.Equal(t, "no-annotation-rt", matches[1].Name)
+
+	selection, err := selector.SelectRuntime(ctx, model, isvc)
+	assert.NoError(t, err)
+	assert.Equal(t, "multi-rt", selection.Name)
+
+	isvc.Spec.Engine.Annotations[constants.DeploymentMode] = ""
+	matches, err = selector.GetCompatibleRuntimes(ctx, model, isvc, "default")
+	assert.NoError(t, err)
+	assert.Len(t, matches, 3)
 }
 
 func TestSelectRuntime_NoRuntimeFoundError_Details(t *testing.T) {

--- a/pkg/runtimeselector/selector_test.go
+++ b/pkg/runtimeselector/selector_test.go
@@ -869,76 +869,6 @@ func TestGetCompatibleRuntimes_ExcludeNoAutoSelect(t *testing.T) {
 	assert.Equal(t, "rt-auto", matches[0].Name)
 }
 
-func TestSelectRuntime_FiltersByRequiredComponents(t *testing.T) {
-	fakeClient := createFakeClient()
-	selector := New(fakeClient)
-
-	noConfigRuntime := &v1beta1.ServingRuntime{
-		ObjectMeta: metav1.ObjectMeta{Name: "no-config-rt", Namespace: "default"},
-		Spec: v1beta1.ServingRuntimeSpec{
-			SupportedModelFormats: []v1beta1.SupportedModelFormat{
-				{ModelFormat: &v1beta1.ModelFormat{Name: "pytorch", Weight: 30}, AutoSelect: ptr(true)},
-			},
-		},
-	}
-	engineOnlyRuntime := &v1beta1.ServingRuntime{
-		ObjectMeta: metav1.ObjectMeta{Name: "engine-only-rt", Namespace: "default"},
-		Spec: v1beta1.ServingRuntimeSpec{
-			SupportedModelFormats: []v1beta1.SupportedModelFormat{
-				{ModelFormat: &v1beta1.ModelFormat{Name: "pytorch", Weight: 20}, AutoSelect: ptr(true)},
-			},
-			EngineConfig: &v1beta1.EngineSpec{},
-		},
-	}
-	engineDecoderRuntime := &v1beta1.ServingRuntime{
-		ObjectMeta: metav1.ObjectMeta{Name: "engine-decoder-rt", Namespace: "default"},
-		Spec: v1beta1.ServingRuntimeSpec{
-			SupportedModelFormats: []v1beta1.SupportedModelFormat{
-				{ModelFormat: &v1beta1.ModelFormat{Name: "pytorch", Weight: 10}, AutoSelect: ptr(true)},
-			},
-			EngineConfig:  &v1beta1.EngineSpec{},
-			DecoderConfig: &v1beta1.DecoderSpec{},
-		},
-	}
-
-	ctx := context.Background()
-	assert.NoError(t, fakeClient.Create(ctx, noConfigRuntime))
-	assert.NoError(t, fakeClient.Create(ctx, engineOnlyRuntime))
-	assert.NoError(t, fakeClient.Create(ctx, engineDecoderRuntime))
-
-	model := &v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: "pytorch"}}
-	isvc := &v1beta1.InferenceService{
-		ObjectMeta: metav1.ObjectMeta{Name: "isvc", Namespace: "default"},
-		Spec: v1beta1.InferenceServiceSpec{
-			Engine: &v1beta1.EngineSpec{
-				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
-					MinReplicas: ptr(1),
-				},
-			},
-			Decoder: &v1beta1.DecoderSpec{
-				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
-					MinReplicas: ptr(1),
-				},
-			},
-		},
-	}
-
-	matches, err := selector.GetCompatibleRuntimes(ctx, model, isvc, "default")
-	assert.NoError(t, err)
-	assert.Len(t, matches, 1)
-	assert.Equal(t, "engine-decoder-rt", matches[0].Name)
-
-	selection, err := selector.SelectRuntime(ctx, model, isvc)
-	assert.NoError(t, err)
-	assert.Equal(t, "engine-decoder-rt", selection.Name)
-
-	isvc.Spec.Engine = &v1beta1.EngineSpec{}
-	isvc.Spec.Decoder = &v1beta1.DecoderSpec{}
-	matches, err = selector.GetCompatibleRuntimes(ctx, model, isvc, "default")
-	assert.NoError(t, err)
-	assert.Len(t, matches, 3)
-}
-
 func TestSelectRuntime_FiltersByDeploymentModeAnnotation(t *testing.T) {
 	fakeClient := createFakeClient()
 	selector := New(fakeClient)
@@ -1289,8 +1219,6 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 				AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
 					AcceleratorClasses: []string{"nvidia-tesla-t4", "nvidia-tesla-v100", "nvidia-a100"},
 				},
-				EngineConfig:  &v1beta1.EngineSpec{},
-				DecoderConfig: &v1beta1.DecoderSpec{},
 			},
 		},
 		{
@@ -1316,8 +1244,6 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 				AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
 					AcceleratorClasses: []string{"nvidia-tesla-t4", "nvidia-tesla-v100", "nvidia-a100"},
 				},
-				EngineConfig:  &v1beta1.EngineSpec{},
-				DecoderConfig: &v1beta1.DecoderSpec{},
 			},
 		},
 		{
@@ -1342,8 +1268,6 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 				AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
 					AcceleratorClasses: []string{"nvidia-tesla-t4", "nvidia-tesla-v100", "nvidia-a100"},
 				},
-				EngineConfig:  &v1beta1.EngineSpec{},
-				DecoderConfig: &v1beta1.DecoderSpec{},
 			},
 		},
 		{
@@ -1368,8 +1292,6 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 				AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
 					AcceleratorClasses: []string{"H100"},
 				},
-				EngineConfig:  &v1beta1.EngineSpec{},
-				DecoderConfig: &v1beta1.DecoderSpec{},
 			},
 		},
 		{
@@ -1394,8 +1316,6 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 				AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
 					AcceleratorClasses: []string{"H100", "nvidia-tesla-t4", "nvidia-tesla-v100", "nvidia-a100"},
 				},
-				EngineConfig:  &v1beta1.EngineSpec{},
-				DecoderConfig: &v1beta1.DecoderSpec{},
 			},
 		},
 	}

--- a/pkg/runtimeselector/selector_test.go
+++ b/pkg/runtimeselector/selector_test.go
@@ -869,6 +869,76 @@ func TestGetCompatibleRuntimes_ExcludeNoAutoSelect(t *testing.T) {
 	assert.Equal(t, "rt-auto", matches[0].Name)
 }
 
+func TestSelectRuntime_FiltersByRequiredComponents(t *testing.T) {
+	fakeClient := createFakeClient()
+	selector := New(fakeClient)
+
+	noConfigRuntime := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-config-rt", Namespace: "default"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{ModelFormat: &v1beta1.ModelFormat{Name: "pytorch", Weight: 30}, AutoSelect: ptr(true)},
+			},
+		},
+	}
+	engineOnlyRuntime := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "engine-only-rt", Namespace: "default"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{ModelFormat: &v1beta1.ModelFormat{Name: "pytorch", Weight: 20}, AutoSelect: ptr(true)},
+			},
+			EngineConfig: &v1beta1.EngineSpec{},
+		},
+	}
+	engineDecoderRuntime := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "engine-decoder-rt", Namespace: "default"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{ModelFormat: &v1beta1.ModelFormat{Name: "pytorch", Weight: 10}, AutoSelect: ptr(true)},
+			},
+			EngineConfig:  &v1beta1.EngineSpec{},
+			DecoderConfig: &v1beta1.DecoderSpec{},
+		},
+	}
+
+	ctx := context.Background()
+	assert.NoError(t, fakeClient.Create(ctx, noConfigRuntime))
+	assert.NoError(t, fakeClient.Create(ctx, engineOnlyRuntime))
+	assert.NoError(t, fakeClient.Create(ctx, engineDecoderRuntime))
+
+	model := &v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: "pytorch"}}
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc", Namespace: "default"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Engine: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					MinReplicas: ptr(1),
+				},
+			},
+			Decoder: &v1beta1.DecoderSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					MinReplicas: ptr(1),
+				},
+			},
+		},
+	}
+
+	matches, err := selector.GetCompatibleRuntimes(ctx, model, isvc, "default")
+	assert.NoError(t, err)
+	assert.Len(t, matches, 1)
+	assert.Equal(t, "engine-decoder-rt", matches[0].Name)
+
+	selection, err := selector.SelectRuntime(ctx, model, isvc)
+	assert.NoError(t, err)
+	assert.Equal(t, "engine-decoder-rt", selection.Name)
+
+	isvc.Spec.Engine = &v1beta1.EngineSpec{}
+	isvc.Spec.Decoder = &v1beta1.DecoderSpec{}
+	matches, err = selector.GetCompatibleRuntimes(ctx, model, isvc, "default")
+	assert.NoError(t, err)
+	assert.Len(t, matches, 3)
+}
+
 func TestSelectRuntime_FiltersByDeploymentModeAnnotation(t *testing.T) {
 	fakeClient := createFakeClient()
 	selector := New(fakeClient)
@@ -1219,6 +1289,8 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 				AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
 					AcceleratorClasses: []string{"nvidia-tesla-t4", "nvidia-tesla-v100", "nvidia-a100"},
 				},
+				EngineConfig:  &v1beta1.EngineSpec{},
+				DecoderConfig: &v1beta1.DecoderSpec{},
 			},
 		},
 		{
@@ -1244,6 +1316,8 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 				AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
 					AcceleratorClasses: []string{"nvidia-tesla-t4", "nvidia-tesla-v100", "nvidia-a100"},
 				},
+				EngineConfig:  &v1beta1.EngineSpec{},
+				DecoderConfig: &v1beta1.DecoderSpec{},
 			},
 		},
 		{
@@ -1268,6 +1342,8 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 				AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
 					AcceleratorClasses: []string{"nvidia-tesla-t4", "nvidia-tesla-v100", "nvidia-a100"},
 				},
+				EngineConfig:  &v1beta1.EngineSpec{},
+				DecoderConfig: &v1beta1.DecoderSpec{},
 			},
 		},
 		{
@@ -1292,6 +1368,8 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 				AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
 					AcceleratorClasses: []string{"H100"},
 				},
+				EngineConfig:  &v1beta1.EngineSpec{},
+				DecoderConfig: &v1beta1.DecoderSpec{},
 			},
 		},
 		{
@@ -1316,6 +1394,8 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 				AcceleratorRequirements: &v1beta1.AcceleratorRequirements{
 					AcceleratorClasses: []string{"H100", "nvidia-tesla-t4", "nvidia-tesla-v100", "nvidia-a100"},
 				},
+				EngineConfig:  &v1beta1.EngineSpec{},
+				DecoderConfig: &v1beta1.DecoderSpec{},
 			},
 		},
 	}


### PR DESCRIPTION
## Context

Runtime auto-selection currently selects compatible runtimes based on model format, accelerator requirements, and related compatibility checks. For models that have separate single-node and multi-node runtimes, the selected runtime also needs to respect the desired component deployment mode.

This PR adds generic deployment mode matching to runtime auto-selection so an InferenceService can distinguish between runtimes intended for different deployment modes.

**Changes:**
- Add component-level `ome.io/deploymentMode` compatibility checks to runtime matching.
- Compare deployment mode annotations between:
  - ISVC `spec.engine.annotations` and runtime `engineConfig.annotations`
  - ISVC `spec.decoder.annotations` and runtime `decoderConfig.annotations`
- Ignore ISVC top-level metadata `ome.io/deploymentMode` during runtime selection.
- Preserve backward compatibility by only filtering out a runtime when:
  - the ISVC component (engine/decoder) has a valid deployment mode annotation,
  - the corresponding runtime component also has a valid deployment mode annotation,
  - and the two values differ.
- Treat missing, empty, or invalid deployment mode annotations as unset, so they do not add filtering constraints.
- Surface deployment mode mismatch reasons through compatibility details.
- Add tests for engine and decoder deployment mode matching, mismatch rejection, top-level annotation ignoring, invalid/empty annotation handling, and selector behavior.

## Compatibility

This keeps existing runtimes selectable when they do not declare component-level deployment mode annotations. Existing ISVCs without component-level deployment mode annotations continue to follow the previous runtime selection behavior.

## Test
Tested in cluster

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
