### PR TITLE
Handle long LWS-derived label values

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -662,12 +662,14 @@ func ModelConfigName(isvcName string) string {
 	return fmt.Sprintf("modelconfig-%s", isvcName)
 }
 
-func LWSName(isvcName string) string {
-	var maxLen = 50
-	if len(isvcName) > maxLen {
-		isvcName = isvcName[len(isvcName)-maxLen:]
-	}
-	return fmt.Sprintf("lws-%s", isvcName)
+func LWSName(componentName string) string {
+	const (
+		lwsNamePrefix = "lws-"
+		// Leave room for downstream prefixes/suffixes when this name is embedded in Pod label values.
+		maxLWSNameLength = 35
+	)
+
+	return TruncateNameWithPrefix(componentName, lwsNamePrefix, maxLWSNameLength)
 }
 
 func InferenceServiceHostName(name string, namespace string, domain string) string {
@@ -950,6 +952,19 @@ func GetModelConfigMapKey(namespace, modelName string, isClusterBaseModel bool) 
 // TruncateNameWithMaxLength return a valid DNS name
 func TruncateNameWithMaxLength(name string, maxLength int) string {
 	return truncateWithHashTweaks(name, maxLength)
+}
+
+func TruncateNameWithPrefix(name, prefix string, maxLength int) string {
+	if maxLength <= 0 {
+		return ""
+	}
+
+	payloadMaxLength := maxLength - len(prefix)
+	if payloadMaxLength <= 0 {
+		return TruncateNameWithMaxLength(prefix, maxLength)
+	}
+
+	return prefix + TruncateNameWithMaxLength(name, payloadMaxLength)
 }
 
 // ParseModelInfoFromConfigMapKey attempts to parse model information from a ConfigMap key

--- a/pkg/constants/constants_test.go
+++ b/pkg/constants/constants_test.go
@@ -1,1 +1,64 @@
 package constants
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLWSNameTruncates(t *testing.T) {
+	tests := []struct {
+		name              string
+		componentName     string
+		expectedTruncated bool
+	}{
+		{
+			name:              "short component name",
+			componentName:     "my-model-engine",
+			expectedTruncated: false,
+		},
+		{
+			name:              "actual long engine component name",
+			componentName:     "amaaaaaabgjpxjqamiuior4qamufon2clgneukbxomingadlfcsgq67sicoa-engine",
+			expectedTruncated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const (
+				maxLabelValueLength        = 63
+				maxLWSNameLength           = 35
+				lwsNamePrefix              = "lws-"
+				workerStatefulSetSuffix    = "-0"
+				statefulSetRevisionHash    = "75965d8c9f"
+				kueueLeaderWorkerSetPrefix = "leaderworkerset-"
+				kueueWorkloadHashSuffix    = "-ece5c"
+			)
+
+			got := LWSName(tt.componentName)
+			workerStatefulSetName := got + workerStatefulSetSuffix
+			revisionLabelValue := workerStatefulSetName + "-" + statefulSetRevisionHash
+			kueueWorkloadLabelValue := kueueLeaderWorkerSetPrefix + got + workerStatefulSetSuffix + kueueWorkloadHashSuffix
+			expected := TruncateNameWithPrefix(tt.componentName, lwsNamePrefix, maxLWSNameLength)
+
+			if len(got) > maxLWSNameLength {
+				t.Fatalf("LWSName length = %d, want <= %d: %q", len(got), maxLWSNameLength, got)
+			}
+			if !strings.HasPrefix(got, lwsNamePrefix) {
+				t.Fatalf("LWSName = %q, want prefix %q", got, lwsNamePrefix)
+			}
+			if tt.expectedTruncated && got == lwsNamePrefix+tt.componentName {
+				t.Fatalf("LWSName = %q, want truncated name", got)
+			}
+			if len(revisionLabelValue) > maxLabelValueLength {
+				t.Fatalf("StatefulSet revision label value length = %d, want <= %d: %q", len(revisionLabelValue), maxLabelValueLength, revisionLabelValue)
+			}
+			if len(kueueWorkloadLabelValue) > maxLabelValueLength {
+				t.Fatalf("Kueue workload label value length = %d, want <= %d: %q", len(kueueWorkloadLabelValue), maxLabelValueLength, kueueWorkloadLabelValue)
+			}
+			if got != expected {
+				t.Fatalf("LWSName = %q, want %q", got, expected)
+			}
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/lws/lws_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/lws/lws_reconciler.go
@@ -53,7 +53,7 @@ func createLWS(headPod *corev1.PodSpec,
 	workerPodMeta := componentMeta.DeepCopy()
 	lwsObjectMeta := componentMeta.DeepCopy()
 	lwsObjectMeta.Name = constants.LWSName(componentMeta.Name)
-	headPodMeta.Labels["app"] = constants.GetRawServiceLabel(componentMeta.Name)
+	headPodMeta.Labels["app"] = constants.TruncateNameWithMaxLength(componentMeta.Name, 63)
 	headPodMeta.Labels["ray.io/node-type"] = "head"
 	utils.SetPodLabelsFromAnnotations(headPodMeta)
 	utils.SetPodLabelsFromAnnotations(workerPodMeta)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/lws/lws_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/lws/lws_reconciler_test.go
@@ -163,6 +163,34 @@ func TestNewLWSReconciler(t *testing.T) {
 	assert.Equal(t, int32(2), *reconciler.LWS.Spec.Replicas)                  // From componentExt.MinReplicas
 }
 
+func TestCreateLWSTruncatesLeaderAppLabel(t *testing.T) {
+	testContainer := corev1.Container{
+		Name:  "test-container",
+		Image: "test-image:latest",
+	}
+	headPod := &corev1.PodSpec{
+		Containers: []corev1.Container{testContainer},
+	}
+	workerPod := &corev1.PodSpec{
+		Containers: []corev1.Container{testContainer},
+	}
+	componentMeta := metav1.ObjectMeta{
+		Name:      "amaaaaaabgjpxjqamiuior4qamufon2clgneukbxomingadlfcsgq67sicoa-engine",
+		Namespace: "default",
+		Labels: map[string]string{
+			"app": "test-isvc",
+		},
+	}
+	componentExt := &v1beta1.ComponentExtensionSpec{}
+
+	leaderWorkerSet := createLWS(headPod, workerPod, 1, componentExt, componentMeta)
+	expectedAppLabel := constants.TruncateNameWithMaxLength(componentMeta.Name, 63)
+
+	assert.Len(t, leaderWorkerSet.Spec.LeaderWorkerTemplate.LeaderTemplate.Labels["app"], 63)
+	assert.Equal(t, expectedAppLabel, leaderWorkerSet.Spec.LeaderWorkerTemplate.LeaderTemplate.Labels["app"])
+	assert.Equal(t, "test-isvc", leaderWorkerSet.Spec.LeaderWorkerTemplate.WorkerTemplate.Labels["app"])
+}
+
 func TestReconcile(t *testing.T) {
 	// Setup test scheme
 	scheme := runtime.NewScheme()


### PR DESCRIPTION
## Why we need it
Long inference service component names can produce generated resource names or pod labels that exceed Kubernetes label value length limits.

## Changes
- Truncate the LWS leader pod `app` label to 63 characters.
  This prevents long component names from being copied directly into the leader pod’s `app` label value and violating Kubernetes label constraints.

- Limit generated LWS name to 35 characters.
  This keeps derived names safely below label-value limits after downstream controllers add their own prefixes, indexes, and hash suffixes. It also adds coverage for short and long component names, including common derived label values.

## Tests
Tested

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
