### PR TITLE
[Core] Prioritize model-agent delete and same-path reuse tasks

### DIFF
--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -58,6 +58,8 @@ spec:
         - {{ .Values.modelAgent.hostPath }}
         - --num-download-worker
         - '2'
+        - --num-high-priority-worker
+        - '1'
         - --same-path-wait-timeout
         - 30m
         env:

--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -58,6 +58,8 @@ spec:
         - {{ .Values.modelAgent.hostPath }}
         - --num-download-worker
         - '2'
+        - --same-path-wait-timeout
+        - 30m
         env:
         - name: NODE_NAME
           valueFrom:

--- a/cmd/model-agent/main.go
+++ b/cmd/model-agent/main.go
@@ -32,19 +32,20 @@ import (
 
 // config holds all configuration parameters for the model agent
 type config struct {
-	port                 int
-	modelsRootDir        string
-	modelsRootDirOnHost  string
-	nodeName             string
-	nodeLabelRetry       int
-	concurrency          int
-	multipartConcurrency int
-	downloadRetry        int
-	downloadAuthType     string
-	numDownloadWorker    int
-	samePathWaitTimeout  time.Duration
-	namespace            string
-	logLevel             string
+	port                  int
+	modelsRootDir         string
+	modelsRootDirOnHost   string
+	nodeName              string
+	nodeLabelRetry        int
+	concurrency           int
+	multipartConcurrency  int
+	downloadRetry         int
+	downloadAuthType      string
+	numDownloadWorker     int
+	numHighPriorityWorker int
+	samePathWaitTimeout   time.Duration
+	namespace             string
+	logLevel              string
 }
 
 // Logger type alias for zap.SugaredLogger
@@ -73,6 +74,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&cfg.concurrency, "concurrency", 4, "Number of concurrent download workers per gopher")
 	rootCmd.PersistentFlags().IntVar(&cfg.multipartConcurrency, "multipart-concurrency", 4, "Number of concurrent multipart download workers per gopher")
 	rootCmd.PersistentFlags().IntVar(&cfg.numDownloadWorker, "num-download-worker", 5, "Number of download workers")
+	rootCmd.PersistentFlags().IntVar(&cfg.numHighPriorityWorker, "num-high-priority-worker", 1, "Number of high-priority workers for delete and same-path reuse tasks")
 	rootCmd.PersistentFlags().DurationVar(&cfg.samePathWaitTimeout, "same-path-wait-timeout", 30*time.Minute, "Maximum time to wait for same-path model reuse before falling back to normal download")
 	rootCmd.PersistentFlags().StringVar(&cfg.namespace, "namespace", "ome", "Kubernetes namespace to use")
 	rootCmd.PersistentFlags().StringVar(&cfg.logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
@@ -348,7 +350,7 @@ func runCommand(cmd *cobra.Command, args []string) {
 	}()
 
 	// Start gopher (download workers)
-	go gopher.Run(stopCh, cfg.numDownloadWorker)
+	go gopher.Run(stopCh, cfg.numDownloadWorker, cfg.numHighPriorityWorker)
 
 	// Start scout (watchers)
 	if err := scout.Run(stopCh); err != nil {

--- a/cmd/model-agent/main.go
+++ b/cmd/model-agent/main.go
@@ -42,6 +42,7 @@ type config struct {
 	downloadRetry        int
 	downloadAuthType     string
 	numDownloadWorker    int
+	samePathWaitTimeout  time.Duration
 	namespace            string
 	logLevel             string
 }
@@ -72,6 +73,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&cfg.concurrency, "concurrency", 4, "Number of concurrent download workers per gopher")
 	rootCmd.PersistentFlags().IntVar(&cfg.multipartConcurrency, "multipart-concurrency", 4, "Number of concurrent multipart download workers per gopher")
 	rootCmd.PersistentFlags().IntVar(&cfg.numDownloadWorker, "num-download-worker", 5, "Number of download workers")
+	rootCmd.PersistentFlags().DurationVar(&cfg.samePathWaitTimeout, "same-path-wait-timeout", 30*time.Minute, "Maximum time to wait for same-path model reuse before falling back to normal download")
 	rootCmd.PersistentFlags().StringVar(&cfg.namespace, "namespace", "ome", "Kubernetes namespace to use")
 	rootCmd.PersistentFlags().StringVar(&cfg.logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 
@@ -264,6 +266,7 @@ func initializeComponents(
 		cfg.downloadRetry,
 		cfg.modelsRootDir,
 		gopherTaskChan,
+		cfg.samePathWaitTimeout,
 		nodeLabelReconciler,
 		metrics,
 		logger,

--- a/cmd/model-agent/main_test.go
+++ b/cmd/model-agent/main_test.go
@@ -113,6 +113,7 @@ func TestDefaultConfig(t *testing.T) {
 	testCmd.Flags().IntVar(&cfg.downloadRetry, "download-retry", 3, "retry times for model download")
 	testCmd.Flags().StringVar(&cfg.downloadAuthType, "download-auth-type", "instance-principal", "authentication method for model download")
 	testCmd.Flags().IntVar(&cfg.numDownloadWorker, "num-download-worker", 3, "number of download workers")
+	testCmd.Flags().IntVar(&cfg.numHighPriorityWorker, "num-high-priority-worker", 1, "number of high-priority workers")
 	testCmd.Flags().DurationVar(&cfg.samePathWaitTimeout, "same-path-wait-timeout", 30*time.Minute, "same-path wait timeout")
 	testCmd.Flags().StringVar(&cfg.namespace, "namespace", "ome", "the namespace of the ome model agents daemon set")
 
@@ -128,6 +129,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 3, cfg.downloadRetry)
 	assert.Equal(t, "instance-principal", cfg.downloadAuthType)
 	assert.Equal(t, 3, cfg.numDownloadWorker)
+	assert.Equal(t, 1, cfg.numHighPriorityWorker)
 	assert.Equal(t, 30*time.Minute, cfg.samePathWaitTimeout)
 	assert.Equal(t, "ome", cfg.namespace)
 }

--- a/cmd/model-agent/main_test.go
+++ b/cmd/model-agent/main_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
@@ -112,6 +113,7 @@ func TestDefaultConfig(t *testing.T) {
 	testCmd.Flags().IntVar(&cfg.downloadRetry, "download-retry", 3, "retry times for model download")
 	testCmd.Flags().StringVar(&cfg.downloadAuthType, "download-auth-type", "instance-principal", "authentication method for model download")
 	testCmd.Flags().IntVar(&cfg.numDownloadWorker, "num-download-worker", 3, "number of download workers")
+	testCmd.Flags().DurationVar(&cfg.samePathWaitTimeout, "same-path-wait-timeout", 30*time.Minute, "same-path wait timeout")
 	testCmd.Flags().StringVar(&cfg.namespace, "namespace", "ome", "the namespace of the ome model agents daemon set")
 
 	// Call initConfig to set cfg.nodeName
@@ -126,6 +128,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 3, cfg.downloadRetry)
 	assert.Equal(t, "instance-principal", cfg.downloadAuthType)
 	assert.Equal(t, 3, cfg.numDownloadWorker)
+	assert.Equal(t, 30*time.Minute, cfg.samePathWaitTimeout)
 	assert.Equal(t, "ome", cfg.namespace)
 }
 

--- a/config/model-agent/daemonset.yaml
+++ b/config/model-agent/daemonset.yaml
@@ -49,6 +49,8 @@ spec:
         - /raid/models
         - --num-download-worker
         - '2'
+        - --same-path-wait-timeout
+        - 30m
         - --concurrency
         - '2'
         env:

--- a/config/model-agent/daemonset.yaml
+++ b/config/model-agent/daemonset.yaml
@@ -49,6 +49,8 @@ spec:
         - /raid/models
         - --num-download-worker
         - '2'
+        - --num-high-priority-worker
+        - '1'
         - --same-path-wait-timeout
         - 30m
         - --concurrency

--- a/pkg/modelagent/gopher.go
+++ b/pkg/modelagent/gopher.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/oracle/oci-go-sdk/v65/objectstorage"
@@ -263,6 +264,22 @@ func (s *Gopher) processTask(task *GopherTask) error {
 	ctx := context.Background()
 	var cancel context.CancelFunc
 
+	if task.TaskType == Download || task.TaskType == DownloadOverride {
+		if skip, runDeleteCleanup := s.shouldSkipStaleDownloadTask(task); skip {
+			if runDeleteCleanup {
+				s.logger.Infof("Model %s is deleting, running cleanup instead of download", modelInfo)
+				return s.processTask(&GopherTask{
+					TaskType:               Delete,
+					BaseModel:              task.BaseModel,
+					ClusterBaseModel:       task.ClusterBaseModel,
+					TensorRTLLMShapeFilter: task.TensorRTLLMShapeFilter,
+				})
+			}
+			s.logger.Infof("Model %s no longer exists, skipping stale download task", modelInfo)
+			return nil
+		}
+	}
+
 	// For Download and DownloadOverride tasks, set the node label to "Updating"
 	if task.TaskType == Download || task.TaskType == DownloadOverride {
 		s.logger.Infof("Setting model %s status to Updating before download", modelInfo)
@@ -421,6 +438,20 @@ func (s *Gopher) processTask(task *GopherTask) error {
 			s.logger.Infof("Successfully downloaded ClusterBaseModel %s", task.ClusterBaseModel.Name)
 		}
 
+		if skip, runDeleteCleanup := s.shouldSkipStaleDownloadTask(task); skip {
+			if runDeleteCleanup {
+				s.logger.Infof("Model %s is deleting after download, running cleanup instead of marking Ready", modelInfo)
+				return s.processTask(&GopherTask{
+					TaskType:               Delete,
+					BaseModel:              task.BaseModel,
+					ClusterBaseModel:       task.ClusterBaseModel,
+					TensorRTLLMShapeFilter: task.TensorRTLLMShapeFilter,
+				})
+			}
+			s.logger.Infof("Model %s no longer exists after download, skipping Ready update", modelInfo)
+			return nil
+		}
+
 		// mark the model as Ready on both node labels and ConfigMap
 		nodeLabelOp := &NodeLabelOp{
 			ModelStateOnNode: Ready,
@@ -539,6 +570,46 @@ func (s *Gopher) processTask(task *GopherTask) error {
 
 func shouldUseSamePathObjectStorageReuse(task *GopherTask) bool {
 	return task != nil && task.TaskType == Download
+}
+
+func (s *Gopher) shouldSkipStaleDownloadTask(task *GopherTask) (bool, bool) {
+	if task == nil {
+		return false, false
+	}
+
+	if task.BaseModel != nil {
+		if s.baseModelLister == nil {
+			return false, false
+		}
+		latestModel, err := s.baseModelLister.BaseModels(task.BaseModel.Namespace).Get(task.BaseModel.Name)
+		if apierrors.IsNotFound(err) {
+			return true, false
+		}
+		if err != nil {
+			s.logger.Warnf("Cannot check latest BaseModel %s/%s before download: %v", task.BaseModel.Namespace, task.BaseModel.Name, err)
+			return false, false
+		}
+		isDeleting := latestModel.DeletionTimestamp != nil
+		return isDeleting, isDeleting
+	}
+
+	if task.ClusterBaseModel != nil {
+		if s.clusterBaseModelLister == nil {
+			return false, false
+		}
+		latestModel, err := s.clusterBaseModelLister.Get(task.ClusterBaseModel.Name)
+		if apierrors.IsNotFound(err) {
+			return true, false
+		}
+		if err != nil {
+			s.logger.Warnf("Cannot check latest ClusterBaseModel %s before download: %v", task.ClusterBaseModel.Name, err)
+			return false, false
+		}
+		isDeleting := latestModel.DeletionTimestamp != nil
+		return isDeleting, isDeleting
+	}
+
+	return false, false
 }
 
 // isPathReferencedByOtherModels checks if the given path is still referenced by other BaseModel or ClusterBaseModel resources

--- a/pkg/modelagent/gopher.go
+++ b/pkg/modelagent/gopher.go
@@ -45,6 +45,12 @@ type GopherTask struct {
 	ClusterBaseModel       *v1beta1.ClusterBaseModel
 	TensorRTLLMShapeFilter *TensorRTLLMShapeFilter
 	SamePathWaitStartedAt  time.Time
+	NormalPriorityOnly     bool
+}
+
+type activeDownload struct {
+	token  string
+	cancel context.CancelFunc
 }
 
 type Gopher struct {
@@ -65,9 +71,10 @@ type Gopher struct {
 	clusterBaseModelLister omev1beta1lister.ClusterBaseModelLister
 
 	// Track active downloads for cancellation
-	activeDownloads      map[string]context.CancelFunc // key: model UID
+	activeDownloads      map[string]activeDownload // key: model UID
 	activeDownloadsMutex sync.RWMutex
 
+	taskQueue           *gopherTaskQueue
 	samePathWaitDelay   time.Duration
 	samePathWaitTimeout time.Duration
 }
@@ -116,62 +123,128 @@ func NewGopher(
 		nodeLabelReconciler:    nodeLabelReconciler,
 		metrics:                metrics,
 		logger:                 logger,
-		activeDownloads:        make(map[string]context.CancelFunc),
+		activeDownloads:        make(map[string]activeDownload),
 		baseModelLister:        baseModelLister,
 		clusterBaseModelLister: clusterBaseModelLister,
+		taskQueue:              newGopherTaskQueue(),
 		samePathWaitDelay:      defaultSamePathWaitDelay,
 		samePathWaitTimeout:    samePathWaitTimeout,
 	}, nil
 }
 
-func (s *Gopher) Run(stopCh <-chan struct{}, numWorker int) {
+func (s *Gopher) Run(stopCh <-chan struct{}, numWorker int, numHighPriorityWorker int) {
 	// Start the ConfigMap reconciliation service
 	s.configMapReconciler.StartReconciliation()
 	s.logger.Info("Started ConfigMap reconciliation service")
+
+	if s.taskQueue == nil {
+		s.taskQueue = newGopherTaskQueue()
+	}
+	if numHighPriorityWorker < 1 {
+		numHighPriorityWorker = 1
+	}
+	dispatchStopCh := make(chan struct{})
+	go s.dispatchTasks(dispatchStopCh)
 
 	// Start worker goroutines
 	for i := 0; i < numWorker; i++ {
 		go s.runWorker()
 	}
+	for i := 0; i < numHighPriorityWorker; i++ {
+		go s.runHighPriorityWorker()
+	}
 
 	// Wait for stop signal
 	<-stopCh
+	close(dispatchStopCh)
 
 	// Stop the ConfigMap reconciliation service
 	s.configMapReconciler.StopReconciliation()
+	s.taskQueue.close()
 	s.logger.Info("Stopped ConfigMap reconciliation service")
 
 	s.logger.Info("Received stop signal, shutting down Gopher workers...")
 }
 
-func (s *Gopher) runWorker() {
+func (s *Gopher) dispatchTasks(stopCh <-chan struct{}) {
 	for {
 		select {
 		case task, ok := <-s.gopherChan:
-			if ok {
-				// Process delete tasks immediately by checking active downloads
-				if task.TaskType == Delete {
-					modelUID := getModelUID(task)
-					s.activeDownloadsMutex.RLock()
-					_, isDownloading := s.activeDownloads[modelUID]
-					s.activeDownloadsMutex.RUnlock()
-
-					if isDownloading {
-						s.logger.Infof("Model %s is currently downloading, will cancel it", getModelInfoForLogging(task))
-					}
-				}
-
-				err := s.processTask(task)
-				if err != nil {
-					s.logger.Errorf("Gopher task failed with error: %s", err.Error())
-				}
-			} else {
-				s.logger.Info("gopher channel closed, worker exits.")
+			if !ok {
+				s.logger.Info("gopher channel closed, dispatcher exits.")
+				s.taskQueue.close()
 				return
 			}
-		default:
-			time.Sleep(500 * time.Millisecond)
+			s.enqueueTask(task)
+		case <-stopCh:
+			s.taskQueue.close()
+			return
 		}
+	}
+}
+
+func (s *Gopher) enqueueTask(task *GopherTask) {
+	if task == nil {
+		return
+	}
+	if s.taskQueue == nil {
+		s.taskQueue = newGopherTaskQueue()
+	}
+	if task.TaskType == Delete {
+		s.cancelActiveDownload(task)
+	}
+	s.taskQueue.enqueue(task)
+}
+
+func (s *Gopher) runWorker() {
+	if s.taskQueue == nil {
+		s.taskQueue = newGopherTaskQueue()
+	}
+	for {
+		task, ok := s.taskQueue.popNormal()
+		if !ok {
+			s.logger.Info("gopher task queue closed, worker exits.")
+			return
+		}
+		if task.TaskType == Delete {
+			s.cancelActiveDownload(task)
+		}
+		err := s.processTask(task)
+		if err != nil {
+			s.logger.Errorf("Gopher task failed with error: %s", err.Error())
+		}
+	}
+}
+
+func (s *Gopher) runHighPriorityWorker() {
+	if s.taskQueue == nil {
+		s.taskQueue = newGopherTaskQueue()
+	}
+	for {
+		task, ok := s.taskQueue.popHighPriority()
+		if !ok {
+			s.logger.Info("gopher high-priority task queue closed, worker exits.")
+			return
+		}
+		if task.TaskType == Delete {
+			s.cancelActiveDownload(task)
+		}
+		err := s.processTaskWithOptions(task, false)
+		if err != nil {
+			s.logger.Errorf("Gopher high-priority task failed with error: %s", err.Error())
+		}
+	}
+}
+
+func (s *Gopher) cancelActiveDownload(task *GopherTask) {
+	modelUID := getModelUID(task)
+	s.activeDownloadsMutex.RLock()
+	active, isDownloading := s.activeDownloads[modelUID]
+	s.activeDownloadsMutex.RUnlock()
+
+	if isDownloading {
+		s.logger.Infof("Model %s is currently downloading, will cancel it", getModelInfoForLogging(task))
+		active.cancel()
 	}
 }
 
@@ -254,6 +327,10 @@ func (s *Gopher) safeParseAndUpdateModelConfig(modelPath string, baseModel *v1be
 }
 
 func (s *Gopher) processTask(task *GopherTask) error {
+	return s.processTaskWithOptions(task, true)
+}
+
+func (s *Gopher) processTaskWithOptions(task *GopherTask, allowFallbackDownload bool) error {
 	if task.BaseModel == nil && task.ClusterBaseModel == nil {
 		return fmt.Errorf("gopher got empty task")
 	}
@@ -311,15 +388,17 @@ func (s *Gopher) processTask(task *GopherTask) error {
 		ctx, cancel = context.WithCancel(context.Background())
 
 		// Register the cancel function
+		activeDownloadToken := fmt.Sprintf("%s-%d", modelUID, time.Now().UnixNano())
 		s.activeDownloadsMutex.Lock()
-		s.activeDownloads[modelUID] = cancel
+		s.activeDownloads[modelUID] = activeDownload{
+			token:  activeDownloadToken,
+			cancel: cancel,
+		}
 		s.activeDownloadsMutex.Unlock()
 
 		// Ensure cleanup on completion
 		defer func() {
-			s.activeDownloadsMutex.Lock()
-			delete(s.activeDownloads, modelUID)
-			s.activeDownloadsMutex.Unlock()
+			s.unregisterActiveDownload(modelUID, activeDownloadToken)
 			cancel() // Ensure context is cancelled
 		}()
 	}
@@ -391,6 +470,9 @@ func (s *Gopher) processTask(task *GopherTask) error {
 					s.logger.Infof("Reusing Ready same-path model artifact for %s/%s from %s at %s", namespace, name, matchedKey, destPath)
 				} else if matchedKey, wait := s.findUpdatingObjectStorageModelWithSamePath(ctx, task, baseModelSpec, destPath); wait &&
 					s.requeueSamePathInFlightReuseWait(task, matchedKey) {
+					return nil
+				} else if !allowFallbackDownload {
+					s.demoteToNormalPriority(task)
 					return nil
 				} else if err := downloadObjectStorageModel(); err != nil {
 					return err
@@ -484,9 +566,9 @@ func (s *Gopher) processTask(task *GopherTask) error {
 	case Delete:
 		// First, cancel any ongoing download for this model
 		s.activeDownloadsMutex.RLock()
-		if cancelFunc, exists := s.activeDownloads[modelUID]; exists {
+		if active, exists := s.activeDownloads[modelUID]; exists {
 			s.logger.Infof("Cancelling ongoing download for model %s", modelInfo)
-			cancelFunc() // This will cancel the download context
+			active.cancel() // This will cancel the download context
 		}
 		s.activeDownloadsMutex.RUnlock()
 
@@ -582,6 +664,23 @@ func (s *Gopher) processTask(task *GopherTask) error {
 	}
 
 	return nil
+}
+
+func (s *Gopher) unregisterActiveDownload(modelUID string, token string) {
+	s.activeDownloadsMutex.Lock()
+	defer s.activeDownloadsMutex.Unlock()
+	if active, exists := s.activeDownloads[modelUID]; exists && active.token == token {
+		delete(s.activeDownloads, modelUID)
+	}
+}
+
+func (s *Gopher) demoteToNormalPriority(task *GopherTask) {
+	if task == nil {
+		return
+	}
+	task.NormalPriorityOnly = true
+	s.logger.Infof("Demoting %s to normal priority for fallback download/validation", getModelInfoForLogging(task))
+	s.enqueueTask(task)
 }
 
 func shouldUseSamePathObjectStorageReuse(task *GopherTask) bool {

--- a/pkg/modelagent/gopher.go
+++ b/pkg/modelagent/gopher.go
@@ -44,6 +44,7 @@ type GopherTask struct {
 	BaseModel              *v1beta1.BaseModel
 	ClusterBaseModel       *v1beta1.ClusterBaseModel
 	TensorRTLLMShapeFilter *TensorRTLLMShapeFilter
+	SamePathWaitStartedAt  time.Time
 }
 
 type Gopher struct {
@@ -55,7 +56,7 @@ type Gopher struct {
 	modelRootDir           string
 	xetConfig              *xet.Config
 	kubeClient             kubernetes.Interface
-	gopherChan             <-chan *GopherTask
+	gopherChan             chan *GopherTask
 	nodeLabelReconciler    *NodeLabelReconciler
 	metrics                *Metrics
 	logger                 *zap.SugaredLogger
@@ -66,10 +67,16 @@ type Gopher struct {
 	// Track active downloads for cancellation
 	activeDownloads      map[string]context.CancelFunc // key: model UID
 	activeDownloadsMutex sync.RWMutex
+
+	samePathWaitDelay   time.Duration
+	samePathWaitTimeout time.Duration
 }
 
 const (
 	BigFileSizeInMB = 200
+
+	defaultSamePathWaitDelay   = 30 * time.Second
+	defaultSamePathWaitTimeout = 30 * time.Minute
 )
 
 func NewGopher(
@@ -81,7 +88,8 @@ func NewGopher(
 	multipartConcurrency int,
 	downloadRetry int,
 	modelRootDir string,
-	gopherChan <-chan *GopherTask,
+	gopherChan chan *GopherTask,
+	samePathWaitTimeout time.Duration,
 	nodeLabelReconciler *NodeLabelReconciler,
 	metrics *Metrics,
 	logger *zap.SugaredLogger,
@@ -90,6 +98,9 @@ func NewGopher(
 
 	if xetConfig == nil {
 		return nil, fmt.Errorf("xet hugging face config cannot be nil")
+	}
+	if samePathWaitTimeout <= 0 {
+		samePathWaitTimeout = defaultSamePathWaitTimeout
 	}
 
 	return &Gopher{
@@ -108,6 +119,8 @@ func NewGopher(
 		activeDownloads:        make(map[string]context.CancelFunc),
 		baseModelLister:        baseModelLister,
 		clusterBaseModelLister: clusterBaseModelLister,
+		samePathWaitDelay:      defaultSamePathWaitDelay,
+		samePathWaitTimeout:    samePathWaitTimeout,
 	}, nil
 }
 
@@ -376,6 +389,9 @@ func (s *Gopher) processTask(task *GopherTask) error {
 			if shouldUseSamePathObjectStorageReuse(task) {
 				if matchedKey, reused := s.findReadyObjectStorageModelWithSamePath(ctx, task, baseModelSpec, destPath); reused {
 					s.logger.Infof("Reusing Ready same-path model artifact for %s/%s from %s at %s", namespace, name, matchedKey, destPath)
+				} else if matchedKey, wait := s.findUpdatingObjectStorageModelWithSamePath(ctx, task, baseModelSpec, destPath); wait &&
+					s.requeueSamePathInFlightReuseWait(task, matchedKey) {
+					return nil
 				} else if err := downloadObjectStorageModel(); err != nil {
 					return err
 				}
@@ -832,6 +848,14 @@ func (s *Gopher) createOCIOSDataStore(baseModelSpec v1beta1.BaseModelSpec) (*oci
 // copied model CRs with the same source and destination can reuse Ready local
 // files. DownloadOverride keeps the existing download/validation path.
 func (s *Gopher) findReadyObjectStorageModelWithSamePath(ctx context.Context, task *GopherTask, baseModelSpec v1beta1.BaseModelSpec, destPath string) (string, bool) {
+	return s.findObjectStorageModelWithSamePathAndStatus(ctx, task, baseModelSpec, destPath, ModelStatusReady, true)
+}
+
+func (s *Gopher) findUpdatingObjectStorageModelWithSamePath(ctx context.Context, task *GopherTask, baseModelSpec v1beta1.BaseModelSpec, destPath string) (string, bool) {
+	return s.findObjectStorageModelWithSamePathAndStatus(ctx, task, baseModelSpec, destPath, ModelStatusUpdating, false)
+}
+
+func (s *Gopher) findObjectStorageModelWithSamePathAndStatus(ctx context.Context, task *GopherTask, baseModelSpec v1beta1.BaseModelSpec, destPath string, status ModelStatus, requireLocalPath bool) (string, bool) {
 	if task == nil || (task.BaseModel == nil && task.ClusterBaseModel == nil) {
 		return "", false
 	}
@@ -841,9 +865,11 @@ func (s *Gopher) findReadyObjectStorageModelWithSamePath(ctx context.Context, ta
 	if s.configMapReconciler == nil {
 		return "", false
 	}
-	if _, err := os.Stat(destPath); err != nil {
-		s.logger.Warnf("Cannot reuse same-path model artifact at %s because it is not available locally: %v", destPath, err)
-		return "", false
+	if requireLocalPath {
+		if _, err := os.Stat(destPath); err != nil {
+			s.logger.Warnf("Cannot reuse same-path model artifact at %s because it is not available locally: %v", destPath, err)
+			return "", false
+		}
 	}
 
 	configMap, err := s.configMapReconciler.getConfigMap(ctx)
@@ -857,9 +883,15 @@ func (s *Gopher) findReadyObjectStorageModelWithSamePath(ctx context.Context, ta
 		clusterBaseModels, err := s.clusterBaseModelLister.List(labels.Everything())
 		if err == nil {
 			for _, model := range clusterBaseModels {
+				if model.DeletionTimestamp != nil {
+					continue
+				}
 				key := constants.GetModelConfigMapKey("", model.Name, true)
-				if key != currentKey && isReadyModelEntry(configMap.Data[key]) &&
+				if key != currentKey && hasModelEntryStatus(configMap.Data[key], status) &&
 					sameModelStoragePath(baseModelSpec.Storage, model.Spec.Storage, s.modelRootDir, destPath) {
+					if status == ModelStatusUpdating && !shouldWaitForSamePathCandidate(task, currentKey, key, model.CreationTimestamp.Time) {
+						continue
+					}
 					return key, true
 				}
 			}
@@ -872,9 +904,15 @@ func (s *Gopher) findReadyObjectStorageModelWithSamePath(ctx context.Context, ta
 		baseModels, err := s.baseModelLister.List(labels.Everything())
 		if err == nil {
 			for _, model := range baseModels {
+				if model.DeletionTimestamp != nil {
+					continue
+				}
 				key := constants.GetModelConfigMapKey(model.Namespace, model.Name, false)
-				if key != currentKey && isReadyModelEntry(configMap.Data[key]) &&
+				if key != currentKey && hasModelEntryStatus(configMap.Data[key], status) &&
 					sameModelStoragePath(baseModelSpec.Storage, model.Spec.Storage, s.modelRootDir, destPath) {
+					if status == ModelStatusUpdating && !shouldWaitForSamePathCandidate(task, currentKey, key, model.CreationTimestamp.Time) {
+						continue
+					}
 					return key, true
 				}
 			}
@@ -885,12 +923,65 @@ func (s *Gopher) findReadyObjectStorageModelWithSamePath(ctx context.Context, ta
 	return "", false
 }
 
-func isReadyModelEntry(dataEntry string) bool {
+func hasModelEntryStatus(dataEntry string, status ModelStatus) bool {
 	var entry ModelEntry
 	if err := json.Unmarshal([]byte(dataEntry), &entry); err != nil {
 		return false
 	}
-	return entry.Status == ModelStatusReady
+	return entry.Status == status
+}
+
+func shouldWaitForSamePathCandidate(task *GopherTask, currentKey string, candidateKey string, candidateCreatedAt time.Time) bool {
+	currentCreatedAt := getTaskModelCreationTime(task)
+	if !candidateCreatedAt.IsZero() && !currentCreatedAt.IsZero() && !candidateCreatedAt.Equal(currentCreatedAt) {
+		return candidateCreatedAt.Before(currentCreatedAt)
+	}
+	return candidateKey < currentKey
+}
+
+func getTaskModelCreationTime(task *GopherTask) time.Time {
+	if task == nil {
+		return time.Time{}
+	}
+	if task.BaseModel != nil {
+		return task.BaseModel.CreationTimestamp.Time
+	}
+	if task.ClusterBaseModel != nil {
+		return task.ClusterBaseModel.CreationTimestamp.Time
+	}
+	return time.Time{}
+}
+
+func (s *Gopher) requeueSamePathInFlightReuseWait(task *GopherTask, matchedKey string) bool {
+	if task == nil || s.gopherChan == nil {
+		return false
+	}
+	now := time.Now()
+	timeout := s.samePathWaitTimeout
+	if timeout <= 0 {
+		timeout = defaultSamePathWaitTimeout
+	}
+	if task.SamePathWaitStartedAt.IsZero() {
+		task.SamePathWaitStartedAt = now
+	} else if now.Sub(task.SamePathWaitStartedAt) >= timeout {
+		s.logger.Warnf("Timed out waiting for same-path model %s to become Ready for %s; falling back to normal download", matchedKey, getModelInfoForLogging(task))
+		return false
+	}
+
+	delay := s.samePathWaitDelay
+	if delay <= 0 {
+		delay = defaultSamePathWaitDelay
+	}
+	s.logger.Infof("Same-path model %s is Updating for %s; requeueing after %s before starting duplicate download", matchedKey, getModelInfoForLogging(task), delay)
+	time.AfterFunc(delay, func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.logger.Warnf("Cannot requeue same-path wait task for %s because gopher channel is closed: %v", getModelInfoForLogging(task), r)
+			}
+		}()
+		s.gopherChan <- task
+	})
+	return true
 }
 
 func sameModelStoragePath(currentStorage *v1beta1.StorageSpec, candidateStorage *v1beta1.StorageSpec, modelRootDir string, destPath string) bool {

--- a/pkg/modelagent/gopher_task_queue.go
+++ b/pkg/modelagent/gopher_task_queue.go
@@ -1,0 +1,122 @@
+package modelagent
+
+import (
+	"sync"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+type gopherTaskQueue struct {
+	mutex  sync.Mutex
+	cond   *sync.Cond
+	high   []*GopherTask
+	normal []*GopherTask
+	closed bool
+}
+
+func newGopherTaskQueue() *gopherTaskQueue {
+	queue := &gopherTaskQueue{}
+	queue.cond = sync.NewCond(&queue.mutex)
+	return queue
+}
+
+func (q *gopherTaskQueue) enqueue(task *GopherTask) {
+	if task == nil {
+		return
+	}
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	if q.closed {
+		return
+	}
+	if task.TaskType == Delete {
+		// Delete preempts pending work for the same model and should run before
+		// reuse-wait tasks, so it is the only non-FIFO insertion.
+		q.high = removeSupersededTasks(q.high, task)
+		q.normal = removeSupersededTasks(q.normal, task)
+		q.high = append([]*GopherTask{task}, q.high...)
+	} else if shouldUseHighPriorityQueue(task) {
+		q.high = append(q.high, task)
+	} else {
+		q.normal = append(q.normal, task)
+	}
+	q.cond.Broadcast()
+}
+
+func (q *gopherTaskQueue) popNormal() (*GopherTask, bool) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	for len(q.normal) == 0 && !q.closed {
+		q.cond.Wait()
+	}
+	if len(q.normal) > 0 {
+		task := q.normal[0]
+		q.normal = q.normal[1:]
+		return task, true
+	}
+	return nil, false
+}
+
+func (q *gopherTaskQueue) popHighPriority() (*GopherTask, bool) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	for len(q.high) == 0 && !q.closed {
+		q.cond.Wait()
+	}
+	if len(q.high) > 0 {
+		task := q.high[0]
+		q.high = q.high[1:]
+		return task, true
+	}
+	return nil, false
+}
+
+func (q *gopherTaskQueue) close() {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	q.closed = true
+	q.cond.Broadcast()
+}
+
+func (q *gopherTaskQueue) len() int {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	return len(q.high) + len(q.normal)
+}
+
+func shouldUseHighPriorityQueue(task *GopherTask) bool {
+	return task.TaskType == Delete || isObjectStorageDownloadTask(task) || (!task.NormalPriorityOnly && !task.SamePathWaitStartedAt.IsZero())
+}
+
+func isObjectStorageDownloadTask(task *GopherTask) bool {
+	if task == nil || task.TaskType != Download || task.NormalPriorityOnly {
+		return false
+	}
+	var storageSpec *v1beta1.StorageSpec
+	if task.BaseModel != nil {
+		storageSpec = task.BaseModel.Spec.Storage
+	} else if task.ClusterBaseModel != nil {
+		storageSpec = task.ClusterBaseModel.Spec.Storage
+	}
+	if storageSpec == nil || storageSpec.StorageUri == nil {
+		return false
+	}
+	storageType, err := storage.GetStorageType(*storageSpec.StorageUri)
+	return err == nil && storageType == storage.StorageTypeOCI
+}
+
+func removeSupersededTasks(tasks []*GopherTask, deleteTask *GopherTask) []*GopherTask {
+	modelUID := getModelUID(deleteTask)
+	if modelUID == "" {
+		return tasks
+	}
+	kept := tasks[:0]
+	for _, task := range tasks {
+		if task.TaskType != Delete && getModelUID(task) == modelUID {
+			continue
+		}
+		kept = append(kept, task)
+	}
+	return kept
+}

--- a/pkg/modelagent/gopher_task_queue_test.go
+++ b/pkg/modelagent/gopher_task_queue_test.go
@@ -1,0 +1,246 @@
+package modelagent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestGopherTaskQueueUsesSeparateFIFOs(t *testing.T) {
+	queue := newGopherTaskQueue()
+	download1 := &GopherTask{
+		TaskType: Download,
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "download-1", Namespace: "service-ns", UID: "download-1-uid"},
+			Spec: v1beta1.BaseModelSpec{
+				Storage: &v1beta1.StorageSpec{StorageUri: stringPtr("hf://repo/model-1")},
+			},
+		},
+	}
+	download2 := &GopherTask{
+		TaskType: Download,
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "download-2", Namespace: "service-ns", UID: "download-2-uid"},
+			Spec: v1beta1.BaseModelSpec{
+				Storage: &v1beta1.StorageSpec{StorageUri: stringPtr("hf://repo/model-2")},
+			},
+		},
+	}
+	wait1 := &GopherTask{
+		TaskType:              Download,
+		SamePathWaitStartedAt: time.Now(),
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "wait-1", Namespace: "service-ns", UID: "wait-1-uid"},
+		},
+	}
+	wait2 := &GopherTask{
+		TaskType:              Download,
+		SamePathWaitStartedAt: time.Now(),
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "wait-2", Namespace: "service-ns", UID: "wait-2-uid"},
+		},
+	}
+
+	queue.enqueue(download1)
+	queue.enqueue(wait1)
+	queue.enqueue(download2)
+	queue.enqueue(wait2)
+
+	task, ok := queue.popNormal()
+	require.True(t, ok)
+	assert.Equal(t, "download-1", task.BaseModel.Name)
+	task, ok = queue.popNormal()
+	require.True(t, ok)
+	assert.Equal(t, "download-2", task.BaseModel.Name)
+	task, ok = queue.popHighPriority()
+	require.True(t, ok)
+	assert.Equal(t, "wait-1", task.BaseModel.Name)
+	task, ok = queue.popHighPriority()
+	require.True(t, ok)
+	assert.Equal(t, "wait-2", task.BaseModel.Name)
+}
+
+func TestGopherTaskQueueRoutesObjectStorageDownloadToHighPriority(t *testing.T) {
+	queue := newGopherTaskQueue()
+	task := &GopherTask{
+		TaskType: Download,
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "oci-model", Namespace: "service-ns", UID: "oci-model-uid"},
+			Spec: v1beta1.BaseModelSpec{
+				Storage: &v1beta1.StorageSpec{StorageUri: stringPtr("oci://n/ns/b/bucket/o/model")},
+			},
+		},
+	}
+
+	queue.enqueue(task)
+
+	queued, ok := queue.popHighPriority()
+	require.True(t, ok)
+	assert.Equal(t, "oci-model", queued.BaseModel.Name)
+}
+
+func TestGopherTaskQueueKeepsDownloadOverrideNormal(t *testing.T) {
+	queue := newGopherTaskQueue()
+	task := &GopherTask{
+		TaskType: DownloadOverride,
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "oci-model", Namespace: "service-ns", UID: "oci-model-uid"},
+			Spec: v1beta1.BaseModelSpec{
+				Storage: &v1beta1.StorageSpec{StorageUri: stringPtr("oci://n/ns/b/bucket/o/model")},
+			},
+		},
+	}
+
+	queue.enqueue(task)
+
+	queued, ok := queue.popNormal()
+	require.True(t, ok)
+	assert.Equal(t, "oci-model", queued.BaseModel.Name)
+}
+
+func TestGopherTaskQueueDeleteSupersedesPendingDownloadsForSameModel(t *testing.T) {
+	queue := newGopherTaskQueue()
+	model := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "service-ns", UID: "model-uid"},
+	}
+
+	queue.enqueue(&GopherTask{TaskType: Download, BaseModel: model})
+	queue.enqueue(&GopherTask{TaskType: DownloadOverride, BaseModel: model})
+	queue.enqueue(&GopherTask{TaskType: Delete, BaseModel: model})
+
+	task, ok := queue.popHighPriority()
+	require.True(t, ok)
+	assert.Equal(t, Delete, task.TaskType)
+	assert.Equal(t, 0, queue.len())
+}
+
+func TestGopherTaskQueueDeletePreemptsHighPriorityFIFO(t *testing.T) {
+	queue := newGopherTaskQueue()
+	wait := &GopherTask{
+		TaskType:              Download,
+		SamePathWaitStartedAt: time.Now(),
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "wait", Namespace: "service-ns", UID: "wait-uid"},
+		},
+	}
+	deleteTask := &GopherTask{
+		TaskType: Delete,
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "delete", Namespace: "service-ns", UID: "delete-uid"},
+		},
+	}
+
+	queue.enqueue(wait)
+	queue.enqueue(deleteTask)
+
+	task, ok := queue.popHighPriority()
+	require.True(t, ok)
+	assert.Equal(t, Delete, task.TaskType)
+	task, ok = queue.popHighPriority()
+	require.True(t, ok)
+	assert.Equal(t, "wait", task.BaseModel.Name)
+}
+
+func TestGopherTaskQueuePopHighPriorityOnly(t *testing.T) {
+	queue := newGopherTaskQueue()
+	download := &GopherTask{
+		TaskType: Download,
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "download", Namespace: "service-ns", UID: "download-uid"},
+		},
+	}
+	wait := &GopherTask{
+		TaskType:              Download,
+		SamePathWaitStartedAt: time.Now(),
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "wait", Namespace: "service-ns", UID: "wait-uid"},
+		},
+	}
+
+	queue.enqueue(download)
+	queue.enqueue(wait)
+
+	task, ok := queue.popHighPriority()
+	require.True(t, ok)
+	assert.Equal(t, "wait", task.BaseModel.Name)
+	assert.Equal(t, 1, queue.len())
+
+	task, ok = queue.popNormal()
+	require.True(t, ok)
+	assert.Equal(t, "download", task.BaseModel.Name)
+}
+
+func TestGopherTaskQueueDemotedSamePathWaitUsesNormalQueue(t *testing.T) {
+	queue := newGopherTaskQueue()
+	demoted := &GopherTask{
+		TaskType:              Download,
+		SamePathWaitStartedAt: time.Now(),
+		NormalPriorityOnly:    true,
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "demoted", Namespace: "service-ns", UID: "demoted-uid"},
+		},
+	}
+	deleteTask := &GopherTask{
+		TaskType: Delete,
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "delete", Namespace: "service-ns", UID: "delete-uid"},
+		},
+	}
+
+	queue.enqueue(demoted)
+	queue.enqueue(deleteTask)
+
+	task, ok := queue.popHighPriority()
+	require.True(t, ok)
+	assert.Equal(t, Delete, task.TaskType)
+	task, ok = queue.popNormal()
+	require.True(t, ok)
+	assert.Equal(t, "demoted", task.BaseModel.Name)
+}
+
+func TestGopherTaskQueueEnqueueWakesMatchingBlockedWorker(t *testing.T) {
+	queue := newGopherTaskQueue()
+	normalDone := make(chan struct{})
+	highDone := make(chan *GopherTask, 1)
+
+	go func() {
+		if _, ok := queue.popNormal(); ok {
+			close(normalDone)
+		}
+	}()
+	go func() {
+		task, ok := queue.popHighPriority()
+		if ok {
+			highDone <- task
+		}
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	waitTask := &GopherTask{
+		TaskType:              Download,
+		SamePathWaitStartedAt: time.Now(),
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "wait", Namespace: "service-ns", UID: "wait-uid"},
+		},
+	}
+	queue.enqueue(waitTask)
+
+	select {
+	case task := <-highDone:
+		assert.Equal(t, "wait", task.BaseModel.Name)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected blocked high-priority worker to wake for high-priority task")
+	}
+
+	select {
+	case <-normalDone:
+		t.Fatal("normal worker should not consume high-priority task")
+	default:
+	}
+	queue.close()
+}

--- a/pkg/modelagent/gopher_test.go
+++ b/pkg/modelagent/gopher_test.go
@@ -703,7 +703,7 @@ func newGopherForProcessTask(cm *corev1.ConfigMap, nodeLabels ...map[string]stri
 		configMapReconciler: cmr,
 		nodeLabelReconciler: NewNodeLabelReconciler(cm.Name, client, 1, logger),
 		logger:              logger,
-		activeDownloads:     map[string]context.CancelFunc{},
+		activeDownloads:     map[string]activeDownload{},
 	}
 }
 
@@ -1025,6 +1025,98 @@ func TestRequeueSamePathInFlightReuseWaitTimesOut(t *testing.T) {
 	select {
 	case <-g.gopherChan:
 		t.Fatal("timed out same-path wait task should not be requeued")
+	default:
+	}
+}
+
+func TestProcessTaskWithOptions_HighPriorityDemotesFallbackDownload(t *testing.T) {
+	storageURI := "oci://n/object-ns/b/model-bucket/o/models/large-model"
+	modelPath := filepath.Join(t.TempDir(), "large-model")
+	model := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "service-ns", UID: "current-uid"},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{
+				StorageUri: &storageURI,
+				Path:       &modelPath,
+			},
+		},
+	}
+	g := newGopherForProcessTask(makeConfigMap("node-1", map[string]string{}))
+	g.baseModelLister = &mockBaseModelLister{models: []*v1beta1.BaseModel{model}}
+	g.taskQueue = newGopherTaskQueue()
+	task := &GopherTask{
+		TaskType:              Download,
+		BaseModel:             model,
+		SamePathWaitStartedAt: time.Now(),
+	}
+
+	err := g.processTaskWithOptions(task, false)
+
+	require.NoError(t, err)
+	queued, ok := g.taskQueue.popNormal()
+	require.True(t, ok)
+	assert.Equal(t, model.Name, queued.BaseModel.Name)
+	assert.True(t, queued.NormalPriorityOnly)
+	assert.Equal(t, 0, g.taskQueue.len())
+}
+
+func TestGopherEnqueueDeleteCancelsActiveDownload(t *testing.T) {
+	model := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "service-ns", UID: "model-uid"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{}))
+	g.taskQueue = newGopherTaskQueue()
+	g.activeDownloads = map[string]activeDownload{
+		string(model.UID): {
+			token:  "download-token",
+			cancel: cancel,
+		},
+	}
+
+	g.enqueueTask(&GopherTask{TaskType: Delete, BaseModel: model})
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected delete enqueue to cancel active download")
+	}
+}
+
+func TestUnregisterActiveDownloadDoesNotRemoveNewerRegistration(t *testing.T) {
+	modelUID := "model-uid"
+	oldCtx, oldCancel := context.WithCancel(context.Background())
+	newCtx, newCancel := context.WithCancel(context.Background())
+	t.Cleanup(oldCancel)
+	t.Cleanup(newCancel)
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{}))
+	g.activeDownloads = map[string]activeDownload{
+		modelUID: {
+			token:  "old-token",
+			cancel: oldCancel,
+		},
+	}
+	g.activeDownloads[modelUID] = activeDownload{
+		token:  "new-token",
+		cancel: newCancel,
+	}
+
+	g.unregisterActiveDownload(modelUID, "old-token")
+
+	g.activeDownloadsMutex.RLock()
+	active, exists := g.activeDownloads[modelUID]
+	g.activeDownloadsMutex.RUnlock()
+	require.True(t, exists)
+	assert.Equal(t, "new-token", active.token)
+	active.cancel()
+	select {
+	case <-newCtx.Done():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected newer active download cancel function to remain registered")
+	}
+	select {
+	case <-oldCtx.Done():
+		t.Fatal("old cancel function should not be called")
 	default:
 	}
 }

--- a/pkg/modelagent/gopher_test.go
+++ b/pkg/modelagent/gopher_test.go
@@ -15,8 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
@@ -260,7 +262,42 @@ func (m *mockBaseModelLister) List(selector labels.Selector) ([]*v1beta1.BaseMod
 }
 
 func (m *mockBaseModelLister) BaseModels(namespace string) omev1beta1lister.BaseModelNamespaceLister {
-	return nil // Not used in our test
+	return &mockBaseModelNamespaceLister{
+		namespace: namespace,
+		models:    m.models,
+		err:       m.err,
+	}
+}
+
+type mockBaseModelNamespaceLister struct {
+	namespace string
+	models    []*v1beta1.BaseModel
+	err       error
+}
+
+func (m *mockBaseModelNamespaceLister) List(selector labels.Selector) ([]*v1beta1.BaseModel, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	var models []*v1beta1.BaseModel
+	for _, model := range m.models {
+		if model.Namespace == m.namespace {
+			models = append(models, model)
+		}
+	}
+	return models, nil
+}
+
+func (m *mockBaseModelNamespaceLister) Get(name string) (*v1beta1.BaseModel, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	for _, model := range m.models {
+		if model.Namespace == m.namespace && model.Name == name {
+			return model, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "ome.io", Resource: "basemodels"}, name)
 }
 
 type mockClusterBaseModelLister struct {
@@ -279,7 +316,7 @@ func (m *mockClusterBaseModelLister) Get(name string) (*v1beta1.ClusterBaseModel
 			return model, nil
 		}
 	}
-	return nil, errors.New("not found")
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "ome.io", Resource: "clusterbasemodels"}, name)
 }
 
 // TestIsPathReferencedByOtherModels tests the isPathReferencedByOtherModels method
@@ -647,6 +684,28 @@ func newGopherWithConfigMap(cm *corev1.ConfigMap) *Gopher {
 	}
 }
 
+func newGopherForProcessTask(cm *corev1.ConfigMap, nodeLabels ...map[string]string) *Gopher {
+	labels := map[string]string{}
+	if len(nodeLabels) > 0 {
+		labels = nodeLabels[0]
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   cm.Name,
+			Labels: labels,
+		},
+	}
+	client := k8sfake.NewSimpleClientset(cm, node)
+	logger := zap.NewNop().Sugar()
+	cmr := NewConfigMapReconciler(cm.Name, cm.Namespace, client, logger)
+	return &Gopher{
+		configMapReconciler: cmr,
+		nodeLabelReconciler: NewNodeLabelReconciler(cm.Name, client, 1, logger),
+		logger:              logger,
+		activeDownloads:     map[string]context.CancelFunc{},
+	}
+}
+
 func entryJSON(sha, parentName string, parentPath string) string {
 	entry := struct {
 		Config struct {
@@ -787,6 +846,142 @@ func TestShouldUseSamePathObjectStorageReuse(t *testing.T) {
 			assert.Equal(t, tt.want, shouldUseSamePathObjectStorageReuse(tt.task))
 		})
 	}
+}
+
+func TestShouldSkipStaleDownloadTask_BaseModelDeletingRequestsCleanup(t *testing.T) {
+	now := metav1.Now()
+	staleTaskModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "service-ns"},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{StorageUri: stringPtr("oci://n/ns/b/bucket/o/model")},
+		},
+	}
+	latestModel := staleTaskModel.DeepCopy()
+	latestModel.DeletionTimestamp = &now
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{}))
+	g.baseModelLister = &mockBaseModelLister{models: []*v1beta1.BaseModel{latestModel}}
+
+	skip, runDeleteCleanup := g.shouldSkipStaleDownloadTask(&GopherTask{TaskType: Download, BaseModel: staleTaskModel})
+
+	assert.True(t, skip)
+	assert.True(t, runDeleteCleanup)
+}
+
+func TestShouldSkipStaleDownloadTask_BaseModelDeletedSkipsWithoutCleanup(t *testing.T) {
+	staleTaskModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "service-ns"},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{StorageUri: stringPtr("oci://n/ns/b/bucket/o/model")},
+		},
+	}
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{}))
+	g.baseModelLister = &mockBaseModelLister{}
+
+	skip, runDeleteCleanup := g.shouldSkipStaleDownloadTask(&GopherTask{TaskType: Download, BaseModel: staleTaskModel})
+
+	assert.True(t, skip)
+	assert.False(t, runDeleteCleanup)
+}
+
+func TestShouldSkipStaleDownloadTask_BaseModelActiveDoesNotSkip(t *testing.T) {
+	model := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "service-ns"},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{StorageUri: stringPtr("oci://n/ns/b/bucket/o/model")},
+		},
+	}
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{}))
+	g.baseModelLister = &mockBaseModelLister{models: []*v1beta1.BaseModel{model}}
+
+	skip, runDeleteCleanup := g.shouldSkipStaleDownloadTask(&GopherTask{TaskType: Download, BaseModel: model})
+
+	assert.False(t, skip)
+	assert.False(t, runDeleteCleanup)
+}
+
+func TestShouldSkipStaleDownloadTask_ClusterBaseModelDeletingRequestsCleanup(t *testing.T) {
+	now := metav1.Now()
+	staleTaskModel := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "model"},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{StorageUri: stringPtr("oci://n/ns/b/bucket/o/model")},
+		},
+	}
+	latestModel := staleTaskModel.DeepCopy()
+	latestModel.DeletionTimestamp = &now
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{}))
+	g.clusterBaseModelLister = &mockClusterBaseModelLister{models: []*v1beta1.ClusterBaseModel{latestModel}}
+
+	skip, runDeleteCleanup := g.shouldSkipStaleDownloadTask(&GopherTask{TaskType: Download, ClusterBaseModel: staleTaskModel})
+
+	assert.True(t, skip)
+	assert.True(t, runDeleteCleanup)
+}
+
+func TestShouldSkipStaleDownloadTask_ClusterBaseModelDeletedSkipsWithoutCleanup(t *testing.T) {
+	staleTaskModel := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "model"},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{StorageUri: stringPtr("oci://n/ns/b/bucket/o/model")},
+		},
+	}
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{}))
+	g.clusterBaseModelLister = &mockClusterBaseModelLister{}
+
+	skip, runDeleteCleanup := g.shouldSkipStaleDownloadTask(&GopherTask{TaskType: Download, ClusterBaseModel: staleTaskModel})
+
+	assert.True(t, skip)
+	assert.False(t, runDeleteCleanup)
+}
+
+func TestProcessTask_SkipsMissingBaseModelWithoutWritingStatus(t *testing.T) {
+	storageURI := "local:///models/model"
+	model := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "service-ns", UID: "uid-model"},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{StorageUri: &storageURI},
+		},
+	}
+	labelKey, err := getModelLabelKey(&NodeLabelOp{ModelStateOnNode: Updating, BaseModel: model})
+	require.NoError(t, err)
+	cm := makeConfigMap("node-1", map[string]string{})
+	g := newGopherForProcessTask(cm, map[string]string{labelKey: string(Updating)})
+	g.baseModelLister = &mockBaseModelLister{}
+
+	err = g.processTask(&GopherTask{TaskType: Download, BaseModel: model})
+
+	require.NoError(t, err)
+	latest, err := g.configMapReconciler.kubeClient.CoreV1().ConfigMaps(cm.Namespace).Get(context.Background(), cm.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotContains(t, latest.Data, constants.GetModelConfigMapKey(model.Namespace, model.Name, false))
+}
+
+func TestProcessTask_TerminatingClusterBaseModelRunsDeleteCleanup(t *testing.T) {
+	modelName := "model"
+	modelKey := constants.GetModelConfigMapKey("", modelName, true)
+	cm := makeConfigMap("node-1", map[string]string{
+		modelKey: modelEntryJSON(ModelStatusReady),
+	})
+	g := newGopherForProcessTask(cm)
+
+	now := metav1.Now()
+	storageURI := "local:///models/model"
+	staleTaskModel := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: modelName, UID: "uid-cluster-model"},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{StorageUri: &storageURI},
+		},
+	}
+	latestModel := staleTaskModel.DeepCopy()
+	latestModel.DeletionTimestamp = &now
+	g.clusterBaseModelLister = &mockClusterBaseModelLister{models: []*v1beta1.ClusterBaseModel{latestModel}}
+
+	err := g.processTask(&GopherTask{TaskType: Download, ClusterBaseModel: staleTaskModel})
+
+	require.NoError(t, err)
+	latest, err := g.configMapReconciler.kubeClient.CoreV1().ConfigMaps(cm.Namespace).Get(context.Background(), cm.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotContains(t, latest.Data, modelKey)
 }
 
 func TestHandelReuseArtifactIfNecessary_NoReusePolicy(t *testing.T) {

--- a/pkg/modelagent/gopher_test.go
+++ b/pkg/modelagent/gopher_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"go.uber.org/zap/zaptest"
 
@@ -814,6 +815,217 @@ func TestFindReadyObjectStorageModelWithSamePath(t *testing.T) {
 				assert.Empty(t, matchedKey)
 			}
 		})
+	}
+}
+
+func TestFindUpdatingObjectStorageModelWithSamePathDoesNotRequireLocalPath(t *testing.T) {
+	storageURI := "oci://n/object-ns/b/model-bucket/o/models/large-model"
+	missingModelPath := filepath.Join(t.TempDir(), "missing-model")
+	readyKey := constants.GetModelConfigMapKey("default", "large-model", false)
+	currentCreatedAt := metav1.NewTime(time.Now())
+	candidateCreatedAt := metav1.NewTime(currentCreatedAt.Add(-time.Minute))
+	current := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "service-ns", CreationTimestamp: currentCreatedAt},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{
+				StorageUri: &storageURI,
+				Path:       &missingModelPath,
+			},
+		},
+	}
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{
+		readyKey: modelEntryJSON(ModelStatusUpdating),
+	}))
+	g.baseModelLister = &mockBaseModelLister{
+		models: []*v1beta1.BaseModel{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "default", CreationTimestamp: candidateCreatedAt},
+				Spec: v1beta1.BaseModelSpec{
+					Storage: &v1beta1.StorageSpec{
+						StorageUri: &storageURI,
+						Path:       &missingModelPath,
+					},
+				},
+			},
+		},
+	}
+
+	matchedKey, wait := g.findUpdatingObjectStorageModelWithSamePath(context.Background(), &GopherTask{BaseModel: current}, current.Spec, missingModelPath)
+
+	assert.True(t, wait)
+	assert.Equal(t, readyKey, matchedKey)
+}
+
+func TestFindUpdatingObjectStorageModelWithSamePathIgnoresNewerCandidate(t *testing.T) {
+	storageURI := "oci://n/object-ns/b/model-bucket/o/models/large-model"
+	modelPath := filepath.Join(t.TempDir(), "large-model")
+	currentCreatedAt := metav1.NewTime(time.Now())
+	candidateCreatedAt := metav1.NewTime(currentCreatedAt.Add(time.Minute))
+	current := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "service-ns", CreationTimestamp: currentCreatedAt},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{
+				StorageUri: &storageURI,
+				Path:       &modelPath,
+			},
+		},
+	}
+	newerModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "another-ns", CreationTimestamp: candidateCreatedAt},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{
+				StorageUri: &storageURI,
+				Path:       &modelPath,
+			},
+		},
+	}
+	newerKey := constants.GetModelConfigMapKey(newerModel.Namespace, newerModel.Name, false)
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{
+		newerKey: modelEntryJSON(ModelStatusUpdating),
+	}))
+	g.baseModelLister = &mockBaseModelLister{models: []*v1beta1.BaseModel{newerModel}}
+
+	matchedKey, wait := g.findUpdatingObjectStorageModelWithSamePath(context.Background(), &GopherTask{BaseModel: current}, current.Spec, modelPath)
+
+	assert.False(t, wait)
+	assert.Empty(t, matchedKey)
+}
+
+func TestFindUpdatingObjectStorageModelWithSamePathIgnoresDeletingCandidate(t *testing.T) {
+	storageURI := "oci://n/object-ns/b/model-bucket/o/models/large-model"
+	modelPath := filepath.Join(t.TempDir(), "large-model")
+	now := metav1.Now()
+	currentCreatedAt := metav1.NewTime(now.Add(time.Minute))
+	candidateCreatedAt := metav1.NewTime(now.Add(-time.Minute))
+	current := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "service-ns", CreationTimestamp: currentCreatedAt},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{
+				StorageUri: &storageURI,
+				Path:       &modelPath,
+			},
+		},
+	}
+	deletingModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "default", CreationTimestamp: candidateCreatedAt, DeletionTimestamp: &now},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{
+				StorageUri: &storageURI,
+				Path:       &modelPath,
+			},
+		},
+	}
+	deletingKey := constants.GetModelConfigMapKey(deletingModel.Namespace, deletingModel.Name, false)
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{
+		deletingKey: modelEntryJSON(ModelStatusUpdating),
+	}))
+	g.baseModelLister = &mockBaseModelLister{models: []*v1beta1.BaseModel{deletingModel}}
+
+	matchedKey, wait := g.findUpdatingObjectStorageModelWithSamePath(context.Background(), &GopherTask{BaseModel: current}, current.Spec, modelPath)
+
+	assert.False(t, wait)
+	assert.Empty(t, matchedKey)
+}
+
+func TestFindReadyObjectStorageModelWithSamePathIgnoresDeletingCandidate(t *testing.T) {
+	storageURI := "oci://n/object-ns/b/model-bucket/o/models/large-model"
+	modelPath := filepath.Join(t.TempDir(), "large-model")
+	require.NoError(t, os.MkdirAll(modelPath, 0755))
+	now := metav1.Now()
+	current := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "service-ns"},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{
+				StorageUri: &storageURI,
+				Path:       &modelPath,
+			},
+		},
+	}
+	deletingModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "default", DeletionTimestamp: &now},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{
+				StorageUri: &storageURI,
+				Path:       &modelPath,
+			},
+		},
+	}
+	deletingKey := constants.GetModelConfigMapKey(deletingModel.Namespace, deletingModel.Name, false)
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{
+		deletingKey: modelEntryJSON(ModelStatusReady),
+	}))
+	g.baseModelLister = &mockBaseModelLister{models: []*v1beta1.BaseModel{deletingModel}}
+
+	matchedKey, reused := g.findReadyObjectStorageModelWithSamePath(context.Background(), &GopherTask{BaseModel: current}, current.Spec, modelPath)
+
+	assert.False(t, reused)
+	assert.Empty(t, matchedKey)
+}
+
+func TestProcessTask_RequeuesSamePathUpdatingObjectStorageModel(t *testing.T) {
+	storageURI := "oci://n/object-ns/b/model-bucket/o/models/large-model"
+	modelPath := filepath.Join(t.TempDir(), "large-model")
+	currentCreatedAt := metav1.NewTime(time.Now())
+	candidateCreatedAt := metav1.NewTime(currentCreatedAt.Add(-time.Minute))
+	current := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "service-ns", UID: "current-uid", CreationTimestamp: currentCreatedAt},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{
+				StorageUri: &storageURI,
+				Path:       &modelPath,
+			},
+		},
+	}
+	updatingModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "large-model", Namespace: "default", CreationTimestamp: candidateCreatedAt},
+		Spec: v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{
+				StorageUri: &storageURI,
+				Path:       &modelPath,
+			},
+		},
+	}
+	updatingKey := constants.GetModelConfigMapKey(updatingModel.Namespace, updatingModel.Name, false)
+	g := newGopherForProcessTask(makeConfigMap("node-1", map[string]string{
+		updatingKey: modelEntryJSON(ModelStatusUpdating),
+	}))
+	g.baseModelLister = &mockBaseModelLister{models: []*v1beta1.BaseModel{current, updatingModel}}
+	g.gopherChan = make(chan *GopherTask, 1)
+	g.samePathWaitDelay = time.Millisecond
+	g.samePathWaitTimeout = time.Hour
+
+	err := g.processTask(&GopherTask{TaskType: Download, BaseModel: current})
+
+	require.NoError(t, err)
+	select {
+	case task := <-g.gopherChan:
+		assert.Equal(t, current.Name, task.BaseModel.Name)
+		assert.False(t, task.SamePathWaitStartedAt.IsZero())
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected same-path Updating task to be requeued")
+	}
+}
+
+func TestRequeueSamePathInFlightReuseWaitTimesOut(t *testing.T) {
+	g := newGopherWithConfigMap(makeConfigMap("node-1", map[string]string{}))
+	g.gopherChan = make(chan *GopherTask, 1)
+	g.samePathWaitDelay = time.Millisecond
+	g.samePathWaitTimeout = time.Millisecond
+	task := &GopherTask{
+		TaskType:              Download,
+		SamePathWaitStartedAt: time.Now().Add(-time.Hour),
+		BaseModel: &v1beta1.BaseModel{
+			ObjectMeta: metav1.ObjectMeta{Name: "model", Namespace: "service-ns"},
+		},
+	}
+
+	requeued := g.requeueSamePathInFlightReuseWait(task, "default.basemodel.model")
+
+	assert.False(t, requeued)
+	select {
+	case <-g.gopherChan:
+		t.Fatal("timed out same-path wait task should not be requeued")
+	default:
 	}
 }
 


### PR DESCRIPTION
## What this PR does

Improves model-agent task dispatch and stale-task handling for model deletion and copied Object Storage-backed model reuse flows.

Changes include:
- Re-check the latest BaseModel / ClusterBaseModel deletion state before starting download/reuse/validation and again before writing Ready.
- Skip stale download tasks when the model CR no longer exists.
- Run delete cleanup instead of download when the model CR is already terminating.
- Requeue copied same-path Object Storage model work while the source same-path model is still Updating, instead of starting duplicate download/validation to the same local path.
- Add a dedicated high-priority worker path for lightweight delete and same-path reuse/wait work so it is not blocked behind long-running normal download/validation work.

## Why we need it

Large model download and validation can take a long time. If deletion or copied-model reuse work waits behind those tasks, model deletion finalizers and inference service creation can be delayed.

This PR reduces latency for:
- model deletion cleanup
- copied model CR reconciliation when the same Object Storage-backed artifact is already present or being prepared on the same node

It also prevents stale queued download work from marking a model Ready after deletion has started.

Fixes #

## How to test

```bash
go test -count=1 ./pkg/modelagent ./cmd/model-agent
```

E2E validation:
- Delete a model while download/validation is queued or running, and verify delete cleanup removes the node ConfigMap entry without writing Ready afterward.
- Copy/create a same-path Object Storage-backed model while the source model is Ready on the same node, and verify the copied model reuses the local artifact quickly.
- Copy/create a same-path Object Storage-backed model while the source model is Updating, and verify the copied model requeues/waits instead of starting duplicate download/validation.
- Verify DownloadOverride follows normal download/validation behavior and does not use same-path reuse/wait.
- Compatibility / Regression Coverage

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
