### PR TITLE
[API] Add conditions + PVC reasons to model status

### DIFF
--- a/charts/ome-crd/templates/ome.io_basemodels.yaml
+++ b/charts/ome-crd/templates/ome.io_basemodels.yaml
@@ -324,6 +324,48 @@ spec:
             type: object
           status:
             properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastReconcileTime:
+                format: date-time
+                type: string
               lifecycle:
                 type: string
               nodesFailed:
@@ -336,6 +378,9 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              observedGeneration:
+                format: int64
+                type: integer
               state:
                 enum:
                 - Creating

--- a/charts/ome-crd/templates/ome.io_clusterbasemodels.yaml
+++ b/charts/ome-crd/templates/ome.io_clusterbasemodels.yaml
@@ -324,6 +324,48 @@ spec:
             type: object
           status:
             properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastReconcileTime:
+                format: date-time
+                type: string
               lifecycle:
                 type: string
               nodesFailed:
@@ -336,6 +378,9 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              observedGeneration:
+                format: int64
+                type: integer
               state:
                 enum:
                 - Creating

--- a/charts/ome-crd/templates/ome.io_finetunedweights.yaml
+++ b/charts/ome-crd/templates/ome.io_finetunedweights.yaml
@@ -223,6 +223,48 @@ spec:
             type: object
           status:
             properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastReconcileTime:
+                format: date-time
+                type: string
               lifecycle:
                 type: string
               nodesFailed:
@@ -235,6 +277,9 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              observedGeneration:
+                format: int64
+                type: integer
               state:
                 enum:
                 - Creating

--- a/config/crd/full/ome.io_basemodels.yaml
+++ b/config/crd/full/ome.io_basemodels.yaml
@@ -324,6 +324,48 @@ spec:
             type: object
           status:
             properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastReconcileTime:
+                format: date-time
+                type: string
               lifecycle:
                 type: string
               nodesFailed:
@@ -336,6 +378,9 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              observedGeneration:
+                format: int64
+                type: integer
               state:
                 enum:
                 - Creating

--- a/config/crd/full/ome.io_clusterbasemodels.yaml
+++ b/config/crd/full/ome.io_clusterbasemodels.yaml
@@ -324,6 +324,48 @@ spec:
             type: object
           status:
             properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastReconcileTime:
+                format: date-time
+                type: string
               lifecycle:
                 type: string
               nodesFailed:
@@ -336,6 +378,9 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              observedGeneration:
+                format: int64
+                type: integer
               state:
                 enum:
                 - Creating

--- a/config/crd/full/ome.io_finetunedweights.yaml
+++ b/config/crd/full/ome.io_finetunedweights.yaml
@@ -223,6 +223,48 @@ spec:
             type: object
           status:
             properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastReconcileTime:
+                format: date-time
+                type: string
               lifecycle:
                 type: string
               nodesFailed:
@@ -235,6 +277,9 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              observedGeneration:
+                format: int64
+                type: integer
               state:
                 enum:
                 - Creating

--- a/pkg/apis/ome/v1beta1/model.go
+++ b/pkg/apis/ome/v1beta1/model.go
@@ -404,6 +404,47 @@ const (
 	LifeCycleDetailFailed     string = "Associated JobRun Failed"
 )
 
+// Model status condition types and reasons.
+const (
+	// ModelConditionSourceReachable reports whether OME can access the model source.
+	ModelConditionSourceReachable = "SourceReachable"
+	// ModelConditionReady reports whether the model status is ready for serving consumers.
+	ModelConditionReady = "Ready"
+
+	// ModelConditionReasonNotChecked means the controller has not checked this condition yet.
+	ModelConditionReasonNotChecked = "NotChecked"
+	// ModelConditionReasonSourceReachable means the model source is reachable.
+	ModelConditionReasonSourceReachable = "SourceReachable"
+	// ModelConditionReasonSourceNotReachable means the model source is not reachable.
+	ModelConditionReasonSourceNotReachable = "SourceNotReachable"
+
+	// ModelConditionReasonPVCInvalid means the PVC storage URI is malformed
+	// or violates the BaseModel/ClusterBaseModel namespace rules.
+	ModelConditionReasonPVCInvalid = "PVCInvalid"
+	// ModelConditionReasonPVCNotFound means the referenced PVC does not exist.
+	ModelConditionReasonPVCNotFound = "PVCNotFound"
+	// ModelConditionReasonPVCNotBound means the referenced PVC exists but is not Bound.
+	ModelConditionReasonPVCNotBound = "PVCNotBound"
+	// ModelConditionReasonPVCValidated means the referenced PVC exists and is Bound.
+	ModelConditionReasonPVCValidated = "PVCValidated"
+	// ModelConditionReasonPVCMetadataPending means the PVC is valid but model
+	// metadata has not yet been extracted.
+	ModelConditionReasonPVCMetadataPending = "PVCMetadataPending"
+	// ModelConditionReasonPVCMetadataExtracting means the metadata-extraction
+	// Job is currently running against the PVC.
+	ModelConditionReasonPVCMetadataExtracting = "PVCMetadataExtracting"
+	// ModelConditionReasonPVCMetadataExtractionFailed means the metadata
+	// extraction Job failed; reconcile will surface the Job's failure message.
+	ModelConditionReasonPVCMetadataExtractionFailed = "PVCMetadataExtractionFailed"
+	// ModelConditionReasonPVCMetadataReady means the metadata-extraction Job
+	// completed successfully and the model is ready to serve.
+	ModelConditionReasonPVCMetadataReady = "PVCMetadataReady"
+	// ModelConditionReasonPVCConfigMissing means the controller has no
+	// ome-agent image configured and therefore cannot spawn the metadata
+	// extraction Job.
+	ModelConditionReasonPVCConfigMissing = "PVCConfigMissing"
+)
+
 // ModelStatusSpec defines the observed state of Model weight
 type ModelStatusSpec struct {
 	// LifeCycle is an enum of Deprecated, Experiment, Public, Internal
@@ -412,11 +453,33 @@ type ModelStatusSpec struct {
 	// Status of the model weight
 	State LifeCycleState `json:"state"`
 
+	// ObservedGeneration is the .metadata.generation the controller last
+	// reconciled against. If this lags behind .metadata.generation, the
+	// controller has not yet observed the latest spec edit.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// LastReconcileTime is the wall-clock timestamp of the controller's most
+	// recent reconcile pass for this object. Liveness signal — if it falls
+	// behind by more than the reconcile period, the controller is wedged or
+	// not scheduled. Distinct from Condition.lastTransitionTime, which only
+	// advances on actual status flips.
+	// +optional
+	LastReconcileTime *metav1.Time `json:"lastReconcileTime,omitempty"`
+
 	// +listType=atomic
 	NodesReady []string `json:"nodesReady,omitempty"`
 
 	// +listType=atomic
 	NodesFailed []string `json:"nodesFailed,omitempty"`
+
+	// Conditions describe model readiness and source/metadata state. The PVC
+	// path reports SourceReachable and Ready; PerNode models continue to
+	// report node-level state through NodesReady and NodesFailed.
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // BaseModel is the Schema for the basemodels API

--- a/pkg/apis/ome/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/ome/v1beta1/zz_generated.deepcopy.go
@@ -1811,6 +1811,10 @@ func (in *ModelStatusSpec) DeepCopyInto(out *ModelStatusSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.LastReconcileTime != nil {
+		in, out := &in.LastReconcileTime, &out.LastReconcileTime
+		*out = (*in).DeepCopy()
+	}
 	if in.NodesReady != nil {
 		in, out := &in.NodesReady, &out.NodesReady
 		*out = make([]string, len(*in))
@@ -1820,6 +1824,13 @@ func (in *ModelStatusSpec) DeepCopyInto(out *ModelStatusSpec) {
 		in, out := &in.NodesFailed, &out.NodesFailed
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]metav1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -5178,6 +5178,19 @@ func schema_pkg_apis_ome_v1beta1_ModelStatusSpec(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObservedGeneration is the .metadata.generation the controller last reconciled against. If this lags behind .metadata.generation, the controller has not yet observed the latest spec edit.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"lastReconcileTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LastReconcileTime is the wall-clock timestamp of the controller's most recent reconcile pass for this object. Liveness signal — if it falls behind by more than the reconcile period, the controller is wedged or not scheduled. Distinct from Condition.lastTransitionTime, which only advances on actual status flips.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 					"nodesReady": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -5216,10 +5229,34 @@ func schema_pkg_apis_ome_v1beta1_ModelStatusSpec(ref common.ReferenceCallback) c
 							},
 						},
 					},
+					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Conditions describe model readiness and source/metadata state. The PVC path reports SourceReachable and Ready; PerNode models continue to report node-level state through NodesReady and NodesFailed.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Condition"),
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"state"},
 			},
 		},
+		Dependencies: []string{
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Condition", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -2867,6 +2867,22 @@
         "state"
       ],
       "properties": {
+        "conditions": {
+          "description": "Conditions describe model readiness and source/metadata state. The PVC path reports SourceReachable and Ready; PerNode models continue to report node-level state through NodesReady and NodesFailed.",
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/v1.Condition"
+          },
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "lastReconcileTime": {
+          "description": "LastReconcileTime is the wall-clock timestamp of the controller's most recent reconcile pass for this object. Liveness signal — if it falls behind by more than the reconcile period, the controller is wedged or not scheduled. Distinct from Condition.lastTransitionTime, which only advances on actual status flips.",
+          "$ref": "#/definitions/v1.Time"
+        },
         "lifecycle": {
           "description": "LifeCycle is an enum of Deprecated, Experiment, Public, Internal",
           "type": "string"
@@ -2886,6 +2902,11 @@
             "default": ""
           },
           "x-kubernetes-list-type": "atomic"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the .metadata.generation the controller last reconciled against. If this lags behind .metadata.generation, the controller has not yet observed the latest spec edit.",
+          "type": "integer",
+          "format": "int64"
         },
         "state": {
           "description": "Status of the model weight",


### PR DESCRIPTION
## What this PR does

Add Conditions ([]metav1.Condition), ObservedGeneration, and
LastReconcileTime to ModelStatusSpec, plus SourceReachable/Ready
condition types and the source-reachability + PVC-lifecycle reason
constants (PVCInvalid/NotFound/NotBound/Validated/MetadataPending/
Extracting/ExtractionFailed/Ready/ConfigMissing).

## Why we need it

Foundation for PVC-backed BaseModel support: the PVC reconcile path is
condition-driven, and upstream model status was State-only. Additive
and omitempty — no behavior change until the PVC backend writes them.
Regenerated deepcopy, CRDs, and openapi.


## How to test

 go build ./pkg/..., go vet, deepcopy handles the slice+pointer, CRDs expose the fields, apis test passes.

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
