### PR TITLE
[Core] PVC-backed BaseModel support

### DIFF
--- a/charts/ome-resources/templates/ome-controller/configmap.yaml
+++ b/charts/ome-resources/templates/ome-controller/configmap.yaml
@@ -70,6 +70,21 @@ data:
         "authType" : "{{ .Values.ome.omeAgent.authType }}",
         "region": "{{ .Values.ome.omeAgent.region }}"
     }
+  omeAgent: |-
+    {
+        "image": "{{ include "ome.imageWithHub" (dict "values" .Values "repository" .Values.ome.omeAgent.image "tag" .Values.ome.omeAgent.tag) }}",
+        "serviceAccount": "{{ .Values.ome.omeAgent.metadataJob.serviceAccount }}",
+        "memoryRequest": "{{ .Values.ome.omeAgent.metadataJob.memoryRequest }}",
+        "memoryLimit": "{{ .Values.ome.omeAgent.metadataJob.memoryLimit }}",
+        "cpuRequest": "{{ .Values.ome.omeAgent.metadataJob.cpuRequest }}",
+        "cpuLimit": "{{ .Values.ome.omeAgent.metadataJob.cpuLimit }}",
+        "backoffLimit": {{ .Values.ome.omeAgent.metadataJob.backoffLimit | default 2 }},
+        "ttlSecondsAfterFinished": {{ .Values.ome.omeAgent.metadataJob.ttlSecondsAfterFinished | default 3600 }},
+        "nodeSelector": {{ .Values.ome.omeAgent.metadataJob.nodeSelector | default dict | toJson }},
+        "tolerations": {{ .Values.ome.omeAgent.metadataJob.tolerations | default list | toJson }},
+        "affinity": {{ .Values.ome.omeAgent.metadataJob.affinity | default dict | toJson }},
+        "priorityClassName": "{{ .Values.ome.omeAgent.metadataJob.priorityClassName | default "" }}"
+    }
   kedaConfig: |-
     {
       "enableKeda" : {{ .Values.ome.kedaConfig.enableKeda | default true }},

--- a/charts/ome-resources/templates/ome-controller/metadata-job-rbac.yaml
+++ b/charts/ome-resources/templates/ome-controller/metadata-job-rbac.yaml
@@ -1,0 +1,46 @@
+{{- /*
+ServiceAccount + ClusterRole/Binding used by the metadata-extraction Job
+spawned by the BaseModel/ClusterBaseModel controller for PVC-backed
+models. The Job runs `ome-agent model-metadata`, parses the model
+directory mounted from the PVC, and writes a single per-model status
+ConfigMap in the OME namespace (deterministic name via
+constants.GetPVCMetadataConfigMapName). The BaseModel controller Gets
+that ConfigMap directly and updates the CR spec/state — the Job itself
+never writes to the CR.
+*/ -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.ome.omeAgent.metadataJob.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: "ome-model-metadata-job"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.ome.omeAgent.metadataJob.serviceAccount }}
+  labels:
+    app.kubernetes.io/component: "ome-model-metadata-job"
+rules:
+  # Per-model status ConfigMap in the OME namespace. Granted cluster-scoped
+  # so the same SA works for ClusterBaseModel Jobs that may run in any
+  # namespace; the ConfigMap itself always lands in the OME namespace.
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "get", "list", "create", "update", "patch" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.ome.omeAgent.metadataJob.serviceAccount }}
+  labels:
+    app.kubernetes.io/component: "ome-model-metadata-job"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.ome.omeAgent.metadataJob.serviceAccount }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.ome.omeAgent.metadataJob.serviceAccount }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -83,6 +83,24 @@ ome:
       memoryLimit: 320Gi
       cpuRequest: 15
       cpuLimit: 15
+    # metadataJob configures the metadata-extraction Job the BaseModel
+    # controller spawns on demand for PVC-backed models. It runs
+    # `ome-agent model-metadata` against the PVC-mounted model directory.
+    metadataJob:
+      serviceAccount: ome-model-metadata
+      memoryRequest: 256Mi
+      memoryLimit: 512Mi
+      cpuRequest: 100m
+      cpuLimit: 500m
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 3600
+      # Pass-through scheduling hints applied to the metadata Job pod.
+      # Use these when the PVC's CSI driver only mounts on a subset of
+      # nodes or when models live on tainted nodes (e.g., GPU nodes).
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+      priorityClassName: ""
   kedaConfig:
     enableKeda: true
     promServerAddress: "http://prometheus-operated.monitoring.svc.cluster.local:9090"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -220,6 +220,11 @@ func main() {
 		setupLog.Error(err, "Failed to initialize ingress configuration")
 		os.Exit(1)
 	}
+	omeAgentConfig, err := controllerconfig.NewOmeAgentConfig(clientSet)
+	if err != nil {
+		setupLog.Error(err, "Failed to initialize ome-agent configuration")
+		os.Exit(1)
+	}
 
 	// Register optional schemes based on CRD availability
 	setupLog.Info("Registering optional CRD schemes")
@@ -271,9 +276,10 @@ func main() {
 	// Setup BaseModel and ClusterBaseModel controllers with the manager
 	setupLog.Info("Setting up BaseModel controller")
 	if err = (&v1beta1basemodelcontroller.BaseModelReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("BaseModel"),
-		Scheme: mgr.GetScheme(),
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("BaseModel"),
+		Scheme:         mgr.GetScheme(),
+		OmeAgentConfig: omeAgentConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create BaseModel controller")
 		os.Exit(1)
@@ -281,9 +287,10 @@ func main() {
 
 	setupLog.Info("Setting up ClusterBaseModel controller")
 	if err = (&v1beta1basemodelcontroller.ClusterBaseModelReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("ClusterBaseModel"),
-		Scheme: mgr.GetScheme(),
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("ClusterBaseModel"),
+		Scheme:         mgr.GetScheme(),
+		OmeAgentConfig: omeAgentConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create ClusterBaseModel controller")
 		os.Exit(1)

--- a/pkg/constants/pvc.go
+++ b/pkg/constants/pvc.go
@@ -1,0 +1,40 @@
+package constants
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+const (
+	// PVCStorageConfigMapLabel marks a per-PVC model status ConfigMap
+	// (written by the metadata-extraction Job) in the OME namespace, as
+	// distinct from the per-node model-agent status ConfigMaps.
+	PVCStorageConfigMapLabel = "models.ome/pvc-status"
+	// PVCMetadataModelNameLabel records the BaseModel/ClusterBaseModel name
+	// on the metadata Job and its per-PVC status ConfigMap.
+	PVCMetadataModelNameLabel = "models.ome/model-name"
+	// PVCMetadataScopeLabel is "namespaced" or "cluster".
+	PVCMetadataScopeLabel = "models.ome/model-scope"
+	// PVCMetadataLastErrorAnnotation captures the last extraction error the
+	// agent reported on the per-PVC status ConfigMap.
+	PVCMetadataLastErrorAnnotation = "models.ome/pvc-metadata-last-error"
+)
+
+// pvcMetadataConfigMapPrefix and PVCMetadataNameHashLen together define the
+// deterministic per-PVC status ConfigMap name.
+const (
+	pvcMetadataConfigMapPrefix = "pvc-metadata-"
+	PVCMetadataNameHashLen     = 8
+)
+
+// GetPVCMetadataConfigMapName returns the deterministic name of the per-PVC
+// status ConfigMap for a model. Cluster-scoped models key on the model name
+// alone; namespaced models key on namespace/name.
+func GetPVCMetadataConfigMapName(modelName, modelNamespace string, isClusterScoped bool) string {
+	keySource := modelName
+	if !isClusterScoped {
+		keySource = modelNamespace + "/" + modelName
+	}
+	sum := sha256.Sum256([]byte(keySource))
+	return pvcMetadataConfigMapPrefix + hex.EncodeToString(sum[:])[:PVCMetadataNameHashLen]
+}

--- a/pkg/controller/v1beta1/basemodel/backend.go
+++ b/pkg/controller/v1beta1/basemodel/backend.go
@@ -8,6 +8,7 @@ import (
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/backends/pernode"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/backends/pvc"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
 )
 
@@ -32,6 +33,15 @@ func (perNodeBackend) Name() string                          { return "pernode" 
 func (perNodeBackend) Matches(_ *v1beta1.BaseModelSpec) bool { return true }
 
 func (perNodeBackend) Reconcile(ctx context.Context, a shared.BackendArgs) (ctrl.Result, error) {
+	// A model whose storage URI flipped away from pvc:// lands on the
+	// per-node backend; scrub any leftover PVC Job / ConfigMap / conditions
+	// before running the per-node flow. Idempotent no-op when there are no
+	// PVC artifacts (the common case).
+	if err := pvc.CleanupStaleArtifacts(ctx, a.Client, a.Log, a.Obj, a.IsClusterScoped); err != nil {
+		a.Log.Error(err, "Failed to clean up stale PVC artifacts after URI swap")
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
+	}
+
 	if err := pernode.ReconcileStatusFromConfigMaps(ctx, a.Client, a.Log, a.Obj, a.IsClusterScoped, a.Kind); err != nil {
 		a.Log.Error(err, "Failed to update "+a.Kind+" status")
 		return ctrl.Result{RequeueAfter: time.Minute}, err

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/backend.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/backend.go
@@ -1,0 +1,55 @@
+package pvc
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
+)
+
+// Backend handles PVC-backed BaseModels: spawns a metadata-extraction
+// Job, reads the per-PVC ConfigMap output. Bypasses the per-node
+// ConfigMap flow entirely (no Status.NodesReady entries). A nil
+// OmeAgentConfig surfaces as PVCConfigMissing via status.
+type Backend struct {
+	omeAgentConfig *controllerconfig.OmeAgentConfig
+}
+
+func New(omeAgentConfig *controllerconfig.OmeAgentConfig) Backend {
+	return Backend{omeAgentConfig: omeAgentConfig}
+}
+
+func (Backend) Name() string { return "pvc" }
+
+func (Backend) Matches(spec *v1beta1.BaseModelSpec) bool { return IsPVCStorage(spec) }
+
+func (b Backend) Reconcile(ctx context.Context, a shared.BackendArgs) (ctrl.Result, error) {
+	return Reconcile(ctx, a.Client, a.Scheme, a.Log, a.Obj, a.Spec, a.IsClusterScoped, omeAgentConfigToMetadataJobConfig(b.omeAgentConfig))
+}
+
+func (Backend) HandleDeletion(ctx context.Context, a shared.BackendArgs) (ctrl.Result, error) {
+	return HandleModelDeletion(ctx, a.Client, a.Log, a.Obj, a.IsClusterScoped, a.Finalizer)
+}
+
+func omeAgentConfigToMetadataJobConfig(c *controllerconfig.OmeAgentConfig) MetadataJobConfig {
+	if c == nil {
+		return MetadataJobConfig{}
+	}
+	return MetadataJobConfig{
+		Image:                   c.Image,
+		ServiceAccount:          c.ServiceAccount,
+		CPURequest:              c.CPURequest,
+		MemoryRequest:           c.MemoryRequest,
+		CPULimit:                c.CPULimit,
+		MemoryLimit:             c.MemoryLimit,
+		BackoffLimit:            c.BackoffLimit,
+		TTLSecondsAfterFinished: c.TTLSecondsAfterFinished,
+		NodeSelector:            c.NodeSelector,
+		Tolerations:             c.Tolerations,
+		Affinity:                c.Affinity,
+		PriorityClassName:       c.PriorityClassName,
+	}
+}

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_job.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_job.go
@@ -1,0 +1,312 @@
+package pvc
+
+import (
+	"cmp"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+const (
+	// metadataJobScopeNamespaced / metadataJobScopeCluster are the values
+	// written under constants.PVCMetadataScopeLabel. They mirror the
+	// agent-side values in internal/ome-agent/model-metadata so the same
+	// label can be used to filter both the Job and its ConfigMap.
+	metadataJobScopeNamespaced = "namespaced"
+	metadataJobScopeCluster    = "cluster"
+
+	// metadataJobModelMountPath is where the metadata extractor expects the
+	// model directory to be mounted.
+	metadataJobModelMountPath = "/model"
+	// metadataJobModelVolumeName is the in-pod name of the PVC volume.
+	metadataJobModelVolumeName = "model"
+
+	// metadataJobNameSuffix is appended to the model name to produce the
+	// Job name. The total length is bounded by combining with a short hash.
+	metadataJobNameSuffix = "-metadata-"
+
+	// metadataJobAgentConfigPath is the path to the bundled ome-agent
+	// config file inside the standard ome-agent image
+	// (dockerfiles/ome-agent.Dockerfile:85). The agent's configProvider
+	// (cmd/ome-agent/config.go:28) errors with "no config file provided"
+	// if --config is empty, even though `model-metadata` reads all its
+	// runtime params from --model-path / --basemodel-name / etc. flags.
+	// Passing the bundled path satisfies the gratuitous existence check
+	// without requiring a per-Job ConfigMap mount.
+	metadataJobAgentConfigPath = "/ome-agent.yaml"
+)
+
+// MetadataJobConfig is the runtime configuration the BaseModel reconciler
+// needs to spawn a metadata-extraction Job.
+type MetadataJobConfig struct {
+	// Image is the ome-agent container image (must include the
+	// `model-metadata` subcommand — currently shipped in the same binary).
+	Image string
+	// ServiceAccount the Job pod runs as. Must have permission to
+	// get/list/create/update/patch ConfigMaps in the OME namespace; the
+	// agent writes a per-model status ConfigMap there. The same SA is
+	// shared across BaseModel and ClusterBaseModel Jobs (the latter may
+	// run in any namespace), so a cluster-scoped binding is required.
+	ServiceAccount string
+	// CPURequest / MemoryRequest / CPULimit / MemoryLimit follow the
+	// standard Kubernetes resource shape; empty strings fall back to
+	// Kubernetes defaults.
+	CPURequest    string
+	MemoryRequest string
+	CPULimit      string
+	MemoryLimit   string
+	// BackoffLimit caps Job retries. Default is 2 if zero.
+	BackoffLimit int32
+	// TTLSecondsAfterFinished controls cleanup of completed Jobs. Default
+	// 3600 if zero.
+	TTLSecondsAfterFinished int32
+
+	// NodeSelector / Tolerations / Affinity / PriorityClassName let
+	// operators target the metadata Job onto specific nodes when the
+	// PVC's underlying storage is restricted (e.g., a CSI driver only
+	// available on a subset of nodes, or models that live on tainted
+	// GPU nodes). Pass-through into the pod spec. All optional; nil
+	// values mean "K8s default".
+	NodeSelector      map[string]string
+	Tolerations       []corev1.Toleration
+	Affinity          *corev1.Affinity
+	PriorityClassName string
+}
+
+// metadataJobShortHashLen is the number of hex chars used for the
+// deterministic name suffix on both the metadata Job and the per-model
+// status ConfigMap. Eight hex chars give ~10^9 keyspace per (model,uri)
+// pair which is more than enough for non-cryptographic uniqueness.
+const metadataJobShortHashLen = 8
+
+// metadataJobName returns a deterministic, ≤63-char Job name derived from
+// the model name and PVC URI. URI hashing means a spec edit that changes
+// the URI yields a fresh Job rather than reusing a stale one.
+func metadataJobName(modelName, storageURI string) string {
+	sum := sha256.Sum256([]byte(storageURI))
+	hash := hex.EncodeToString(sum[:])[:metadataJobShortHashLen]
+
+	name := modelName + metadataJobNameSuffix + hash
+	const maxNameLen = 63
+	if len(name) > maxNameLen {
+		// Trim the model-name portion; keep the suffix + hash intact for
+		// determinism.
+		excess := len(name) - maxNameLen
+		trimmed := modelName[:len(modelName)-excess]
+		// Guard against a fully-trimmed model name producing a leading
+		// dash (DNS-1123 requires alphanumeric start). Fall back to a
+		// hash-only name with a stable prefix.
+		if trimmed == "" {
+			return "metadata" + metadataJobNameSuffix + hash
+		}
+		name = trimmed + metadataJobNameSuffix + hash
+	}
+	return name
+}
+
+// buildMetadataJob constructs (without creating) the Job that runs
+// `ome-agent model-metadata` against a PVC-mounted model directory.
+//
+// The Job is placed in pvcNamespace (which equals the BaseModel's namespace
+// for namespaced BaseModel, and the URI-specified namespace for
+// ClusterBaseModel). An OwnerReference to obj is attached so the Job is
+// garbage-collected with its owner; this works for namespaced BaseModel
+// (same-ns Job) and for cluster-scoped ClusterBaseModel (cluster-scoped
+// owners may own children in any namespace).
+func buildMetadataJob(obj client.Object, isClusterScoped bool, components *storage.PVCStorageComponents, pvcNamespace string, cfg MetadataJobConfig, scheme *runtime.Scheme) (*batchv1.Job, error) {
+	if obj == nil || components == nil {
+		return nil, fmt.Errorf("buildMetadataJob: nil object or components")
+	}
+	if cfg.Image == "" {
+		return nil, fmt.Errorf("buildMetadataJob: ome-agent image must be configured")
+	}
+
+	storageURI, err := storageURIOf(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	jobName := metadataJobName(obj.GetName(), storageURI)
+	scope := metadataJobScopeNamespaced
+	if isClusterScoped {
+		scope = metadataJobScopeCluster
+	}
+	jobLabels := map[string]string{
+		constants.PVCMetadataModelNameLabel: obj.GetName(),
+		constants.PVCMetadataScopeLabel:     scope,
+	}
+
+	args := []string{
+		"model-metadata",
+		"--config", metadataJobAgentConfigPath,
+		"--model-path", metadataJobModelMountPath,
+		"--basemodel-name", obj.GetName(),
+	}
+	if isClusterScoped {
+		args = append(args, "--cluster-scoped")
+	} else {
+		args = append(args, "--basemodel-namespace", obj.GetNamespace())
+	}
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: pvcNamespace,
+			Labels:    jobLabels,
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            ptr.To(cmp.Or(cfg.BackoffLimit, int32(2))),
+			TTLSecondsAfterFinished: ptr.To(cmp.Or(cfg.TTLSecondsAfterFinished, int32(3600))),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: jobLabels,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: cfg.ServiceAccount,
+					RestartPolicy:      corev1.RestartPolicyNever,
+					SecurityContext:    metadataJobPodSecurityContext(),
+					NodeSelector:       cfg.NodeSelector,
+					Tolerations:        cfg.Tolerations,
+					Affinity:           cfg.Affinity,
+					PriorityClassName:  cfg.PriorityClassName,
+					Volumes: []corev1.Volume{
+						{
+							Name: metadataJobModelVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: components.PVCName,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            "model-metadata",
+							Image:           cfg.Image,
+							Args:            args,
+							SecurityContext: metadataJobContainerSecurityContext(),
+							// constants.OMENamespace reads the controller
+							// pod's POD_NAMESPACE at process start (default
+							// "ome"). The agent uses the same constant
+							// to compute the per-PVC status ConfigMap's
+							// namespace, so without this env on the Job
+							// pod an OME install in (e.g.) "ome-prod"
+							// would have the controller writing RBAC in
+							// "ome-prod" while the agent tried to write
+							// the ConfigMap in "ome" — perpetual
+							// "configmap not found" on reconcile.
+							Env: []corev1.EnvVar{
+								{Name: "POD_NAMESPACE", Value: constants.OMENamespace},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      metadataJobModelVolumeName,
+									MountPath: metadataJobModelMountPath,
+									SubPath:   components.SubPath,
+									ReadOnly:  true,
+								},
+							},
+							Resources: buildResourceRequirements(cfg),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(obj, job, scheme); err != nil {
+		return nil, fmt.Errorf("set owner reference: %w", err)
+	}
+	return job, nil
+}
+
+// buildResourceRequirements assembles a ResourceRequirements from the
+// optional CPU/memory strings on cfg. Empty strings are skipped.
+func buildResourceRequirements(cfg MetadataJobConfig) corev1.ResourceRequirements {
+	requests := corev1.ResourceList{}
+	limits := corev1.ResourceList{}
+	if cfg.CPURequest != "" {
+		requests[corev1.ResourceCPU] = resource.MustParse(cfg.CPURequest)
+	}
+	if cfg.MemoryRequest != "" {
+		requests[corev1.ResourceMemory] = resource.MustParse(cfg.MemoryRequest)
+	}
+	if cfg.CPULimit != "" {
+		limits[corev1.ResourceCPU] = resource.MustParse(cfg.CPULimit)
+	}
+	if cfg.MemoryLimit != "" {
+		limits[corev1.ResourceMemory] = resource.MustParse(cfg.MemoryLimit)
+	}
+	rr := corev1.ResourceRequirements{}
+	if len(requests) > 0 {
+		rr.Requests = requests
+	}
+	if len(limits) > 0 {
+		rr.Limits = limits
+	}
+	return rr
+}
+
+func storageURIOf(obj client.Object) (string, error) {
+	var spec *v1beta1.BaseModelSpec
+	switch m := obj.(type) {
+	case *v1beta1.BaseModel:
+		spec = &m.Spec
+	case *v1beta1.ClusterBaseModel:
+		spec = &m.Spec
+	default:
+		return "", fmt.Errorf("unsupported object type %T", obj)
+	}
+	if spec.Storage == nil || spec.Storage.StorageUri == nil {
+		return "", fmt.Errorf("storage URI is not set on %s/%s", obj.GetNamespace(), obj.GetName())
+	}
+	return *spec.Storage.StorageUri, nil
+}
+
+// metadataJobNonRootUID is the UID/GID the agent runs as. 65532 is the
+// nonroot user shipped in distroless / Chainguard base images, which the
+// upstream ome-agent Dockerfile uses (or is compatible with).
+const metadataJobNonRootUID int64 = 65532
+
+// metadataJobPodSecurityContext returns the pod-level security context
+// required to satisfy PodSecurity admission's `restricted` profile.
+func metadataJobPodSecurityContext() *corev1.PodSecurityContext {
+	uid := metadataJobNonRootUID
+	return &corev1.PodSecurityContext{
+		RunAsNonRoot:   ptr.To(true),
+		RunAsUser:      &uid,
+		RunAsGroup:     &uid,
+		FSGroup:        &uid,
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
+}
+
+// metadataJobContainerSecurityContext returns the container-level security
+// context required to satisfy PodSecurity admission's `restricted` profile.
+func metadataJobContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		// SeccompProfile already set at the pod level; restating it on the
+		// container guards against the pod default being weakened by an
+		// admission mutator.
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
+}

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_rbac.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/metadata_rbac.go
@@ -1,0 +1,149 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// metadataJobRBACComponent is the value of the
+// app.kubernetes.io/component label on RBAC objects this file creates.
+// Matches the value the Helm chart puts on its OME-namespace SA so
+// chart-installed and controller-installed objects are filterable
+// together (kubectl get -l app.kubernetes.io/component=ome-model-metadata-job).
+const metadataJobRBACComponent = "ome-model-metadata-job"
+
+// metadataJobSourceNamespaceLabel records which user namespace a
+// cross-ns RoleBinding in the OME namespace was created for. Lets an
+// operator answer "which BaseModel namespaces have the controller
+// granted OME-ns write access to?" via a single kubectl get -L.
+const metadataJobSourceNamespaceLabel = "models.ome/metadata-source-namespace"
+
+// ensureMetadataJobRBAC makes sure the RBAC the metadata-extraction
+// Job needs in `jobNamespace` exists. The chart pre-installs everything
+// in the OME namespace; this function patches the gap for any other
+// namespace (BaseModel's own ns when namespaced, or the URI-derived ns
+// when ClusterBaseModel points at a PVC outside ome).
+//
+// Two objects are needed for a Job in `jobNamespace` to succeed:
+//
+//  1. A ServiceAccount in `jobNamespace`. Without it, kubelet rejects
+//     pod creation with "serviceaccount not found" — the Job sits at
+//     0/1 ready forever (no pod ever starts).
+//
+//  2. A RoleBinding in the OME namespace binding the existing cluster-
+//     scoped ClusterRole to the SA in `jobNamespace`. The agent only
+//     writes the per-model status ConfigMap in the OME namespace
+//     (model-metadata/metadata.go:179 hardcodes constants.OMENamespace),
+//     so an in-namespace RoleBinding wouldn't help — the agent needs
+//     cross-namespace write to ome/configmaps.
+//
+// Both objects are looked up by Get-or-Create so re-reconciles are
+// no-ops; they outlive the BaseModel that triggered them so other BMs
+// in the same namespace don't lose RBAC. Garbage collection is via
+// namespace deletion (typical for short-lived test namespaces) or
+// manual cleanup (long-lived production namespaces).
+//
+// Skips when jobNamespace == omeNamespace because the chart already
+// provisions everything there; creating an extra RoleBinding with the
+// same name would conflict with the chart-managed ClusterRoleBinding.
+func ensureMetadataJobRBAC(ctx context.Context, c client.Client, log logr.Logger, jobNamespace, saName, clusterRoleName string) error {
+	if saName == "" {
+		// Caller's responsibility — buildMetadataJob would also fail
+		// later with "ome-agent image must be configured" or similar.
+		// Treat as no-op so we don't create a nameless SA.
+		return nil
+	}
+	if jobNamespace == constants.OMENamespace {
+		return nil
+	}
+
+	if err := ensureMetadataJobServiceAccount(ctx, c, log, jobNamespace, saName); err != nil {
+		return err
+	}
+	return ensureMetadataJobOMENamespaceRoleBinding(ctx, c, log, jobNamespace, saName, clusterRoleName)
+}
+
+func ensureMetadataJobServiceAccount(ctx context.Context, c client.Client, log logr.Logger, namespace, saName string) error {
+	sa := &corev1.ServiceAccount{}
+	err := c.Get(ctx, types.NamespacedName{Name: saName, Namespace: namespace}, sa)
+	if err == nil {
+		return nil
+	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("get metadata Job ServiceAccount %s/%s: %w", namespace, saName, err)
+	}
+
+	sa = &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: namespace,
+			Labels:    map[string]string{"app.kubernetes.io/component": metadataJobRBACComponent},
+		},
+	}
+	if err := c.Create(ctx, sa); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("create metadata Job ServiceAccount %s/%s: %w", namespace, saName, err)
+	}
+	log.Info("Created metadata Job ServiceAccount", "namespace", namespace, "name", saName)
+	return nil
+}
+
+// metadataJobOMENamespaceRoleBindingName returns the deterministic name
+// of the cross-ns RoleBinding the controller maintains in the OME
+// namespace for a given source `jobNamespace`. The pattern keeps a
+// 1:1 mapping per source ns so concurrent BaseModels in the same
+// jobNamespace reuse the same RoleBinding (idempotent), and BMs in
+// different namespaces get distinct RoleBindings (no subject churn).
+func metadataJobOMENamespaceRoleBindingName(saName, jobNamespace string) string {
+	return saName + "-" + jobNamespace
+}
+
+func ensureMetadataJobOMENamespaceRoleBinding(ctx context.Context, c client.Client, log logr.Logger, jobNamespace, saName, clusterRoleName string) error {
+	rbName := metadataJobOMENamespaceRoleBindingName(saName, jobNamespace)
+	rb := &rbacv1.RoleBinding{}
+	err := c.Get(ctx, types.NamespacedName{Name: rbName, Namespace: constants.OMENamespace}, rb)
+	if err == nil {
+		return nil
+	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("get metadata Job RoleBinding %s/%s: %w", constants.OMENamespace, rbName, err)
+	}
+
+	rb = &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rbName,
+			Namespace: constants.OMENamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/component":   metadataJobRBACComponent,
+				metadataJobSourceNamespaceLabel: jobNamespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      saName,
+			Namespace: jobNamespace,
+		}},
+	}
+	if err := c.Create(ctx, rb); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("create metadata Job RoleBinding %s/%s: %w", constants.OMENamespace, rbName, err)
+	}
+	log.Info("Created metadata Job RoleBinding in OME namespace",
+		"name", rbName,
+		"jobNamespace", jobNamespace,
+		"clusterRole", clusterRoleName)
+	return nil
+}

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/pvc.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/pvc.go
@@ -1,0 +1,611 @@
+package pvc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
+	"sigs.k8s.io/ome/pkg/modelagent"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+// pvcRequeueAfter is the timer backstop for PVC-backed reconciles. The
+// primary triggers are the PVC, Job, and ConfigMap watches in
+// SetupWithManager; this requeue exists to re-check progress in case a
+// watch event was missed.
+//
+// Kept short (5s) so an operator looking at "why is my model still
+// Importing?" sees a Failed terminal state within a few seconds when
+// the underlying Job hits BackoffLimit, not after a 30s pause. Cost:
+// idle PVC-backed BaseModels reconcile a few times more frequently;
+// each reconcile is one apiserver Get for the Job and one for the
+// per-PVC ConfigMap, both cache-backed.
+const pvcRequeueAfter = 5 * time.Second
+
+// IsPVCStorage reports whether the given BaseModel/ClusterBaseModel spec
+// references a PVC-backed storage URI.
+func IsPVCStorage(spec *v1beta1.BaseModelSpec) bool {
+	if spec == nil || spec.Storage == nil || spec.Storage.StorageUri == nil {
+		return false
+	}
+	storageType, err := storage.GetStorageType(*spec.Storage.StorageUri)
+	if err != nil {
+		return false
+	}
+	return storageType == storage.StorageTypePVC
+}
+
+// resolvePVCNamespace returns the namespace the metadata-extraction Job and
+// the InferenceService pod must run in to access the PVC.
+//
+// For namespaced BaseModel: the URI must NOT carry a namespace prefix
+// (`pvc://name/sub-path`) and the model's own namespace is used.
+//
+// For ClusterBaseModel: the URI MUST carry a namespace prefix
+// (`pvc://ns:name/sub-path`); that namespace is returned.
+func resolvePVCNamespace(modelNamespace string, isClusterScoped bool, components *storage.PVCStorageComponents) (string, error) {
+	if components == nil {
+		return "", fmt.Errorf("PVC storage components are nil")
+	}
+
+	if isClusterScoped {
+		if components.Namespace == "" {
+			return "", fmt.Errorf("ClusterBaseModel PVC URI must specify a namespace (format: pvc://{namespace}:{pvc-name}/{sub-path})")
+		}
+		return components.Namespace, nil
+	}
+
+	if components.Namespace != "" {
+		return "", fmt.Errorf("namespaced BaseModel PVC URI must not specify a namespace; the BaseModel's own namespace is used")
+	}
+	return modelNamespace, nil
+}
+
+// Reconcile handles the PVC-specific reconcile flow for a BaseModel or
+// ClusterBaseModel:
+//
+//  1. Parse the URI, resolve the PVC namespace, validate the PVC exists
+//     and is Bound (pre-Job).
+//  2. Ensure the metadata-extraction Job exists.
+//  3. Read the per-PVC status ConfigMap (one ConfigMap per PVC model,
+//     looked up by deterministic name — there is no node concept here)
+//     and apply its ModelEntry to the BaseModel spec + LifeCycleState.
+//
+// PVC-backed models do NOT participate in the per-node ConfigMap flow:
+// Status.NodesReady stays empty, processModelStatus is never invoked,
+// and we never list ConfigMaps to find this model.
+//
+// State transitions written by this branch:
+//
+//	URI invalid / ns rules violated   → state=Failed,    SourceReachable=False (terminal)
+//	PVC not found                     → state=Failed,    SourceReachable=False
+//	PVC pending                       → state=In_Transit,SourceReachable=True  (PVCNotBound)
+//	Image config missing              → state=Failed,    SourceReachable=False (terminal)
+//	Job in flight, ConfigMap absent   → state=In_Transit,SourceReachable=True  (PVCMetadataExtracting)
+//	ConfigMap reports Status=Ready    → state=Ready,     SourceReachable=True + Ready=True
+//	ConfigMap reports Status=Failed   → state=Failed,    Ready=False (PVCMetadataExtractionFailed)
+func Reconcile(ctx context.Context, kubeClient client.Client, scheme *runtime.Scheme, log logr.Logger, obj client.Object, spec *v1beta1.BaseModelSpec, isClusterScoped bool, cfg MetadataJobConfig) (ctrl.Result, error) {
+	uri := *spec.Storage.StorageUri
+
+	components, err := storage.ParsePVCStorageURI(uri)
+	if err != nil {
+		// Terminal: only a CR edit can fix a malformed URI; CR update
+		// re-enqueues the reconcile, no need for a timer requeue.
+		return setPVCFailedTerminal(ctx, kubeClient, log, obj,
+			v1beta1.ModelConditionReasonPVCInvalid,
+			fmt.Sprintf("invalid PVC storage URI %q: %v", uri, err))
+	}
+
+	pvcNamespace, err := resolvePVCNamespace(obj.GetNamespace(), isClusterScoped, components)
+	if err != nil {
+		return setPVCFailedTerminal(ctx, kubeClient, log, obj,
+			v1beta1.ModelConditionReasonPVCInvalid,
+			err.Error())
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	pvcKey := types.NamespacedName{Namespace: pvcNamespace, Name: components.PVCName}
+	if err := kubeClient.Get(ctx, pvcKey, pvc); err != nil {
+		if errors.IsNotFound(err) {
+			return setPVCFailedStatus(ctx, kubeClient, log, obj,
+				v1beta1.ModelConditionReasonPVCNotFound,
+				fmt.Sprintf("PVC %s/%s not found", pvcNamespace, components.PVCName))
+		}
+		log.Error(err, "Failed to get PVC", "pvc", pvcKey)
+		return ctrl.Result{}, err
+	}
+
+	if pvc.Status.Phase != corev1.ClaimBound {
+		return setPVCInTransitStatus(ctx, kubeClient, log, obj,
+			v1beta1.ModelConditionReasonPVCNotBound,
+			fmt.Sprintf("PVC %s/%s is not Bound (phase: %s)", pvcNamespace, components.PVCName, pvc.Status.Phase))
+	}
+
+	if cfg.Image == "" {
+		// Terminal: needs a controller restart with a fixed config to
+		// recover; the BaseModel CR itself can't change anything. The
+		// configmap watch will re-enqueue once the operator updates it.
+		return setPVCFailedTerminal(ctx, kubeClient, log, obj,
+			v1beta1.ModelConditionReasonPVCConfigMissing,
+			"ome-agent image is not configured (set the omeAgent block in inferenceservice-config)")
+	}
+
+	job, result, err := ensureMetadataJob(ctx, kubeClient, scheme, log, obj, isClusterScoped, components, pvcNamespace, cfg)
+	if err != nil {
+		return result, err
+	}
+	if job == nil {
+		// Job was just created (or build failed and a status was already
+		// written). Either way, defer to the next reconcile.
+		return result, nil
+	}
+
+	// The Job is the only way the per-PVC status ConfigMap gets written;
+	// once we've ensured it exists we apply whatever the agent has produced
+	// so far. If the ConfigMap doesn't exist yet (Job still running), we
+	// stay at the InTransit set by ensureMetadataJob.
+	return applyPVCStatusFromConfigMap(ctx, kubeClient, log, obj, isClusterScoped, job)
+}
+
+// ensureMetadataJob makes sure the metadata-extraction Job exists and
+// returns the live Job (after Get, on the existing-Job path) so the
+// caller can inspect its status. Returns (nil, result, nil) on the
+// just-created path because the freshly-created Job has no Status yet
+// and reading it would race the API server's status subresource init.
+//
+// State writes inside this function:
+//
+//	build error            → terminal Failed (PVCConfigMissing)
+//	Job just created       → InTransit (PVCMetadataExtracting)
+//	otherwise              → no state write — caller drives state from
+//	                         the ConfigMap and/or the returned Job.
+func ensureMetadataJob(ctx context.Context, kubeClient client.Client, scheme *runtime.Scheme, log logr.Logger, obj client.Object, isClusterScoped bool, components *storage.PVCStorageComponents, pvcNamespace string, cfg MetadataJobConfig) (*batchv1.Job, ctrl.Result, error) {
+	want, err := buildMetadataJob(obj, isClusterScoped, components, pvcNamespace, cfg, scheme)
+	if err != nil {
+		result, statusErr := setPVCFailedTerminal(ctx, kubeClient, log, obj,
+			v1beta1.ModelConditionReasonPVCConfigMissing,
+			fmt.Sprintf("failed to build metadata extraction Job: %v", err))
+		return nil, result, statusErr
+	}
+
+	got := &batchv1.Job{}
+	jobKey := types.NamespacedName{Namespace: want.Namespace, Name: want.Name}
+	switch err := kubeClient.Get(ctx, jobKey, got); {
+	case errors.IsNotFound(err):
+		// Make sure the SA + cross-ns RoleBinding exist BEFORE we
+		// submit the Job. Without this, Jobs in non-OME namespaces
+		// sit at 0/1 ready forever ("serviceaccount not found") and
+		// the BaseModel never leaves InTransit. Idempotent for the
+		// in-OME-namespace case.
+		if err := ensureMetadataJobRBAC(ctx, kubeClient, log, want.Namespace, cfg.ServiceAccount, cfg.ServiceAccount); err != nil {
+			log.Error(err, "Failed to ensure metadata Job RBAC", "namespace", want.Namespace)
+			return nil, ctrl.Result{}, err
+		}
+		if err := kubeClient.Create(ctx, want); err != nil && !errors.IsAlreadyExists(err) {
+			log.Error(err, "Failed to create metadata extraction Job", "job", jobKey)
+			return nil, ctrl.Result{}, err
+		}
+		log.Info("Created metadata extraction Job", "job", jobKey)
+		// Job just created; assert InTransit and let the next reconcile
+		// (triggered by the Job watch) read the ConfigMap.
+		result, statusErr := setPVCInTransitStatus(ctx, kubeClient, log, obj,
+			v1beta1.ModelConditionReasonPVCMetadataExtracting,
+			fmt.Sprintf("metadata extraction Job %s/%s created", jobKey.Namespace, jobKey.Name))
+		return nil, result, statusErr
+	case err != nil:
+		log.Error(err, "Failed to get metadata extraction Job", "job", jobKey)
+		return nil, ctrl.Result{}, err
+	}
+
+	return got, ctrl.Result{}, nil
+}
+
+// jobFailedConditionMessage returns (true, message) if the Job has
+// reached its terminal Failed state (BackoffLimit exhausted or
+// DeadlineExceeded). The message is the failure reason kubelet/job
+// controller surfaced — useful for operator debugging.
+//
+// Detects ONLY the terminal Failed condition, not transient pod failures
+// that the BackoffLimit will retry. For metadata Jobs the failure
+// message is typically "Job has reached the specified backoff limit"
+// followed by the agent pod's exit reason.
+func jobFailedConditionMessage(job *batchv1.Job) (bool, string) {
+	if job == nil {
+		return false, ""
+	}
+	for _, cond := range job.Status.Conditions {
+		if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue {
+			msg := cond.Message
+			if cond.Reason != "" {
+				msg = cond.Reason + ": " + msg
+			}
+			if msg == "" {
+				msg = "metadata extraction Job exhausted its retry budget"
+			}
+			return true, msg
+		}
+	}
+	return false, ""
+}
+
+// applyPVCStatusFromConfigMap reads the per-PVC status ConfigMap by exact
+// name (not via the per-node List path), parses the ModelEntry the agent
+// wrote, and updates the BaseModel spec + LifeCycleState accordingly.
+//
+// `job` is the live metadata Job (may be nil on the just-created path).
+// We use it to detect the BackoffLimit-exhausted case where the agent
+// pod was OOM-killed or evicted before its SIGTERM handler could write a
+// Failed entry. Without this check the BaseModel would sit at InTransit
+// indefinitely waiting on a ConfigMap that will never appear.
+//
+// Behavior:
+//
+//	ConfigMap absent + Job Failed → state=Failed (PVCMetadataExtractionFailed)
+//	                                with the Job's failure message.
+//	ConfigMap absent + Job running → leave state alone (already InTransit
+//	                                per ensureMetadataJob).
+//	ModelEntry.Status=Ready       → state=Ready, SourceReachable+Ready=True,
+//	                                update spec from cfg.
+//	ModelEntry.Status=Failed      → state=Failed, Ready=False with reason
+//	                                PVCMetadataExtractionFailed and the
+//	                                agent's error message.
+//	ModelEntry.Status=anything    → state=In_Transit (extraction in progress).
+//	bad ConfigMap shape           → log + In_Transit (don't crash on bad data).
+//
+// Status.NodesReady is intentionally never set for PVC — there is no node.
+func applyPVCStatusFromConfigMap(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, isClusterScoped bool, job *batchv1.Job) (ctrl.Result, error) {
+	cmName := constants.GetPVCMetadataConfigMapName(obj.GetName(), obj.GetNamespace(), isClusterScoped)
+	cm := &corev1.ConfigMap{}
+	switch err := kubeClient.Get(ctx, types.NamespacedName{Namespace: constants.OMENamespace, Name: cmName}, cm); {
+	case errors.IsNotFound(err):
+		// No ConfigMap yet. If the Job has already given up
+		// (BackoffLimit exhausted, DeadlineExceeded, etc.) the agent
+		// will never write one — surface a Failed state instead of
+		// looping at InTransit forever.
+		if failed, msg := jobFailedConditionMessage(job); failed {
+			log.Info("Metadata Job reached terminal Failed without writing ConfigMap; surfacing extraction failure",
+				"job", job.Name, "namespace", job.Namespace, "message", msg)
+			return setPVCExtractionFailedStatus(ctx, kubeClient, log, obj, msg)
+		}
+		// Watches handle re-enqueue: the agent's ConfigMap-create event
+		// fires the PVC-status ConfigMap predicate; the Job's status-change
+		// event fires Owns(&Job{}). Timer requeue is a backstop only.
+		return ctrl.Result{RequeueAfter: pvcRequeueAfter}, nil
+	case err != nil:
+		log.Error(err, "Failed to get PVC metadata ConfigMap", "name", cmName)
+		return ctrl.Result{}, err
+	}
+
+	modelKey := constants.GetModelConfigMapKey(obj.GetNamespace(), obj.GetName(), isClusterScoped)
+	raw, ok := cm.Data[modelKey]
+	if !ok {
+		log.Info("PVC metadata ConfigMap missing model entry; staying In_Transit", "configMap", cmName, "key", modelKey)
+		return setPVCInTransitStatus(ctx, kubeClient, log, obj,
+			v1beta1.ModelConditionReasonPVCMetadataExtracting,
+			fmt.Sprintf("PVC metadata ConfigMap %s lacks entry %q yet", cmName, modelKey))
+	}
+	var entry modelagent.ModelEntry
+	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+		log.Error(err, "Failed to parse PVC ConfigMap model entry", "configMap", cmName, "key", modelKey)
+		return setPVCInTransitStatus(ctx, kubeClient, log, obj,
+			v1beta1.ModelConditionReasonPVCMetadataExtracting,
+			fmt.Sprintf("PVC metadata ConfigMap %s entry is not valid JSON", cmName))
+	}
+
+	switch entry.Status {
+	case modelagent.ModelStatusReady:
+		// Apply spec from the agent's parsed metadata. Re-read the latest
+		// CR to avoid clobbering concurrent edits.
+		if entry.Config != nil {
+			if err := applyPVCSpecUpdate(ctx, kubeClient, log, obj, entry.Config); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return setPVCReadyStatus(ctx, kubeClient, log, obj,
+			fmt.Sprintf("PVC metadata extraction succeeded; ConfigMap %s applied", cmName))
+	case modelagent.ModelStatusFailed:
+		msg := cm.Annotations[constants.PVCMetadataLastErrorAnnotation]
+		if msg == "" {
+			msg = "agent reported Failed without an error message"
+		}
+		return setPVCExtractionFailedStatus(ctx, kubeClient, log, obj, msg)
+	default:
+		return setPVCInTransitStatus(ctx, kubeClient, log, obj,
+			v1beta1.ModelConditionReasonPVCMetadataExtracting,
+			fmt.Sprintf("PVC metadata extraction in progress (ConfigMap status=%q)", entry.Status))
+	}
+}
+
+// applyPVCSpecUpdate applies the agent's ModelConfig to the model spec,
+// reading the latest CR via retry-on-conflict to avoid clobbering writes.
+func applyPVCSpecUpdate(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, cfg *modelagent.ModelConfig) error {
+	return shared.RetryUpdate(ctx, kubeClient, log, obj, "pvc-spec", func(ctx context.Context, c client.Client, latest client.Object) error {
+		var spec *v1beta1.BaseModelSpec
+		switch m := latest.(type) {
+		case *v1beta1.BaseModel:
+			spec = &m.Spec
+		case *v1beta1.ClusterBaseModel:
+			spec = &m.Spec
+		default:
+			return fmt.Errorf("unsupported model type for PVC spec update: %T", latest)
+		}
+		if !shared.UpdateSpecWithConfig(spec, cfg) {
+			return nil
+		}
+		return c.Update(ctx, latest)
+	})
+}
+
+// HandleModelDeletion is the deletion path for PVC-backed BaseModel and
+// ClusterBaseModel. Unlike per-node models, PVC models have no agent to
+// mark Status=Deleted across N nodes — there is exactly one ConfigMap to
+// clean up. Order: delete the Job first so the agent stops re-creating
+// the ConfigMap, then delete the ConfigMap, then drop the finalizer.
+func HandleModelDeletion(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, isClusterScoped bool, finalizer string) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(obj, finalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	// 1. Delete the Job. We use a label-narrowed list rather than a
+	// name-derived Get because the Job lives in the PVC's namespace which
+	// requires URI parsing — easier to find by labels we set ourselves.
+	jobs := &batchv1.JobList{}
+	scope := metadataJobScopeNamespaced
+	if isClusterScoped {
+		scope = metadataJobScopeCluster
+	}
+	if err := kubeClient.List(ctx, jobs,
+		client.MatchingLabels{
+			constants.PVCMetadataModelNameLabel: obj.GetName(),
+			constants.PVCMetadataScopeLabel:     scope,
+		},
+	); err != nil {
+		log.Error(err, "Failed to list metadata Jobs for deletion", "model", obj.GetName())
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
+	}
+	for i := range jobs.Items {
+		propagation := metav1.DeletePropagationBackground
+		if err := kubeClient.Delete(ctx, &jobs.Items[i], &client.DeleteOptions{PropagationPolicy: &propagation}); err != nil && !errors.IsNotFound(err) {
+			log.Error(err, "Failed to delete metadata Job", "name", jobs.Items[i].Name)
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, err
+		}
+	}
+
+	// 2. Delete the per-PVC status ConfigMap.
+	if err := deletePVCStatusConfigMap(ctx, kubeClient, log, obj, isClusterScoped); err != nil {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
+	}
+
+	// 3. Remove the finalizer. Re-fetch to avoid clobbering concurrent edits.
+	if err := shared.RetryUpdate(ctx, kubeClient, log, obj, "pvc-finalizer-remove", func(ctx context.Context, c client.Client, latest client.Object) error {
+		controllerutil.RemoveFinalizer(latest, finalizer)
+		return c.Update(ctx, latest)
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+	log.Info("PVC-backed model deletion complete", "name", obj.GetName(), "namespace", obj.GetNamespace())
+	return ctrl.Result{}, nil
+}
+
+// CleanupStaleArtifacts deletes any per-PVC ConfigMap, any metadata
+// extraction Jobs, and strips PVC-specific stale conditions from a
+// BaseModel/ClusterBaseModel that is no longer PVC-backed.
+//
+// Called when a model whose previous spec was pvc:// has its
+// storage URI changed to a non-PVC backend (oci://, hf://, etc.).
+// Without this, the orphaned Job keeps running, the orphaned
+// ConfigMap stays in the OME namespace forever, and stale
+// SourceReachable/Ready conditions confuse downstream consumers.
+//
+// Idempotent: safe to call on every non-PVC reconcile (no-op when
+// no PVC artifacts exist for this model). The List + per-CR
+// condition trim is the cost of the no-op path; both are O(per-model)
+// label-selector queries.
+func CleanupStaleArtifacts(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, isClusterScoped bool) error {
+	// 1. Delete metadata extraction Jobs labeled for this model.
+	jobs := &batchv1.JobList{}
+	scope := metadataJobScopeNamespaced
+	if isClusterScoped {
+		scope = metadataJobScopeCluster
+	}
+	if err := kubeClient.List(ctx, jobs,
+		client.MatchingLabels{
+			constants.PVCMetadataModelNameLabel: obj.GetName(),
+			constants.PVCMetadataScopeLabel:     scope,
+		},
+	); err != nil {
+		return fmt.Errorf("list stale PVC metadata Jobs: %w", err)
+	}
+	for i := range jobs.Items {
+		propagation := metav1.DeletePropagationBackground
+		if err := kubeClient.Delete(ctx, &jobs.Items[i], &client.DeleteOptions{PropagationPolicy: &propagation}); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("delete stale PVC metadata Job %s/%s: %w", jobs.Items[i].Namespace, jobs.Items[i].Name, err)
+		}
+		log.Info("Deleted orphaned PVC metadata Job after non-PVC reconcile",
+			"job", jobs.Items[i].Name, "namespace", jobs.Items[i].Namespace)
+	}
+
+	// 2. Delete the per-PVC status ConfigMap.
+	if err := deletePVCStatusConfigMap(ctx, kubeClient, log, obj, isClusterScoped); err != nil {
+		return fmt.Errorf("delete stale per-PVC ConfigMap: %w", err)
+	}
+
+	// 3. Strip PVC-specific conditions from the CR's status. We re-fetch
+	// inside RetryUpdate to avoid clobbering concurrent edits. No-op if
+	// no PVC conditions are present.
+	return shared.RetryUpdate(ctx, kubeClient, log, obj, "pvc-condition-cleanup", func(ctx context.Context, c client.Client, latest client.Object) error {
+		var conditions *[]metav1.Condition
+		switch m := latest.(type) {
+		case *v1beta1.BaseModel:
+			conditions = &m.Status.Conditions
+		case *v1beta1.ClusterBaseModel:
+			conditions = &m.Status.Conditions
+		default:
+			return fmt.Errorf("CleanupStaleArtifacts: unsupported type %T", latest)
+		}
+		filtered := make([]metav1.Condition, 0, len(*conditions))
+		removed := false
+		for _, cnd := range *conditions {
+			if isPVCConditionReason(cnd.Reason) {
+				removed = true
+				continue
+			}
+			filtered = append(filtered, cnd)
+		}
+		if !removed {
+			return nil
+		}
+		*conditions = filtered
+		return c.Status().Update(ctx, latest)
+	})
+}
+
+// isPVCConditionReason reports whether the supplied condition Reason
+// is part of the PVC reconcile branch's reason set. Used by
+// CleanupStaleArtifacts to identify stale conditions left behind
+// after a URI swap from pvc:// to non-PVC.
+func isPVCConditionReason(reason string) bool {
+	switch reason {
+	case v1beta1.ModelConditionReasonPVCInvalid,
+		v1beta1.ModelConditionReasonPVCNotFound,
+		v1beta1.ModelConditionReasonPVCNotBound,
+		v1beta1.ModelConditionReasonPVCValidated,
+		v1beta1.ModelConditionReasonPVCMetadataPending,
+		v1beta1.ModelConditionReasonPVCMetadataExtracting,
+		v1beta1.ModelConditionReasonPVCMetadataExtractionFailed,
+		v1beta1.ModelConditionReasonPVCMetadataReady,
+		v1beta1.ModelConditionReasonPVCConfigMissing:
+		return true
+	}
+	return false
+}
+
+// deletePVCStatusConfigMap removes the per-PVC status ConfigMap.
+func deletePVCStatusConfigMap(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, isClusterScoped bool) error {
+	cmName := constants.GetPVCMetadataConfigMapName(obj.GetName(), obj.GetNamespace(), isClusterScoped)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: constants.OMENamespace,
+		},
+	}
+	if err := kubeClient.Delete(ctx, cm); err != nil && !errors.IsNotFound(err) {
+		log.Error(err, "Failed to delete PVC metadata ConfigMap", "name", cmName)
+		return err
+	}
+	return nil
+}
+
+// setPVCFailedStatus marks pre-Job validation failures that are recoverable
+// without a CR edit (e.g., PVC not yet created). Caller wakes us up via
+// PVC/ConfigMap watches, but we keep the timer requeue as a backstop.
+func setPVCFailedStatus(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, reason, message string) (ctrl.Result, error) {
+	if err := writePVCFailedStatus(ctx, kubeClient, log, obj, reason, message); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: pvcRequeueAfter}, nil
+}
+
+// setPVCFailedTerminal marks pre-Job validation failures that can only be
+// fixed by a CR edit (malformed URI) or a controller-config change
+// (missing ome-agent image). Both paths re-enqueue via watches, so the
+// reconciler does not requeue on a timer.
+func setPVCFailedTerminal(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, reason, message string) (ctrl.Result, error) {
+	if err := writePVCFailedStatus(ctx, kubeClient, log, obj, reason, message); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func writePVCFailedStatus(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, reason, message string) error {
+	return updatePVCConditionedStatus(ctx, kubeClient, log, obj, ptr.To(v1beta1.LifeCycleStateFailed), []metav1.Condition{
+		{Type: v1beta1.ModelConditionSourceReachable, Status: metav1.ConditionFalse, Reason: reason, Message: message},
+		{Type: v1beta1.ModelConditionReady, Status: metav1.ConditionFalse, Reason: reason, Message: message},
+	})
+}
+
+// setPVCInTransitStatus marks in-flight states (PVC pending, Job running,
+// agent extraction in progress) where SourceReachable is True but the
+// model isn't Ready yet.
+func setPVCInTransitStatus(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, reason, message string) (ctrl.Result, error) {
+	if err := updatePVCConditionedStatus(ctx, kubeClient, log, obj, ptr.To(v1beta1.LifeCycleStateInTransit), []metav1.Condition{
+		{Type: v1beta1.ModelConditionSourceReachable, Status: metav1.ConditionTrue, Reason: reason, Message: message},
+		{Type: v1beta1.ModelConditionReady, Status: metav1.ConditionFalse, Reason: reason, Message: message},
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: pvcRequeueAfter}, nil
+}
+
+// setPVCReadyStatus is the success terminal: state=Ready, both conditions
+// True. No timer requeue — watches handle further changes.
+func setPVCReadyStatus(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, message string) (ctrl.Result, error) {
+	if err := updatePVCConditionedStatus(ctx, kubeClient, log, obj, ptr.To(v1beta1.LifeCycleStateReady), []metav1.Condition{
+		{Type: v1beta1.ModelConditionSourceReachable, Status: metav1.ConditionTrue, Reason: v1beta1.ModelConditionReasonPVCValidated, Message: "PVC is reachable"},
+		{Type: v1beta1.ModelConditionReady, Status: metav1.ConditionTrue, Reason: v1beta1.ModelConditionReasonPVCMetadataReady, Message: message},
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// setPVCExtractionFailedStatus is the agent-failure terminal: PVC was
+// reachable, but the extraction Job reported Failed. State=Failed,
+// SourceReachable=True (PVC works), Ready=False (extraction failed).
+func setPVCExtractionFailedStatus(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, message string) (ctrl.Result, error) {
+	if err := updatePVCConditionedStatus(ctx, kubeClient, log, obj, ptr.To(v1beta1.LifeCycleStateFailed), []metav1.Condition{
+		{Type: v1beta1.ModelConditionSourceReachable, Status: metav1.ConditionTrue, Reason: v1beta1.ModelConditionReasonPVCValidated, Message: "PVC is reachable"},
+		{Type: v1beta1.ModelConditionReady, Status: metav1.ConditionFalse, Reason: v1beta1.ModelConditionReasonPVCMetadataExtractionFailed, Message: message},
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// updatePVCConditionedStatus is the shared write-path for PVC-driven status
+// updates. If `state` is nil only conditions are written; otherwise the
+// model's LifeCycleState is also set. Retries on resource conflicts.
+func updatePVCConditionedStatus(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object, state *v1beta1.LifeCycleState, conditions []metav1.Condition) error {
+	return shared.RetryUpdate(ctx, kubeClient, log, obj, "pvc-status", func(ctx context.Context, c client.Client, latest client.Object) error {
+		var statusConditions *[]metav1.Condition
+		var status *v1beta1.ModelStatusSpec
+		switch m := latest.(type) {
+		case *v1beta1.BaseModel:
+			if state != nil {
+				m.Status.State = *state
+			}
+			statusConditions = &m.Status.Conditions
+			status = &m.Status
+		case *v1beta1.ClusterBaseModel:
+			if state != nil {
+				m.Status.State = *state
+			}
+			statusConditions = &m.Status.Conditions
+			status = &m.Status
+		default:
+			return fmt.Errorf("unsupported model type for PVC status update: %T", latest)
+		}
+		for _, cond := range conditions {
+			meta.SetStatusCondition(statusConditions, cond)
+		}
+		shared.StampObservedReconcile(latest, status)
+		return c.Status().Update(ctx, latest)
+	})
+}

--- a/pkg/controller/v1beta1/basemodel/backends/pvc/watches.go
+++ b/pkg/controller/v1beta1/basemodel/backends/pvc/watches.go
@@ -1,0 +1,107 @@
+package pvc
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+// CreatePhasePredicate fires on PVC create, delete, and phase
+// transitions (e.g. Pending → Bound). Drops same-phase updates to
+// avoid pointless re-reconciles on PVC annotation churn.
+func CreatePhasePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(_ event.CreateEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPVC, ok := e.ObjectOld.(*corev1.PersistentVolumeClaim)
+			if !ok {
+				return false
+			}
+			newPVC, ok := e.ObjectNew.(*corev1.PersistentVolumeClaim)
+			if !ok {
+				return false
+			}
+			return oldPVC.Status.Phase != newPVC.Status.Phase
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool { return true },
+	}
+}
+
+// MapToBaseModels enqueues BaseModels in the PVC's namespace that
+// reference this PVC by URI.
+func MapToBaseModels(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object) []reconcile.Request {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return nil
+	}
+	bms := &v1beta1.BaseModelList{}
+	if err := kubeClient.List(ctx, bms, client.InNamespace(pvc.Namespace)); err != nil {
+		log.Error(err, "Failed to list BaseModels for PVC mapping", "pvc", pvc.Name, "namespace", pvc.Namespace)
+		return nil
+	}
+	var reqs []reconcile.Request
+	for i := range bms.Items {
+		bm := &bms.Items[i]
+		if !pvcSpecMatches(&bm.Spec, pvc.Name, pvc.Namespace, false) {
+			continue
+		}
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: bm.Name, Namespace: bm.Namespace},
+		})
+	}
+	return reqs
+}
+
+// MapToClusterBaseModels enqueues ClusterBaseModels whose pvc://
+// URI references this PVC's (namespace, name).
+func MapToClusterBaseModels(ctx context.Context, kubeClient client.Client, log logr.Logger, obj client.Object) []reconcile.Request {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return nil
+	}
+	cbms := &v1beta1.ClusterBaseModelList{}
+	if err := kubeClient.List(ctx, cbms); err != nil {
+		log.Error(err, "Failed to list ClusterBaseModels for PVC mapping", "pvc", pvc.Name, "namespace", pvc.Namespace)
+		return nil
+	}
+	var reqs []reconcile.Request
+	for i := range cbms.Items {
+		cbm := &cbms.Items[i]
+		if !pvcSpecMatches(&cbm.Spec, pvc.Name, pvc.Namespace, true) {
+			continue
+		}
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: cbm.Name},
+		})
+	}
+	return reqs
+}
+
+// pvcSpecMatches reports whether spec references the PVC identified
+// by (pvcName, pvcNamespace). pvc:// URI format is pvc://namespace/name. Namespaced
+// callers scope their List by namespace; cluster-scoped callers don't.
+func pvcSpecMatches(spec *v1beta1.BaseModelSpec, pvcName, pvcNamespace string, isClusterScoped bool) bool {
+	if !IsPVCStorage(spec) {
+		return false
+	}
+	components, err := storage.ParsePVCStorageURI(*spec.Storage.StorageUri)
+	if err != nil {
+		return false
+	}
+	if components.PVCName != pvcName {
+		return false
+	}
+	if isClusterScoped {
+		return components.Namespace == pvcNamespace
+	}
+	return components.Namespace == ""
+}

--- a/pkg/controller/v1beta1/basemodel/controller.go
+++ b/pkg/controller/v1beta1/basemodel/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -11,13 +12,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/backends/pernode"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/backends/pvc"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
 )
 
 // +kubebuilder:rbac:groups=ome.io,resources=basemodels,verbs=get;list;watch;create;update;patch;delete
@@ -28,30 +33,40 @@ import (
 // +kubebuilder:rbac:groups=ome.io,resources=clusterbasemodels/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;update;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
 
 // BaseModelReconciler reconciles BaseModel objects
 type BaseModelReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log            logr.Logger
+	Scheme         *runtime.Scheme
+	OmeAgentConfig *controllerconfig.OmeAgentConfig
 }
 
 // ClusterBaseModelReconciler reconciles ClusterBaseModel objects
 type ClusterBaseModelReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log            logr.Logger
+	Scheme         *runtime.Scheme
+	OmeAgentConfig *controllerconfig.OmeAgentConfig
 }
 
-// backends builds the dispatch slice. perNodeBackend always matches, so
-// it goes last as the fallback. Additional backends (pvc, sharded) slot
-// in ahead of it.
+// backends builds the dispatch slice in match order: pvc → pernode.
+// perNodeBackend always matches, so it goes last as the fallback.
 func (r *BaseModelReconciler) backends() []shared.Backend {
-	return []shared.Backend{perNodeBackend{}}
+	return []shared.Backend{
+		pvc.New(r.OmeAgentConfig),
+		perNodeBackend{},
+	}
 }
 
 func (r *ClusterBaseModelReconciler) backends() []shared.Backend {
-	return []shared.Backend{perNodeBackend{}}
+	return []shared.Backend{
+		pvc.New(r.OmeAgentConfig),
+		perNodeBackend{},
+	}
 }
 
 // Reconcile handles BaseModel reconciliation
@@ -67,7 +82,7 @@ func (r *BaseModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		log.Error(err, "Failed to get BaseModel")
 		return ctrl.Result{}, err
 	}
-	return reconcileModel(ctx, r.Client, log, r.backends(), baseModel, constants.BaseModelFinalizer, false, "BaseModel")
+	return reconcileModel(ctx, r.Client, r.Scheme, log, r.backends(), baseModel, constants.BaseModelFinalizer, false, "BaseModel")
 }
 
 // Reconcile handles ClusterBaseModel reconciliation
@@ -83,13 +98,13 @@ func (r *ClusterBaseModelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		log.Error(err, "Failed to get ClusterBaseModel")
 		return ctrl.Result{}, err
 	}
-	return reconcileModel(ctx, r.Client, log, r.backends(), clusterBaseModel, constants.ClusterBaseModelFinalizer, true, "ClusterBaseModel")
+	return reconcileModel(ctx, r.Client, r.Scheme, log, r.backends(), clusterBaseModel, constants.ClusterBaseModelFinalizer, true, "ClusterBaseModel")
 }
 
 // reconcileModel is the backend-agnostic reconcile core: resolve the
 // spec/status, pick the backend, add the finalizer, and dispatch
 // deletion/reconcile to that backend.
-func reconcileModel(ctx context.Context, c client.Client, log logr.Logger, backends []shared.Backend, obj client.Object, finalizer string, isClusterScoped bool, kind string) (ctrl.Result, error) {
+func reconcileModel(ctx context.Context, c client.Client, scheme *runtime.Scheme, log logr.Logger, backends []shared.Backend, obj client.Object, finalizer string, isClusterScoped bool, kind string) (ctrl.Result, error) {
 	spec, status, err := shared.ModelSpecAndStatus(obj)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -100,6 +115,7 @@ func reconcileModel(ctx context.Context, c client.Client, log logr.Logger, backe
 	backend := pickBackend(backends, spec)
 	args := shared.BackendArgs{
 		Client:          c,
+		Scheme:          scheme,
 		Log:             log,
 		Obj:             obj,
 		Spec:            spec,
@@ -133,12 +149,16 @@ func reconcileModel(ctx context.Context, c client.Client, log logr.Logger, backe
 func (r *BaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.BaseModel{}).
+		Owns(&batchv1.Job{}).
 		Watches(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 				return pernode.MapConfigMapToModelRequests(obj, r.Log, true) // true = namespaced
 			}),
-			builder.WithPredicates(pernode.CreateModelStatusConfigMapPredicate()),
+			// OR'd: per-node basemodel-status ConfigMaps (agent flow) +
+			// per-PVC pvc-status ConfigMaps (extraction Job output). Both are
+			// keyed by GetModelConfigMapKey, so one mapper fits both.
+			builder.WithPredicates(predicate.Or(pernode.CreateModelStatusConfigMapPredicate(), createPVCStatusConfigMapPredicate())),
 		).
 		Watches(
 			&corev1.Node{},
@@ -146,6 +166,13 @@ func (r *BaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return pernode.HandleNodeDeletion(ctx, r.Client, r.Log, obj)
 			}),
 			builder.WithPredicates(pernode.CreateNodeDeletionPredicate()),
+		).
+		Watches(
+			&corev1.PersistentVolumeClaim{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+				return pvc.MapToBaseModels(ctx, r.Client, r.Log, obj)
+			}),
+			builder.WithPredicates(pvc.CreatePhasePredicate()),
 		).
 		Complete(r)
 }
@@ -154,12 +181,13 @@ func (r *BaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *ClusterBaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.ClusterBaseModel{}).
+		Owns(&batchv1.Job{}).
 		Watches(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 				return pernode.MapConfigMapToModelRequests(obj, r.Log, false) // false = cluster-scoped
 			}),
-			builder.WithPredicates(pernode.CreateModelStatusConfigMapPredicate()),
+			builder.WithPredicates(predicate.Or(pernode.CreateModelStatusConfigMapPredicate(), createPVCStatusConfigMapPredicate())),
 		).
 		Watches(
 			&corev1.Node{},
@@ -168,5 +196,29 @@ func (r *ClusterBaseModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}),
 			builder.WithPredicates(pernode.CreateNodeDeletionPredicate()),
 		).
+		Watches(
+			&corev1.PersistentVolumeClaim{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+				return pvc.MapToClusterBaseModels(ctx, r.Client, r.Log, obj)
+			}),
+			builder.WithPredicates(pvc.CreatePhasePredicate()),
+		).
 		Complete(r)
+}
+
+// createPVCStatusConfigMapPredicate fires on ConfigMaps in the OME namespace
+// carrying the PVC-status label. Lives here (not in pvc/) because it's OR'd
+// with pernode's predicate in the single ConfigMap watch.
+func createPVCStatusConfigMapPredicate() predicate.Predicate {
+	isPVC := func(obj client.Object) bool {
+		if obj.GetNamespace() != constants.OMENamespace {
+			return false
+		}
+		return obj.GetLabels()[constants.PVCStorageConfigMapLabel] == "true"
+	}
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return isPVC(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool { return isPVC(e.ObjectNew) },
+		DeleteFunc: func(e event.DeleteEvent) bool { return isPVC(e.Object) },
+	}
 }

--- a/pkg/controller/v1beta1/basemodel/controller_test.go
+++ b/pkg/controller/v1beta1/basemodel/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,7 @@ func TestBaseModelReconcile(t *testing.T) {
 	scheme := runtime.NewScheme()
 	g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
 	g.Expect(corev1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	g.Expect(batchv1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
 
 	tests := []struct {
 		name       string
@@ -596,6 +598,7 @@ func TestClusterBaseModelReconcile(t *testing.T) {
 	scheme := runtime.NewScheme()
 	g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
 	g.Expect(corev1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	g.Expect(batchv1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
 
 	tests := []struct {
 		name             string

--- a/pkg/controller/v1beta1/basemodel/shared/shared.go
+++ b/pkg/controller/v1beta1/basemodel/shared/shared.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -34,6 +36,7 @@ type Backend interface {
 // backend-specific imports.
 type BackendArgs struct {
 	Client          client.Client
+	Scheme          *runtime.Scheme
 	Log             logr.Logger
 	Obj             client.Object
 	Spec            *v1beta1.BaseModelSpec
@@ -54,6 +57,21 @@ func ModelSpecAndStatus(obj client.Object) (*v1beta1.BaseModelSpec, *v1beta1.Mod
 	default:
 		return nil, nil, fmt.Errorf("unsupported model type: %T", obj)
 	}
+}
+
+// StampObservedReconcile records that the controller has observed the
+// object's current generation and stamps the reconcile wall-clock time.
+// A no-op-safe helper the condition-writing backends call on every status
+// write so ObservedGeneration/LastReconcileTime stay fresh.
+func StampObservedReconcile(obj client.Object, status *v1beta1.ModelStatusSpec) {
+	if status == nil {
+		return
+	}
+	if status.ObservedGeneration != obj.GetGeneration() {
+		status.ObservedGeneration = obj.GetGeneration()
+	}
+	now := metav1.NewTime(time.Now())
+	status.LastReconcileTime = &now
 }
 
 // RetryUpdate retries updateFunc on conflict up to 3 times, with

--- a/pkg/controller/v1beta1/controllerconfig/configmap.go
+++ b/pkg/controller/v1beta1/controllerconfig/configmap.go
@@ -18,6 +18,7 @@ const (
 	DeployConfigName       = "deploy"
 	MultiNodeProberName    = "multinodeProber"
 	BenchmarkJobConfigName = "benchmarkjob"
+	OmeAgentConfigName     = "omeAgent"
 
 	DefaultDomainTemplate = "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}"
 	DefaultIngressDomain  = "example.com"
@@ -86,6 +87,41 @@ type MultiNodeProberConfig struct {
 // +kubebuilder:object:generate=false
 type DeployConfig struct {
 	DefaultDeploymentMode string `json:"defaultDeploymentMode,omitempty"`
+}
+
+// OmeAgentConfig configures the metadata-extraction Job the BaseModel
+// controller spawns for PVC-backed models. Unlike the model-agent
+// DaemonSet (whose image is Helm-only), the controller creates this Job in
+// Go and therefore needs the agent image + Job settings at runtime.
+// +kubebuilder:object:generate=false
+type OmeAgentConfig struct {
+	// Image is the ome-agent container image. Required.
+	Image string `json:"image"`
+	// ServiceAccount the metadata Job pod runs as. Must have RBAC to
+	// get/list/create/update/patch ConfigMaps in the OME namespace — the
+	// agent surfaces extracted metadata via a per-model status ConfigMap,
+	// not via direct CR updates.
+	ServiceAccount string `json:"serviceAccount,omitempty"`
+	// CPURequest/MemoryRequest/CPULimit/MemoryLimit follow the standard
+	// resource shape; empty strings fall back to the K8s default.
+	CPURequest    string `json:"cpuRequest,omitempty"`
+	MemoryRequest string `json:"memoryRequest,omitempty"`
+	CPULimit      string `json:"cpuLimit,omitempty"`
+	MemoryLimit   string `json:"memoryLimit,omitempty"`
+	// BackoffLimit caps Job retries. Default 2 if zero.
+	BackoffLimit int32 `json:"backoffLimit,omitempty"`
+	// TTLSecondsAfterFinished controls cleanup of completed Jobs.
+	// Default 3600 if zero.
+	TTLSecondsAfterFinished int32 `json:"ttlSecondsAfterFinished,omitempty"`
+
+	// NodeSelector / Tolerations / Affinity / PriorityClassName are
+	// pass-through scheduling hints applied to the metadata Job pod.
+	// Necessary when the PVC's CSI driver only mounts on a subset of
+	// nodes, or when the cluster taints GPU nodes that hold the models.
+	NodeSelector      map[string]string `json:"nodeSelector,omitempty"`
+	Tolerations       []v1.Toleration   `json:"tolerations,omitempty"`
+	Affinity          *v1.Affinity      `json:"affinity,omitempty"`
+	PriorityClassName string            `json:"priorityClassName,omitempty"`
 }
 
 func NewInferenceServicesConfig(clientset kubernetes.Interface) (*InferenceServicesConfig, error) {
@@ -213,4 +249,22 @@ func NewBenchmarkJobConfig(clientset kubernetes.Interface) (*BenchmarkJobConfig,
 		}
 	}
 	return benchmarkJobConfig, nil
+}
+
+// NewOmeAgentConfig loads the omeAgent block from the inferenceservice-config
+// ConfigMap in the OME namespace. A missing block yields a zero-value config
+// (not an error) so the PVC path can surface PVCConfigMissing via status
+// rather than failing controller startup.
+func NewOmeAgentConfig(clientset kubernetes.Interface) (*OmeAgentConfig, error) {
+	configMap, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Get(context.TODO(), constants.InferenceServiceConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	cfg := &OmeAgentConfig{}
+	if data, ok := configMap.Data[OmeAgentConfigName]; ok {
+		if err := json.Unmarshal([]byte(data), cfg); err != nil {
+			return nil, fmt.Errorf("unable to parse omeAgent config json: %w", err)
+		}
+	}
+	return cfg, nil
 }


### PR DESCRIPTION
## What this PR does

Adds a **PVC backend** to the BaseModel/ClusterBaseModel controller's
backend registry so `pvc://`-backed models actually reach `Ready` instead
of sitting in `Importing` forever. Upstream can *parse* `pvc://` URIs but
never *acts* on them — the observational per-node flow only reflects the
status ConfigMaps the model-agent DaemonSet writes, and the agent never
writes an entry for a PVC model (nothing is downloaded; the model already
lives on the PVC). This closes that gap.
## Why we need it

PVC is the natural source for pre-provisioned / air-gapped model weights on
shared storage (CSI, NFS, Lustre) — no per-node download, no egress. Today
a PVC-backed BaseModel is inert: it parses but never becomes servable. This
makes it a first-class, `Ready`-reaching model source via the
backend-registry seam, without touching the per-node path.

Depends on the backend-registry refactor PR (`Backend` interface + `pernode`
extraction). The status-conditions API it uses is already in the CRD.

## What changes:
The PVC backend (`backends/pvc/`):
- Matches specs whose storage URI is `pvc://`, ahead of the per-node fallback.
- Validates the PVC exists and is `Bound`; resolves the namespace (the
  model's own ns for BaseModel, the URI-specified ns for ClusterBaseModel).
- Spawns an on-demand metadata-extraction **Job** (`ome-agent
  model-metadata`) mounting the PVC read-only; ensures the Job's SA +
  cross-namespace RoleBinding exist first.
- Reads the per-PVC status ConfigMap the agent writes and drives
  `SourceReachable`/`Ready` conditions + `LifeCycleState`.
- Handles deletion (Job → ConfigMap → finalizer) and scrubs stale PVC
  artifacts when a model's URI flips away from `pvc://`.

Supporting pieces:
- `OmeAgentConfig` + `NewOmeAgentConfig` in `controllerconfig` (reads a new
  `omeAgent` key from `inferenceservice-config`) — the controller builds
  the Job in Go, so it needs the agent image + Job settings at runtime.
- PVC constants + `GetPVCMetadataConfigMapName`; `StampObservedReconcile`
  + `Scheme` on `BackendArgs`.
- Wiring: `pvc.New(cfg)` in `backends()`, `Owns(Job)` + PVC watch +
  PVC-status ConfigMap predicate, main.go config load, PVC/Job RBAC markers.
- Helm: `metadataJob` values block, `omeAgent` ConfigMap key, and
  `metadata-job-rbac.yaml` (SA + ClusterRole + binding so the Job can write
  the status ConfigMap in the OME namespace).
Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
