### PR TITLE
[Core] Mount PVC-backed models into ISVC pods

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -89,14 +89,26 @@ func UpdateVolumeMounts(b *BaseComponentFields, isvc *v1beta1.InferenceService, 
 	}
 
 	// Add model volume mount if base model is specified and it's necessary
-	if b.BaseModel != nil && b.BaseModel.Storage != nil && b.BaseModel.Storage.Path != nil && b.BaseModelMeta != nil {
+	if b.BaseModel != nil && b.BaseModel.Storage != nil && b.BaseModelMeta != nil {
 		if isvcutils.IsOriginalModelVolumeMountNecessary(objectMeta.Annotations) {
-			vm := corev1.VolumeMount{
-				Name:      b.BaseModelMeta.Name,
-				MountPath: *b.BaseModel.Storage.Path,
-				ReadOnly:  true,
+			if pvc := parsePVCComponents(b); pvc != nil {
+				// PVC-backed model: mount at the default model path, selecting
+				// the model directory within the claim via SubPath.
+				vm := corev1.VolumeMount{
+					Name:      b.BaseModelMeta.Name,
+					MountPath: constants.ModelDefaultMountPath,
+					SubPath:   pvc.SubPath,
+					ReadOnly:  true,
+				}
+				isvcutils.AppendVolumeMount(container, &vm)
+			} else if b.BaseModel.Storage.Path != nil {
+				vm := corev1.VolumeMount{
+					Name:      b.BaseModelMeta.Name,
+					MountPath: *b.BaseModel.Storage.Path,
+					ReadOnly:  true,
+				}
+				isvcutils.AppendVolumeMount(container, &vm)
 			}
-			isvcutils.AppendVolumeMount(container, &vm)
 		}
 	}
 
@@ -138,7 +150,14 @@ func UpdateEnvVariables(b *BaseComponentFields, isvc *v1beta1.InferenceService, 
 	if !b.FineTunedServing {
 		// Base model serving - add MODEL_PATH env variable if necessary
 		if isvcutils.IsOriginalModelVolumeMountNecessary(objectMeta.Annotations) {
-			if b.BaseModel != nil && b.BaseModel.Storage != nil && b.BaseModel.Storage.Path != nil {
+			if isPVCBaseModel(b) {
+				// PVC-backed model: weights are mounted at the default model
+				// path (Storage.Path is nil for pvc:// models).
+				b.Log.Info("Base model serving (PVC) - adding MODEL_PATH env variable if not provided", "inference service", isvc.Name, "namespace", isvc.Namespace)
+				isvcutils.AppendEnvVarsIfNotExist(container, &[]corev1.EnvVar{
+					{Name: constants.ModelPathEnvVarKey, Value: constants.ModelDefaultMountPath},
+				})
+			} else if b.BaseModel != nil && b.BaseModel.Storage != nil && b.BaseModel.Storage.Path != nil {
 				b.Log.Info("Base model serving - adding MODEL_PATH env variable if not provided", "inference service", isvc.Name, "namespace", isvc.Namespace)
 				isvcutils.AppendEnvVarsIfNotExist(container, &[]corev1.EnvVar{
 					{Name: constants.ModelPathEnvVarKey, Value: *b.BaseModel.Storage.Path},
@@ -204,6 +223,25 @@ func UpdatePodSpecNodeSelector(b *BaseComponentFields, isvc *v1beta1.InferenceSe
 		return
 	}
 
+	// Skip the per-node model-ready affinity for PVC-backed models. PVCs
+	// aren't tied to specific nodes and the model agent never labels nodes
+	// for them, so the readiness selector would leave the pod unschedulable.
+	// The runtime/AcceleratorClass node selectors below still apply.
+	if isPVCBaseModel(b) {
+		b.Log.Info("Skipping model-ready node selector for PVC-backed BaseModel",
+			"inferenceService", isvc.Name, "namespace", isvc.Namespace)
+		mergedNodeSelector := isvcutils.MergeNodeSelector(b.Runtime, b.AcceleratorClass, isvc, componentType)
+		if len(mergedNodeSelector) > 0 {
+			if podSpec.NodeSelector == nil {
+				podSpec.NodeSelector = make(map[string]string)
+			}
+			for k, v := range mergedNodeSelector {
+				podSpec.NodeSelector[k] = v
+			}
+		}
+		return
+	}
+
 	// Add preferred node affinity for model readiness using the shared utility function
 	isvcutils.AddNodeSelectorForModelReadyNode(podSpec, b.BaseModelMeta)
 
@@ -228,16 +266,30 @@ func UpdatePodSpecNodeSelector(b *BaseComponentFields, isvc *v1beta1.InferenceSe
 // UpdatePodSpecVolumes updates pod spec with common volumes
 func UpdatePodSpecVolumes(b *BaseComponentFields, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec, objectMeta *metav1.ObjectMeta) {
 	// Add model volume if base model is specified
-	if b.BaseModel != nil && b.BaseModel.Storage != nil && b.BaseModel.Storage.Path != nil && b.BaseModelMeta != nil {
-		modelVolume := corev1.Volume{
-			Name: b.BaseModelMeta.Name,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: *b.BaseModel.Storage.Path,
+	if b.BaseModel != nil && b.BaseModel.Storage != nil && b.BaseModelMeta != nil {
+		if pvc := parsePVCComponents(b); pvc != nil {
+			// PVC-backed model: mount the claim directly (read-only).
+			modelVolume := corev1.Volume{
+				Name: b.BaseModelMeta.Name,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvc.PVCName,
+						ReadOnly:  true,
+					},
 				},
-			},
+			}
+			podSpec.Volumes = append(podSpec.Volumes, modelVolume)
+		} else if b.BaseModel.Storage.Path != nil {
+			modelVolume := corev1.Volume{
+				Name: b.BaseModelMeta.Name,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: *b.BaseModel.Storage.Path,
+					},
+				},
+			}
+			podSpec.Volumes = append(podSpec.Volumes, modelVolume)
 		}
-		podSpec.Volumes = append(podSpec.Volumes, modelVolume)
 	}
 
 	// Add empty model directory volume if required for fine-tuned serving

--- a/pkg/controller/v1beta1/inferenceservice/components/pvc.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/pvc.go
@@ -1,0 +1,50 @@
+package components
+
+import (
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+// isPVCBaseModel reports whether b's referenced BaseModel is PVC-backed.
+func isPVCBaseModel(b *BaseComponentFields) bool {
+	if b == nil || b.BaseModel == nil {
+		return false
+	}
+	return isPVCStorage(b.BaseModel.Storage)
+}
+
+// parsePVCComponents returns the parsed PVC URI for b's BaseModel. Returns
+// nil if the model is not PVC-backed or the URI is malformed; the caller is
+// expected to have validated the model upstream (via the BaseModel
+// reconciler / admission webhook), so a parse error here is treated as
+// "no PVC" rather than fatal.
+func parsePVCComponents(b *BaseComponentFields) *storage.PVCStorageComponents {
+	if !isPVCBaseModel(b) {
+		return nil
+	}
+	return parsePVCStorage(b.BaseModel.Storage)
+}
+
+// isPVCStorage / parsePVCStorage are the StorageSpec-level forms behind the
+// BaseModel helpers above.
+func isPVCStorage(s *v1beta1.StorageSpec) bool {
+	if s == nil || s.StorageUri == nil {
+		return false
+	}
+	t, err := storage.GetStorageType(*s.StorageUri)
+	if err != nil {
+		return false
+	}
+	return t == storage.StorageTypePVC
+}
+
+func parsePVCStorage(s *v1beta1.StorageSpec) *storage.PVCStorageComponents {
+	if !isPVCStorage(s) {
+		return nil
+	}
+	components, err := storage.ParsePVCStorageURI(*s.StorageUri)
+	if err != nil {
+		return nil
+	}
+	return components
+}

--- a/pkg/controller/v1beta1/inferenceservice/components/pvc_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/pvc_test.go
@@ -1,0 +1,122 @@
+package components
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func newPVCBaseComponent(uri string) *BaseComponentFields {
+	return &BaseComponentFields{
+		BaseModel: &v1beta1.BaseModelSpec{
+			Storage: &v1beta1.StorageSpec{StorageUri: ptr.To(uri)},
+		},
+		BaseModelMeta: &metav1.ObjectMeta{Name: "llama-7b", Namespace: "models"},
+		Log:           ctrl.Log.WithName("test"),
+	}
+}
+
+func TestUpdatePodSpecVolumes_PVC(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	b := newPVCBaseComponent("pvc://my-pvc/models/llama")
+
+	podSpec := &v1.PodSpec{}
+	UpdatePodSpecVolumes(b, &v1beta1.InferenceService{}, podSpec, &metav1.ObjectMeta{})
+
+	g.Expect(podSpec.Volumes).To(gomega.HaveLen(1))
+	vol := podSpec.Volumes[0]
+	g.Expect(vol.Name).To(gomega.Equal("llama-7b"))
+	g.Expect(vol.PersistentVolumeClaim).NotTo(gomega.BeNil())
+	g.Expect(vol.PersistentVolumeClaim.ClaimName).To(gomega.Equal("my-pvc"))
+	g.Expect(vol.PersistentVolumeClaim.ReadOnly).To(gomega.BeTrue())
+	g.Expect(vol.HostPath).To(gomega.BeNil())
+}
+
+func TestUpdatePodSpecVolumes_PVC_ClusterScoped(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	b := newPVCBaseComponent("pvc://shared:my-pvc/models/llama")
+
+	podSpec := &v1.PodSpec{}
+	UpdatePodSpecVolumes(b, &v1beta1.InferenceService{}, podSpec, &metav1.ObjectMeta{})
+
+	g.Expect(podSpec.Volumes).To(gomega.HaveLen(1))
+	g.Expect(podSpec.Volumes[0].PersistentVolumeClaim.ClaimName).To(gomega.Equal("my-pvc"))
+}
+
+func TestUpdatePodSpecVolumes_HostPath_Unchanged(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	path := "/mnt/data/models/llama"
+	b := &BaseComponentFields{
+		BaseModel: &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: ptr.To("oci://n/ns/b/bucket/o/path"),
+			Path:       &path,
+		}},
+		BaseModelMeta: &metav1.ObjectMeta{Name: "llama-7b", Namespace: "models"},
+		Log:           ctrl.Log.WithName("test"),
+	}
+
+	podSpec := &v1.PodSpec{}
+	UpdatePodSpecVolumes(b, &v1beta1.InferenceService{}, podSpec, &metav1.ObjectMeta{})
+
+	g.Expect(podSpec.Volumes).To(gomega.HaveLen(1))
+	g.Expect(podSpec.Volumes[0].HostPath).NotTo(gomega.BeNil())
+	g.Expect(podSpec.Volumes[0].HostPath.Path).To(gomega.Equal(path))
+	g.Expect(podSpec.Volumes[0].PersistentVolumeClaim).To(gomega.BeNil())
+}
+
+func TestUpdateVolumeMounts_PVC(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	b := newPVCBaseComponent("pvc://my-pvc/models/llama")
+
+	container := &v1.Container{Name: "main"}
+	UpdateVolumeMounts(b, &v1beta1.InferenceService{}, container, &metav1.ObjectMeta{})
+
+	g.Expect(container.VolumeMounts).To(gomega.HaveLen(1))
+	vm := container.VolumeMounts[0]
+	g.Expect(vm.Name).To(gomega.Equal("llama-7b"))
+	g.Expect(vm.MountPath).To(gomega.Equal(constants.ModelDefaultMountPath))
+	g.Expect(vm.SubPath).To(gomega.Equal("models/llama"))
+	g.Expect(vm.ReadOnly).To(gomega.BeTrue())
+}
+
+func TestUpdatePodSpecNodeSelector_PVC_Skipped(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	b := newPVCBaseComponent("pvc://my-pvc/models/llama")
+
+	podSpec := &v1.PodSpec{}
+	UpdatePodSpecNodeSelector(b, &v1beta1.InferenceService{}, podSpec, "")
+
+	if podSpec.NodeSelector != nil {
+		for k := range podSpec.NodeSelector {
+			g.Expect(k).NotTo(gomega.HavePrefix("models.ome.io/"),
+				"PVC-backed BaseModel must not get model node selector")
+		}
+	}
+	if podSpec.Affinity != nil && podSpec.Affinity.NodeAffinity != nil {
+		g.Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).
+			To(gomega.BeEmpty(), "PVC-backed BaseModel must not get preferred node affinity")
+	}
+}
+
+func TestUpdateEnvVariables_PVC_SetsModelPath(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	b := newPVCBaseComponent("pvc://my-pvc/models/llama")
+
+	container := &v1.Container{Name: "main"}
+	UpdateEnvVariables(b, &v1beta1.InferenceService{}, container, &metav1.ObjectMeta{})
+
+	var got string
+	for _, e := range container.Env {
+		if e.Name == constants.ModelPathEnvVarKey {
+			got = e.Value
+		}
+	}
+	g.Expect(got).To(gomega.Equal(constants.ModelDefaultMountPath))
+}


### PR DESCRIPTION
## What this PR does

Makes PVC-backed BaseModels servable by mounting the PVC into
InferenceService pods. A `pvc://` model has `Storage.Path == nil` (nothing
is downloaded to a node), so the existing HostPath-based volume/mount logic
never fires for it — the pod would come up with no model. This adds PVC
handling to pod-spec assembly.
## Why we need it

This is the serving-side half of PVC support. The BaseModel controller can
bring a `pvc://` model to Ready, but without mounting the claim into the
serving pod the model isn't reachable. PVC is the natural source for
pre-provisioned / air-gapped weights on shared storage (CSI, NFS, Lustre) —
no per-node download, no egress.

## What changes
- **`components/pvc.go`** *(new)* — pure helpers (`isPVCBaseModel`,
  `parsePVCComponents`, and the StorageSpec-level `isPVCStorage` /
  `parsePVCStorage`) over `pkg/utils/storage`.
- **PVC branches in four `components/base.go` functions** (each falls back
  to the existing HostPath/Path behavior for non-PVC models):
  - `UpdatePodSpecVolumes` — a `PersistentVolumeClaimVolumeSource{ClaimName,
    ReadOnly}` instead of a HostPath volume.
  - `UpdateVolumeMounts` — mount at `ModelDefaultMountPath` with `SubPath`
    set to the model's sub-path within the claim, read-only.
  - `UpdatePodSpecNodeSelector` — **skip** the per-node model-ready affinity:
    PVCs aren't node-pinned and the model agent never labels nodes for them,
    so that selector would leave the pod unschedulable. Runtime /
    AcceleratorClass node selectors still apply.
  - `UpdateEnvVariables` — set `MODEL_PATH` to `ModelDefaultMountPath`
    (`Storage.Path` is nil for PVC).
Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
