### PR TITLE
[Core] Validate pvc:// BaseModel storage URIs

### DIFF
--- a/pkg/validation/basemodel.go
+++ b/pkg/validation/basemodel.go
@@ -1,0 +1,43 @@
+// Package validation holds pure validation helpers (no Kubernetes client
+// dependencies) shared between CRD validators and admission webhooks.
+package validation
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+// ValidatePVCStorage enforces the pvc:// URI rules for a BaseModel /
+// ClusterBaseModel spec:
+//
+//   - namespaced BaseModel: pvc:// URIs must NOT carry a namespace prefix
+//     (pvc://{pvc-name}/{sub-path}); the model's own namespace is used.
+//   - ClusterBaseModel: pvc:// URIs MUST carry a namespace prefix
+//     (pvc://{namespace}:{pvc-name}/{sub-path}).
+//   - the URI itself must parse (a sub-path is required).
+//
+// Non-PVC URIs are accepted unchanged.
+func ValidatePVCStorage(spec *v1beta1.BaseModelSpec, isClusterScoped bool) error {
+	if spec == nil || spec.Storage == nil || spec.Storage.StorageUri == nil {
+		return nil
+	}
+	uri := *spec.Storage.StorageUri
+	storageType, err := storage.GetStorageType(uri)
+	if err != nil || storageType != storage.StorageTypePVC {
+		return nil
+	}
+
+	components, err := storage.ParsePVCStorageURI(uri)
+	if err != nil {
+		return fmt.Errorf("invalid PVC storage URI %q: %w", uri, err)
+	}
+	if isClusterScoped && components.Namespace == "" {
+		return fmt.Errorf("ClusterBaseModel PVC URI must specify a namespace (format: pvc://{namespace}:{pvc-name}/{sub-path}), got %q", uri)
+	}
+	if !isClusterScoped && components.Namespace != "" {
+		return fmt.Errorf("namespaced BaseModel PVC URI must not specify a namespace; the BaseModel's own namespace is used, got %q", uri)
+	}
+	return nil
+}

--- a/pkg/validation/basemodel_test.go
+++ b/pkg/validation/basemodel_test.go
@@ -1,0 +1,62 @@
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestValidatePVCStorage(t *testing.T) {
+	tests := []struct {
+		name            string
+		spec            *v1beta1.BaseModelSpec
+		isClusterScoped bool
+		wantErr         bool
+	}{
+		{name: "nil spec is allowed", spec: nil},
+		{name: "no storage is allowed", spec: &v1beta1.BaseModelSpec{}},
+		{
+			name: "non-pvc URI is allowed",
+			spec: &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("oci://n/ns/b/bucket/o/path")}},
+		},
+		{
+			name: "valid namespaced PVC URI",
+			spec: &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://my-pvc/models/llama")}},
+		},
+		{
+			name:            "valid cluster-scoped PVC URI",
+			spec:            &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://shared:my-pvc/models/llama")}},
+			isClusterScoped: true,
+		},
+		{
+			name:    "namespaced BaseModel must not include namespace prefix",
+			spec:    &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://shared:my-pvc/models/llama")}},
+			wantErr: true,
+		},
+		{
+			name:            "ClusterBaseModel must include namespace prefix",
+			spec:            &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://my-pvc/models/llama")}},
+			isClusterScoped: true,
+			wantErr:         true,
+		},
+		{
+			name:    "malformed PVC URI",
+			spec:    &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: ptr.To("pvc://")}},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePVCStorage(tc.spec, tc.isClusterScoped)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds a new `pkg/validation` package with `ValidatePVCStorage` — a pure
function (no Kubernetes client deps) that enforces the `pvc://` URI shape
for BaseModel / ClusterBaseModel specs
## Why we need it

Reject malformed or wrongly-scoped `pvc://` URIs deterministically and
early (at admission, in the follow-up webhook PR) rather than letting a bad
URI surface as a confusing reconcile-time failure. Centralizing the rule in
one pure function keeps the webhook and any CRD-level validator in
agreement.

## What changes:
- namespaced BaseModel: URI must **not** carry a namespace prefix
  (`pvc://{pvc}/{sub-path}`); the model's own namespace is used.
- ClusterBaseModel: URI **must** carry a namespace prefix
  (`pvc://{namespace}:{pvc}/{sub-path}`).
- the URI must parse — a sub-path is required.

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
