### PR TITLE
[Core] BaseModel pvc:// admission webhook

### DIFF
--- a/charts/ome-resources/templates/ome-controller/webhooks/basemodelvalidator.yaml
+++ b/charts/ome-resources/templates/ome-controller/webhooks/basemodelvalidator.yaml
@@ -1,0 +1,57 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: basemodel.ome.io
+  annotations:
+    cert-manager.io/inject-ca-from: ome/serving-cert
+webhooks:
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: ome-webhook-server-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-ome-io-v1beta1-basemodel
+    failurePolicy: Fail
+    name: basemodel.ome-webhook-server.validator
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
+    rules:
+      - apiGroups:
+          - ome.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - basemodels
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: clusterbasemodel.ome.io
+  annotations:
+    cert-manager.io/inject-ca-from: ome/serving-cert
+webhooks:
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: ome-webhook-server-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-ome-io-v1beta1-clusterbasemodel
+    failurePolicy: Fail
+    name: clusterbasemodel.ome-webhook-server.validator
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
+    rules:
+      - apiGroups:
+          - ome.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clusterbasemodels

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/ome/pkg/runtimeselector"
 	"sigs.k8s.io/ome/pkg/utils"
 	"sigs.k8s.io/ome/pkg/version"
+	basemodelwebhook "sigs.k8s.io/ome/pkg/webhook/admission/basemodel"
 	"sigs.k8s.io/ome/pkg/webhook/admission/benchmark"
 	"sigs.k8s.io/ome/pkg/webhook/admission/isvc"
 	"sigs.k8s.io/ome/pkg/webhook/admission/pod"
@@ -366,6 +367,16 @@ func main() {
 		setupLog.Info("Registering ControllerRevision immutability validator webhook to the webhook server")
 		hookServer.Register("/validate-apps-v1-controllerrevision", &webhook.Admission{
 			Handler: &runtimerevisionwebhook.ImmutabilityValidator{Decoder: admission.NewDecoder(mgr.GetScheme())},
+		})
+
+		setupLog.Info("Registering BaseModel validator webhook to the webhook server")
+		hookServer.Register("/validate-ome-io-v1beta1-basemodel", &webhook.Admission{
+			Handler: &basemodelwebhook.BaseModelValidator{Decoder: admission.NewDecoder(mgr.GetScheme())},
+		})
+
+		setupLog.Info("Registering ClusterBaseModel validator webhook to the webhook server")
+		hookServer.Register("/validate-ome-io-v1beta1-clusterbasemodel", &webhook.Admission{
+			Handler: &basemodelwebhook.ClusterBaseModelValidator{Decoder: admission.NewDecoder(mgr.GetScheme())},
 		})
 
 		if err = ctrl.NewWebhookManagedBy(mgr).

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -219,3 +219,57 @@ webhooks:
           - UPDATE
         resources:
           - benchmarkjobs
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: basemodel.ome.io
+webhooks:
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: $(webhookServiceName)
+        namespace: $(omeNamespace)
+        path: /validate-ome-io-v1beta1-basemodel
+    failurePolicy: Fail
+    name: basemodel.ome-webhook-server.validator
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
+    rules:
+      - apiGroups:
+          - ome.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - basemodels
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: clusterbasemodel.ome.io
+webhooks:
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: $(webhookServiceName)
+        namespace: $(omeNamespace)
+        path: /validate-ome-io-v1beta1-clusterbasemodel
+    failurePolicy: Fail
+    name: clusterbasemodel.ome-webhook-server.validator
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
+    rules:
+      - apiGroups:
+          - ome.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clusterbasemodels

--- a/pkg/webhook/admission/basemodel/basemodel_webhook.go
+++ b/pkg/webhook/admission/basemodel/basemodel_webhook.go
@@ -1,0 +1,57 @@
+package basemodel
+
+import (
+	"context"
+	"net/http"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/validation"
+)
+
+var log = logf.Log.WithName("basemodel-validation-webhook")
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-ome-io-v1beta1-basemodel,mutating=false,failurePolicy=fail,groups=ome.io,resources=basemodels,versions=v1beta1,name=basemodel.ome-webhook-server.validator
+// +kubebuilder:object:generate=false
+
+// BaseModelValidator denies BaseModels whose pvc:// URI violates the
+// storage-URI shape rules. Pure schema check — no API server reads, hence
+// no Client.
+type BaseModelValidator struct {
+	Decoder admission.Decoder
+}
+
+func (v *BaseModelValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	bm := &v1beta1.BaseModel{}
+	if err := v.Decoder.Decode(req, bm); err != nil {
+		log.Error(err, "Failed to decode BaseModel", "name", bm.Name, "namespace", bm.Namespace)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	if err := validation.ValidatePVCStorage(&bm.Spec, false); err != nil {
+		return admission.Denied(err.Error())
+	}
+	return admission.Allowed("")
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-ome-io-v1beta1-clusterbasemodel,mutating=false,failurePolicy=fail,groups=ome.io,resources=clusterbasemodels,versions=v1beta1,name=clusterbasemodel.ome-webhook-server.validator
+// +kubebuilder:object:generate=false
+
+// ClusterBaseModelValidator is the cluster-scoped sibling of
+// BaseModelValidator; same shape rules, no API server reads.
+type ClusterBaseModelValidator struct {
+	Decoder admission.Decoder
+}
+
+func (v *ClusterBaseModelValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	cbm := &v1beta1.ClusterBaseModel{}
+	if err := v.Decoder.Decode(req, cbm); err != nil {
+		log.Error(err, "Failed to decode ClusterBaseModel", "name", cbm.Name)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	if err := validation.ValidatePVCStorage(&cbm.Spec, true); err != nil {
+		return admission.Denied(err.Error())
+	}
+	return admission.Allowed("")
+}

--- a/pkg/webhook/admission/basemodel/basemodel_webhook_test.go
+++ b/pkg/webhook/admission/basemodel/basemodel_webhook_test.go
@@ -1,0 +1,92 @@
+package basemodel
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func newDecoder(t *testing.T) admission.Decoder {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	return admission.NewDecoder(scheme)
+}
+
+func TestBaseModelValidator_Handle(t *testing.T) {
+	v := &BaseModelValidator{Decoder: newDecoder(t)}
+
+	tests := []struct {
+		name        string
+		uri         *string
+		wantAllowed bool
+	}{
+		{name: "no storage allowed", uri: nil, wantAllowed: true},
+		{name: "non-pvc allowed", uri: ptr.To("oci://n/ns/b/bucket/o/path"), wantAllowed: true},
+		{name: "valid namespaced pvc allowed", uri: ptr.To("pvc://my-pvc/models/llama"), wantAllowed: true},
+		{name: "namespaced pvc with namespace prefix denied", uri: ptr.To("pvc://shared:my-pvc/models/llama"), wantAllowed: false},
+		{name: "malformed pvc denied", uri: ptr.To("pvc://"), wantAllowed: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bm := &v1beta1.BaseModel{ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "models"}}
+			if tc.uri != nil {
+				bm.Spec.Storage = &v1beta1.StorageSpec{StorageUri: tc.uri}
+			}
+			raw, err := json.Marshal(bm)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			resp := v.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{Object: runtime.RawExtension{Raw: raw}},
+			})
+			if resp.Allowed != tc.wantAllowed {
+				t.Fatalf("allowed=%v, want %v (result: %+v)", resp.Allowed, tc.wantAllowed, resp.Result)
+			}
+		})
+	}
+}
+
+func TestClusterBaseModelValidator_Handle(t *testing.T) {
+	v := &ClusterBaseModelValidator{Decoder: newDecoder(t)}
+
+	tests := []struct {
+		name        string
+		uri         *string
+		wantAllowed bool
+	}{
+		{name: "valid cluster-scoped pvc allowed", uri: ptr.To("pvc://shared:my-pvc/models/llama"), wantAllowed: true},
+		{name: "cluster-scoped pvc without namespace prefix denied", uri: ptr.To("pvc://my-pvc/models/llama"), wantAllowed: false},
+		{name: "non-pvc allowed", uri: ptr.To("oci://n/ns/b/bucket/o/path"), wantAllowed: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cbm := &v1beta1.ClusterBaseModel{ObjectMeta: metav1.ObjectMeta{Name: "m"}}
+			if tc.uri != nil {
+				cbm.Spec.Storage = &v1beta1.StorageSpec{StorageUri: tc.uri}
+			}
+			raw, err := json.Marshal(cbm)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			resp := v.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{Object: runtime.RawExtension{Raw: raw}},
+			})
+			if resp.Allowed != tc.wantAllowed {
+				t.Fatalf("allowed=%v, want %v (result: %+v)", resp.Allowed, tc.wantAllowed, resp.Result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds a validating admission webhook for BaseModel and ClusterBaseModel that
rejects malformed or wrongly-scoped `pvc://` storage URIs at CREATE/UPDATE —
so a bad URI is denied at `kubectl apply` time instead of surfacing later as
a reconcile-time `Failed` status.
## Why we need it

Fail fast and clearly. Without the webhook, a wrongly-scoped or malformed
`pvc://` URI is only caught during reconcile — the model lands in a
`Failed`/`PVCInvalid` state the operator has to go read. Rejecting at
admission gives immediate, actionable feedback at apply time, and keeps the
rule in one place (`pkg/validation`) shared with any CRD-level validator.
## What changes
- **`pkg/webhook/admission/basemodel/`** *(new)* — `BaseModelValidator` +
  `ClusterBaseModelValidator`. Each `Handle` decodes the object and calls
  `validation.ValidatePVCStorage`, returning `Denied` on a rule violation
  and `Allowed` otherwise. Pure schema check — no API-server reads, so no
  client.
- **`cmd/manager/main.go`** — registers both validators on the webhook
  server (`/validate-ome-io-v1beta1-basemodel`,
  `/validate-ome-io-v1beta1-clusterbasemodel`), mirroring the servingruntime
  validator registration.
- **Webhook manifests (both deploy paths)** — a Helm
  `ValidatingWebhookConfiguration`
  (`charts/…/webhooks/basemodelvalidator.yaml`) and the kustomize entries in
  `config/webhook/manifests.yaml`.

Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
