### PR TITLE
[Mics] fix webhook kustomization missing webhooks CA injection

### DIFF
--- a/config/default/basemodel_validatingwebhook_cainjection_patch.yaml
+++ b/config/default/basemodel_validatingwebhook_cainjection_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: basemodel.ome.io
+  annotations:
+    cert-manager.io/inject-ca-from: $(omeNamespace)/serving-cert
+webhooks:
+  - name: basemodel.ome-webhook-server.validator

--- a/config/default/clusterbasemodel_validatingwebhook_cainjection_patch.yaml
+++ b/config/default/clusterbasemodel_validatingwebhook_cainjection_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: clusterbasemodel.ome.io
+  annotations:
+    cert-manager.io/inject-ca-from: $(omeNamespace)/serving-cert
+webhooks:
+  - name: clusterbasemodel.ome-webhook-server.validator

--- a/config/default/controllerrevision_validatingwebhook_cainjection_patch.yaml
+++ b/config/default/controllerrevision_validatingwebhook_cainjection_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: controllerrevision-immutability.ome.io
+  annotations:
+    cert-manager.io/inject-ca-from: $(omeNamespace)/serving-cert
+webhooks:
+  - name: controllerrevision-immutability.ome-webhook-server.validator

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -54,6 +54,26 @@ replacements:
       kind: ValidatingWebhookConfiguration
       name: servingruntime.ome.io
   - fieldPaths:
+    - webhooks.*.clientConfig.service.name
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: controllerrevision-immutability.ome.io
+  - fieldPaths:
+    - webhooks.*.clientConfig.service.name
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: basemodel.ome.io
+  - fieldPaths:
+    - webhooks.*.clientConfig.service.name
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: clusterbasemodel.ome.io
+  - fieldPaths:
+    - spec.conversion.webhook.clientConfig.service.name
+    select:
+      kind: CustomResourceDefinition
+      name: inferenceservices.ome.io
+  - fieldPaths:
     - spec.commonName
     - spec.dnsNames.0
     options:
@@ -94,6 +114,26 @@ replacements:
     select:
       kind: ValidatingWebhookConfiguration
       name: servingruntime.ome.io
+  - fieldPaths:
+    - webhooks.*.clientConfig.service.namespace
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: controllerrevision-immutability.ome.io
+  - fieldPaths:
+    - webhooks.*.namespaceSelector.matchLabels.[kubernetes.io/metadata.name]
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: controllerrevision-immutability.ome.io
+  - fieldPaths:
+    - webhooks.*.clientConfig.service.namespace
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: basemodel.ome.io
+  - fieldPaths:
+    - webhooks.*.clientConfig.service.namespace
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: clusterbasemodel.ome.io
   - fieldPaths:
     - spec.commonName
     - spec.dnsNames.0
@@ -152,6 +192,30 @@ replacements:
     select:
       kind: ValidatingWebhookConfiguration
       name: servingruntime.ome.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: controllerrevision-immutability.ome.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: basemodel.ome.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: clusterbasemodel.ome.io
 
 patches:
 - path: manager_image_patch.yaml
@@ -165,3 +229,6 @@ patches:
 - path: isvc_conversion_webhook.yaml
 - path: cainjection_conversion_webhook.yaml
 - path: benchmarkjob_validationwebhook_cainjection_patch.yaml
+- path: controllerrevision_validatingwebhook_cainjection_patch.yaml
+- path: basemodel_validatingwebhook_cainjection_patch.yaml
+- path: clusterbasemodel_validatingwebhook_cainjection_patch.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -143,33 +143,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: capacityreservation.ome.io
-webhooks:
-  - clientConfig:
-      caBundle: Cg==
-      service:
-        name: $(webhookServiceName)
-        namespace: $(omeNamespace)
-        path: /validate-ome-io-v1beta1-capacityreservation
-    failurePolicy: Fail
-    name: capacityreservation.ome-webhook-server.validator
-    sideEffects: None
-    admissionReviewVersions: ["v1beta1"]
-    rules:
-      - apiGroups:
-          - ome.io
-        apiVersions:
-          - v1beta1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - clustercapacityreservations
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  creationTimestamp: null
   name: servingruntime.ome.io
 webhooks:
   - clientConfig:


### PR DESCRIPTION
## What this PR does

`config/webhook/manifests.yaml` defines 8 validating webhooks (plus 1 mutating),
but the `config/default` kustomize overlay only resolved 4 of them. Deploying via
kustomize therefore emitted broken webhook configs for the rest. This PR wires up
the missing webhooks, fixes two unresolved placeholders, and removes one orphaned
webhook — bringing the kustomize path to parity with the Helm chart.
## Why we need it

The `config/default` overlay resolves each webhook's `service.name`, `service.namespace`,
and `cert-manager.io/inject-ca-from` annotation via kustomize `replacements` + a
CA-injection patch. These were only present for `inferenceservice`, `clusterservingruntime`,
`servingruntime`, and `benchmarkjob`. The other four were left with literal
`$(webhookServiceName)` / `$(omeNamespace)` placeholders and no CA injection, so:

- `basemodel` / `clusterbasemodel` (both `failurePolicy: Fail`) would point at a
  nonexistent service with an empty `caBundle` → the API server can't reach them →
  **all BaseModel/ClusterBaseModel create/update admission fails closed**.
- `controllerrevision-immutability` additionally had a `namespaceSelector` matchLabel
  stuck at literal `$(omeNamespace)`, matching no namespace → the immutability guard
  was **silently inert**.

## What changes:
**Wire the 3 missing served webhooks** (`controllerrevision-immutability`, `basemodel`,
`clusterbasemodel`) — each gets `service.name` + `service.namespace` replacements and a
`*_cainjection_patch.yaml` for the `cert-manager.io/inject-ca-from` annotation. Webhook
paths were cross-checked against their registrations in `cmd/manager/main.go`.

**Fix the `controllerrevision-immutability` namespaceSelector** — added a replacement so
`namespaceSelector.matchLabels[kubernetes.io/metadata.name]` resolves to the OME namespace
instead of the literal placeholder.

**Fix the InferenceService CRD conversion webhook** — added a replacement for
`spec.conversion.webhook.clientConfig.service.name`, which was rendering as literal
`$(webhookServiceName)` (kustomize's namespace transformer had resolved the namespace,
but nothing resolved the service name). Latent today since the CRD is single-version, but
would break all conversions once a second served version is introduced.

**Remove the orphaned `capacityreservation.ome.io` webhook** — it was defined in
`manifests.yaml` but has no CRD, API type, controller, RBAC, or handler registration (and
is absent from the Helm chart). With `failurePolicy: Fail` it would have blocked writes to
a resource the API server 404s on. Removed rather than wired.
Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
