### PR TITLE
Ignore parsed model metadata for DownloadOverride decisions

### DIFF
--- a/pkg/modelagent/scout.go
+++ b/pkg/modelagent/scout.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
@@ -45,6 +46,17 @@ type TensorRTLLMShapeFilter struct {
 	IsTensorrtLLMModel bool
 	ShapeAlias         string
 	ModelType          string
+}
+
+type downloadOverrideChangeCandidate struct {
+	name     string
+	old, new interface{}
+}
+
+type modelDownloadInputs struct {
+	Storage              *v1beta1.StorageSpec
+	IsTensorRTLLMModel   bool
+	TensorRTLLMModelType string
 }
 
 func NewScout(ctx context.Context, nodeName string,
@@ -346,22 +358,15 @@ func (w *Scout) updateBaseModel(old, new interface{}) {
 	// Exclude DownloadPolicy from Spec diff — policy changes are detected separately above.
 	ignoreDownloadPolicy := cmpopts.IgnoreFields(v1beta1.StorageSpec{}, "DownloadPolicy")
 
-	hasChanges := false
-	for _, diff := range []struct {
-		name     string
-		old, new interface{}
-	}{
+	hasChanges, err := hasDownloadOverrideChanges([]downloadOverrideChangeCandidate{
 		{"Labels", oldBaseModel.Labels, newBaseModel.Labels},
 		{"Annotations", oldBaseModel.Annotations, newBaseModel.Annotations},
-		{"Spec", oldBaseModel.Spec, newBaseModel.Spec},
-	} {
-		result, err := kmp.SafeDiff(diff.old, diff.new, ignoreDownloadPolicy)
-		if err != nil {
-			w.logger.Errorf("Failed to diff %s for BaseModel: %s in namespace %s",
-				diff.name, newBaseModel.Name, newBaseModel.Namespace)
-			return
-		}
-		hasChanges = hasChanges || (result != "")
+		{"DownloadInputs", modelDownloadInputsFromSpec(oldBaseModel.Spec), modelDownloadInputsFromSpec(newBaseModel.Spec)},
+	}, ignoreDownloadPolicy)
+	if err != nil {
+		w.logger.Errorf("Failed to diff BaseModel %s in namespace %s: %v",
+			newBaseModel.Name, newBaseModel.Namespace, err)
+		return
 	}
 
 	if (policyChanged || hasChanges) && w.shouldDownloadModel(newBaseModel.Spec.Storage) {
@@ -402,27 +407,48 @@ func (w *Scout) updateClusterBaseModel(old, new interface{}) {
 	// Exclude DownloadPolicy from Spec diff — policy changes are detected separately above.
 	ignoreDownloadPolicy := cmpopts.IgnoreFields(v1beta1.StorageSpec{}, "DownloadPolicy")
 
-	hasChanges := false
-	for _, diff := range []struct {
-		name     string
-		old, new interface{}
-	}{
+	hasChanges, err := hasDownloadOverrideChanges([]downloadOverrideChangeCandidate{
 		{"Labels", oldClusterBaseModel.Labels, newClusterBaseModel.Labels},
 		{"Annotations", oldClusterBaseModel.Annotations, newClusterBaseModel.Annotations},
-		{"Spec", oldClusterBaseModel.Spec, newClusterBaseModel.Spec},
-	} {
-		result, err := kmp.SafeDiff(diff.old, diff.new, ignoreDownloadPolicy)
-		if err != nil {
-			w.logger.Errorf("Failed to diff %s for BaseModel: %s in namespace %s",
-				diff.name, newClusterBaseModel.Name, newClusterBaseModel.Namespace)
-			return
-		}
-		hasChanges = hasChanges || (result != "")
+		{"DownloadInputs", modelDownloadInputsFromSpec(oldClusterBaseModel.Spec), modelDownloadInputsFromSpec(newClusterBaseModel.Spec)},
+	}, ignoreDownloadPolicy)
+	if err != nil {
+		w.logger.Errorf("Failed to diff ClusterBaseModel %s: %v", newClusterBaseModel.Name, err)
+		return
 	}
 
 	if (policyChanged || hasChanges) && w.shouldDownloadModel(newClusterBaseModel.Spec.Storage) {
 		w.logger.Infof("ClusterBaseModel %s need refresh", newClusterBaseModel.GetName())
 		w.generateDownloadOverrideTaskBasedOnClusterBaseModel(newClusterBaseModel)
+	}
+}
+
+func hasDownloadOverrideChanges(candidates []downloadOverrideChangeCandidate, opts ...cmp.Option) (bool, error) {
+	for _, candidate := range candidates {
+		result, err := kmp.SafeDiff(candidate.old, candidate.new, opts...)
+		if err != nil {
+			return false, fmt.Errorf("failed to diff %s: %w", candidate.name, err)
+		}
+		if result != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func modelDownloadInputsFromSpec(spec v1beta1.BaseModelSpec) modelDownloadInputs {
+	isTensorRTLLMModel := spec.ModelFormat.Name == constants.TensorRTLLM
+	modelType := ""
+	if isTensorRTLLMModel {
+		modelType = string(constants.ServingBaseModel)
+		if modelTypeFromMetadata, ok := spec.AdditionalMetadata["type"]; ok {
+			modelType = modelTypeFromMetadata
+		}
+	}
+	return modelDownloadInputs{
+		Storage:              spec.Storage,
+		IsTensorRTLLMModel:   isTensorRTLLMModel,
+		TensorRTLLMModelType: modelType,
 	}
 }
 

--- a/pkg/modelagent/scout.go
+++ b/pkg/modelagent/scout.go
@@ -53,7 +53,7 @@ type downloadOverrideChangeCandidate struct {
 	old, new interface{}
 }
 
-type modelDownloadInputs struct {
+type downloadOverrideInputs struct {
 	Storage              *v1beta1.StorageSpec
 	IsTensorRTLLMModel   bool
 	TensorRTLLMModelType string
@@ -361,7 +361,7 @@ func (w *Scout) updateBaseModel(old, new interface{}) {
 	hasChanges, err := hasDownloadOverrideChanges([]downloadOverrideChangeCandidate{
 		{"Labels", oldBaseModel.Labels, newBaseModel.Labels},
 		{"Annotations", oldBaseModel.Annotations, newBaseModel.Annotations},
-		{"DownloadInputs", modelDownloadInputsFromSpec(oldBaseModel.Spec), modelDownloadInputsFromSpec(newBaseModel.Spec)},
+		{"DownloadOverrideInputs", downloadOverrideInputsFromSpec(oldBaseModel.Spec), downloadOverrideInputsFromSpec(newBaseModel.Spec)},
 	}, ignoreDownloadPolicy)
 	if err != nil {
 		w.logger.Errorf("Failed to diff BaseModel %s in namespace %s: %v",
@@ -410,7 +410,7 @@ func (w *Scout) updateClusterBaseModel(old, new interface{}) {
 	hasChanges, err := hasDownloadOverrideChanges([]downloadOverrideChangeCandidate{
 		{"Labels", oldClusterBaseModel.Labels, newClusterBaseModel.Labels},
 		{"Annotations", oldClusterBaseModel.Annotations, newClusterBaseModel.Annotations},
-		{"DownloadInputs", modelDownloadInputsFromSpec(oldClusterBaseModel.Spec), modelDownloadInputsFromSpec(newClusterBaseModel.Spec)},
+		{"DownloadOverrideInputs", downloadOverrideInputsFromSpec(oldClusterBaseModel.Spec), downloadOverrideInputsFromSpec(newClusterBaseModel.Spec)},
 	}, ignoreDownloadPolicy)
 	if err != nil {
 		w.logger.Errorf("Failed to diff ClusterBaseModel %s: %v", newClusterBaseModel.Name, err)
@@ -436,7 +436,7 @@ func hasDownloadOverrideChanges(candidates []downloadOverrideChangeCandidate, op
 	return false, nil
 }
 
-func modelDownloadInputsFromSpec(spec v1beta1.BaseModelSpec) modelDownloadInputs {
+func downloadOverrideInputsFromSpec(spec v1beta1.BaseModelSpec) downloadOverrideInputs {
 	isTensorRTLLMModel := spec.ModelFormat.Name == constants.TensorRTLLM
 	modelType := ""
 	if isTensorRTLLMModel {
@@ -445,7 +445,7 @@ func modelDownloadInputsFromSpec(spec v1beta1.BaseModelSpec) modelDownloadInputs
 			modelType = modelTypeFromMetadata
 		}
 	}
-	return modelDownloadInputs{
+	return downloadOverrideInputs{
 		Storage:              spec.Storage,
 		IsTensorRTLLMModel:   isTensorRTLLMModel,
 		TensorRTLLMModelType: modelType,

--- a/pkg/modelagent/scout_test.go
+++ b/pkg/modelagent/scout_test.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
@@ -1437,17 +1438,18 @@ func TestUpdateBaseModel_NoDuplicateTaskOnPolicyOnlyChange(t *testing.T) {
 	sugaredLogger := logger.Sugar()
 	defer func(s *zap.SugaredLogger) { _ = s.Sync() }(sugaredLogger)
 
-	ch := make(chan *GopherTask, 10)
-	scout := &Scout{
-		nodeShapeAlias: "a10",
-		gopherChan:     ch,
-		logger:         sugaredLogger,
-		nodeInfo: &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "test-node",
-				Labels: map[string]string{"gpu-model": "a10"},
+	newScout := func(ch chan<- *GopherTask) *Scout {
+		return &Scout{
+			nodeShapeAlias: "a10",
+			gopherChan:     ch,
+			logger:         sugaredLogger,
+			nodeInfo: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-node",
+					Labels: map[string]string{"gpu-model": "a10"},
+				},
 			},
-		},
+		}
 	}
 
 	tests := []struct {
@@ -1472,24 +1474,22 @@ func TestUpdateBaseModel_NoDuplicateTaskOnPolicyOnlyChange(t *testing.T) {
 			description:   "Dedicated handler skips non-HF, spec diff excludes DownloadPolicy",
 		},
 		{
-			name: "non-policy spec change - exactly 1 task from hasChanges block",
+			name: "download-affecting storage change - exactly 1 task from hasChanges block",
 			oldModel: &v1beta1.BaseModel{
 				ObjectMeta: metav1.ObjectMeta{Name: "model-3"},
 				Spec: v1beta1.BaseModelSpec{
-					ModelExtensionSpec: v1beta1.ModelExtensionSpec{DisplayName: ptr("Old Name")},
 					Storage: &v1beta1.StorageSpec{
 						DownloadPolicy: ptr(v1beta1.AlwaysDownload),
-						StorageUri:     ptr("hf://meta-llama/llama-3"),
+						StorageUri:     ptr("oci://bucket/old-model"),
 					},
 				},
 			},
 			newModel: &v1beta1.BaseModel{
 				ObjectMeta: metav1.ObjectMeta{Name: "model-3"},
 				Spec: v1beta1.BaseModelSpec{
-					ModelExtensionSpec: v1beta1.ModelExtensionSpec{DisplayName: ptr("New Name")},
 					Storage: &v1beta1.StorageSpec{
 						DownloadPolicy: ptr(v1beta1.AlwaysDownload),
-						StorageUri:     ptr("hf://meta-llama/llama-3"),
+						StorageUri:     ptr("oci://bucket/new-model"),
 					},
 				},
 			},
@@ -1501,30 +1501,93 @@ func TestUpdateBaseModel_NoDuplicateTaskOnPolicyOnlyChange(t *testing.T) {
 			oldModel: &v1beta1.BaseModel{
 				ObjectMeta: metav1.ObjectMeta{Name: "model-4"},
 				Spec: v1beta1.BaseModelSpec{
-					ModelExtensionSpec: v1beta1.ModelExtensionSpec{DisplayName: ptr("Old Name")},
 					Storage: &v1beta1.StorageSpec{
 						DownloadPolicy: ptr(v1beta1.ReuseIfExists),
-						StorageUri:     ptr("hf://meta-llama/llama-3"),
+						StorageUri:     ptr("hf://meta-llama/old-model"),
 					},
 				},
 			},
 			newModel: &v1beta1.BaseModel{
 				ObjectMeta: metav1.ObjectMeta{Name: "model-4"},
 				Spec: v1beta1.BaseModelSpec{
-					ModelExtensionSpec: v1beta1.ModelExtensionSpec{DisplayName: ptr("New Name")},
 					Storage: &v1beta1.StorageSpec{
 						DownloadPolicy: ptr(v1beta1.AlwaysDownload),
-						StorageUri:     ptr("hf://meta-llama/llama-3"),
+						StorageUri:     ptr("hf://meta-llama/new-model"),
 					},
 				},
 			},
 			expectedTasks: 1,
 			description:   "Single task even when both policy and spec change",
 		},
+		{
+			name: "parsed model metadata spec enrichment - 0 tasks",
+			oldModel: &v1beta1.BaseModel{
+				ObjectMeta: metav1.ObjectMeta{Name: "model-5"},
+				Spec: v1beta1.BaseModelSpec{
+					Storage: &v1beta1.StorageSpec{
+						DownloadPolicy: ptr(v1beta1.ReuseIfExists),
+						StorageUri:     ptr("oci://bucket/model"),
+					},
+				},
+			},
+			newModel: &v1beta1.BaseModel{
+				ObjectMeta: metav1.ObjectMeta{Name: "model-5"},
+				Spec: v1beta1.BaseModelSpec{
+					ModelType:          ptr("qwen3"),
+					ModelArchitecture:  ptr("Qwen3ForCausalLM"),
+					ModelFramework:     &v1beta1.ModelFrameworkSpec{Name: "transformers", Version: ptr("4.51.0")},
+					ModelFormat:        v1beta1.ModelFormat{Name: "safetensors", Version: ptr("1.0.0")},
+					ModelParameterSize: ptr("8.19B"),
+					ModelCapabilities:  []string{"TEXT_TO_TEXT"},
+					MaxTokens:          ptr(int32(40960)),
+					ModelConfiguration: runtime.RawExtension{Raw: []byte(`{"model_type":"qwen3"}`)},
+					AdditionalMetadata: map[string]string{"type": "custom"},
+					Storage: &v1beta1.StorageSpec{
+						DownloadPolicy: ptr(v1beta1.ReuseIfExists),
+						StorageUri:     ptr("oci://bucket/model"),
+					},
+				},
+			},
+			expectedTasks: 0,
+			description:   "Parser-populated metadata does not change artifact lifecycle inputs",
+		},
+		{
+			name: "label touch still triggers manual refresh - exactly 1 task",
+			oldModel: func() *v1beta1.BaseModel {
+				model := newBaseModel("model-6", v1beta1.ReuseIfExists, "oci://bucket/model")
+				model.Labels = map[string]string{"refresh": "old"}
+				return model
+			}(),
+			newModel: func() *v1beta1.BaseModel {
+				model := newBaseModel("model-6", v1beta1.ReuseIfExists, "oci://bucket/model")
+				model.Labels = map[string]string{"refresh": "new"}
+				return model
+			}(),
+			expectedTasks: 1,
+			description:   "Metadata touches preserve DownloadOverride so local MD5 validation can redownload corrupted files",
+		},
+		{
+			name: "annotation touch still triggers manual refresh - exactly 1 task",
+			oldModel: func() *v1beta1.BaseModel {
+				model := newBaseModel("model-7", v1beta1.ReuseIfExists, "oci://bucket/model")
+				model.Annotations = map[string]string{"refresh": "old"}
+				return model
+			}(),
+			newModel: func() *v1beta1.BaseModel {
+				model := newBaseModel("model-7", v1beta1.ReuseIfExists, "oci://bucket/model")
+				model.Annotations = map[string]string{"refresh": "new"}
+				return model
+			}(),
+			expectedTasks: 1,
+			description:   "Annotation touches preserve DownloadOverride so local MD5 validation can redownload corrupted files",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ch := make(chan *GopherTask, 10)
+			scout := newScout(ch)
+
 			scout.updateBaseModel(tc.oldModel, tc.newModel)
 			assert.Equal(t, tc.expectedTasks, len(ch), tc.description)
 			for range tc.expectedTasks {
@@ -1540,17 +1603,18 @@ func TestUpdateClusterBaseModel_NoDuplicateTaskOnPolicyOnlyChange(t *testing.T) 
 	sugaredLogger := logger.Sugar()
 	defer func(s *zap.SugaredLogger) { _ = s.Sync() }(sugaredLogger)
 
-	ch := make(chan *GopherTask, 10)
-	scout := &Scout{
-		nodeShapeAlias: "a10",
-		gopherChan:     ch,
-		logger:         sugaredLogger,
-		nodeInfo: &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "test-node",
-				Labels: map[string]string{"gpu-model": "a10"},
+	newScout := func(ch chan<- *GopherTask) *Scout {
+		return &Scout{
+			nodeShapeAlias: "a10",
+			gopherChan:     ch,
+			logger:         sugaredLogger,
+			nodeInfo: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-node",
+					Labels: map[string]string{"gpu-model": "a10"},
+				},
 			},
-		},
+		}
 	}
 
 	tests := []struct {
@@ -1575,34 +1639,97 @@ func TestUpdateClusterBaseModel_NoDuplicateTaskOnPolicyOnlyChange(t *testing.T) 
 			description:   "Dedicated handler skips non-HF, spec diff excludes DownloadPolicy",
 		},
 		{
-			name: "non-policy spec change - exactly 1 task",
+			name: "download-affecting storage change - exactly 1 task",
 			oldModel: &v1beta1.ClusterBaseModel{
 				ObjectMeta: metav1.ObjectMeta{Name: "cbm-3"},
 				Spec: v1beta1.BaseModelSpec{
-					ModelExtensionSpec: v1beta1.ModelExtensionSpec{DisplayName: ptr("Old Name")},
 					Storage: &v1beta1.StorageSpec{
 						DownloadPolicy: ptr(v1beta1.AlwaysDownload),
-						StorageUri:     ptr("hf://meta-llama/llama-3"),
+						StorageUri:     ptr("oci://bucket/old-model"),
 					},
 				},
 			},
 			newModel: &v1beta1.ClusterBaseModel{
 				ObjectMeta: metav1.ObjectMeta{Name: "cbm-3"},
 				Spec: v1beta1.BaseModelSpec{
-					ModelExtensionSpec: v1beta1.ModelExtensionSpec{DisplayName: ptr("New Name")},
 					Storage: &v1beta1.StorageSpec{
 						DownloadPolicy: ptr(v1beta1.AlwaysDownload),
-						StorageUri:     ptr("hf://meta-llama/llama-3"),
+						StorageUri:     ptr("oci://bucket/new-model"),
 					},
 				},
 			},
 			expectedTasks: 1,
 			description:   "Only the hasChanges block should fire",
 		},
+		{
+			name: "parsed model metadata spec enrichment - 0 tasks",
+			oldModel: &v1beta1.ClusterBaseModel{
+				ObjectMeta: metav1.ObjectMeta{Name: "cbm-4"},
+				Spec: v1beta1.BaseModelSpec{
+					Storage: &v1beta1.StorageSpec{
+						DownloadPolicy: ptr(v1beta1.ReuseIfExists),
+						StorageUri:     ptr("oci://bucket/model"),
+					},
+				},
+			},
+			newModel: &v1beta1.ClusterBaseModel{
+				ObjectMeta: metav1.ObjectMeta{Name: "cbm-4"},
+				Spec: v1beta1.BaseModelSpec{
+					ModelType:          ptr("qwen3"),
+					ModelArchitecture:  ptr("Qwen3ForCausalLM"),
+					ModelFramework:     &v1beta1.ModelFrameworkSpec{Name: "transformers", Version: ptr("4.51.0")},
+					ModelFormat:        v1beta1.ModelFormat{Name: "safetensors", Version: ptr("1.0.0")},
+					ModelParameterSize: ptr("8.19B"),
+					ModelCapabilities:  []string{"TEXT_TO_TEXT"},
+					MaxTokens:          ptr(int32(40960)),
+					ModelConfiguration: runtime.RawExtension{Raw: []byte(`{"model_type":"qwen3"}`)},
+					AdditionalMetadata: map[string]string{"type": "custom"},
+					Storage: &v1beta1.StorageSpec{
+						DownloadPolicy: ptr(v1beta1.ReuseIfExists),
+						StorageUri:     ptr("oci://bucket/model"),
+					},
+				},
+			},
+			expectedTasks: 0,
+			description:   "Parser-populated metadata does not change artifact lifecycle inputs",
+		},
+		{
+			name: "label touch still triggers manual refresh - exactly 1 task",
+			oldModel: func() *v1beta1.ClusterBaseModel {
+				model := newClusterBaseModel("cbm-5", v1beta1.ReuseIfExists, "oci://bucket/model")
+				model.Labels = map[string]string{"refresh": "old"}
+				return model
+			}(),
+			newModel: func() *v1beta1.ClusterBaseModel {
+				model := newClusterBaseModel("cbm-5", v1beta1.ReuseIfExists, "oci://bucket/model")
+				model.Labels = map[string]string{"refresh": "new"}
+				return model
+			}(),
+			expectedTasks: 1,
+			description:   "Metadata touches preserve DownloadOverride so local MD5 validation can redownload corrupted files",
+		},
+		{
+			name: "annotation touch still triggers manual refresh - exactly 1 task",
+			oldModel: func() *v1beta1.ClusterBaseModel {
+				model := newClusterBaseModel("cbm-6", v1beta1.ReuseIfExists, "oci://bucket/model")
+				model.Annotations = map[string]string{"refresh": "old"}
+				return model
+			}(),
+			newModel: func() *v1beta1.ClusterBaseModel {
+				model := newClusterBaseModel("cbm-6", v1beta1.ReuseIfExists, "oci://bucket/model")
+				model.Annotations = map[string]string{"refresh": "new"}
+				return model
+			}(),
+			expectedTasks: 1,
+			description:   "Annotation touches preserve DownloadOverride so local MD5 validation can redownload corrupted files",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ch := make(chan *GopherTask, 10)
+			scout := newScout(ch)
+
 			scout.updateClusterBaseModel(tc.oldModel, tc.newModel)
 			assert.Equal(t, tc.expectedTasks, len(ch), tc.description)
 			for range tc.expectedTasks {


### PR DESCRIPTION
## What this PR does

Updates model-agent Scout `DownloadOverride` detection to ignore parser-populated model metadata fields, while still triggering refresh for storage changes, label/annotation changes, and TensorRT-LLM download routing changes.

## Why we need it

Model config parsing can enrich `BaseModel` / `ClusterBaseModel` spec with metadata such as model type, framework, format, capabilities, and decoded configuration. Those metadata-only updates should not cause a `DownloadOverride`, because they do not change what artifact is downloaded.

Label/annotation updates are still preserved as a manual refresh path, so operators can force download validation and repair corrupted local files via the existing MD5/size check.

Fixes #

## How to test

- `go test ./pkg/modelagent -count=1`
- `go test ./pkg/modelagent -count=1 -run 'TestUpdateBaseModel_NoDuplicateTaskOnPolicyOnlyChange|TestUpdateClusterBaseModel_NoDuplicateTaskOnPolicyOnlyChange|TestGenerateDownloadOverride'`

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
