### PR TITLE
[Bugfix] Preserve ModelConfiguration if already set to stop BaseModel…

### DIFF
--- a/pkg/modelparser/config_parser.go
+++ b/pkg/modelparser/config_parser.go
@@ -1,7 +1,6 @@
 package modelparser
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -661,7 +660,12 @@ func updateField(current interface{}, new interface{}) bool {
 			return true
 		}
 	case *runtime.RawExtension:
-		if new != nil && len(new.([]byte)) > 0 && !bytes.Equal(c.Raw, new.([]byte)) {
+		// Preserve-if-unset, like every other field. ModelConfiguration is a
+		// preserve-unknown-fields RawExtension: the apiserver re-serializes it
+		// with sorted keys, so byte-comparing that against the parser's
+		// struct-order output never matches — which marked the field "changed"
+		// every reconcile and churned the spec. Write once.
+		if len(c.Raw) == 0 && new != nil && len(new.([]byte)) > 0 {
 			c.Raw = append(c.Raw[:0], new.([]byte)...)
 			return true
 		}

--- a/pkg/modelparser/config_parser_test.go
+++ b/pkg/modelparser/config_parser_test.go
@@ -380,6 +380,55 @@ func TestUpdateModelSpec(t *testing.T) {
 	assert.Equal(t, "7B", *existingSpec.ModelParameterSize)
 }
 
+// TestUpdateModelSpecPreservesModelConfiguration guards the preserve-if-unset
+// contract for the ModelConfiguration RawExtension. It is stored as a
+// preserve-unknown-fields field, so the apiserver serves it with sorted keys
+// while the parser emits struct-declaration order — byte-comparing the two would
+// never match and would rewrite the spec every reconcile. This locks in that an
+// already-set ModelConfiguration is NOT overwritten on a byte difference.
+func TestUpdateModelSpecPreservesModelConfiguration(t *testing.T) {
+	parser := &ModelConfigParser{logger: zap.NewNop().Sugar()}
+
+	// Same content, different byte order: sorted keys (apiserver) vs struct order (parser).
+	storedConfig := []byte(`{"architecture":"llama","model_type":"llama"}`)
+	parsedConfig := []byte(`{"model_type":"llama","architecture":"llama"}`)
+
+	// Fully-parsed spec: every field metadata provides is already set, so
+	// preserve-if-unset must leave everything untouched and report no change.
+	existingType := "llama"
+	existingArch := "LlamaForCausalLM"
+	existingSize := "7B"
+	existingMaxTokens := int32(4096)
+	spec := &v1beta1.BaseModelSpec{
+		ModelType:          &existingType,
+		ModelArchitecture:  &existingArch,
+		ModelParameterSize: &existingSize,
+		MaxTokens:          &existingMaxTokens,
+		ModelCapabilities:  []string{"CAP"},
+		ModelFramework:     &v1beta1.ModelFrameworkSpec{Name: "transformers"},
+		ModelFormat:        v1beta1.ModelFormat{Name: "safetensors"},
+		DiffusionPipeline:  &v1beta1.DiffusionPipelineSpec{},
+	}
+	spec.ModelConfiguration.Raw = storedConfig
+
+	// Metadata carries a byte-different ModelConfiguration (and other values that
+	// must be ignored because the corresponding spec fields are already set).
+	metadata := ModelMetadata{
+		ModelType:          "changed",
+		ModelArchitecture:  "changed",
+		ModelParameterSize: "13B",
+		MaxTokens:          8192,
+		ModelCapabilities:  []string{"OTHER"},
+		ModelConfiguration: parsedConfig,
+	}
+
+	updated := parser.updateModelSpec(spec, metadata)
+
+	assert.False(t, updated, "updateModelSpec must report no change when all fields are already set")
+	assert.Equal(t, storedConfig, spec.ModelConfiguration.Raw,
+		"ModelConfiguration must be preserved, not overwritten on a byte difference")
+}
+
 func TestParseDiffusionPipelineSpec(t *testing.T) {
 	data := []byte(`{
   "_class_name": "StableDiffusionPipeline",


### PR DESCRIPTION

## What this PR does

`updateField` overwrote `spec.modelConfiguration` whenever the freshly-parsed bytes
differed from the stored bytes. Because that field is a `runtime.RawExtension` stored as
`x-kubernetes-preserve-unknown-fields`, the apiserver re-serializes it with **sorted keys**,
while the parser emits **struct-declaration order** — so the byte comparison **never matched**.
Result: `updateModelSpec` returned `updated=true` on every reconcile, and the model agent
rewrote the BaseModel spec on every reconcile.

This changes the `RawExtension` case to **preserve-if-unset** (write only when `c.Raw` is
empty), matching every other field in `updateField` and its own documented contract:
*"writes new into current only when current is the zero value."*
## Why we need it

- `updateField` promises to write only when the current field is the zero value. 10 of 11
  fields honor that; the `RawExtension` case was the exception — it wrote on *difference*
  (`!bytes.Equal`).
- `modelConfiguration` is `x-kubernetes-preserve-unknown-fields: true` in the CRD, so the
  apiserver stores/serves it as a sorted-key object.
- The parser produces it via `json.Marshal(struct)` in declaration order → different bytes →
  `!bytes.Equal` always true → perpetual "changed" → spec rewrite every reconcile.
## Changes

`pkg/modelparser/config_parser.go`
- `updateField` `*runtime.RawExtension` case: `!bytes.Equal(c.Raw, new)` → `len(c.Raw) == 0`.
- Removed the now-unused `bytes` import.
- Added a comment explaining *why*, so it isn't reverted to overwrite-on-diff.

`pkg/modelparser/config_parser_test.go`
- Added `TestUpdateModelSpecPreservesModelConfiguration`: sets `ModelConfiguration.Raw` to
  sorted-key bytes, runs `updateModelSpec` with byte-different (struct-order) config plus
  other already-set fields, and asserts `updated == false` and `Raw` is unchanged. Reverting
  to overwrite-on-diff fails this test.

## How to test

- `go build ./pkg/modelparser/...` ✓
- `gofmt -l` clean ✓
- `go test ./pkg/modelparser/...` ✓ — including the new `TestUpdateModelSpecPreservesModelConfiguration`
  and the existing `TestUpdateModelSpec`.
## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
