### PR TITLE
[CI/Tests] Enforce web-console npm lockfile in sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,3 +91,11 @@ repos:
         language: system
         types: [go]
         pass_filenames: false
+
+      - id: npm-lockfile-sync
+        name: npm lockfile in sync
+        description: Ensure web-console/frontend package-lock.json matches package.json
+        entry: bash -c 'cd web-console/frontend && npm install --package-lock-only --ignore-scripts --no-audit --no-fund && git diff --exit-code package-lock.json'
+        language: system
+        files: ^web-console/frontend/package(-lock)?\.json$
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ When submitting a pull request:
 - **Go Formatting**: `go-fmt`, `go-vet` with workspace-wide formatting
 - **Helm Linting**: `helm-lint` with all warnings treated as errors
 - **Spell Checking**: `codespell` for catching typos across all text files
+- **Web Console**: `npm-lockfile-sync` keeps `web-console/frontend/package-lock.json` in sync with `package.json`, so CI's `npm ci` stays reproducible
 To set up:
 
 ```bash
@@ -41,6 +42,8 @@ To run it:
 pre-commit run --all-files #run all hooks on all files.
 pre-commit run go-fmt --all-files # run go-fmt hooks on all files.
 ```
+
+> **Note:** The `npm-lockfile-sync` hook regenerates the lockfile via `npm install --package-lock-only`, whose output can vary slightly across npm versions. To avoid spurious lockfile diffs, use the same Node.js major version as CI — **Node 23** (e.g. `nvm use 23`).
 
 ### PR Template
 


### PR DESCRIPTION
## What this PR does

Adds a `pre-commit` hook that keeps `web-console/frontend/package-lock.json`
in sync with `package.json`, catching a stale or missing lockfile at commit
time instead of in CI.

## Why we need it
In order to fix web-console CI, we switch ci install step to sue 'npm ci'.
The web-console CI install step uses `npm ci`, which installs the exact
versions pinned in `package-lock.json` and **fails if the lockfile is missing
or out of sync** with `package.json`. That determinism is the point — it's
what stops "passes locally, fails in CI" dependency drift — but it only holds
if the committed lockfile is always up to date. This hook enforces that
invariant locally so contributors can't accidentally commit a stale lockfile.

## What changes
- **`.pre-commit-config.yaml`** — new `npm-lockfile-sync` local hook. When
  `web-console/frontend/package.json` or `package-lock.json` is staged, it
  regenerates the lockfile with `npm install --package-lock-only` and fails if
  that produces a diff, leaving the corrected lockfile staged-ready. This
  mirrors the existing `go-mod-tidy` hook's regenerate-then-diff pattern. The
  `files:` filter scopes it to the frontend package files, so it adds no
  overhead to unrelated commits.
- **`CONTRIBUTING.md`** — documents the new check and notes that contributors
  should use the same Node.js major version as CI (**Node 23**) to avoid
  npm-version–induced lockfile churn.



## How to test

- `pre-commit validate-config` → valid.
- To verify locally: `pre-commit run npm-lockfile-sync --all-files` (expect
  Passed — the lockfile is currently in sync). Bumping a dependency in
  `package.json` without updating the lock should make the hook fail.

## Notes
- The `npm ci` CI switch already landed on `main`; this PR is only the
  complementary local guard plus docs.
- As with `go-mod-tidy`, lockfile output can vary slightly across npm
  versions — hence the Node 23 note in CONTRIBUTING.
## Checklist

- [ ] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [ ] `make test` passes locally
