### PR TITLE
[Misc] Adding B300 as a compatible OCI instance type

### DIFF
--- a/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
@@ -22,6 +22,7 @@ data:
       "BM.GPU.H200.8": "H200",
       "BM.GPU.H200-NC.8": "H200",
       "BM.GPU.B200.8": "B200",
+      "BM.GPU.B300.8": "B300",
       "p5.48xlarge": "H100",
       "Standard_ND96isr_H100_v5": "H100",
       "a3-highgpu-8g": "H100",

--- a/config/model-agent/configmap.yaml
+++ b/config/model-agent/configmap.yaml
@@ -22,6 +22,7 @@ data:
       "BM.GPU.H200.8": "H200",
       "BM.GPU.H200-NC.8": "H200",
       "BM.GPU.B200.8": "B200",
+      "BM.GPU.B300.8": "B300",
       "p5.48xlarge": "H100",
       "Standard_ND96isr_H100_v5": "H100",
       "a3-highgpu-8g": "H100",

--- a/pkg/utils/instance_type_util.go
+++ b/pkg/utils/instance_type_util.go
@@ -27,6 +27,7 @@ var defaultInstanceTypeMap = map[string]string{
 	"BM.GPU.H200.8":    "H200",
 	"BM.GPU.H200-NC.8": "H200",
 	"BM.GPU.B200.8":    "B200",
+	"BM.GPU.B300.8":    "B300",
 
 	// AWS instance types
 	"p5.48xlarge": "H100",

--- a/pkg/utils/instance_type_util_test.go
+++ b/pkg/utils/instance_type_util_test.go
@@ -40,6 +40,12 @@ func TestGetInstanceTypeShortName(t *testing.T) {
 			expected:     "H200",
 			expectError:  false,
 		},
+		{
+			name:         "OCI B300 instance",
+			instanceType: "BM.GPU.B300.8",
+			expected:     "B300",
+			expectError:  false,
+		},
 		// AWS tests
 		{
 			name:         "AWS H100 instance",


### PR DESCRIPTION
## What this PR does

Add support for B300 OCI Compute Shape in model agent

## Why we need it

We need this for B300 support in OCI

## How to test

Added a unit test and ran `make test` successfully
```
🧪 Running comprehensive test suite (Toolchain: go1.25.0+auto )...
🧪 Running cmd tests ...
ok  	sigs.k8s.io/ome/cmd/crd-gen	2.621s	coverage: 82.6% of statements
ok  	sigs.k8s.io/ome/cmd/manager	4.788s	coverage: 15.8% of statements
ok  	sigs.k8s.io/ome/cmd/model-agent	4.787s	coverage: 37.5% of statements
ok  	sigs.k8s.io/ome/cmd/multinode-prober	2.111s	coverage: 57.8% of statements
ok  	sigs.k8s.io/ome/cmd/ome-agent	5.152s	coverage: 45.6% of statements
ok  	sigs.k8s.io/ome/cmd/qpext	2.914s	coverage: 69.4% of statements
	sigs.k8s.io/ome/cmd/spec-gen		coverage: 0.0% of statements
✅ cmd tests passed
🧪 Running pkg tests ...
ok  	sigs.k8s.io/ome/pkg/acceleratorclassselector	3.538s	coverage: 73.7% of statements
ok  	sigs.k8s.io/ome/pkg/afero	2.006s	coverage: 21.4% of statements
	sigs.k8s.io/ome/pkg/apis		coverage: 0.0% of statements
ok  	sigs.k8s.io/ome/pkg/apis/ome/v1beta1	3.769s	coverage: 0.7% of statements
ok  	sigs.k8s.io/ome/pkg/auth	5.362s	coverage: 81.2% of statements
ok  	sigs.k8s.io/ome/pkg/auth/aws	4.635s	coverage: 90.0% of statements
ok  	sigs.k8s.io/ome/pkg/auth/azure	3.902s	coverage: 73.7% of statements
ok  	sigs.k8s.io/ome/pkg/auth/gcp	5.987s	coverage: 87.0% of statements
ok  	sigs.k8s.io/ome/pkg/auth/oci	233.417s	coverage: 91.0% of statements
ok  	sigs.k8s.io/ome/pkg/configutils	3.865s	coverage: 56.5% of statements
ok  	sigs.k8s.io/ome/pkg/constants	4.693s	coverage: 14.1% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/acceleratorclass	3.483s	coverage: 72.8% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel	3.615s	coverage: 50.7% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/backends/pernode	4.627s	coverage: 30.0% of statements
	sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/backends/pvc		coverage: 0.0% of statements
	sigs.k8s.io/ome/pkg/controller/v1beta1/basemodel/shared		coverage: 0.0% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/benchmark	5.219s	coverage: 67.9% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/benchmark/reconcilers/job	3.396s	coverage: 78.3% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/benchmark/utils	7.854s	coverage: 68.8% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig	5.954s	coverage: 57.5% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice	220.424s	coverage: 40.0% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/components	3.332s	coverage: 63.7% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler	5.244s	coverage: 31.1% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/common	6.263s	coverage: 44.2% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment	4.265s	coverage: 96.2% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/external_service	6.818s	coverage: 84.4% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa	6.698s	coverage: 42.6% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress	4.559s	coverage: 93.5% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/builders	7.451s	coverage: 77.8% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/factory	5.470s	coverage: 100.0% of statements
?   	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/interfaces	[no test files]
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/services	5.738s	coverage: 91.5% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/strategies	3.776s	coverage: 72.7% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/istiosidecar	2.755s	coverage: 95.8% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/keda	3.683s	coverage: 41.9% of statements
	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/knative		coverage: 0.0% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/lws	2.243s	coverage: 98.6% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/modelconfig	3.107s	coverage: 72.9% of statements
	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/multinode		coverage: 0.0% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/multinodevllm	5.849s	coverage: 54.6% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/pdb	4.290s	coverage: 92.0% of statements
	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/raw		coverage: 0.0% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/rbac	5.232s	coverage: 82.5% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/service	4.678s	coverage: 29.5% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/status	3.227s	coverage: 91.6% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils	3.914s	coverage: 49.0% of statements
ok  	sigs.k8s.io/ome/pkg/controller/v1beta1/runtimerevision	4.470s	coverage: 37.6% of statements
ok  	sigs.k8s.io/ome/pkg/hfutil/hub	3.556s	coverage: 68.9% of statements
	sigs.k8s.io/ome/pkg/hfutil/hub/samples/basic_download		coverage: 0.0% of statements
	sigs.k8s.io/ome/pkg/hfutil/hub/samples/enhanced_client		coverage: 0.0% of statements
	sigs.k8s.io/ome/pkg/hfutil/hub/samples/llama_download		coverage: 0.0% of statements
	sigs.k8s.io/ome/pkg/hfutil/hub/samples/progress_logging		coverage: 0.0% of statements
ok  	sigs.k8s.io/ome/pkg/imds	2.420s	coverage: 81.1% of statements
ok  	sigs.k8s.io/ome/pkg/logging	2.832s	coverage: 20.1% of statements
ok  	sigs.k8s.io/ome/pkg/logging/ginlog	2.673s	coverage: 31.1% of statements
ok  	sigs.k8s.io/ome/pkg/modelagent	5.663s	coverage: 53.9% of statements
ok  	sigs.k8s.io/ome/pkg/modelconfig	1.401s	coverage: 71.6% of statements
	sigs.k8s.io/ome/pkg/modelconfig/examples		coverage: 0.0% of statements
ok  	sigs.k8s.io/ome/pkg/modelparser	4.301s	coverage: 76.6% of statements
ok  	sigs.k8s.io/ome/pkg/modelver	3.962s	coverage: 80.5% of statements
ok  	sigs.k8s.io/ome/pkg/ociobjectstore	6.919s	coverage: 32.2% of statements
	sigs.k8s.io/ome/pkg/principals		coverage: 0.0% of statements
ok  	sigs.k8s.io/ome/pkg/runtimerevision	3.556s	coverage: 84.6% of statements
ok  	sigs.k8s.io/ome/pkg/runtimeselector	3.841s	coverage: 80.5% of statements
ok  	sigs.k8s.io/ome/pkg/storage	5.294s	coverage: 64.0% of statements
ok  	sigs.k8s.io/ome/pkg/storage/providers/gcs	3.966s	coverage: 6.2% of statements
ok  	sigs.k8s.io/ome/pkg/storage/providers/oci	5.279s	coverage: 12.2% of statements
	sigs.k8s.io/ome/pkg/storage/providers/s3		coverage: 0.0% of statements
ok  	sigs.k8s.io/ome/pkg/utils	2.936s	coverage: 61.5% of statements
ok  	sigs.k8s.io/ome/pkg/utils/storage	3.308s	coverage: 89.2% of statements
ok  	sigs.k8s.io/ome/pkg/validation	4.243s	coverage: 100.0% of statements
ok  	sigs.k8s.io/ome/pkg/vault	1.456s	coverage: 90.3% of statements
ok  	sigs.k8s.io/ome/pkg/vault/kmscrypto	3.686s	coverage: 30.9% of statements
ok  	sigs.k8s.io/ome/pkg/vault/kmsmgm	3.504s	coverage: 23.3% of statements
ok  	sigs.k8s.io/ome/pkg/vault/kmsvault	3.556s	coverage: 25.4% of statements
ok  	sigs.k8s.io/ome/pkg/vault/secret	3.613s	coverage: 36.2% of statements
ok  	sigs.k8s.io/ome/pkg/vault/secret_in_vault	4.148s	coverage: 78.6% of statements
ok  	sigs.k8s.io/ome/pkg/vault/secret_retrieval	3.413s	coverage: 72.8% of statements
ok  	sigs.k8s.io/ome/pkg/vault/vault	3.663s	coverage: 36.2% of statements
?   	sigs.k8s.io/ome/pkg/version	[no test files]
ok  	sigs.k8s.io/ome/pkg/webhook/admission/basemodel	3.627s	coverage: 71.4% of statements
ok  	sigs.k8s.io/ome/pkg/webhook/admission/benchmark	3.731s	coverage: 79.3% of statements
ok  	sigs.k8s.io/ome/pkg/webhook/admission/isvc	2.642s	coverage: 82.7% of statements
ok  	sigs.k8s.io/ome/pkg/webhook/admission/pod	8.366s	coverage: 67.7% of statements
ok  	sigs.k8s.io/ome/pkg/webhook/admission/runtimerevision	2.169s	coverage: 78.9% of statements
ok  	sigs.k8s.io/ome/pkg/webhook/admission/servingruntime	3.198s	coverage: 64.2% of statements
ok  	sigs.k8s.io/ome/pkg/zipper	2.032s	coverage: 83.8% of statements
✅ pkg tests passed
🧪 Running internal tests ...
ok  	sigs.k8s.io/ome/internal/ome-agent/enigma	3.186s	coverage: 37.2% of statements
	sigs.k8s.io/ome/internal/ome-agent/fine-tuned-adapter		coverage: 0.0% of statements
ok  	sigs.k8s.io/ome/internal/ome-agent/model-metadata	2.260s	coverage: 39.8% of statements
ok  	sigs.k8s.io/ome/internal/ome-agent/replica	3.764s	coverage: 61.9% of statements
ok  	sigs.k8s.io/ome/internal/ome-agent/replica/common	4.523s	coverage: 100.0% of statements
ok  	sigs.k8s.io/ome/internal/ome-agent/replica/replicator	5.220s	coverage: 55.2% of statements
ok  	sigs.k8s.io/ome/internal/ome-agent/serving-agent	6.923s	coverage: 59.1% of statements
✅ internal tests passed

🎉 All tests completed successfully!
```

## Checklist

- [ x ] Tests added/updated (if applicable)
- [ x ] Docs updated (if applicable)
- [ x ] `make test` passes locally
