### PR TITLE
[Helm] Single-source instance-type map and integrate with enigma init container

### DIFF
--- a/charts/ome-resources/templates/_helpers.tpl
+++ b/charts/ome-resources/templates/_helpers.tpl
@@ -16,3 +16,13 @@ Parameters:
 {{- printf "%s:%s" $repo $tag -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Instance-type -> short-name map as a compact JSON string.
+Single source of truth (.Values.modelAgent.instanceTypeMap) rendered into both
+the model-agent ConfigMap (instance-type-map key) and the enigma init
+container's INSTANCE_TYPE_MAP env var (ome-controller/configmap.yaml).
+*/}}
+{{- define "ome.instanceTypeMap" -}}
+{{- .Values.modelAgent.instanceTypeMap | toJson -}}
+{{- end }}

--- a/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
@@ -4,33 +4,6 @@ metadata:
   name: model-agent-config-map
   namespace: {{ .Release.Namespace }}
 data:
-  # Instance type mappings for various cloud providers:
-  # - Oracle Cloud (OCI) shapes
-  # - AWS instance types
-  # - Azure instance types
-  # - Google Cloud instance types
-  # - CoreWeave instance types
-  # - Nebius instance types
-  instance-type-map: |-
-    {
-      "BM.GPU.A10.4": "A10",
-      "BM.GPU.A100-v2.8": "A100-80G",
-      "BM.GPU4.8": "A100-40G",
-      "BM.GPU.B4.8": "A100-40G",
-      "BM.GPU.H100.8": "H100",
-      "BM.GPU.H100-NC.8": "H100",
-      "BM.GPU.H200.8": "H200",
-      "BM.GPU.H200-NC.8": "H200",
-      "BM.GPU.B200.8": "B200",
-      "BM.GPU.B300.8": "B300",
-      "p5.48xlarge": "H100",
-      "Standard_ND96isr_H100_v5": "H100",
-      "a3-highgpu-8g": "H100",
-      "gd-8xh100ib-i128": "H100",
-      "gd-8xh200ib-i128": "H200",
-      "gd-8xl40-i128": "L40",
-      "gpu-h100-sxm": "H100",
-      "gpu-h200-sxm": "H200",
-      "gpu-b200-sxm": "B200",
-      "gpu-l40s": "L40S"
-    }
+  # Instance-type -> short-name map. Source of truth: values.yaml
+  # modelAgent.instanceTypeMap (rendered via the ome.instanceTypeMap helper).
+  instance-type-map: {{ include "ome.instanceTypeMap" . | quote }}

--- a/charts/ome-resources/templates/ome-controller/configmap.yaml
+++ b/charts/ome-resources/templates/ome-controller/configmap.yaml
@@ -1,3 +1,5 @@
+{{- /* enigma init container's INSTANCE_TYPE_MAP env: single source in values.yaml (modelAgent.instanceTypeMap) via the ome.instanceTypeMap helper. */ -}}
+{{- $instanceTypeMap := include "ome.instanceTypeMap" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -56,7 +58,7 @@ data:
         "authType" : "{{ .Values.ome.omeAgent.authType }}",
         "vaultId": "{{ .Values.ome.omeAgent.vaultId }}",
         "region": "{{ .Values.ome.omeAgent.region }}",
-        "extraEnvVars": {{ toJson .Values.ome.omeAgent.modelInit.extraEnvVars }},
+        "extraEnvVars": {{ concat (.Values.ome.omeAgent.modelInit.extraEnvVars | default list) (list (dict "name" "INSTANCE_TYPE_MAP" "value" $instanceTypeMap)) | toJson }},
         "extraVolumeMounts": {{ toJson .Values.ome.omeAgent.modelInit.extraVolumeMounts }}
     }
   servingSidecar: |-

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -120,6 +120,38 @@ modelAgent:
     pullPolicy: Always
     tag: *defaultVersion
 
+  # Instance-type -> short-name mappings, by cloud provider. Single source of
+  # truth: rendered into the model-agent ConfigMap (instance-type-map) and the
+  # enigma init container's INSTANCE_TYPE_MAP env var via the
+  # "ome.instanceTypeMap" helper. To onboard a new GPU shape, add it here only.
+  instanceTypeMap:
+    # Oracle Cloud (OCI)
+    BM.GPU.A10.4: A10
+    BM.GPU.A100-v2.8: A100-80G
+    BM.GPU4.8: A100-40G
+    BM.GPU.B4.8: A100-40G
+    BM.GPU.H100.8: H100
+    BM.GPU.H100-NC.8: H100
+    BM.GPU.H200.8: H200
+    BM.GPU.H200-NC.8: H200
+    BM.GPU.B200.8: B200
+    BM.GPU.B300.8: B300
+    # AWS
+    p5.48xlarge: H100
+    # Azure
+    Standard_ND96isr_H100_v5: H100
+    # Google Cloud
+    a3-highgpu-8g: H100
+    # CoreWeave
+    gd-8xh100ib-i128: H100
+    gd-8xh200ib-i128: H200
+    gd-8xl40-i128: L40
+    # Nebius
+    gpu-h100-sxm: H100
+    gpu-h200-sxm: H200
+    gpu-b200-sxm: B200
+    gpu-l40s: L40S
+
   # When enabled, the model agent will only run on nodes with GPU
   gpuNodesOnly: false
 

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -44,7 +44,13 @@ data:
         "compartmentId": "ocid1.compartment.oc1..aaaaaaaarncfmdarfvbvhfj2oknyuvvftcp4p6ra77xlswftk67kcffmm2xq",
         "authType" : "InstancePrincipal",
         "vaultId": "ocid1.vault.oc1.eu-frankfurt-1.ens4gnknaaec4.abtheljrqneswo524ce3ytfqv3wqdjz4yi2drovyjnuo5lghz2fr76a7l7lq",
-        "region": "eu-frankfurt-1"
+        "region": "eu-frankfurt-1",
+        "extraEnvVars": [
+          {
+            "name": "INSTANCE_TYPE_MAP",
+            "value": "{\"BM.GPU.A10.4\":\"A10\",\"BM.GPU.A100-v2.8\":\"A100-80G\",\"BM.GPU4.8\":\"A100-40G\",\"BM.GPU.B4.8\":\"A100-40G\",\"BM.GPU.H100.8\":\"H100\",\"BM.GPU.H100-NC.8\":\"H100\",\"BM.GPU.H200.8\":\"H200\",\"BM.GPU.H200-NC.8\":\"H200\",\"BM.GPU.B200.8\":\"B200\",\"BM.GPU.B300.8\":\"B300\",\"p5.48xlarge\":\"H100\",\"Standard_ND96isr_H100_v5\":\"H100\",\"a3-highgpu-8g\":\"H100\",\"gd-8xh100ib-i128\":\"H100\",\"gd-8xh200ib-i128\":\"H200\",\"gd-8xl40-i128\":\"L40\",\"gpu-h100-sxm\":\"H100\",\"gpu-h200-sxm\":\"H200\",\"gpu-b200-sxm\":\"B200\",\"gpu-l40s\":\"L40S\"}"
+          }
+        ]
     }
 
   multinodeProber: |-


### PR DESCRIPTION
## What this PR does

Two related changes to how the GPU instance-type → short-name map is configured:

1. Wires `INSTANCE_TYPE_MAP` into the enigma model-init container, so it resolves node shapes from configuration instead of only the compiled-in Go fallback.
2. Collapses the map to a single source of truth in `values.yaml` (modelAgent.instanceTypeMap), rendered into both the model-agent ConfigMap and the enigma container's env via a new ome.instanceTypeMap helper.
## Why we need it

Onboarding a new GPU shape (e.g. B300 in #669) meant editing the map in several hardcoded places. Worse, the enigma init container — injected into InferenceService serving pods by the pod webhook — never received INSTANCE_TYPE_MAP, so it always fell back to the Go defaultInstanceTypeMap. For a shape only present in the ConfigMap, enigma resolved the wrong alias (the raw shape, e.g. BM.GPU.B300.8 instead of B300), breaking the TensorRT-LLM per-shape file filter. Net effect: onboarding a shape still required patching upstream Go, defeating the purpose of the ConfigMap.

Because serving pods run in user namespaces, a cross-namespace configMapKeyRef to model-agent-config-map (in ome) won't work — so the map is injected as a literal env value at admission time via the existing modelInit.extraEnvVars seam.

## What changes
- `values.yaml` — new modelAgent.instanceTypeMap (provider-grouped, the only place to edit going forward).
- `_helpers.tpl` — new ome.instanceTypeMap helper → compact JSON of that value.
- `model-agent-daemonset/configmap.yaml` — instance-type-map: {{ include "ome.instanceTypeMap" . | quote }} (was 20 hardcoded lines).
- `ome-controller/configmap.yaml` — enigma modelInit.extraEnvVars now injects INSTANCE_TYPE_MAP from the helper, merged ahead of any operator-supplied extraEnvVars.
- `config/configmap/inferenceservice.yaml` — same INSTANCE_TYPE_MAP entry for the non-Helm kustomize path (hardcoded; can't use Helm helpers).
No Go changes. The Go defaultInstanceTypeMap is retained as the no-env / bare-binary / test fallback.

Fixes #

## How to test

### renders cleanly
helm template ome charts/ome-resources >/dev/null

### single-source proof: one values edit reaches BOTH consumers
cat > /tmp/ov.yaml <<'EOF'
modelAgent:
  instanceTypeMap:
    BM.GPU.TEST.9: TESTSHAPE
EOF
helm template ome charts/ome-resources -f /tmp/ov.yaml \
  --show-only templates/model-agent-daemonset/configmap.yaml | grep TESTSHAPE
helm template ome charts/ome-resources -f /tmp/ov.yaml \
  --show-only templates/ome-controller/configmap.yaml | grep TESTSHAPE
Verified: both ConfigMaps render the same 20-entry map (B300→B300); the override reaches both consumers (21 entries); full chart renders with no errors.
## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
