### PR TITLE
[Helm] add ThinkingMachines Inkling NVFP4 runtime

### DIFF
--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -52,3 +52,5 @@ resources:
 - vllm/mixtral-8x7b-instruct-rt.yaml
 - vllm/deepseek-ai/deepseek-v4-flash-rt.yaml
 - vllm/deepseek-ai/deepseek-v4-pro-rt.yaml
+# Tokenspeed runtimes
+- tokenspeed/thinkingmachines/inkling-nvfp4-rt.yaml

--- a/config/runtimes/tokenspeed/thinkingmachines/inkling-nvfp4-rt.yaml
+++ b/config/runtimes/tokenspeed/thinkingmachines/inkling-nvfp4-rt.yaml
@@ -1,0 +1,207 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: tokenspeed-inkling-nvfp4
+spec:
+  acceleratorRequirements:
+    acceleratorClasses:
+      - nvidia-b200-4
+      - nvidia-b200-8
+  disabled: false
+  supportedModelFormats:
+    - modelFramework:
+        # Inkling does not declare a transformers_version in config.json.
+        name: transformers
+      modelFormat:
+        name: safetensors
+        version: "1.0.0"
+      autoSelect: true
+      modelArchitecture: InklingForConditionalGeneration
+      version: "1.0.0"
+      quantization: nvfp4
+      priority: 1
+      acceleratorConfig:
+        nvidia-b200-4:
+          tensorParallelismOverride:
+            tensorParallelSize: 4
+          runtimeArgsOverride:
+            - --attn-tp-size=4
+            - --moe-tp-size=4
+        nvidia-b200-8:
+          tensorParallelismOverride:
+            tensorParallelSize: 8
+          runtimeArgsOverride:
+            - --attn-tp-size=8
+            - --moe-tp-size=8
+  modelSizeRange:
+    min: 900B
+    max: 1050B
+  protocolVersions:
+    - openAI
+  routerConfig:
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: "29000"
+      prometheus.io/scrape: "true"
+    labels:
+      logging-forward: enabled
+    runner:
+      name: router
+      image: ghcr.io/lightseekorg/smg:nightly-20260717-ab43710
+      terminationMessagePolicy: FallbackToLogsOnError
+      ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "8"
+          memory: 16Gi
+      command:
+        - smg
+        - launch
+      args:
+        - --host
+        - 0.0.0.0
+        - --port
+        - "8080"
+        - --service-discovery
+        - --service-discovery-namespace
+        - $(NAMESPACE)
+        - --service-discovery-port
+        - "8080"
+        - --selector
+        - component=engine ome.io/inferenceservice=$(INFERENCESERVICE_NAME)
+        - --reasoning-parser
+        - inkling
+        - --tool-call-parser
+        - inkling
+        - --policy
+        - cache_aware
+        - --enable-igw
+        - --log-json
+        - --disable-retries
+        - --disable-circuit-breaker
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INFERENCESERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['ome.io/inferenceservice']
+      readinessProbe:
+        httpGet:
+          path: /readiness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /liveness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 20
+        timeoutSeconds: 10
+        initialDelaySeconds: 30
+  engineConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: /metrics
+    labels:
+      logging-forward: enabled
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+    volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+    runner:
+      name: ome-container
+      image: ghcr.io/lightseekorg/smg:ab43710-tokenspeed-tml
+      terminationMessagePolicy: FallbackToLogsOnError
+      ports:
+        - containerPort: 8080
+          name: grpc1
+          protocol: TCP
+      command:
+        - python3
+        - -m
+        - smg_grpc_servicer.tokenspeed
+      args:
+        - --host=0.0.0.0
+        - --port=8080
+        - --model=$(MODEL_PATH)
+        - --attn-tp-size=4
+        - --moe-tp-size=4
+        - --max-model-len=81920
+        - --max-num-seqs=16
+        - --max-prefill-tokens=8192
+        - --chunked-prefill-size=8192
+        - --gpu-memory-utilization=0.95
+        - --disable-cuda-graph-padding
+        - --trust-remote-code
+        - --attention-backend=fa4
+        - --moe-backend=flashinfer_trtllm
+        - --enable-prefix-caching
+        - --disable-kvstore
+        - --block-size=128
+        - --enable-cache-report
+        - --speculative-algorithm=MTP
+        - --speculative-num-steps=3
+        - --speculative-eagle-topk=1
+        - --speculative-num-draft-tokens=4
+        - --served-model-name=vllm-model
+      env:
+        - name: HF_HUB_OFFLINE
+          value: "1"
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+      resources:
+        requests:
+          cpu: 32
+          memory: 512Gi
+          nvidia.com/gpu: 4
+        limits:
+          cpu: 128
+          memory: 512Gi
+          nvidia.com/gpu: 4
+      readinessProbe:
+        grpc:
+          port: 8080
+          service: tokenspeed.grpc.scheduler.TokenSpeedScheduler
+        failureThreshold: 3
+        successThreshold: 1
+        periodSeconds: 90
+        timeoutSeconds: 60
+      livenessProbe:
+        grpc:
+          port: 8080
+        failureThreshold: 5
+        successThreshold: 1
+        periodSeconds: 60
+        timeoutSeconds: 60
+      startupProbe:
+        grpc:
+          port: 8080
+        failureThreshold: 200
+        successThreshold: 1
+        periodSeconds: 6
+        initialDelaySeconds: 60
+        timeoutSeconds: 30


### PR DESCRIPTION
## What this PR does

Adds a new tokenspeed serving-engine family under config/runtimes/tokenspeed/ — alongside the existing srt/ and vllm/ families — and lands its first runtime: tokenspeed-inkling-nvfp4, a ClusterServingRuntime for the ThinkingMachines Inkling model in NVFP4 on B200.
## What Changes
- **Model matching** — safetensors + transformers, architecture InklingForConditionalGeneration, quantization: nvfp4, autoSelect: true, priority 2, size range 900B–1050B. (Inkling doesn't declare a transformers_version in config.json, hence the unpinned framework match.)
- **Accelerators** — nvidia-b200-4 / nvidia-b200-8, with per-class acceleratorConfig tensor-parallel overrides: TP 4 (--attn-tp-size=4 --moe-tp-size=4) and TP 8 (--attn-tp-size=8 --moe-tp-size=8).
- **Router** — smg:nightly-20260717-ab43710 running smg launch; discovers engine pods via component=engine ome.io/inferenceservice=$(INFERENCESERVICE_NAME); inkling reasoning + tool-call parsers; cache_aware policy; --enable-igw; retries and circuit breaker disabled. OpenAI protocol on :8080.
- **Engine** — smg:ab43710-tokenspeed-tml running python3 -m smg_grpc_servicer.tokenspeed over gRPC on :8080; 4× B200; fa4 attention + flashinfer_trtllm MoE backends; prefix caching with block size 128; MTP speculative decoding (3 steps, eagle-topk 1, 4 draft tokens); --max-model-len=81920; HF_HUB_OFFLINE=1; gRPC probes against tokenspeed.grpc.scheduler.TokenSpeedScheduler (startup budget ~20 min for weight load).



Fixes #

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
