### PR TITLE
[Runtime] Add SEA-LION v4 32B source runtime

### DIFF
--- a/config/models/aisingapore/Qwen-SEA-LION-v4-32B-IT.yaml
+++ b/config/models/aisingapore/Qwen-SEA-LION-v4-32B-IT.yaml
@@ -1,0 +1,22 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: qwen-sea-lion-v4-32b-it
+spec:
+  modelCapabilities:
+    - TEXT_TO_TEXT
+  vendor: aisingapore
+  displayName: aisingapore.qwen-sea-lion-v4-32b-it
+  disabled: false
+  version: "1.0.0"
+  modelArchitecture: Qwen3ForCausalLM
+  modelFormat:
+    name: safetensors
+    version: "1.0.0"
+  modelFramework:
+    name: transformers
+    version: "4.51.0"
+  modelParameterSize: 32.762B
+  storage:
+    storageUri: hf://aisingapore/Qwen-SEA-LION-v4-32B-IT
+    path: /raid/models/aisingapore/Qwen-SEA-LION-v4-32B-IT

--- a/config/models/kustomization.yaml
+++ b/config/models/kustomization.yaml
@@ -5,6 +5,9 @@ resources:
   # adept
   - adept/persimmon-8b-chat.yaml
 
+  # aisingapore
+  - aisingapore/Qwen-SEA-LION-v4-32B-IT.yaml
+
   # Alibaba-NLP
   - Alibaba-NLP/gme-Qwen2-VL-2B-Instruct.yaml
   - Alibaba-NLP/gte-Qwen2-7B-instruct.yaml

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
 - srt/mixtral-8x7b-instruct-pd-rt.yaml
 - srt/mixtral-8x7b-instruct-rt.yaml
 # vLLM runtimes
+- vllm/Qwen/qwen-3-32b-rt.yaml
 - vllm/e5-mistral-7b-instruct-rt.yaml
 - vllm/llama-3-1-405b-instruct-fp8-rt.yaml
 - vllm/llama-3-1-8b-instruct-rt.yaml

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -33,7 +33,7 @@ resources:
 - srt/mixtral-8x7b-instruct-pd-rt.yaml
 - srt/mixtral-8x7b-instruct-rt.yaml
 # vLLM runtimes
-- vllm/Qwen/qwen-3-32b-rt.yaml
+- vllm/aisingapore/qwen-sea-lion-v4-32b-it-rt.yaml
 - vllm/e5-mistral-7b-instruct-rt.yaml
 - vllm/llama-3-1-405b-instruct-fp8-rt.yaml
 - vllm/llama-3-1-8b-instruct-rt.yaml

--- a/config/runtimes/vllm/Qwen/qwen-3-32b-rt.yaml
+++ b/config/runtimes/vllm/Qwen/qwen-3-32b-rt.yaml
@@ -1,0 +1,168 @@
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: vllm-qwen-3-32b
+spec:
+  disabled: false
+  routerConfig:
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: "29000"
+      prometheus.io/scrape: "true"
+    labels:
+      logging-forward: enabled
+    runner:
+      name: router
+      image: docker.io/lightseekorg/smg:1.4.1
+      ports:
+        - containerPort: 8080
+          name: http
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "8"
+          memory: 16Gi
+      args:
+        - --host
+        - 0.0.0.0
+        - --port
+        - "8080"
+        - --service-discovery
+        - --service-discovery-namespace
+        - $(NAMESPACE)
+        - --service-discovery-port
+        - "8080"
+        - --selector
+        - component=engine ome.io/inferenceservice=$(INFERENCESERVICE_NAME)
+        - --enable-igw
+        - --request-id-headers
+        - opc-request-id
+        - --log-json
+        - --disable-retries
+        - --disable-circuit-breaker
+        - --disable-tokenizer-autoload
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INFERENCESERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['ome.io/inferenceservice']
+      readinessProbe:
+        httpGet:
+          path: /readiness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /liveness
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 30
+        timeoutSeconds: 10
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        periodSeconds: 20
+        timeoutSeconds: 10
+        initialDelaySeconds: 30
+  supportedModelFormats:
+    - modelFramework:
+        name: transformers
+        version: "4.51.0"
+      modelFormat:
+        name: safetensors
+        version: "1.0.0"
+      modelArchitecture: Qwen3ForCausalLM
+      autoSelect: false
+      priority: 3
+      version: "1.0.0"
+  modelSizeRange:
+    min: 30B
+    max: 34B
+  protocolVersions:
+    - openAI
+  engineConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: /metrics
+    labels:
+      logging-forward: enabled
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+    volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+    runner:
+      name: ome-container
+      image: docker.io/vllm/vllm-openai:v0.23.0-cu129
+      ports:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+      command:
+        - vllm
+        - serve
+      args:
+        - $(MODEL_PATH)
+        - --port=8080
+        - --enable-log-requests
+        - --served-model-name=vllm-model
+        - --tensor-parallel-size=2
+        - --gpu-memory-utilization=0.9
+        - --max-model-len=32768
+        - --reasoning-parser=qwen3
+        - --enable-auto-tool-choice
+        - --tool-call-parser=hermes
+      env:
+        - name: VLLM_LOGGING_LEVEL
+          value: INFO
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+      resources:
+        requests:
+          cpu: 20
+          memory: 120Gi
+          nvidia.com/gpu: 2
+        limits:
+          cpu: 20
+          memory: 120Gi
+          nvidia.com/gpu: 2
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 3
+        successThreshold: 1
+        periodSeconds: 90
+        timeoutSeconds: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 5
+        successThreshold: 1
+        periodSeconds: 60
+        timeoutSeconds: 60
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        failureThreshold: 100
+        successThreshold: 1
+        periodSeconds: 6
+        initialDelaySeconds: 60
+        timeoutSeconds: 30

--- a/config/runtimes/vllm/aisingapore/qwen-sea-lion-v4-32b-it-rt.yaml
+++ b/config/runtimes/vllm/aisingapore/qwen-sea-lion-v4-32b-it-rt.yaml
@@ -1,7 +1,7 @@
 apiVersion: ome.io/v1beta1
 kind: ClusterServingRuntime
 metadata:
-  name: vllm-qwen-3-32b
+  name: vllm-qwen-sea-lion-v4-32b-it
 spec:
   disabled: false
   routerConfig:
@@ -122,9 +122,11 @@ spec:
         - --served-model-name=vllm-model
         - --tensor-parallel-size=2
         - --gpu-memory-utilization=0.9
-        - --max-model-len=32768
+        - --max-model-len=40960
         - --reasoning-parser=qwen3
+        - '--default-chat-template-kwargs={"enable_thinking":false}'
         - --enable-auto-tool-choice
+        - --exclude-tools-when-tool-choice-none
         - --tool-call-parser=hermes
       env:
         - name: VLLM_LOGGING_LEVEL

--- a/config/runtimes/vllm/aisingapore/qwen-sea-lion-v4-32b-it-rt.yaml
+++ b/config/runtimes/vllm/aisingapore/qwen-sea-lion-v4-32b-it-rt.yaml
@@ -13,7 +13,7 @@ spec:
       logging-forward: enabled
     runner:
       name: router
-      image: docker.io/lightseekorg/smg:1.4.1
+      image: docker.io/lightseekorg/smg:1.7.0
       ports:
         - containerPort: 8080
           name: http
@@ -107,7 +107,7 @@ spec:
           medium: Memory
     runner:
       name: ome-container
-      image: docker.io/vllm/vllm-openai:v0.23.0-cu129
+      image: docker.io/vllm/vllm-openai:v0.24.0-cu129
       ports:
         - containerPort: 8080
           name: http1

--- a/config/runtimes/vllm/aisingapore/qwen-sea-lion-v4-32b-it-rt.yaml
+++ b/config/runtimes/vllm/aisingapore/qwen-sea-lion-v4-32b-it-rt.yaml
@@ -13,7 +13,7 @@ spec:
       logging-forward: enabled
     runner:
       name: router
-      image: docker.io/lightseekorg/smg:1.7.0
+      image: docker.io/lightseekorg/smg:1.8.0
       ports:
         - containerPort: 8080
           name: http
@@ -107,7 +107,7 @@ spec:
           medium: Memory
     runner:
       name: ome-container
-      image: docker.io/vllm/vllm-openai:v0.24.0-cu129
+      image: docker.io/vllm/vllm-openai:v0.25.1-cu129
       ports:
         - containerPort: 8080
           name: http1

--- a/config/samples/isvc/aisingapore/qwen-sea-lion-v4-32b-it.yaml
+++ b/config/samples/isvc/aisingapore/qwen-sea-lion-v4-32b-it.yaml
@@ -7,7 +7,7 @@ spec:
   model:
     name: qwen-sea-lion-v4-32b-it
   runtime:
-    name: vllm-qwen-3-32b
+    name: vllm-qwen-sea-lion-v4-32b-it
   engine:
     minReplicas: 1
     maxReplicas: 1

--- a/config/samples/isvc/aisingapore/qwen-sea-lion-v4-32b-it.yaml
+++ b/config/samples/isvc/aisingapore/qwen-sea-lion-v4-32b-it.yaml
@@ -1,0 +1,16 @@
+apiVersion: ome.io/v1beta1
+kind: InferenceService
+metadata:
+  name: qwen-sea-lion-v4-32b-it
+  namespace: qwen-sea-lion-v4-32b-it
+spec:
+  model:
+    name: qwen-sea-lion-v4-32b-it
+  runtime:
+    name: vllm-qwen-3-32b
+  engine:
+    minReplicas: 1
+    maxReplicas: 1
+  router:
+    minReplicas: 1
+    maxReplicas: 1


### PR DESCRIPTION
## What this PR does

Adds the public OME source bundle for `aisingapore/Qwen-SEA-LION-v4-32B-IT` with a dedicated runtime:

- Adds the exact `ClusterBaseModel` and sample `InferenceService`.
- Adds `vllm-qwen-sea-lion-v4-32b-it`, selected explicitly and `autoSelect:false`.
- Uses official public `lightseekorg/smg:1.8.0` and `vllm/vllm-openai:v0.25.1-cu129`, TP2, the artifact's
  40,960 total-sequence cap, Qwen3 reasoning parsing, and Hermes tool parsing.
- Sets SEA-LION's non-thinking default explicitly while allowing request-level thinking opt-in.
- Registers the model and runtime in their kustomizations.

The dedicated runtime is required because SEA-LION's checkpoint defaults to non-thinking while base
`Qwen/Qwen3-32B` defaults to thinking. Reusing or editing a generic Qwen3 runtime would either misroute SEA-LION
answers into `reasoning` or change the existing base model's behavior.

## Runtime arguments

```text
--max-model-len=40960
--reasoning-parser=qwen3
--default-chat-template-kwargs={"enable_thinking":false}
--enable-auto-tool-choice
--exclude-tools-when-tool-choice-none
--tool-call-parser=hermes
```

These match the pinned artifact's default and Hermes-style `<tool_call>` template. `qwen3_xml` is for a different
Qwen3-Coder tool grammar.

## Relationship to #628

This PR is semantically independent of #628's generic Qwen3-32B runtime: it adds a model-specific AI Singapore
runtime, and this sample pins it explicitly. Both PRs still touch shared kustomizations, and #628 currently needs
rebase/conflict and review resolution before either merge order can be treated as clean. If both land after that
coordination, neither runtime is made a global default by this PR.

## Why we need it

The Flash release process makes public OME the source of truth for generic container versions, engine arguments,
formats, size ranges, probes, and validation assumptions. The first exact H100 Runtime CI run at TP2/4/8 proved
the model-specific default mismatch and drove this dedicated contract. Startup, BF16 loading, short benchmark,
substantial context, and explicit thinking passed. The first corrected dispatch reached no GPU because Runtime CI
incorrectly required auto-selection from this intentionally explicit-only runtime. PR #107 now adds the
explicit-runtime admission path, pinned-revision storage, a strict 40,960 boundary probe, and strict tool-loop
semantics before launching a fresh matrix:
[Runtime CI PR #107](https://github.com/model-infra/ome-runtime-ci/pull/107).

Promotion blockers remain:

1. The dedicated runtime uses the artifact/vLLM ceiling of 40,960. The model author calls 32,768 the native
   context, so the full 40,960 boundary must pass exact capacity/performance validation before promotion.
2. SMG 1.8.0 and vLLM 0.25.1-cu129 change the full serving fingerprint. Re-run model load/CUDA-graph warmup and
   streaming/non-streaming none/auto/required/named/replay semantics on all 14 declared OCI accelerator lanes.
3. The exact linux/amd64 images are digest-verified in the Chicago OCI source namespace; approved import and FRA
   replication still must complete before qualification.
4. The target card advertises `Qwen-SEA-LION-v4.5-27B-IT` as its newer version. Confirm that v4-32B should be
   onboarded instead of, or alongside, that successor.

This draft is source preparation, not proof of production support.

## How to test

1. `kubectl kustomize config/models`
2. `kubectl kustomize config/runtimes`
3. `pre-commit run --files config/runtimes/vllm/aisingapore/qwen-sea-lion-v4-32b-it-rt.yaml config/models/aisingapore/Qwen-SEA-LION-v4-32B-IT.yaml config/samples/isvc/aisingapore/qwen-sea-lion-v4-32b-it.yaml config/runtimes/kustomization.yaml config/models/kustomization.yaml`
4. `make test`
5. Review corrected exact-model Runtime CI rows before promotion.

## Checklist

- [x] Tests added/updated (N/A: config-only source bundle; rendered manifests and existing suites cover it)
- [x] Docs updated (N/A: model/runtime/sample manifests are the public contract)
- [x] Full `make test` passed after the final dedicated-runtime rename and argument correction
