### PR TITLE
[Bugfix] lock Cargo caches during multi-arch builds

### DIFF
--- a/dockerfiles/model-agent.Dockerfile
+++ b/dockerfiles/model-agent.Dockerfile
@@ -39,10 +39,10 @@ COPY pkg/ pkg/
 
 # Build the XET library first.
 # Cache the cargo registry and git checkouts across builds so crates and the
-# huggingface/xet-core git deps aren't re-downloaded on every rebuild — faster
-# and resilient to transient network failures (e.g. curl [18] partial file).
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
+# huggingface/xet-core git deps aren't re-downloaded on every rebuild. Lock the
+# caches because the amd64 and arm64 build stages run concurrently.
+RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,target=/root/.cargo/git,sharing=locked \
     cd pkg/xet && make build
 
 # Verify static library exists and remove dynamic library to force static linking


### PR DESCRIPTION
## What this PR does

- Configures the Cargo registry and Git cache mounts with `sharing=locked`.
- Prevents concurrent `amd64` and `arm64` builds from modifying the same Cargo cache.
- Preserves dependency caching while avoiding corrupted crate and `xet-core` checkouts.

## Why we need it

The model-agent image builds both platforms concurrently. BuildKit cache mounts default to shared access, allowing both Cargo processes to modify the same registry and Git checkout.

This intermittently caused missing files such as:

```text
failed to stat '/root/.cargo/git/checkouts/xet-core-.../git_xet/src/git_repo.rs'
```
Related failure: https://github.com/ome-projects/ome/actions/runs/29587912083/job/87909374980


## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
