### PR TITLE
Add component metadata exclusion support

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -427,11 +427,16 @@ const (
 // DefaultModelLocalMountPath is where models will be mounted by the storage-initializer
 const DefaultModelLocalMountPath = "/mnt/models"
 
+// ComponentMetadataExclusionsAnnotationKey lists comma-separated parent metadata keys that
+// should not be propagated to component metadata.
+const ComponentMetadataExclusionsAnnotationKey = "ome.io/component-metadata-exclusions"
+
 var (
 	ServiceAnnotationDisallowedList = []string{
 		autoscaling.MinScaleAnnotationKey,
 		autoscaling.MaxScaleAnnotationKey,
 		StorageInitializerSourceUriInternalAnnotationKey,
+		ComponentMetadataExclusionsAnnotationKey,
 		"kubectl.kubernetes.io/last-applied-configuration",
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -477,6 +478,41 @@ func ProcessBaseAnnotations(b *BaseComponentFields, isvc *v1beta1.InferenceServi
 	}
 
 	return annotations, nil
+}
+
+func componentMetadataExclusions(isvc *v1beta1.InferenceService) map[string]struct{} {
+	exclusions := map[string]struct{}{
+		constants.ComponentMetadataExclusionsAnnotationKey: {},
+	}
+	if isvc == nil || isvc.Annotations == nil {
+		return exclusions
+	}
+
+	for _, key := range strings.Split(isvc.Annotations[constants.ComponentMetadataExclusionsAnnotationKey], ",") {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			exclusions[key] = struct{}{}
+		}
+	}
+	return exclusions
+}
+
+func filterComponentMetadata(metadata map[string]string, exclusions map[string]struct{}) map[string]string {
+	return utils.Filter(metadata, func(key string) bool {
+		_, excluded := exclusions[key]
+		return !excluded
+	})
+}
+
+func filterServiceAnnotationsForComponent(isvc *v1beta1.InferenceService) map[string]string {
+	exclusions := componentMetadataExclusions(isvc)
+	return utils.Filter(isvc.Annotations, func(key string) bool {
+		if utils.Includes(constants.ServiceAnnotationDisallowedList, key) {
+			return false
+		}
+		_, excluded := exclusions[key]
+		return !excluded
+	})
 }
 
 // ProcessBaseLabels processes common labels

--- a/pkg/controller/v1beta1/inferenceservice/components/decoder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder.go
@@ -203,9 +203,7 @@ func (d *Decoder) reconcileObjectMeta(isvc *v1beta1.InferenceService) (metav1.Ob
 
 // processAnnotations processes the annotations for the decoder
 func (d *Decoder) processAnnotations(isvc *v1beta1.InferenceService) (map[string]string, error) {
-	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
-		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
-	})
+	annotations := filterServiceAnnotationsForComponent(isvc)
 
 	// Merge with decoder annotations
 	mergedAnnotations := annotations
@@ -225,10 +223,10 @@ func (d *Decoder) processAnnotations(isvc *v1beta1.InferenceService) (map[string
 
 // processLabels processes the labels for the decoder
 func (d *Decoder) processLabels(isvc *v1beta1.InferenceService) (map[string]string, error) {
-	mergedLabels := isvc.Labels
+	mergedLabels := filterComponentMetadata(isvc.Labels, componentMetadataExclusions(isvc))
 	if d.decoderSpec != nil {
 		decoderLabels := d.decoderSpec.Labels
-		mergedLabels = utils.Union(isvc.Labels, decoderLabels)
+		mergedLabels = utils.Union(mergedLabels, decoderLabels)
 	}
 
 	// Use common function for base labels processing

--- a/pkg/controller/v1beta1/inferenceservice/components/engine.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine.go
@@ -203,9 +203,7 @@ func (e *Engine) reconcileObjectMeta(isvc *v1beta1.InferenceService) (metav1.Obj
 
 // processAnnotations processes the annotations for the engine
 func (e *Engine) processAnnotations(isvc *v1beta1.InferenceService) (map[string]string, error) {
-	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
-		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
-	})
+	annotations := filterServiceAnnotationsForComponent(isvc)
 
 	// Merge with engine annotations
 	mergedAnnotations := annotations
@@ -225,10 +223,10 @@ func (e *Engine) processAnnotations(isvc *v1beta1.InferenceService) (map[string]
 
 // processLabels processes the labels for the engine
 func (e *Engine) processLabels(isvc *v1beta1.InferenceService) (map[string]string, error) {
-	mergedLabels := isvc.Labels
+	mergedLabels := filterComponentMetadata(isvc.Labels, componentMetadataExclusions(isvc))
 	if e.engineSpec != nil {
 		engineLabels := e.engineSpec.Labels
-		mergedLabels = utils.Union(isvc.Labels, engineLabels)
+		mergedLabels = utils.Union(mergedLabels, engineLabels)
 	}
 
 	// Use common function for base labels processing

--- a/pkg/controller/v1beta1/inferenceservice/components/engine_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine_test.go
@@ -753,10 +753,18 @@ func TestEngineReconcileObjectMeta(t *testing.T) {
 					Name:      "test-isvc",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"custom-annotation": "value",
+						"custom-annotation":                                "value",
+						"example.com/stable-resource-id":                   "resource-1",
+						"example.com/request-id":                           "request-1",
+						constants.ComponentMetadataExclusionsAnnotationKey: "example.com/request-id, example.com/workflow-id",
+						"kubectl.kubernetes.io/last-applied-configuration": "ignored",
 					},
 					Labels: map[string]string{
-						"custom-label": "value",
+						"custom-label":                   "value",
+						"example.com/stable-created-at":  "2026-07-20T00-00-00Z",
+						"example.com/stable-resource-id": "resource-1",
+						"example.com/request-id":         "request-1",
+						"example.com/workflow-id":        "workflow-1",
 					},
 				},
 			},
@@ -788,6 +796,7 @@ func TestEngineReconcileObjectMeta(t *testing.T) {
 			runtimeName: "test-runtime",
 			expectedAnnotations: map[string]string{
 				"custom-annotation":                    "value",
+				"example.com/stable-resource-id":       "resource-1",
 				"engine-annotation":                    "engine-value",
 				constants.BaseModelName:                "base-model",
 				constants.BaseModelFormat:              "safetensors",
@@ -797,6 +806,8 @@ func TestEngineReconcileObjectMeta(t *testing.T) {
 			},
 			expectedLabels: map[string]string{
 				"custom-label":                                  "value",
+				"example.com/stable-created-at":                 "2026-07-20T00-00-00Z",
+				"example.com/stable-resource-id":                "resource-1",
 				"engine-label":                                  "engine-value",
 				constants.InferenceServicePodLabelKey:           "test-isvc",
 				constants.OMEComponentLabel:                     "engine",
@@ -913,6 +924,10 @@ func TestEngineReconcileObjectMeta(t *testing.T) {
 			for k, v := range tt.expectedLabels {
 				g.Expect(objectMeta.Labels).To(gomega.HaveKeyWithValue(k, v))
 			}
+			g.Expect(objectMeta.Annotations).NotTo(gomega.HaveKey(constants.ComponentMetadataExclusionsAnnotationKey))
+			g.Expect(objectMeta.Annotations).NotTo(gomega.HaveKey("example.com/request-id"))
+			g.Expect(objectMeta.Labels).NotTo(gomega.HaveKey("example.com/request-id"))
+			g.Expect(objectMeta.Labels).NotTo(gomega.HaveKey("example.com/workflow-id"))
 		})
 	}
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/router.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/router.go
@@ -178,9 +178,7 @@ func (r *Router) reconcileObjectMeta(isvc *v1beta1.InferenceService) (metav1.Obj
 
 // processAnnotations processes the annotations for the router
 func (r *Router) processAnnotations(isvc *v1beta1.InferenceService) (map[string]string, error) {
-	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
-		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
-	})
+	annotations := filterServiceAnnotationsForComponent(isvc)
 
 	// Merge with router annotations
 	mergedAnnotations := annotations
@@ -200,10 +198,10 @@ func (r *Router) processAnnotations(isvc *v1beta1.InferenceService) (map[string]
 
 // processLabels processes the labels for the router
 func (r *Router) processLabels(isvc *v1beta1.InferenceService) (map[string]string, error) {
-	mergedLabels := isvc.Labels
+	mergedLabels := filterComponentMetadata(isvc.Labels, componentMetadataExclusions(isvc))
 	if r.routerSpec != nil {
 		routerLabels := r.routerSpec.Labels
-		mergedLabels = utils.Union(isvc.Labels, routerLabels)
+		mergedLabels = utils.Union(mergedLabels, routerLabels)
 	}
 
 	// Use common function for base labels processing


### PR DESCRIPTION
## What this PR does

Adds a generic metadata propagation safeguard for InferenceService components.

This PR introduces `ome.io/component-metadata-exclusions`, a comma-separated annotation on an InferenceService. When present, OME preserves the listed metadata keys on the top-level InferenceService but filters them out when constructing Engine, Decoder, and Router component annotations/labels.

Example:

```yaml
metadata:
  annotations:
    ome.io/component-metadata-exclusions: "example.com/request-id,example.com/workflow-id"
```

## Why we need it

Some metadata is useful for top-level correlation and debugging but should not be propagated into generated component metadata. Dynamic metadata that changes per request or operation can otherwise cause unnecessary rollout churn when copied into component workload metadata.

This keeps the behavior provider-neutral: OME does not need to know which metadata keys are dynamic or vendor-specific. The creator of the InferenceService decides which parent metadata should not flow into generated components.

Fixes #

## How to test

```bash
GOCACHE=/private/tmp/ome-debug-endpoint-dac-oss-ome/.gocache go test ./pkg/controller/v1beta1/inferenceservice/status ./pkg/controller/v1beta1/inferenceservice/components
GOCACHE=/private/tmp/ome-debug-endpoint-dac-oss-ome/.gocache make test
```

Both passed locally.

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally
