### PR TITLE
[Helm] Bump image references to v1.2.1

### DIFF
--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -8,7 +8,7 @@ global:
   imagePullSecrets: []
 
 ome:
-  version: &defaultVersion v1.2.0
+  version: &defaultVersion v1.2.1
   metricsaggregator:
     enableMetricAggregation: "false"
     enablePrometheusScraping: "false"

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -36,7 +36,7 @@ data:
 
   modelInit: |-
     {
-        "image" : "ghcr.io/moirai-internal/ome-agent:v1.2.0",
+        "image" : "ghcr.io/moirai-internal/ome-agent:v1.2.1",
         "memoryRequest": "320Gi",
         "memoryLimit": "320Gi",
         "cpuRequest": "15",
@@ -55,7 +55,7 @@ data:
 
   multinodeProber: |-
     {
-      "image" : "ghcr.io/moirai-internal/multinode-prober:v1.2.0",
+      "image" : "ghcr.io/moirai-internal/multinode-prober:v1.2.1",
       "memoryRequest": "100Mi",
       "memoryLimit": "100Mi",
       "cpuRequest": "100m",

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: manager
-          image: ghcr.io/moirai-internal/ome-manager:v1.2.0
+          image: ghcr.io/moirai-internal/ome-manager:v1.2.1

--- a/config/default/model_agent_image_patch.yaml
+++ b/config/default/model_agent_image_patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: model-agent
-          image: ghcr.io/moirai-internal/model-agent:v1.2.0
+          image: ghcr.io/moirai-internal/model-agent:v1.2.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
           - "--leader-elect"
           - "webhook"
           - "--zap-encoder=console"
-        image: ghcr.io/moirai-internal/ome-manager:v1.2.0
+        image: ghcr.io/moirai-internal/ome-manager:v1.2.1
         imagePullPolicy: Always
         name: manager
         securityContext:

--- a/config/model-agent/daemonset.yaml
+++ b/config/model-agent/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
           type: DirectoryOrCreate
       containers:
       - name: model-agent
-        image: ghcr.io/moirai-internal/model-agent:v1.2.0
+        image: ghcr.io/moirai-internal/model-agent:v1.2.1
         imagePullPolicy: Always
         ports:
         - name: metrics


### PR DESCRIPTION
## What this PR does

Cut the 1.2.1 release: the deployed manager, model-agent, ome-agent, and multinode-prober should pull the v1.2.1 images. Keeping the chart and kustomize manifests in lockstep avoids a split where one deploy path moves to the new image while the other stays on v1.2.0.
## Why we need it

- Helm chart — charts/ome-resources/values.yaml: the ome.version anchor (&defaultVersion) → v1.2.1, which propagates to every *defaultVersion image tag in the chart.
- Kustomize config/ — the hardcoded tags that don't reference the anchor:
   - ome-manager — config/manager/manager.yaml, config/default/manager_image_patch.yaml
   - model-agent — config/model-agent/daemonset.yaml, config/default/model_agent_image_patch.yaml
   - ome-agent + multinode-prober — config/configmap/inferenceservice.yaml

## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
