### PR TITLE
[CI] Assigns a separate GitHub Actions cache scope to each container …

### DIFF
--- a/.github/workflows/dev-images.yaml
+++ b/.github/workflows/dev-images.yaml
@@ -84,8 +84,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_ORG }}/${{ matrix.component.image }}:dev
             ${{ env.REGISTRY }}/${{ env.IMAGE_ORG }}/${{ matrix.component.image }}:dev-${{ steps.version.outputs.short_sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.component.image }}
+          cache-to: type=gha,scope=${{ matrix.component.image }},mode=max,ignore-error=true
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
             GIT_TAG=dev

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,8 +98,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_ORG }}/${{ matrix.component.image }}:${{ needs.prepare.outputs.tag }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_ORG }}/${{ matrix.component.image }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.component.image }}
+          cache-to: type=gha,scope=${{ matrix.component.image }},mode=max,ignore-error=true
           build-args: |
             VERSION=${{ needs.prepare.outputs.version }}
             GIT_TAG=${{ needs.prepare.outputs.tag }}


### PR DESCRIPTION
…image

## What this PR does

- Assigns a separate GitHub Actions cache scope to each container image.
- Makes cache export failures nonfatal.
- Applies the fix to both development and release image workflows.
## Why we need it

The Dev Images workflow successfully built and pushed the `ome-agent` image, but the job was marked as failed afterward when BuildKit returned `not_found` while exporting its cache.

All matrix components were using BuildKit's default cache scope, causing their caches to overwrite one another. Since caching is only an optimization, a cache backend failure should not fail an otherwise successful image build or cancel the remaining matrix jobs.

Related run: https://github.com/ome-projects/ome/actions/runs/30055351400/job/89420047228


## How to test

<!-- Steps to verify, or "N/A" for docs/config changes -->

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `make test` passes locally
