### PR TITLE
[CI] Preserve hand-written release notes on release re-run

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -253,7 +253,32 @@ jobs:
 
       - name: Generate release notes
         id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          TAG="${{ needs.prepare.outputs.tag }}"
+
+          # This job runs on every tag push AND on workflow_dispatch, so it can
+          # fire more than once for the same tag. Passing a freshly generated
+          # body_path to action-gh-release overwrites whatever is already on the
+          # release — which silently discards hand-written notes. Preserve them:
+          # only (re)generate the template when nobody has edited it yet, which
+          # we detect by the highlights placeholder still being present.
+          EXISTING="$(gh release view "$TAG" --json body,isDraft 2>/dev/null || echo '{}')"
+          EXISTING_BODY="$(jq -r '.body // ""' <<< "$EXISTING")"
+
+          # Never flip an already-published release back to draft on a re-run.
+          echo "draft=$(jq -r 'if .isDraft == null then true else .isDraft end' <<< "$EXISTING")" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$EXISTING_BODY" ]] && ! grep -qF 'Add release highlights here' <<< "$EXISTING_BODY"; then
+            # Write the existing body back verbatim so body_path stays valid and
+            # the update is a no-op for the notes.
+            printf '%s\n' "$EXISTING_BODY" > release-notes.md
+            echo "✅ Preserved existing release notes for ${TAG} ($(wc -c < release-notes.md) bytes)"
+            exit 0
+          fi
+
+          echo "📝 No hand-written notes found for ${TAG}; generating the template"
           cat > release-notes.md << EOF
           # OME ${{ needs.prepare.outputs.version }}
 
@@ -328,7 +353,9 @@ jobs:
           name: OME ${{ needs.prepare.outputs.version }}
           tag_name: ${{ needs.prepare.outputs.tag }}
           body_path: release-notes.md
-          draft: true # Create as draft so you can edit before publishing
+          # New releases start as drafts so you can edit before publishing; an
+          # already-published release stays published on a re-run.
+          draft: ${{ steps.notes.outputs.draft }}
           prerelease: ${{ contains(needs.prepare.outputs.tag, 'rc') || contains(needs.prepare.outputs.tag, 'alpha') || contains(needs.prepare.outputs.tag, 'beta') }}
           files: |
             release-assets/*


### PR DESCRIPTION
## What this PR does

- Preserves an existing hand-written release body instead of overwriting it with the generated template.
- Treats notes as hand-written once the `<!-- Add release highlights here -->` placeholder is gone, and keeps regenerating the template until then.
- Writes the preserved body back to `release-notes.md` verbatim, so `body_path` stays a valid file and the release update becomes a no-op for the notes.
- Reports the release's current draft state instead of hardcoding `draft: true`, so re-running for an already-published tag no longer reverts it to a draft.
## Why we need it

The `create-release` job triggers on both tag push and `workflow_dispatch`, so it can run more than once for the same tag. Every run regenerated the notes template and handed it to `softprops/action-gh-release` as `body_path`. That action updates the release matching `tag_name`, and with `body_path` set and no `append_body`, it replaces the body outright — discarding whatever was there.

Fixes #

## How to test

The guard logic was simulated locally against the four reachable states, using the real v1.2.2 notes as the hand-written body:

| Release state | Notes | `draft` output |
|---------------|-------|----------------|
| Does not exist yet | Regenerated template | `true` |
| Exists, untouched template | Regenerated template | `true` |
| Exists, hand-written, published | **Preserved** | `false` |
| Exists, hand-written, draft | **Preserved** | `true` |


## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `make test` passes locally
