### PR TITLE
[Misc] fix make generate env and openapi churn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,11 +165,15 @@ manifests: controller-gen yq ## 📄 Generate WebhookConfiguration, ClusterRole 
 generate: controller-gen ## 🔄 Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations and client-go libraries.
 	@echo "\n📦 Code Generation Process Starting..."
 	@echo "\n🔧 Step 1: Setting up Go environment..."
-	@go env -w GOFLAGS=-mod=mod
+	@# Use an inline GOFLAGS export instead of `go env -w`, which writes
+	@# to ~/.config/go/env. That path is read-only in many sandboxed
+	@# code-agent environments and made this target fail with cryptic
+	@# permission errors. Inline export is per-recipe and survives to the
+	@# sub-scripts invoked below.
 	@echo "✅ Go environment configured"
 
 	@echo "\n🔄 Step 2: Generating Kubernetes client-go code..."
-	@if ! hack/update-codegen.sh 2>generate.err; then \
+	@if ! GOFLAGS=-mod=mod hack/update-codegen.sh 2>generate.err; then \
 		echo "❌ Error during code generation:"; \
 		cat generate.err; \
 		rm generate.err; \
@@ -179,7 +183,7 @@ generate: controller-gen ## 🔄 Generate code containing DeepCopy, DeepCopyInto
 	@echo "✅ Client-go code generation complete"
 
 	@echo "\n📝 Step 3: Generating OpenAPI specifications..."
-	@if ! hack/update-openapigen.sh 2>openapi.err; then \
+	@if ! GOFLAGS=-mod=mod hack/update-openapigen.sh 2>openapi.err; then \
 		echo "❌ Error during OpenAPI generation:"; \
 		cat openapi.err; \
 		rm openapi.err; \

--- a/hack/update-openapigen.sh
+++ b/hack/update-openapigen.sh
@@ -8,36 +8,41 @@ KNOWN_VIOLATION_EXCEPTIONS=hack/violation_exceptions.list
 CURRENT_VIOLATION_EXCEPTIONS=hack/current_violation_exceptions.list
 OPENAPI_SPEC_FILE=pkg/openapi/openapi_generated.go
 
-GOPATH=$(go env GOPATH)
-if [[ -z $GOPATH ]]
+# openapi-gen requires the working directory to live on a Go import path that
+# matches the module name declared in go.mod (sigs.k8s.io/ome).
+# Rather than mutating the user's real GOPATH (the legacy approach renamed any
+# existing checkout at $GOPATH/src/sigs.k8s.io/ome with a timestamp
+# suffix and accumulated symlink cruft), we synthesize a throwaway GOPATH in a
+# tmpdir whose only job is to satisfy that path requirement. This works
+# uniformly from git worktrees, arbitrary clone paths, and the canonical
+# $GOPATH/src/sigs.k8s.io/ome path, without touching anything
+# outside the tmpdir.
+
+ORIG_GOPATH=$(go env GOPATH)
+if [[ -z $ORIG_GOPATH ]]
 then
     echo >&2 "Error: GOPATH is not set. Please configure your GOPATH environment variable."
     exit 1
 fi
-TARGET_DIR="$GOPATH/src/sigs.k8s.io/ome"
+
 CURRENT_DIR=$(pwd)
+
+# Synthesize a throwaway path layout in a tmpdir. We do NOT touch GOPATH here:
+# the repo uses Go modules, so import resolution is governed by go.mod, not
+# GOPATH/src. The only thing openapi-gen cares about is that its cwd matches
+# the module path declared in go.mod, which is satisfied by the symlink below.
+SYMLINK_ROOT=$(mktemp -d -t ome-openapigen.XXXXXX)
+trap 'rm -rf "$SYMLINK_ROOT"' EXIT
+
+SYMLINK_PATH="$SYMLINK_ROOT/src/sigs.k8s.io/ome"
+mkdir -p "$(dirname "$SYMLINK_PATH")"
+ln -s "$CURRENT_DIR" "$SYMLINK_PATH"
 
 # Redirect stdout to /dev/null but keep stderr
 exec 3>&1 # Save the current stdout to file descriptor 3
 exec 1>/dev/null # Redirect stdout to /dev/null
 
-# Check if the current directory is the target directory
-if [[ "$CURRENT_DIR" != "$TARGET_DIR" ]]; then
-    echo >&2 "You are not in the target directory: $TARGET_DIR"
-
-    # Check if the target directory exists.
-    if [[ -d "$TARGET_DIR" ]]; then
-        mv $TARGET_DIR "${TARGET_DIR}_$(date +%Y%m%d_%H%M%S)"
-    fi
-
-    echo >&2 "Creating a symbolic link for the target directory ..."
-    mkdir -p "$(dirname "$TARGET_DIR")"
-    ln -s "$CURRENT_DIR" "$TARGET_DIR"
-
-    # Change to the target directory
-    echo >&2 "Changing to the target directory: $TARGET_DIR"
-    pushd "$TARGET_DIR" > /dev/null
-fi
+pushd "$SYMLINK_PATH" > /dev/null
 
 # Generating OpenAPI specification
 go run k8s.io/kube-openapi/cmd/openapi-gen \
@@ -53,6 +58,12 @@ go run k8s.io/kube-openapi/cmd/openapi-gen \
 sed -i'.bak' -e 's/Required: \[\]string{\"name\"},//g' $OPENAPI_SPEC_FILE && rm -rf $OPENAPI_SPEC_FILE.bak
 sed -i'.bak' -e 's/Required: \[\]string{\"modelFormat\", \"name\"},/Required: \[\]string{\"modelFormat\"},/g' $OPENAPI_SPEC_FILE && rm -rf $OPENAPI_SPEC_FILE.bak
 
+# kube-openapi's templates emit whitespace-only lines inside struct literals
+# (e.g., a `\t\t\t\t` line between `},` and `},`). gofmt normalizes them so the
+# generated file is byte-stable across runs and the CI generate-drift check
+# doesn't fail on tooling noise.
+gofmt -w $OPENAPI_SPEC_FILE
+
 test -f $CURRENT_VIOLATION_EXCEPTIONS || touch $CURRENT_VIOLATION_EXCEPTIONS
 
 # The API rule fails if generated API rule violation report differs from the
@@ -66,11 +77,13 @@ fi
 # Generating swagger file
 go run cmd/spec-gen/main.go 0.1 > pkg/openapi/swagger.json 2>&1
 
-# Return to the original directory
-if [[ "$CURRENT_DIR" != "$TARGET_DIR" ]]; then
-    echo >&2 "Returning to the original directory: $CURRENT_DIR"
-    popd > /dev/null
-fi
+# `go run k8s.io/kube-openapi/cmd/openapi-gen` resolves the tool's transitive
+# deps (k8s.io/gengo, etc.) and adds stat-only entries for them to go.sum even
+# though our module doesn't import them. `go mod tidy` removes the spurious
+# entries so the CI generate-drift check stays clean.
+go mod tidy
+
+popd > /dev/null
 
 # Restore stdout
 exec 1>&3


### PR DESCRIPTION
## What this PR does

Two developer-tooling fixes for `make generate`:

1. **`hack/update-openapigen.sh` no longer touches the real GOPATH.** The legacy flow renamed any existing checkout at `$GOPATH/src/sigs.k8s.io/ome` with a timestamp suffix and left a symlink behind. openapi-gen only needs its working directory to sit on an import path matching `go.mod`, so the script now synthesizes that layout in a throwaway tmpdir (cleaned on exit). Works from git worktrees and arbitrary clone paths.
2. **Byte-stable generated output.** kube-openapi's templates emit whitespace-only lines that the pre-commit `trailing-whitespace` hook rejects, and `go run .../openapi-gen` adds stat-only `k8s.io/gengo` entries to `go.sum`. The script now runs `gofmt -w` on the generated file and `go mod tidy` afterwards, so `make generate` on a clean checkout produces no diff.
3. The `generate` recipe uses an inline `GOFLAGS=-mod=mod` instead of `go env -w GOFLAGS=-mod=mod`, which permanently mutated the developer's global go env file.

## Why we need it

`make generate` currently has side effects outside the repository (global go env, GOPATH checkout renames) and produces phantom `go.sum`/openapi diffs that contributors either commit as noise or fight with pre-commit.

## How to test

- `make generate && git status --porcelain` → empty on a clean checkout.
- Run it from a clone outside `$GOPATH/src` — no writes outside the repo and the tmpdir.
- `go env GOFLAGS` before/after → unchanged.

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally