### PR TITLE
[Core] admission validation for new API surfaces

### DIFF
--- a/charts/ome-resources/templates/ome-controller/webhooks/inferencereplicavalidator.yaml
+++ b/charts/ome-resources/templates/ome-controller/webhooks/inferencereplicavalidator.yaml
@@ -1,0 +1,34 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: inferencereplica.ome.io
+  annotations:
+    cert-manager.io/inject-ca-from: ome/serving-cert
+webhooks:
+  # InferenceReplica is a controller-only CRD: this webhook rejects
+  # direct user writes unless the ome.io/controller-write=true annotation
+  # is present (set by the ISVC controller's client on every write).
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: ome-webhook-server-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-ome-io-v1beta1-inferencereplica
+    failurePolicy: Fail
+    name: inferencereplica.ome-webhook-server.validator
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    matchConditions:
+      - name: skip-deletion
+        expression: "!has(object.metadata.deletionTimestamp)"
+    rules:
+      - apiGroups:
+          - ome.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - inferencereplicas

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/ome/pkg/version"
 	basemodelwebhook "sigs.k8s.io/ome/pkg/webhook/admission/basemodel"
 	"sigs.k8s.io/ome/pkg/webhook/admission/benchmark"
+	inferencereplicawebhook "sigs.k8s.io/ome/pkg/webhook/admission/inferencereplica"
 	"sigs.k8s.io/ome/pkg/webhook/admission/isvc"
 	"sigs.k8s.io/ome/pkg/webhook/admission/pod"
 	runtimerevisionwebhook "sigs.k8s.io/ome/pkg/webhook/admission/runtimerevision"
@@ -373,6 +374,10 @@ func main() {
 		setupLog.Info("Registering ClusterBaseModel validator webhook to the webhook server")
 		hookServer.Register("/validate-ome-io-v1beta1-clusterbasemodel", &webhook.Admission{
 			Handler: &basemodelwebhook.ClusterBaseModelValidator{Decoder: admission.NewDecoder(mgr.GetScheme())},
+		})
+
+		hookServer.Register("/validate-ome-io-v1beta1-inferencereplica", &webhook.Admission{
+			Handler: &inferencereplicawebhook.Validator{Decoder: admission.NewDecoder(mgr.GetScheme())},
 		})
 
 		if err = ctrl.NewWebhookManagedBy(mgr).

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -246,3 +246,41 @@ webhooks:
           - UPDATE
         resources:
           - clusterbasemodels
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: inferencereplica.ome.io
+webhooks:
+  # InferenceReplica is a controller-only CRD: this webhook rejects
+  # direct user writes unless the ome.io/controller-write=true annotation
+  # is present (set by the ISVC controller's client on every write).
+  # See pkg/webhook/admission/inferencereplica/validator.go for the
+  # exact rejection rules.
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: $(webhookServiceName)
+        namespace: $(omeNamespace)
+        path: /validate-ome-io-v1beta1-inferencereplica
+    failurePolicy: Fail
+    name: inferencereplica.ome-webhook-server.validator
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    # Skip on objects already being deleted: finalizer-only patches
+    # shouldn't trigger spec-invariant checks (would deadlock GC of
+    # owned InferenceReplicas during ISVC cascade delete).
+    matchConditions:
+      - name: skip-deletion
+        expression: "!has(object.metadata.deletionTimestamp)"
+    rules:
+      - apiGroups:
+          - ome.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - inferencereplicas

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -157,6 +157,16 @@ var (
 	IngressPathTemplate            = OMEAPIGroupName + "/ingress-path-template"
 	IngressDisableIstioVirtualHost = OMEAPIGroupName + "/ingress-disable-istio-virtualhost"
 	IngressDisableCreation         = OMEAPIGroupName + "/ingress-disable-creation"
+
+	// InferenceReplica is a controller-only CRD: the validating webhook
+	// rejects direct user writes unless this annotation is set to "true".
+	// The ISVC controller (and only the ISVC controller) stamps the
+	// annotation on every Create / Update of an InferenceReplica it owns.
+	// Convention enforcement, not a security boundary — RBAC restricting
+	// write on inferencereplicas to the OME ServiceAccount is the actual
+	// guard.
+	InferenceReplicaControllerWriteAnnotationKey = OMEAPIGroupName + "/controller-write"
+	InferenceReplicaControllerWriteAnnotationVal = "true"
 )
 
 // InferenceService Annotations for model encryption and decryption

--- a/pkg/constants/traffic_annotations.go
+++ b/pkg/constants/traffic_annotations.go
@@ -1,0 +1,102 @@
+// Traffic-management annotation keys.
+//
+// All annotations live under the OME group prefix (ome.io/). Operators
+// set them on the InferenceService metadata; the traffic translator
+// reads them and threads the values into the emitted backend policy
+// resource.
+package constants
+
+// Backend-policy annotation keys.
+//
+// Long-tail load-balancing knobs that did not graduate to the typed
+// core (TrafficSpec) in alpha. Each key is independently validated by
+// the admission webhook; unknown keys with the `ome.io/` prefix that
+// look like one of these (Levenshtein 2) are rejected with a
+// Did-you-mean suggestion.
+var (
+	// Circuit breaker.
+	CircuitBreakerMaxConnectionsAnnotation            = OMEAPIGroupName + "/circuit-breaker-max-connections"
+	CircuitBreakerMaxParallelRequestsAnnotation       = OMEAPIGroupName + "/circuit-breaker-max-parallel-requests"
+	CircuitBreakerMaxPendingRequestsAnnotation        = OMEAPIGroupName + "/circuit-breaker-max-pending-requests"
+	CircuitBreakerMaxParallelRetriesAnnotation        = OMEAPIGroupName + "/circuit-breaker-max-parallel-retries"
+	CircuitBreakerPerEndpointMaxConnectionsAnnotation = OMEAPIGroupName + "/circuit-breaker-per-endpoint-max-connections"
+
+	// Retries.
+	RetryAttemptsAnnotation      = OMEAPIGroupName + "/retry-attempts"
+	RetryOnAnnotation            = OMEAPIGroupName + "/retry-on"
+	RetryPerTryTimeoutAnnotation = OMEAPIGroupName + "/retry-per-try-timeout"
+
+	// Connection / sub-second timeouts. Request-level timeout stays on
+	// ComponentExtensionSpec.TimeoutSeconds; these cover the rest.
+	TimeoutIdleAnnotation                  = OMEAPIGroupName + "/timeout-idle"
+	TimeoutMaxConnectionDurationAnnotation = OMEAPIGroupName + "/timeout-max-connection-duration"
+	TimeoutTCPConnectAnnotation            = OMEAPIGroupName + "/timeout-tcp-connect"
+)
+
+// Operational annotation keys.
+var (
+	// ManagedByConflictAckedAnnotation, when set to "true" on the
+	// InferenceService, acknowledges a hand-authored backend policy
+	// with the conflicting name OME would use. Suppresses the GA
+	// admission rejection while OME continues to defer to the
+	// manually-authored resource.
+	ManagedByConflictAckedAnnotation = OMEAPIGroupName + "/managed-by-conflict-acked"
+
+	// RolloutReadyTimeoutAnnotation overrides the default timeout for
+	// new-revision pods to reach Ready before the rollout is marked
+	// Failed. Duration string (e.g. "15m"). Default: 15m.
+	RolloutReadyTimeoutAnnotation = OMEAPIGroupName + "/rollout-ready-timeout"
+
+	// RevisionHistoryLimitAnnotation overrides the default number of
+	// non-active revisions per Component retained before garbage
+	// collection (in addition to LatestRolledoutRevision and
+	// PreviousRolledoutRevision). Default: 3.
+	RevisionHistoryLimitAnnotation = OMEAPIGroupName + "/revision-history-limit"
+
+	// RolloutPromoteAnnotation is the operator verb that advances a paused
+	// canary step under Manual promotion (canary with neither auto nor
+	// analysis set). Value: the canary revision
+	// hash (copied from status.canary.canaryRevisionHash) — the hash guards
+	// against promoting a stale revision; "full" is also accepted. The
+	// controller clears the annotation after consuming it. No-op when
+	// spec.rollout.groups[].canary is unset.
+	RolloutPromoteAnnotation = OMEAPIGroupName + "/rollout-promote"
+
+	// RolloutRollbackAnnotation is the operator verb for instant
+	// rollback. Value: "true". Traffic shifts to 100% old, new
+	// revision drains after scaleDownDelaySeconds. Controller clears
+	// the annotation after consuming it.
+	RolloutRollbackAnnotation = OMEAPIGroupName + "/rollout-rollback"
+
+	// PausedRolloutAnnotation, set to "true" on the InferenceService,
+	// freezes every coordination group at its current phase (and the
+	// canary step machine) until the operator clears it. Read by the
+	// OMENative coordination reconciler each pass.
+	PausedRolloutAnnotation = OMEAPIGroupName + "/rollout-paused"
+)
+
+// Pass-through annotation prefixes.
+//
+// Operators can reach implementation-specific fields OME does not
+// type-model by setting annotations under these prefixes. The
+// translator stitches the value verbatim into the named path on the
+// emitted resource. OME performs no schema validation; the gateway
+// controller catches errors and OME surfaces GatewayRejected.
+//
+// Each prefix is per-translator. Using a prefix whose translator is
+// not active surfaces UnsupportedPassthrough at admission.
+//
+// These are var rather than const because OMEAPIGroupName itself is
+// declared as var in this package; same pattern as the existing
+// annotation block in constants.go.
+var (
+	// PassthroughEnvoyGatewayPrefix maps to
+	// gateway.envoyproxy.io/v1alpha1.BackendTrafficPolicy.spec.<path>
+	// when the Envoy Gateway translator is active.
+	PassthroughEnvoyGatewayPrefix = OMEAPIGroupName + "/btp."
+
+	// PassthroughIstioPrefix maps to
+	// networking.istio.io/.../DestinationRule.spec.<path>
+	// when the Istio translator is active.
+	PassthroughIstioPrefix = OMEAPIGroupName + "/dr."
+)

--- a/pkg/constants/traffic_annotations_test.go
+++ b/pkg/constants/traffic_annotations_test.go
@@ -1,0 +1,124 @@
+package constants
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTrafficAnnotations_Prefix(t *testing.T) {
+	// All traffic annotation keys must live under the
+	// ome.io/ namespace. The webhook's Did-you-mean detection relies
+	// on this prefix.
+	keys := []struct {
+		name  string
+		value string
+	}{
+		// Circuit breaker.
+		{"CircuitBreakerMaxConnectionsAnnotation", CircuitBreakerMaxConnectionsAnnotation},
+		{"CircuitBreakerMaxParallelRequestsAnnotation", CircuitBreakerMaxParallelRequestsAnnotation},
+		{"CircuitBreakerMaxPendingRequestsAnnotation", CircuitBreakerMaxPendingRequestsAnnotation},
+		{"CircuitBreakerMaxParallelRetriesAnnotation", CircuitBreakerMaxParallelRetriesAnnotation},
+		{"CircuitBreakerPerEndpointMaxConnectionsAnnotation", CircuitBreakerPerEndpointMaxConnectionsAnnotation},
+		// Retries.
+		{"RetryAttemptsAnnotation", RetryAttemptsAnnotation},
+		{"RetryOnAnnotation", RetryOnAnnotation},
+		{"RetryPerTryTimeoutAnnotation", RetryPerTryTimeoutAnnotation},
+		// Timeouts.
+		{"TimeoutIdleAnnotation", TimeoutIdleAnnotation},
+		{"TimeoutMaxConnectionDurationAnnotation", TimeoutMaxConnectionDurationAnnotation},
+		{"TimeoutTCPConnectAnnotation", TimeoutTCPConnectAnnotation},
+		// Operational.
+		{"ManagedByConflictAckedAnnotation", ManagedByConflictAckedAnnotation},
+		{"RolloutReadyTimeoutAnnotation", RolloutReadyTimeoutAnnotation},
+		{"RevisionHistoryLimitAnnotation", RevisionHistoryLimitAnnotation},
+		{"RolloutPromoteAnnotation", RolloutPromoteAnnotation},
+		{"RolloutRollbackAnnotation", RolloutRollbackAnnotation},
+	}
+	wantPrefix := OMEAPIGroupName + "/"
+	for _, k := range keys {
+		if !strings.HasPrefix(k.value, wantPrefix) {
+			t.Errorf("%s = %q does not start with %q", k.name, k.value, wantPrefix)
+		}
+	}
+}
+
+func TestTrafficAnnotations_Unique(t *testing.T) {
+	// No two keys may collide — otherwise admission Did-you-mean and
+	// the parser would behave non-deterministically.
+	all := []string{
+		CircuitBreakerMaxConnectionsAnnotation,
+		CircuitBreakerMaxParallelRequestsAnnotation,
+		CircuitBreakerMaxPendingRequestsAnnotation,
+		CircuitBreakerMaxParallelRetriesAnnotation,
+		CircuitBreakerPerEndpointMaxConnectionsAnnotation,
+		RetryAttemptsAnnotation,
+		RetryOnAnnotation,
+		RetryPerTryTimeoutAnnotation,
+		TimeoutIdleAnnotation,
+		TimeoutMaxConnectionDurationAnnotation,
+		TimeoutTCPConnectAnnotation,
+		ManagedByConflictAckedAnnotation,
+		RolloutReadyTimeoutAnnotation,
+		RevisionHistoryLimitAnnotation,
+		RolloutPromoteAnnotation,
+		RolloutRollbackAnnotation,
+	}
+	seen := make(map[string]string, len(all))
+	for _, k := range all {
+		if prev, ok := seen[k]; ok {
+			t.Errorf("duplicate annotation key %q (also: %q)", k, prev)
+		}
+		seen[k] = k
+	}
+}
+
+func TestPassthroughPrefixes(t *testing.T) {
+	// Pass-through prefixes must end with "." so a value like
+	// "ome.io/btp.loadBalancer.slowStart" can be cleanly stripped to
+	// "loadBalancer.slowStart". They must not collide with the
+	// known-key namespace (otherwise Did-you-mean would false-positive).
+	if want := OMEAPIGroupName + "/btp."; PassthroughEnvoyGatewayPrefix != want {
+		t.Errorf("PassthroughEnvoyGatewayPrefix = %q, want %q", PassthroughEnvoyGatewayPrefix, want)
+	}
+	if want := OMEAPIGroupName + "/dr."; PassthroughIstioPrefix != want {
+		t.Errorf("PassthroughIstioPrefix = %q, want %q", PassthroughIstioPrefix, want)
+	}
+	if !strings.HasSuffix(PassthroughEnvoyGatewayPrefix, ".") {
+		t.Errorf("PassthroughEnvoyGatewayPrefix must end with .: %q", PassthroughEnvoyGatewayPrefix)
+	}
+	if !strings.HasSuffix(PassthroughIstioPrefix, ".") {
+		t.Errorf("PassthroughIstioPrefix must end with .: %q", PassthroughIstioPrefix)
+	}
+}
+
+func TestKnownAnnotation_NoCollisionWithPassthrough(t *testing.T) {
+	// A known annotation key MUST NOT match a pass-through prefix —
+	// otherwise the webhook can't distinguish them when classifying
+	// a key as known vs pass-through.
+	known := []string{
+		CircuitBreakerMaxConnectionsAnnotation,
+		CircuitBreakerMaxParallelRequestsAnnotation,
+		CircuitBreakerMaxPendingRequestsAnnotation,
+		CircuitBreakerMaxParallelRetriesAnnotation,
+		CircuitBreakerPerEndpointMaxConnectionsAnnotation,
+		RetryAttemptsAnnotation,
+		RetryOnAnnotation,
+		RetryPerTryTimeoutAnnotation,
+		TimeoutIdleAnnotation,
+		TimeoutMaxConnectionDurationAnnotation,
+		TimeoutTCPConnectAnnotation,
+		ManagedByConflictAckedAnnotation,
+		RolloutReadyTimeoutAnnotation,
+		RevisionHistoryLimitAnnotation,
+		RolloutPromoteAnnotation,
+		RolloutRollbackAnnotation,
+	}
+	for _, k := range known {
+		if strings.HasPrefix(k, PassthroughEnvoyGatewayPrefix) {
+			t.Errorf("known key %q collides with Envoy Gateway passthrough prefix", k)
+		}
+		if strings.HasPrefix(k, PassthroughIstioPrefix) {
+			t.Errorf("known key %q collides with Istio passthrough prefix", k)
+		}
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/overlay.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/overlay.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"strings"
+)
+
+const (
+	OverlayMountPathPrefix = "/opt/ml/model-overlays"
+	OverlayEnvVarPrefix    = "OVERLAY_"
+	OverlayEnvVarSuffix    = "_MODEL_PATH"
+)
+
+// OverlayEnvVarName returns the env var through which the runner
+// addresses one overlay model: OVERLAY_<UPPERCASED_NAME>_MODEL_PATH.
+func OverlayEnvVarName(modelName string) string {
+	return OverlayEnvVarPrefix + sanitizeOverlayName(modelName) + OverlayEnvVarSuffix
+}
+
+// OverlayMountPath returns the in-pod mount path for one overlay model.
+func OverlayMountPath(modelName string) string {
+	return OverlayMountPathPrefix + "/" + modelName
+}
+
+func sanitizeOverlayName(name string) string {
+	return strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/overlay_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/overlay_test.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOverlayEnvVarName(t *testing.T) {
+	tests := []struct {
+		modelName string
+		want      string
+	}{
+		{"foo", "OVERLAY_FOO_MODEL_PATH"},
+		{"foo-pvc", "OVERLAY_FOO_PVC_MODEL_PATH"},
+		{"llama-70b-pd-test", "OVERLAY_LLAMA_70B_PD_TEST_MODEL_PATH"},
+		{"already_underscored", "OVERLAY_ALREADY_UNDERSCORED_MODEL_PATH"},
+		{"Mixed-Case-Name", "OVERLAY_MIXED_CASE_NAME_MODEL_PATH"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.modelName, func(t *testing.T) {
+			assert.Equal(t, tc.want, OverlayEnvVarName(tc.modelName))
+		})
+	}
+}
+
+// Two overlays whose names sanitize to the same env var must be
+// rejected by webhook. The sanitization function itself doesn't
+// enforce uniqueness; this test pins the collision behaviour so the
+// webhook check has a stable specification to validate against.
+func TestSanitizeOverlayName_HyphenUnderscoreCollision(t *testing.T) {
+	assert.Equal(t, sanitizeOverlayName("foo-bar"), sanitizeOverlayName("foo_bar"),
+		"hyphens and underscores collapse to the same sanitized form — webhook must reject this combination")
+}
+
+func TestOverlayMountPath(t *testing.T) {
+	assert.Equal(t, "/opt/ml/model-overlays/foo-pvc", OverlayMountPath("foo-pvc"))
+	assert.Equal(t, "/opt/ml/model-overlays/llama-70b-pd-test", OverlayMountPath("llama-70b-pd-test"))
+}

--- a/pkg/validation/canary.go
+++ b/pkg/validation/canary.go
@@ -1,0 +1,239 @@
+package validation
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// ReasonCanaryInvalid is the admission rejection reason for a malformed canary
+// progression on a spec.rollout.groups[] entry. Operators and tests reference it.
+const ReasonCanaryInvalid = "CanaryInvalid"
+
+// ReasonCanaryRequiresOMENative is the rejection reason for a canary group whose
+// Component is not OMENative. Canary relies on per-revision pod selection,
+// partition staging, and the InferenceReplica object — all OMENative/IR-managed
+// constructs — so other deployment modes would silently wedge at Pending.
+const ReasonCanaryRequiresOMENative = "CanaryRequiresOMENative"
+
+// ReasonMultipleCanaryGroups is the rejection reason for a spec.rollout that
+// declares more than one canary group. The canary engine drives a single group
+// (the dispatcher resolves it via GetCanaryGroup, which returns the first);
+// additional canary groups are executed by neither engine and would roll
+// ungated. Sequenced multi-group canary
+// needs the cross-group sequencer that does not exist yet, so admission rejects
+// the shape rather than silently mis-executing all but the first group.
+const ReasonMultipleCanaryGroups = "MultipleCanaryGroups"
+
+// ReasonAnalysisInvalid is the rejection reason for a malformed metric-gated step
+// (a step's analysis). It guards the spec-internal rules a pure validator can
+// check: every analysis step has a complete config — at least one metric, a
+// numeric threshold, a valid operator, a positive interval, and a failure limit
+// >= 1. The metrics source (GroupCanary.Prometheus) is environmental and is
+// resolved controller-side, not checked here.
+const ReasonAnalysisInvalid = "AnalysisInvalid"
+
+// ValidateCanary checks the canary progression on every spec.rollout.groups[]
+// entry that has one. Returns nil when no group canaries (nil-safe). The CRD CEL
+// rule enforces the one-of progression (canary may span multiple Components,
+// primary-driven); these are the value-level rules CEL can't express. Each
+// guards a concrete
+// failure:
+//   - Steps non-empty — an empty plan has nothing to execute.
+//   - Every Component in the group is OMENative — other modes wedge at Pending.
+//   - Final step Traffic == 100 — otherwise the rollout never fully cuts over.
+//   - Final step Capacity == 100% — otherwise it completes on a partial fleet.
+//   - Traffic in [0,100], non-decreasing, and Traffic>0 requires Capacity>0.
+//   - Each analysis step's config is complete and well-formed (delegated to
+//     validateCanaryAnalysis).
+func ValidateCanary(spec *v1beta1.InferenceServiceSpec) error {
+	groups := spec.GetRolloutGroups()
+	modeFor := omenativeDeploymentModeMap(spec)
+	declared := declaredComponents(spec)
+	canaryGroups := 0
+	for gi := range groups {
+		if groups[gi].Canary != nil {
+			canaryGroups++
+		}
+	}
+	if canaryGroups > 1 {
+		return fmt.Errorf("spec.rollout.groups declares %d canary groups; only one is supported — the canary engine drives a single group and the others would roll ungated (%s)",
+			canaryGroups, ReasonMultipleCanaryGroups)
+	}
+	for gi := range groups {
+		g := &groups[gi]
+		if g.Canary == nil {
+			continue
+		}
+		c := g.Canary
+		if len(c.Steps) == 0 {
+			return fmt.Errorf("spec.rollout.groups[%d].canary.steps must not be empty (%s)", gi, ReasonCanaryInvalid)
+		}
+		if err := validateCanaryAnalysis(gi, c); err != nil {
+			return err
+		}
+		for _, comp := range g.Components {
+			// A canary group's Components must be valid and declared on the ISVC:
+			// primaryComponent picks router>engine>decoder among them, so an invalid
+			// or undeclared member becomes a phantom primary that wedges the roll.
+			if _, ok := validComponents[comp]; !ok {
+				return fmt.Errorf("spec.rollout.groups[%d]: canary component %q is not one of router/engine/decoder (%s)",
+					gi, comp, ReasonCanaryInvalid)
+			}
+			if _, ok := declared[comp]; !ok {
+				return fmt.Errorf("spec.rollout.groups[%d]: canary component %q is not declared on the InferenceService (%s)",
+					gi, comp, ReasonCanaryInvalid)
+			}
+			if m, ok := modeFor[comp]; ok && m != string(constants.OMENative) {
+				return fmt.Errorf("spec.rollout.groups[%d]: component %q has deploymentMode=%q; canary requires OMENative (%s)",
+					gi, comp, m, ReasonCanaryRequiresOMENative)
+			}
+		}
+		// A canary group must contain the ISVC's external entrypoint (router if
+		// present, else engine). primaryComponent picks the entrypoint *within the
+		// group* and the engine writes the stepped traffic onto its Service, but
+		// external requests enter through the ISVC entrypoint. A canary group that
+		// omits it shifts traffic on an internal Service only, so the operator's
+		// steps never move real traffic.
+		entry := canaryEntrypoint(spec)
+		hasEntry := false
+		for _, comp := range g.Components {
+			if comp == entry {
+				hasEntry = true
+				break
+			}
+		}
+		if !hasEntry {
+			return fmt.Errorf("spec.rollout.groups[%d]: a canary group must include the entrypoint component %q — external traffic routes through it, so a group without it only shifts traffic on an internal Service (%s)",
+				gi, entry, ReasonCanaryInvalid)
+		}
+		// MaintainRatio is silently ignored by the canary engine (it gates only
+		// coordination-style pacing). Reject rather than no-op so an operator is not
+		// misled into thinking the cross-Component ratio is guarded during the canary.
+		if g.MaintainRatio != nil {
+			return fmt.Errorf("spec.rollout.groups[%d]: maintainRatio is not honored on a canary group (the canary engine does not enforce it) — remove it, or use a blueGreen/rollingUpdate group for ratio-guarded rollout (%s)",
+				gi, ReasonCanaryInvalid)
+		}
+		last := c.Steps[len(c.Steps)-1]
+		if last.Traffic != 100 {
+			return fmt.Errorf("spec.rollout.groups[%d].canary final step traffic must be 100, got %d (%s)", gi, last.Traffic, ReasonCanaryInvalid)
+		}
+		// Only the percentage form is checkable at admission (absolute counts need
+		// the desired replica count); the done sentinel also forces partition 0.
+		if pct, ok := percentValue(last.Capacity); ok && pct != 100 {
+			return fmt.Errorf("spec.rollout.groups[%d].canary final step capacity must be 100%% (rollout completes at full capacity), got %q (%s)",
+				gi, last.Capacity.String(), ReasonCanaryInvalid)
+		}
+		var prevWeight int32
+		for i, s := range c.Steps {
+			if s.Traffic < 0 || s.Traffic > 100 {
+				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d]: traffic %d must be in [0,100] (%s)", gi, i, s.Traffic, ReasonCanaryInvalid)
+			}
+			if s.Traffic < prevWeight {
+				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d]: traffic %d must be >= the previous step's %d (canary weights are non-decreasing) (%s)",
+					gi, i, s.Traffic, prevWeight, ReasonCanaryInvalid)
+			}
+			prevWeight = s.Traffic
+			if s.Traffic > 0 && newCapacityIsZero(s.Capacity) {
+				return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d]: traffic %d>0 requires capacity>0 (%s)", gi, i, s.Traffic, ReasonCanaryInvalid)
+			}
+		}
+	}
+	return nil
+}
+
+// validateCanaryAnalysis enforces the spec-internal rules for each metric-gated
+// step: a positive interval, failureLimit >= 1, and at least one
+// well-formed metric. The metrics source (GroupCanary.Prometheus) is not checked
+// here — an unreachable source is surfaced controller-side as an inconclusive
+// sample, not an admission error.
+func validateCanaryAnalysis(gi int, c *v1beta1.GroupCanary) error {
+	for si := range c.Steps {
+		a := c.Steps[si].Analysis
+		if a == nil {
+			continue
+		}
+		if a.Interval.Duration <= 0 {
+			return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d].analysis: interval must be > 0 (%s)",
+				gi, si, ReasonAnalysisInvalid)
+		}
+		if a.FailureLimit < 1 {
+			return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d].analysis: failureLimit must be >= 1 (%s)",
+				gi, si, ReasonAnalysisInvalid)
+		}
+		if len(a.Metrics) == 0 {
+			return fmt.Errorf("spec.rollout.groups[%d].canary.steps[%d].analysis: at least one metric is required (%s)",
+				gi, si, ReasonAnalysisInvalid)
+		}
+		if err := validateAnalysisMetrics(gi, si, a.Metrics); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateAnalysisMetrics checks each metric is well-formed: unique non-empty
+// name, non-empty query, numeric threshold, valid operator. si < 0 addresses the
+// canary-level defaults; si >= 0 a step's effective metrics.
+func validateAnalysisMetrics(gi, si int, metrics []v1beta1.AnalysisMetric) error {
+	where := fmt.Sprintf("spec.rollout.groups[%d].canary.steps[%d].analysis", gi, si)
+	seen := make(map[string]struct{}, len(metrics))
+	for mi := range metrics {
+		m := &metrics[mi]
+		if m.Name == "" {
+			return fmt.Errorf("%s.metrics[%d].name must not be empty (%s)", where, mi, ReasonAnalysisInvalid)
+		}
+		if _, dup := seen[m.Name]; dup {
+			return fmt.Errorf("%s.metrics[%d]: duplicate metric name %q (%s)", where, mi, m.Name, ReasonAnalysisInvalid)
+		}
+		seen[m.Name] = struct{}{}
+		if strings.TrimSpace(m.Query) == "" {
+			return fmt.Errorf("%s.metrics[%d] (%q): query must not be empty (%s)", where, mi, m.Name, ReasonAnalysisInvalid)
+		}
+		if _, err := strconv.ParseFloat(m.Threshold, 64); err != nil {
+			return fmt.Errorf("%s.metrics[%d] (%q): threshold %q must be numeric (%s)", where, mi, m.Name, m.Threshold, ReasonAnalysisInvalid)
+		}
+		switch m.Operator {
+		case v1beta1.ComparisonLT, v1beta1.ComparisonLTE, v1beta1.ComparisonGT, v1beta1.ComparisonGTE:
+		default:
+			return fmt.Errorf("%s.metrics[%d] (%q): operator %q must be one of LT/LTE/GT/GTE (%s)", where, mi, m.Name, m.Operator, ReasonAnalysisInvalid)
+		}
+	}
+	return nil
+}
+
+// percentValue extracts the integer N from an IntOrString "<N>%" form.
+func percentValue(v intstr.IntOrString) (int, bool) {
+	if v.Type != intstr.String || !strings.HasSuffix(v.StrVal, "%") {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.TrimSuffix(v.StrVal, "%"))
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// newCapacityIsZero reports whether a step's Capacity resolves to zero pods
+// regardless of how it is expressed (integer 0, "0", or "0%").
+func newCapacityIsZero(c intstr.IntOrString) bool {
+	if c.Type == intstr.Int {
+		return c.IntValue() == 0
+	}
+	return c.StrVal == "0" || c.StrVal == "0%"
+}
+
+// canaryEntrypoint returns the ISVC's external entrypoint Component, mirroring
+// DetermineEntrypointComponent: the router when declared, else the engine. The
+// canary group must contain it (see ValidateCanary) so the stepped traffic lands
+// on the Service that actually fronts external requests.
+func canaryEntrypoint(spec *v1beta1.InferenceServiceSpec) v1beta1.ComponentType {
+	if spec != nil && spec.Router != nil {
+		return v1beta1.RouterComponent
+	}
+	return v1beta1.EngineComponent
+}

--- a/pkg/validation/canary_test.go
+++ b/pkg/validation/canary_test.go
@@ -1,0 +1,285 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// canarySpec builds a spec with a single engine-component canary group carrying
+// the given steps (v2 spec.rollout.groups[].canary).
+func canarySpec(steps ...v1beta1.RolloutGroupStep) *v1beta1.InferenceServiceSpec {
+	mode := constants.OMENative
+	return &v1beta1.InferenceServiceSpec{
+		DeploymentMode: &mode,
+		Engine:         &v1beta1.EngineSpec{},
+		Rollout: &v1beta1.RolloutSpec{
+			Groups: []v1beta1.RolloutGroup{
+				{
+					Components: []v1beta1.ComponentType{v1beta1.EngineComponent},
+					Canary:     &v1beta1.GroupCanary{Steps: steps},
+				},
+			},
+		},
+	}
+}
+
+// canarySpecMode builds a canary spec with an engine component at the given
+// deployment mode, for the OMENative-gate tests.
+func canarySpecMode(mode constants.DeploymentModeType, steps ...v1beta1.RolloutGroupStep) *v1beta1.InferenceServiceSpec {
+	s := canarySpec(steps...)
+	s.DeploymentMode = &mode
+	s.Engine = &v1beta1.EngineSpec{}
+	return s
+}
+
+func TestValidateCanary_OK(t *testing.T) {
+	spec := canarySpec(
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("10%"), Traffic: 10},
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100},
+	)
+	if err := ValidateCanary(spec); err != nil {
+		t.Fatalf("valid canary rejected: %v", err)
+	}
+}
+
+func TestValidateCanary_Empty(t *testing.T) {
+	if err := ValidateCanary(canarySpec()); err == nil {
+		t.Fatal("empty steps must be rejected")
+	}
+}
+
+func TestValidateCanary_FinalWeightNot100(t *testing.T) {
+	spec := canarySpec(v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 50})
+	if err := ValidateCanary(spec); err == nil {
+		t.Fatal("final step traffic must be 100")
+	}
+}
+
+func TestValidateCanary_TrafficToZeroCapacity(t *testing.T) {
+	spec := canarySpec(
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromInt(0), Traffic: 10},
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100},
+	)
+	if err := ValidateCanary(spec); err == nil {
+		t.Fatal("traffic>0 with zero Capacity must be rejected")
+	}
+}
+
+func TestValidateCanary_TrafficToZeroPercentCapacity(t *testing.T) {
+	spec := canarySpec(
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("0%"), Traffic: 10},
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100},
+	)
+	if err := ValidateCanary(spec); err == nil {
+		t.Fatal(`traffic>0 with "0%" Capacity must be rejected`)
+	}
+}
+
+func TestValidateCanary_Unset(t *testing.T) {
+	if err := ValidateCanary(&v1beta1.InferenceServiceSpec{}); err != nil {
+		t.Fatalf("unset canary must pass: %v", err)
+	}
+	var nilSpec *v1beta1.InferenceServiceSpec
+	if err := ValidateCanary(nilSpec); err != nil {
+		t.Fatalf("nil spec must pass: %v", err)
+	}
+}
+
+func TestValidateCanary_RequiresOMENative(t *testing.T) {
+	final := v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100}
+	// Non-OMENative component → rejected.
+	spec := canarySpecMode(constants.RawDeployment, final)
+	err := ValidateCanary(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonCanaryRequiresOMENative) {
+		t.Fatalf("canary on RawDeployment must be rejected, got: %v", err)
+	}
+	// OMENative component → accepted.
+	if err := ValidateCanary(canarySpecMode(constants.OMENative, final)); err != nil {
+		t.Fatalf("canary on OMENative must pass: %v", err)
+	}
+	// Unset mode (empty) → rejected (canary needs explicit OMENative).
+	if err := ValidateCanary(canarySpecMode("", final)); err == nil {
+		t.Fatal("canary with unset deploymentMode must be rejected")
+	}
+}
+
+func TestValidateCanary_DecreasingWeight(t *testing.T) {
+	spec := canarySpec(
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("50%"), Traffic: 50},
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("60%"), Traffic: 30},
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100},
+	)
+	if err := ValidateCanary(spec); err == nil {
+		t.Fatal("decreasing traffic must be rejected")
+	}
+}
+
+func TestValidateCanary_BarePauseUnderManualOK(t *testing.T) {
+	// A bare pause (no duration) is a manual gate: "hold here for the promote
+	// annotation." Valid.
+	spec := canarySpec(
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("50%"), Traffic: 50, Pause: &v1beta1.RolloutPause{}},
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100},
+	)
+	if err := ValidateCanary(spec); err != nil {
+		t.Fatalf("bare pause (manual) must pass: %v", err)
+	}
+}
+
+func TestValidateCanary_TimedStepOK(t *testing.T) {
+	// A step with pause.duration and no analysis is a timed gate. Valid (the
+	// old "duration-under-manual" rejection is gone — the gate is per-step now).
+	spec := canarySpec(
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("50%"), Traffic: 50, Pause: &v1beta1.RolloutPause{Duration: &metav1.Duration{Duration: time.Minute}}},
+		v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100},
+	)
+	if err := ValidateCanary(spec); err != nil {
+		t.Fatalf("timed step (pause.duration) must pass: %v", err)
+	}
+}
+
+func goodAnalysis() *v1beta1.RolloutAnalysis {
+	return &v1beta1.RolloutAnalysis{
+		Interval:     metav1.Duration{Duration: time.Minute},
+		FailureLimit: 3,
+		Metrics:      []v1beta1.AnalysisMetric{{Name: "err", Query: "rate(x[1m])", Operator: v1beta1.ComparisonLTE, Threshold: "0.05"}},
+	}
+}
+
+// analysisCanary builds a canary whose single (final) step carries the given
+// self-contained analysis.
+func analysisCanary(step *v1beta1.RolloutAnalysis) *v1beta1.InferenceServiceSpec {
+	return canarySpec(v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100, Analysis: step})
+}
+
+func TestValidateCanary_AnalysisOK(t *testing.T) {
+	if err := ValidateCanary(analysisCanary(goodAnalysis())); err != nil {
+		t.Fatalf("valid analysis step rejected: %v", err)
+	}
+}
+
+func TestValidateCanary_AnalysisIncompleteRejected(t *testing.T) {
+	// interval + failureLimit set but no metrics — the step can never pass, rejected.
+	spec := analysisCanary(&v1beta1.RolloutAnalysis{Interval: metav1.Duration{Duration: time.Minute}, FailureLimit: 1})
+	if err := ValidateCanary(spec); err == nil || !strings.Contains(err.Error(), ReasonAnalysisInvalid) {
+		t.Fatalf("analysis step with no metrics must be rejected, got %v", err)
+	}
+}
+
+func TestValidateCanary_AnalysisBadThreshold(t *testing.T) {
+	a := goodAnalysis()
+	a.Metrics[0].Threshold = "notanumber"
+	if err := ValidateCanary(analysisCanary(a)); err == nil || !strings.Contains(err.Error(), ReasonAnalysisInvalid) {
+		t.Fatalf("non-numeric threshold must be rejected, got %v", err)
+	}
+}
+
+func TestValidateCanary_MultipleCanaryGroupsRejected(t *testing.T) {
+	// The canary engine drives exactly one canary group (GetCanaryGroup returns
+	// the first); a second canary group would be executed by neither engine and
+	// roll ungated. Until cross-group sequencing lands, admission rejects more
+	// than one canary group rather than silently mis-executing the rest.
+	final := v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100}
+	spec := &v1beta1.InferenceServiceSpec{Rollout: &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, Canary: &v1beta1.GroupCanary{Steps: []v1beta1.RolloutGroupStep{final}}},
+			{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, Canary: &v1beta1.GroupCanary{Steps: []v1beta1.RolloutGroupStep{final}}},
+		},
+	}}
+	err := ValidateCanary(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonMultipleCanaryGroups) {
+		t.Fatalf("multiple canary groups: got %v want error with %s", err, ReasonMultipleCanaryGroups)
+	}
+}
+
+func TestValidateCanary_UndeclaredComponentRejected(t *testing.T) {
+	// A canary group listing a Component not declared on the ISVC wedges at
+	// runtime: primaryComponent picks it (router > engine > decoder) but it has no
+	// spec/IR, so the step machine never advances while the real component is
+	// pinned at the step partition. Reject at admission.
+	mode := constants.OMENative
+	final := v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100}
+	spec := &v1beta1.InferenceServiceSpec{
+		DeploymentMode: &mode,
+		Engine:         &v1beta1.EngineSpec{}, // router is NOT declared
+		Rollout: &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.RouterComponent}, Canary: &v1beta1.GroupCanary{Steps: []v1beta1.RolloutGroupStep{final}}},
+		}},
+	}
+	err := ValidateCanary(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonCanaryInvalid) {
+		t.Fatalf("undeclared canary component: got %v want error with %s", err, ReasonCanaryInvalid)
+	}
+}
+
+func TestValidateCanary_InvalidComponentRejected(t *testing.T) {
+	mode := constants.OMENative
+	final := v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100}
+	spec := &v1beta1.InferenceServiceSpec{
+		DeploymentMode: &mode,
+		Engine:         &v1beta1.EngineSpec{},
+		Rollout: &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{"frontend"}, Canary: &v1beta1.GroupCanary{Steps: []v1beta1.RolloutGroupStep{final}}},
+		}},
+	}
+	err := ValidateCanary(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonCanaryInvalid) {
+		t.Fatalf("invalid canary component name: got %v want error with %s", err, ReasonCanaryInvalid)
+	}
+}
+
+// TestValidateCanary_EntrypointRequired: a canary group must contain the ISVC's
+// external entrypoint (router when present). A router-fronted PD ISVC whose canary
+// group is [engine,decoder] would write the stepped traffic onto engine's internal
+// Service while the router keeps shifting by pod ratio — the steps never reach real
+// traffic — so admission rejects it.
+func TestValidateCanary_EntrypointRequired(t *testing.T) {
+	mode := constants.OMENative
+	final := v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100}
+	build := func(groupComps ...v1beta1.ComponentType) *v1beta1.InferenceServiceSpec {
+		return &v1beta1.InferenceServiceSpec{
+			DeploymentMode: &mode,
+			Engine:         &v1beta1.EngineSpec{},
+			Decoder:        &v1beta1.DecoderSpec{},
+			Router:         &v1beta1.RouterSpec{}, // router-fronted → entrypoint is the router
+			Rollout: &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+				{Components: groupComps, Canary: &v1beta1.GroupCanary{Steps: []v1beta1.RolloutGroupStep{final}}},
+			}},
+		}
+	}
+	if err := ValidateCanary(build(v1beta1.EngineComponent, v1beta1.DecoderComponent)); err == nil || !strings.Contains(err.Error(), ReasonCanaryInvalid) {
+		t.Fatalf("canary group missing the router entrypoint must be rejected, got: %v", err)
+	}
+	if err := ValidateCanary(build(v1beta1.RouterComponent, v1beta1.EngineComponent, v1beta1.DecoderComponent)); err != nil {
+		t.Fatalf("canary group including the router entrypoint must pass: %v", err)
+	}
+}
+
+// TestValidateCanary_MaintainRatioRejected: the canary engine never reads
+// MaintainRatio, so setting it on a canary group is a silent no-op (no ratio
+// guard during the roll). Admission rejects it rather than mislead the operator.
+func TestValidateCanary_MaintainRatioRejected(t *testing.T) {
+	mode := constants.OMENative
+	final := v1beta1.RolloutGroupStep{Capacity: intstr.FromString("100%"), Traffic: 100}
+	spec := &v1beta1.InferenceServiceSpec{
+		DeploymentMode: &mode,
+		Engine:         &v1beta1.EngineSpec{}, // engine-fronted → entrypoint engine is in-group
+		Decoder:        &v1beta1.DecoderSpec{},
+		Rollout: &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+			{
+				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: 5},
+				Canary:        &v1beta1.GroupCanary{Steps: []v1beta1.RolloutGroupStep{final}},
+			},
+		}},
+	}
+	if err := ValidateCanary(spec); err == nil || !strings.Contains(err.Error(), ReasonCanaryInvalid) {
+		t.Fatalf("maintainRatio on a canary group must be rejected, got: %v", err)
+	}
+}

--- a/pkg/validation/coordination.go
+++ b/pkg/validation/coordination.go
@@ -1,0 +1,422 @@
+// Cross-Component rollout coordination validation (v2 spec.rollout.groups[]).
+//
+// Webhook-level admission rules for the coordination-style progressions
+// (blueGreen / rollingUpdate) on spec.rollout.groups[]: per-group structural
+// checks (valid components, order subset), cross-group checks (a Component
+// appears in at most one group; a group references a declared Component; groups
+// are OMENative), pacing zero-budget, and the RollingUpdate lockstep on update.
+// The one-of progression shape and order⊆components are also enforced by the CRD
+// CEL rules; these are the value-level mirrors plus the cross-group rules CEL
+// can't express. Canary groups are validated by ValidateCanary.
+package validation
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// Admission rejection reasons. Operators and tests reference these by
+// name, so they're exported constants.
+const (
+	ReasonDuplicateComponentInCoordinationGroups = "DuplicateComponentInCoordinationGroups"
+	ReasonInvalidComponentInCoordinationGroup    = "InvalidComponentInCoordinationGroup"
+	ReasonCoordinationRequiresOMENative          = "CoordinationRequiresOMENative"
+	ReasonRatioToleranceTooHigh                  = "RatioToleranceTooHigh"
+	ReasonOrphanCoordinationGroup                = "OrphanCoordinationGroup"
+	ReasonInvalidCoordinationOrder               = "InvalidCoordinationOrder"
+	ReasonRollingUpdateLockstepViolation         = "RollingUpdateLockstepViolation"
+	// ReasonSequentialDuplicateOrder flags a duplicate entry in a group's Order
+	// (the rule applies to any group's surge Order, not only the v1 Sequential
+	// policy that is gone).
+	ReasonSequentialDuplicateOrder = "SequentialDuplicateOrder"
+	// ReasonSoakNotHonored flags a Soak the engine would silently drop. Soak is
+	// honored only by the Sequential state machine (a collapsed run of
+	// single-Component blueGreen groups); it is never honored on a canary,
+	// multi-Component, or rollingUpdate group, nor on a rollout that does not
+	// collapse to Sequential.
+	ReasonSoakNotHonored = "SoakNotHonored"
+)
+
+// ratioToleranceWarningThreshold is the upper bound the validator considers
+// operator-safe for the MaintainRatio tolerance knob. Values above this trigger a
+// non-blocking warning since they effectively disable ratio enforcement.
+const ratioToleranceWarningThreshold int32 = 50
+
+// validComponents is the closed set of Components allowed in a rollout group.
+var validComponents = map[v1beta1.ComponentType]struct{}{
+	v1beta1.RouterComponent:  {},
+	v1beta1.EngineComponent:  {},
+	v1beta1.DecoderComponent: {},
+}
+
+// ValidateCoordination runs the coordination-style (blueGreen / rollingUpdate)
+// admission rules over spec.rollout.groups[]. Returns the first error; nil on
+// success. Update-time (RollingUpdate lockstep) checks live in
+// ValidateCoordinationUpdate.
+func ValidateCoordination(spec *v1beta1.InferenceServiceSpec) error {
+	groups := spec.GetRolloutGroups()
+	if len(groups) == 0 {
+		return nil
+	}
+	if err := validateGroupComponents(groups); err != nil {
+		return err
+	}
+	if err := validateNoDuplicateMembership(groups); err != nil {
+		return err
+	}
+	if err := validateOrphanGroups(spec, groups); err != nil {
+		return err
+	}
+	if err := validateComponentsAreOMENative(spec, groups); err != nil {
+		return err
+	}
+	if err := validatePacingNotZeroBudget(groups); err != nil {
+		return err
+	}
+	if err := validateSoakOnlyWhenSequenced(groups); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateCoordinationUpdate runs the update-time rule comparing old vs new spec:
+// a rollingUpdate group bumps all its Components together (lockstep). Structural
+// validation runs separately on the new spec.
+func ValidateCoordinationUpdate(oldSpec, newSpec *v1beta1.InferenceServiceSpec) error {
+	groups := newSpec.GetRolloutGroups()
+	for i := range groups {
+		g := &groups[i]
+		if g.RollingUpdate == nil {
+			continue
+		}
+		if err := validateRollingUpdateLockstep(oldSpec, newSpec, g.Components); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CoordinationRatioToleranceWarning returns a warning when any group sets a
+// MaintainRatio tolerance above the safe threshold. Empty when none applies.
+func CoordinationRatioToleranceWarning(spec *v1beta1.InferenceServiceSpec) string {
+	groups := spec.GetRolloutGroups()
+	for i := range groups {
+		mr := groups[i].MaintainRatio
+		if mr == nil {
+			continue
+		}
+		if mr.Tolerance > ratioToleranceWarningThreshold {
+			return fmt.Sprintf(
+				"spec.rollout.groups[%d].maintainRatio.tolerance=%d effectively disables ratio enforcement (>%d) (%s)",
+				i, mr.Tolerance, ratioToleranceWarningThreshold, ReasonRatioToleranceTooHigh)
+		}
+	}
+	return ""
+}
+
+// validateGroupComponents checks that every coordination-style group references
+// only valid Components and that its surge Order is a duplicate-free subset of
+// its Components. Canary groups are validated by ValidateCanary.
+func validateGroupComponents(groups []v1beta1.RolloutGroup) error {
+	for i := range groups {
+		g := &groups[i]
+		if g.Canary != nil {
+			continue
+		}
+		for _, c := range g.Components {
+			if _, ok := validComponents[c]; !ok {
+				return fmt.Errorf("spec.rollout.groups[%d]: component %q is not one of router/engine/decoder (%s)",
+					i, c, ReasonInvalidComponentInCoordinationGroup)
+			}
+		}
+		if err := validateOrderSubset(i, g.Components, g.Order); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateOrderSubset enforces that order is a duplicate-free subset of
+// components. Applies to any group with an Order (the surge sequence).
+func validateOrderSubset(idx int, components, order []v1beta1.ComponentType) error {
+	if len(order) == 0 {
+		return nil
+	}
+	in := make(map[v1beta1.ComponentType]struct{}, len(components))
+	for _, c := range components {
+		in[c] = struct{}{}
+	}
+	seen := make(map[v1beta1.ComponentType]struct{}, len(order))
+	for _, c := range order {
+		if _, ok := in[c]; !ok {
+			return fmt.Errorf("spec.rollout.groups[%d]: order entry %q is not in components (%s)",
+				idx, c, ReasonInvalidCoordinationOrder)
+		}
+		if _, dup := seen[c]; dup {
+			return fmt.Errorf("spec.rollout.groups[%d]: order entry %q appears more than once (%s)",
+				idx, c, ReasonSequentialDuplicateOrder)
+		}
+		seen[c] = struct{}{}
+	}
+	return nil
+}
+
+// validateNoDuplicateMembership rejects a Component appearing in more than one
+// group (across ALL groups, canary included). Each Component rolls under exactly
+// one group.
+func validateNoDuplicateMembership(groups []v1beta1.RolloutGroup) error {
+	seen := map[v1beta1.ComponentType]int{}
+	for i := range groups {
+		for _, c := range groups[i].Components {
+			if prev, ok := seen[c]; ok {
+				return fmt.Errorf("spec.rollout.groups: component %q appears in groups[%d] and groups[%d] (%s)",
+					c, prev, i, ReasonDuplicateComponentInCoordinationGroups)
+			}
+			seen[c] = i
+		}
+	}
+	return nil
+}
+
+func validateOrphanGroups(spec *v1beta1.InferenceServiceSpec, groups []v1beta1.RolloutGroup) error {
+	declared := declaredComponents(spec)
+	for i := range groups {
+		anyDeclared := false
+		for _, c := range groups[i].Components {
+			if _, ok := declared[c]; ok {
+				anyDeclared = true
+				break
+			}
+		}
+		if !anyDeclared {
+			return fmt.Errorf("spec.rollout.groups[%d]: no component in this group is declared on the InferenceService (%s)",
+				i, ReasonOrphanCoordinationGroup)
+		}
+	}
+	return nil
+}
+
+// validateComponentsAreOMENative requires every Component in a coordination-style
+// group to declare OMENative. Canary groups are checked in ValidateCanary.
+func validateComponentsAreOMENative(spec *v1beta1.InferenceServiceSpec, groups []v1beta1.RolloutGroup) error {
+	modeFor := omenativeDeploymentModeMap(spec)
+	for i := range groups {
+		g := &groups[i]
+		if g.Canary != nil {
+			continue
+		}
+		for _, c := range g.Components {
+			declared, ok := modeFor[c]
+			if !ok {
+				continue // not declared — handled by the orphan check
+			}
+			if declared != string(constants.OMENative) {
+				return fmt.Errorf("spec.rollout.groups[%d]: component %q has deploymentMode=%q; coordination requires OMENative (%s)",
+					i, c, declared, ReasonCoordinationRequiresOMENative)
+			}
+		}
+	}
+	return nil
+}
+
+// validatePacingNotZeroBudget rejects a rollingUpdate group that explicitly sets
+// BOTH maxSurge=0 AND maxUnavailable=0: no surge headroom and no drain headroom
+// deadlocks the roll. nil (defaulted) values resolve to 25% and are not zero.
+func validatePacingNotZeroBudget(groups []v1beta1.RolloutGroup) error {
+	for i := range groups {
+		ru := groups[i].RollingUpdate
+		if ru == nil {
+			continue
+		}
+		if explicitZeroIntOrString(ru.MaxSurge) && explicitZeroIntOrString(ru.MaxUnavailable) {
+			return fmt.Errorf("spec.rollout.groups[%d]: maxSurge=0 AND maxUnavailable=0 deadlocks rollouts — set at least one non-zero (%s)",
+				i, ReasonZeroBudgetPacingUnstartable)
+		}
+	}
+	return nil
+}
+
+// explicitZeroIntOrString reports whether the user explicitly set the
+// IntOrString to a zero value (literal 0 or "0" or "0%"). Nil is not zero — nil
+// means "use default" and the resolver fills in 25%.
+func explicitZeroIntOrString(v *intstr.IntOrString) bool {
+	if v == nil {
+		return false
+	}
+	if v.Type == intstr.Int {
+		return v.IntValue() == 0
+	}
+	return v.StrVal == "0" || v.StrVal == "0%"
+}
+
+func validateRollingUpdateLockstep(oldSpec, newSpec *v1beta1.InferenceServiceSpec, components []v1beta1.ComponentType) error {
+	oldImages := componentImages(oldSpec, components)
+	newImages := componentImages(newSpec, components)
+	anyChanged := false
+	allChanged := true
+	for _, c := range components {
+		o, n := oldImages[c], newImages[c]
+		if o != n {
+			anyChanged = true
+		} else {
+			allChanged = false
+		}
+	}
+	if anyChanged && !allChanged {
+		return fmt.Errorf("spec.rollout: rollingUpdate group requires all components to bump together (%s)",
+			ReasonRollingUpdateLockstepViolation)
+	}
+	return nil
+}
+
+// declaredComponents returns the set of Components present on the spec.
+func declaredComponents(spec *v1beta1.InferenceServiceSpec) map[v1beta1.ComponentType]struct{} {
+	out := map[v1beta1.ComponentType]struct{}{}
+	if spec == nil {
+		return out
+	}
+	if spec.Engine != nil {
+		out[v1beta1.EngineComponent] = struct{}{}
+	}
+	if spec.Decoder != nil {
+		out[v1beta1.DecoderComponent] = struct{}{}
+	}
+	if spec.Router != nil {
+		out[v1beta1.RouterComponent] = struct{}{}
+	}
+	return out
+}
+
+// omenativeDeploymentModeMap returns Component → effective
+// deploymentMode value for each Component on the spec. Effective value
+// follows the resolution chain: per-Component annotation >
+// spec.deploymentMode > "" (empty when neither is set). Shape-derived
+// behavior (Leader/Worker → OMENative; PDDisaggregated) is intentionally
+// NOT considered — coordination only cares about the dispatch backend,
+// not the shape.
+func omenativeDeploymentModeMap(spec *v1beta1.InferenceServiceSpec) map[v1beta1.ComponentType]string {
+	out := map[v1beta1.ComponentType]string{}
+	if spec == nil {
+		return out
+	}
+	if spec.Engine != nil {
+		out[v1beta1.EngineComponent] = resolveComponentDeploymentMode(spec.Engine.Annotations, spec.DeploymentMode)
+	}
+	if spec.Decoder != nil {
+		out[v1beta1.DecoderComponent] = resolveComponentDeploymentMode(spec.Decoder.Annotations, spec.DeploymentMode)
+	}
+	if spec.Router != nil {
+		out[v1beta1.RouterComponent] = resolveComponentDeploymentMode(spec.Router.Annotations, spec.DeploymentMode)
+	}
+	return out
+}
+
+// componentImages returns the container image per Component in `components`.
+// Runner.Image takes precedence over the first PodSpec container image.
+func componentImages(spec *v1beta1.InferenceServiceSpec, components []v1beta1.ComponentType) map[v1beta1.ComponentType]string {
+	out := map[v1beta1.ComponentType]string{}
+	if spec == nil {
+		return out
+	}
+	for _, c := range components {
+		var img string
+		switch c {
+		case v1beta1.EngineComponent:
+			if spec.Engine != nil {
+				img = engineRunnerOrPodSpecImage(spec.Engine)
+			}
+		case v1beta1.DecoderComponent:
+			if spec.Decoder != nil {
+				img = decoderRunnerOrPodSpecImage(spec.Decoder)
+			}
+		case v1beta1.RouterComponent:
+			if spec.Router != nil {
+				img = routerRunnerOrPodSpecImage(spec.Router)
+			}
+		}
+		if img != "" {
+			out[c] = img
+		}
+	}
+	return out
+}
+
+func engineRunnerOrPodSpecImage(e *v1beta1.EngineSpec) string {
+	if e.Runner != nil && e.Runner.Image != "" {
+		return e.Runner.Image
+	}
+	if len(e.PodSpec.Containers) > 0 {
+		return e.PodSpec.Containers[0].Image
+	}
+	return ""
+}
+
+func decoderRunnerOrPodSpecImage(d *v1beta1.DecoderSpec) string {
+	if d.Runner != nil && d.Runner.Image != "" {
+		return d.Runner.Image
+	}
+	if len(d.PodSpec.Containers) > 0 {
+		return d.PodSpec.Containers[0].Image
+	}
+	return ""
+}
+
+func routerRunnerOrPodSpecImage(r *v1beta1.RouterSpec) string {
+	if r.Runner != nil && r.Runner.Image != "" {
+		return r.Runner.Image
+	}
+	if len(r.PodSpec.Containers) > 0 {
+		return r.PodSpec.Containers[0].Image
+	}
+	return ""
+}
+
+// rolloutCollapsesToSequential mirrors the engine's collapseSequential: the
+// coordination-style (non-canary) groups fold into the Sequential state machine
+// — the only path that honors Soak — exactly when there are 2+ of them and every
+// one is a single-Component blueGreen group (no rollingUpdate). Anything else (a
+// multi-Component group, a rollingUpdate group, or fewer than 2) runs the groups
+// concurrently, where Soak is dropped.
+func rolloutCollapsesToSequential(groups []v1beta1.RolloutGroup) bool {
+	n := 0
+	for i := range groups {
+		g := &groups[i]
+		if g.Canary != nil {
+			continue // canary groups are excluded from the coordination collapse
+		}
+		n++
+		if len(g.Components) != 1 || g.RollingUpdate != nil {
+			return false
+		}
+	}
+	return n >= 2
+}
+
+// validateSoakOnlyWhenSequenced rejects a Soak the engine would silently drop.
+// Soak is honored only by the Sequential state machine (the collapsed run of
+// single-Component blueGreen groups). It is never honored on a canary group, and
+// on a rollout that does not collapse the groups run concurrently and the soak is
+// dropped. Accepting it there would make an operator believe a wait is enforced
+// when it is not, so admission rejects it instead.
+func validateSoakOnlyWhenSequenced(groups []v1beta1.RolloutGroup) error {
+	collapses := rolloutCollapsesToSequential(groups)
+	for i := range groups {
+		g := &groups[i]
+		if g.Soak == nil {
+			continue
+		}
+		if g.Canary != nil {
+			return fmt.Errorf("spec.rollout.groups[%d]: soak is not honored on a canary group (the canary engine does not gate on it) (%s)",
+				i, ReasonSoakNotHonored)
+		}
+		if !collapses {
+			return fmt.Errorf("spec.rollout.groups[%d]: soak is honored only when the rollout is a sequence of single-Component groups (which roll one-at-a-time); this rollout runs groups concurrently, so the soak would be dropped (%s)",
+				i, ReasonSoakNotHonored)
+		}
+	}
+	return nil
+}

--- a/pkg/validation/coordination_test.go
+++ b/pkg/validation/coordination_test.go
@@ -1,0 +1,447 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestValidateCoordination_NilSpecIsOK(t *testing.T) {
+	if err := ValidateCoordination(nil); err != nil {
+		t.Errorf("nil spec: unexpected error %v", err)
+	}
+}
+
+func TestValidateCoordination_MissingCoordinationBlockIsOK(t *testing.T) {
+	spec := &v1beta1.InferenceServiceSpec{}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Errorf("missing coordination: unexpected error %v", err)
+	}
+}
+
+func TestValidateCoordination_EmptyGroupsIsOK(t *testing.T) {
+	spec := &v1beta1.InferenceServiceSpec{
+		Rollout: &v1beta1.RolloutSpec{Groups: nil},
+	}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Errorf("empty groups: unexpected error %v", err)
+	}
+}
+
+func TestValidateCoordination_DuplicateComponentRejected(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		},
+	}
+	err := ValidateCoordination(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonDuplicateComponentInCoordinationGroups) {
+		t.Errorf("duplicate component: got %v want error with %s", err, ReasonDuplicateComponentInCoordinationGroups)
+	}
+}
+
+func TestValidateCoordination_InvalidComponentName(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{"frontend"}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		},
+	}
+	err := ValidateCoordination(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonInvalidComponentInCoordinationGroup) {
+		t.Errorf("invalid component: got %v want %s", err, ReasonInvalidComponentInCoordinationGroup)
+	}
+}
+
+func TestValidateCoordination_OrphanGroup(t *testing.T) {
+	// Spec declares only engine; group references decoder + router.
+	spec := omeNativeEngineOnlySpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent, v1beta1.RouterComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		},
+	}
+	err := ValidateCoordination(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonOrphanCoordinationGroup) {
+		t.Errorf("orphan group: got %v want %s", err, ReasonOrphanCoordinationGroup)
+	}
+}
+
+func TestValidateCoordination_ComponentMustBeOMENative(t *testing.T) {
+	spec := omeNativePDSpec()
+	// Strip the OMENative annotation off engine.
+	spec.Engine.Annotations = map[string]string{}
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		},
+	}
+	err := ValidateCoordination(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonCoordinationRequiresOMENative) {
+		t.Errorf("non-OMENative component: got %v want %s", err, ReasonCoordinationRequiresOMENative)
+	}
+}
+
+func TestValidateCoordination_InvalidOrderComponent(t *testing.T) {
+	// Order references router, which is not one of the group's components → the
+	// per-group order-subset rule rejects it (still enforced in v2).
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				BlueGreen:  &v1beta1.GroupBlueGreen{},
+				Order:      []v1beta1.ComponentType{v1beta1.DecoderComponent, v1beta1.RouterComponent},
+			},
+		},
+	}
+	err := ValidateCoordination(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonInvalidCoordinationOrder) {
+		t.Errorf("foreign order entry: got %v want %s", err, ReasonInvalidCoordinationOrder)
+	}
+}
+
+func TestValidateCoordination_HappyPath_BlueGreen(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		},
+	}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Errorf("happy atomic: unexpected error %v", err)
+	}
+}
+
+// Sequential is spelled in v2 as one single-Component group per Component, in
+// list order (decoder first, then engine) — the controller collapses this back
+// to Sequential. The validator must accept it.
+func TestValidateCoordination_HappyPath_Sequential(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}, BlueGreen: &v1beta1.GroupBlueGreen{}},
+		},
+	}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Errorf("happy sequential: unexpected error %v", err)
+	}
+}
+
+// Positive case: a multi-Component group guarding the cross-Component ratio
+// (v1 BlueGreen + RatioBalanced pacing → v2 BlueGreen + MaintainRatio) is
+// accepted. The validator must not over-reject.
+func TestValidateCoordination_RatioBalancedWithBlueGreenAccepted(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				BlueGreen:     &v1beta1.GroupBlueGreen{},
+				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: 5},
+			},
+		},
+	}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Errorf("BlueGreen+MaintainRatio: unexpected error %v", err)
+	}
+}
+
+// maxSurge=0 AND maxUnavailable=0 (both explicit zero) is unstartable —
+// no surge, no drain — and must be rejected.
+func TestValidateCoordination_ZeroBudgetPacingRejected(t *testing.T) {
+	zero := intstr.FromInt(0)
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				RollingUpdate: &v1beta1.GroupRollingUpdate{
+					MaxSurge:       &zero,
+					MaxUnavailable: &zero,
+				},
+			},
+		},
+	}
+	err := ValidateCoordination(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonZeroBudgetPacingUnstartable) {
+		t.Errorf("zero-budget pacing: got %v want error with %s", err, ReasonZeroBudgetPacingUnstartable)
+	}
+}
+
+// TestValidateCoordination_SoakOnNonCollapsingRejected: a multi-Component
+// blueGreen group with a soak does not collapse to the Sequential state machine,
+// so the engine would drop the soak. Admission rejects it.
+func TestValidateCoordination_SoakOnNonCollapsingRejected(t *testing.T) {
+	mode := constants.OMENative
+	soak := &metav1.Duration{Duration: 10 * time.Minute}
+	spec := &v1beta1.InferenceServiceSpec{
+		DeploymentMode: &mode,
+		Engine:         &v1beta1.EngineSpec{},
+		Decoder:        &v1beta1.DecoderSpec{},
+		Router:         &v1beta1.RouterSpec{},
+		Rollout: &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, Soak: soak},
+			{Components: []v1beta1.ComponentType{v1beta1.RouterComponent}},
+		}},
+	}
+	if err := ValidateCoordination(spec); err == nil || !strings.Contains(err.Error(), ReasonSoakNotHonored) {
+		t.Fatalf("soak on a non-collapsing group must be rejected, got: %v", err)
+	}
+}
+
+// TestValidateCoordination_SoakOnSequenceAccepted: a run of single-Component
+// blueGreen groups collapses to Sequential, which honors soak, so it passes.
+func TestValidateCoordination_SoakOnSequenceAccepted(t *testing.T) {
+	mode := constants.OMENative
+	soak := &metav1.Duration{Duration: 10 * time.Minute}
+	spec := &v1beta1.InferenceServiceSpec{
+		DeploymentMode: &mode,
+		Engine:         &v1beta1.EngineSpec{},
+		Decoder:        &v1beta1.DecoderSpec{},
+		Rollout: &v1beta1.RolloutSpec{Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.DecoderComponent}, Soak: soak},
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent}},
+		}},
+	}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Fatalf("soak on a collapsing single-Component sequence must pass: %v", err)
+	}
+}
+
+// String "0%" values are equivalent to literal 0 and must produce the
+// same zero-budget rejection.
+func TestValidateCoordination_ZeroBudgetPacingRejectedStringForm(t *testing.T) {
+	zeroPct := intstr.FromString("0%")
+	zeroInt := intstr.FromInt(0)
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				RollingUpdate: &v1beta1.GroupRollingUpdate{
+					MaxSurge:       &zeroPct,
+					MaxUnavailable: &zeroInt,
+				},
+			},
+		},
+	}
+	err := ValidateCoordination(spec)
+	if err == nil || !strings.Contains(err.Error(), ReasonZeroBudgetPacingUnstartable) {
+		t.Errorf("zero-budget (str/int mix): got %v want error with %s", err, ReasonZeroBudgetPacingUnstartable)
+	}
+}
+
+// Positive case: pacing with non-zero MaxSurge is accepted even when
+// MaxUnavailable=0 — the rollout still has surge headroom.
+func TestValidateCoordination_NonZeroSurgePacingAccepted(t *testing.T) {
+	surge := intstr.FromInt(2)
+	zero := intstr.FromInt(0)
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				RollingUpdate: &v1beta1.GroupRollingUpdate{
+					MaxSurge:       &surge,
+					MaxUnavailable: &zero,
+				},
+			},
+		},
+	}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Errorf("non-zero surge + zero unavailable: unexpected error %v", err)
+	}
+}
+
+// Positive case: pacing with non-zero MaxUnavailable is accepted even
+// when MaxSurge=0 — the rollout still has drain headroom.
+func TestValidateCoordination_NonZeroUnavailablePacingAccepted(t *testing.T) {
+	zero := intstr.FromInt(0)
+	pct := intstr.FromString("25%")
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				RollingUpdate: &v1beta1.GroupRollingUpdate{
+					MaxSurge:       &zero,
+					MaxUnavailable: &pct,
+				},
+			},
+		},
+	}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Errorf("zero surge + non-zero unavailable: unexpected error %v", err)
+	}
+}
+
+// Positive case: nil pacing values (no explicit zero) are accepted —
+// the defaulter fills 25% for both MaxSurge and MaxUnavailable. The
+// zero-budget check only fires when both are explicitly set to 0.
+func TestValidateCoordination_NilPacingAccepted(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				RollingUpdate: &v1beta1.GroupRollingUpdate{
+					// MaxSurge / MaxUnavailable nil — defaulter fills 25%.
+				},
+			},
+		},
+	}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Errorf("nil pacing values: unexpected error %v", err)
+	}
+}
+
+// Positive case: omitted pacing knobs entirely is accepted — the
+// defaulter fills a complete budget.
+func TestValidateCoordination_OmittedPacingAccepted(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				BlueGreen:  &v1beta1.GroupBlueGreen{},
+				// No pacing — BlueGreen carries none.
+			},
+		},
+	}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Errorf("omitted pacing: unexpected error %v", err)
+	}
+}
+
+// The zero-budget check only fires for rollingUpdate groups. A BlueGreen group
+// guarding the ratio (v1 RatioBalanced) has no maxSurge/maxUnavailable budget,
+// so the same zero shape is not even expressible — and MaintainRatio is accepted.
+func TestValidateCoordination_RatioBalancedWithZeroBudgetNotRejected(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				BlueGreen:     &v1beta1.GroupBlueGreen{},
+				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: 5},
+			},
+		},
+	}
+	if err := ValidateCoordination(spec); err != nil {
+		t.Errorf("BlueGreen + MaintainRatio: unexpected error %v (zero-budget check is rollingUpdate-only)", err)
+	}
+}
+
+func TestValidateCoordinationUpdate_RollingUpdateBothBumped(t *testing.T) {
+	oldSpec := omeNativePDSpecWithImages("v1", "v1")
+	newSpec := omeNativePDSpecWithImages("v2", "v2")
+	newSpec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, RollingUpdate: &v1beta1.GroupRollingUpdate{}},
+		},
+	}
+	if err := ValidateCoordinationUpdate(oldSpec, newSpec); err != nil {
+		t.Errorf("pairedmixable both-bumped: unexpected error %v", err)
+	}
+}
+
+func TestValidateCoordinationUpdate_RollingUpdateOnlyOneBumpedRejected(t *testing.T) {
+	oldSpec := omeNativePDSpecWithImages("v1", "v1")
+	newSpec := omeNativePDSpecWithImages("v2", "v1")
+	newSpec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, RollingUpdate: &v1beta1.GroupRollingUpdate{}},
+		},
+	}
+	err := ValidateCoordinationUpdate(oldSpec, newSpec)
+	if err == nil || !strings.Contains(err.Error(), ReasonRollingUpdateLockstepViolation) {
+		t.Errorf("rollingupdate lockstep: got %v want %s", err, ReasonRollingUpdateLockstepViolation)
+	}
+}
+
+func TestValidateCoordinationUpdate_RollingUpdateNoBumpsNoOp(t *testing.T) {
+	oldSpec := omeNativePDSpecWithImages("v1", "v1")
+	newSpec := omeNativePDSpecWithImages("v1", "v1")
+	newSpec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{Components: []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, RollingUpdate: &v1beta1.GroupRollingUpdate{}},
+		},
+	}
+	if err := ValidateCoordinationUpdate(oldSpec, newSpec); err != nil {
+		t.Errorf("no bumps: unexpected error %v", err)
+	}
+}
+
+func TestCoordinationRatioToleranceWarning_AboveThreshold(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				BlueGreen:     &v1beta1.GroupBlueGreen{},
+				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: 80},
+			},
+		},
+	}
+	w := CoordinationRatioToleranceWarning(spec)
+	if !strings.Contains(w, ReasonRatioToleranceTooHigh) {
+		t.Errorf("tolerance warning: got %q want contains %s", w, ReasonRatioToleranceTooHigh)
+	}
+}
+
+func TestCoordinationRatioToleranceWarning_BelowThresholdEmpty(t *testing.T) {
+	spec := omeNativePDSpec()
+	spec.Rollout = &v1beta1.RolloutSpec{
+		Groups: []v1beta1.RolloutGroup{
+			{
+				Components:    []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent},
+				BlueGreen:     &v1beta1.GroupBlueGreen{},
+				MaintainRatio: &v1beta1.MaintainRatio{Tolerance: 5},
+			},
+		},
+	}
+	if w := CoordinationRatioToleranceWarning(spec); w != "" {
+		t.Errorf("safe tolerance: got %q want empty", w)
+	}
+}
+
+// Test fixtures.
+
+func omeNativePDSpec() *v1beta1.InferenceServiceSpec {
+	annot := map[string]string{constants.DeploymentMode: string(constants.OMENative)}
+	return &v1beta1.InferenceServiceSpec{
+		Engine: &v1beta1.EngineSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Annotations: annot},
+		},
+		Decoder: &v1beta1.DecoderSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Annotations: annot},
+		},
+	}
+}
+
+func omeNativePDSpecWithImages(engineImage, decoderImage string) *v1beta1.InferenceServiceSpec {
+	spec := omeNativePDSpec()
+	spec.Engine.Runner = &v1beta1.RunnerSpec{Container: corev1.Container{Image: engineImage}}
+	spec.Decoder.Runner = &v1beta1.RunnerSpec{Container: corev1.Container{Image: decoderImage}}
+	return spec
+}
+
+func omeNativeEngineOnlySpec() *v1beta1.InferenceServiceSpec {
+	annot := map[string]string{constants.DeploymentMode: string(constants.OMENative)}
+	return &v1beta1.InferenceServiceSpec{
+		Engine: &v1beta1.EngineSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Annotations: annot},
+		},
+	}
+}

--- a/pkg/validation/isvc.go
+++ b/pkg/validation/isvc.go
@@ -1,0 +1,852 @@
+package validation
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// Multi-node validation reason constants. Operators reference these
+// by name, so they're exported and stable.
+const (
+	// ReasonInvalidLeaderWorkerPairing is the legacy umbrella reason
+	// for any leader/worker shape mismatch. Retained for back-compat
+	// with operators scraping the error string; new errors also embed
+	// the more-specific reason below.
+	ReasonInvalidLeaderWorkerPairing = "InvalidLeaderWorkerPairing"
+
+	// ReasonWorkerSizeMustBePositive rejects worker.size=0 (or nil)
+	// when a leader is declared. The "default 0 means single-pod"
+	// fallback is ambiguous — force the operator to either omit
+	// Worker entirely (single-pod with default Runner) or set Size >= 1.
+	ReasonWorkerSizeMustBePositive = "WorkerSizeMustBePositive"
+
+	// ReasonLeaderRequiresWorker rejects leader-only configs. A leader
+	// without a worker has no gang to lead and is meaningless for
+	// tensor parallelism.
+	ReasonLeaderRequiresWorker = "LeaderRequiresWorker"
+
+	// ReasonWorkerRequiresLeader rejects worker-only configs.
+	// Symmetric to LeaderRequiresWorker; covered by the same
+	// validator function.
+	ReasonWorkerRequiresLeader = "WorkerRequiresLeader"
+
+	// ReasonLeaderSizeMustBeOne rejects user attempts to scale the
+	// leader Runner above 1. The leader is fixed at size=1: the
+	// OME_LEADER_ADDRESS contract resolves to a single
+	// <isvc>-<comp>-<inst>-leader-0 FQDN, so multiple leaders would
+	// produce ambiguous DNS. LeaderSpec has no explicit Size field
+	// today (enforced by type); this validator is a forward-looking
+	// guard in case the API surface evolves.
+	ReasonLeaderSizeMustBeOne = "LeaderSizeMustBeOne"
+
+	// ReasonMultiPodLeanModelNeedsRunner rejects lean (no spec.model,
+	// no spec.runtime) ISVCs that declare a multi-pod Component
+	// without populating both leader.runner.image and
+	// worker.runner.image. The lean path is supported, but
+	// multi-pod lean specs cannot be filled in by runtime selection
+	// (no runtime) or model parsing (no model), so the operator must
+	// supply images explicitly.
+	ReasonMultiPodLeanModelNeedsRunner = "MultiPodLeanModelNeedsRunner"
+
+	// ReasonZeroBudgetPacingUnstartable rejects PerComponent pacing
+	// blocks that set BOTH maxSurge=0 AND maxUnavailable=0. With both
+	// budgets at literal zero there is no surge headroom (no pod can be
+	// added) AND no drain headroom (no pod can be taken offline), so
+	// the rollout has no way to make progress and the Component will
+	// never finish reconciling. Defaulted nil values are not zero —
+	// the defaulter fills 25% for both — so this reason only fires when
+	// the operator has explicitly set both to 0. Mirrored as a runtime
+	// safety net in the coordination groups resolver.
+	ReasonZeroBudgetPacingUnstartable = "ZeroBudgetPacingUnstartable"
+)
+
+func ValidateInferenceServiceName(name string) error {
+	if !IsvcNameRegex.MatchString(name) {
+		return fmt.Errorf("invalid InferenceService name %q, must match %q", name, IsvcNameFmt)
+	}
+	return nil
+}
+
+func ValidateEngineDecoderConfig(spec *v1beta1.InferenceServiceSpec) error {
+	if spec.Decoder != nil && spec.Engine == nil {
+		return fmt.Errorf("decoder cannot be specified without engine")
+	}
+	return nil
+}
+
+// ValidateLeaderWorkerPairing enforces that the Leader / Worker spec
+// pair on each Component (Engine, Decoder) is internally consistent:
+// either both are absent (single-pod) or both are present with
+// Worker.Size > 0 (multi-pod). Rejects orphan-leader, orphan-worker, and
+// declared-worker-with-no-positive-size configurations.
+//
+// Error strings embed both the legacy "InvalidLeaderWorkerPairing"
+// reason (for back-compat with operators / tests grepping for it) and
+// a more-specific reason from the reason constants above.
+func ValidateLeaderWorkerPairing(spec *v1beta1.InferenceServiceSpec) error {
+	if spec.Engine != nil {
+		if err := validateLeaderWorkerPairing("engine", spec.Engine.Leader, spec.Engine.Worker); err != nil {
+			return err
+		}
+	}
+	if spec.Decoder != nil {
+		if err := validateLeaderWorkerPairing("decoder", spec.Decoder.Leader, spec.Decoder.Worker); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateLeaderWorkerPairing(component string, leader *v1beta1.LeaderSpec, worker *v1beta1.WorkerSpec) error {
+	if leader == nil && worker == nil {
+		return nil
+	}
+	if leader != nil && worker == nil {
+		return fmt.Errorf(
+			"%s: %s.leader is set but %s.worker is not; multi-pod configurations require both (%s)",
+			ReasonInvalidLeaderWorkerPairing, component, component, ReasonLeaderRequiresWorker,
+		)
+	}
+	if leader == nil && worker != nil {
+		return fmt.Errorf(
+			"%s: %s.worker is set but %s.leader is not; multi-pod configurations require both (%s)",
+			ReasonInvalidLeaderWorkerPairing, component, component, ReasonWorkerRequiresLeader,
+		)
+	}
+	if worker.Size == nil || *worker.Size <= 0 {
+		return fmt.Errorf(
+			"%s: %s.worker is set but worker.size is not a positive integer; multi-pod configurations require worker.size > 0 (%s)",
+			ReasonInvalidLeaderWorkerPairing, component, ReasonWorkerSizeMustBePositive,
+		)
+	}
+	return nil
+}
+
+// ValidateLeaderSize enforces that no Component sets a leader Runner
+// size greater than 1. The leader is fixed at size=1: the
+// OME_LEADER_ADDRESS env var that workers (and the leader itself)
+// consult resolves to <isvc>-<comp>-<inst>-leader-0; a second leader
+// pod would shadow the DNS contract and break tensor-parallel
+// initialization.
+//
+// LeaderSpec has no explicit Size field today, so this validator is
+// structurally a no-op against the current API. It exists as a
+// forward-looking guard so that any future API evolution adding such
+// a field automatically inherits the rejection, with the stable
+// reason string (%s) already in place for operators and tests.
+//
+// Implementation note: when LeaderSpec gains a Size field, replace
+// the per-component no-op with a check that returns the formatted
+// error using ReasonLeaderSizeMustBeOne.
+func ValidateLeaderSize(spec *v1beta1.InferenceServiceSpec) error {
+	if spec == nil {
+		return nil
+	}
+	// Engine leader: structurally fixed at size=1 — no field to inspect.
+	if err := validateLeaderSize("engine", spec.Engine); err != nil {
+		return err
+	}
+	// Decoder leader: same.
+	if err := validateLeaderSize("decoder", spec.Decoder); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateLeaderSize is the per-Component shape check. LeaderSpec has
+// no Size field today; the function is a no-op placeholder so the
+// public ValidateLeaderSize entry point exists and tests can pin the
+// reason constant. See ValidateLeaderSize doc for the upgrade plan.
+func validateLeaderSize(component string, spec interface{}) error {
+	// No-op against the current API surface. See the doc comment on
+	// ValidateLeaderSize.
+	_ = component
+	_ = spec
+	return nil
+}
+
+// ValidateMultiPodLeanRunner enforces that a lean (no spec.model AND
+// no spec.runtime) InferenceService declaring a multi-pod Component
+// (Engine or Decoder) populates both leader.runner.image and
+// worker.runner.image. Lean ISVCs are supported for the
+// single-pod path because the operator supplies a single Runner
+// image. For multi-pod the controller renders distinct PodSpecs for
+// leader and worker — without a runtime or model to fill in defaults,
+// both Runner images must be explicit.
+//
+// Single-pod lean ISVCs continue to use the existing
+// hasFullRunnerConfig path (runner.image satisfies the requirement).
+// This validator only fires when MultiPod is true.
+func ValidateMultiPodLeanRunner(spec *v1beta1.InferenceServiceSpec) error {
+	if spec == nil {
+		return nil
+	}
+	modelSet := spec.Model != nil && spec.Model.Name != ""
+	runtimeSet := spec.Runtime != nil && spec.Runtime.Name != ""
+	if modelSet || runtimeSet {
+		return nil
+	}
+	// Lean path: at least one of model/runtime must end up set per
+	// ValidateInferenceService elsewhere; if both are absent the user
+	// is in the "spec.engine carries the runner config end-to-end"
+	// path. Multi-pod variants in that path need both leader and
+	// worker runner images present.
+	if err := validateMultiPodLeanRunnerImages(
+		"engine",
+		engineLeader(spec.Engine), engineWorker(spec.Engine),
+	); err != nil {
+		return err
+	}
+	if err := validateMultiPodLeanRunnerImages(
+		"decoder",
+		decoderLeader(spec.Decoder), decoderWorker(spec.Decoder),
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateMultiPodLeanRunnerImages(component string, leader *v1beta1.LeaderSpec, worker *v1beta1.WorkerSpec) error {
+	if leader == nil || worker == nil {
+		// Single-pod or invalid pair (covered by
+		// ValidateLeaderWorkerPairing).
+		return nil
+	}
+	leaderImg := ""
+	if leader.Runner != nil {
+		leaderImg = leader.Runner.Image
+	}
+	workerImg := ""
+	if worker.Runner != nil {
+		workerImg = worker.Runner.Image
+	}
+	if leaderImg != "" && workerImg != "" {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s: %s is multi-pod with no spec.model and no spec.runtime, but %s.leader.runner.image (%q) or %s.worker.runner.image (%q) is empty; multi-pod lean specs must declare both runner images",
+		ReasonMultiPodLeanModelNeedsRunner,
+		component, component, leaderImg, component, workerImg,
+	)
+}
+
+func engineLeader(e *v1beta1.EngineSpec) *v1beta1.LeaderSpec {
+	if e == nil {
+		return nil
+	}
+	return e.Leader
+}
+
+func engineWorker(e *v1beta1.EngineSpec) *v1beta1.WorkerSpec {
+	if e == nil {
+		return nil
+	}
+	return e.Worker
+}
+
+func decoderLeader(d *v1beta1.DecoderSpec) *v1beta1.LeaderSpec {
+	if d == nil {
+		return nil
+	}
+	return d.Leader
+}
+
+func decoderWorker(d *v1beta1.DecoderSpec) *v1beta1.WorkerSpec {
+	if d == nil {
+		return nil
+	}
+	return d.Worker
+}
+
+// ValidateEngineDecoderDeploymentMode enforces that when both Engine and
+// Decoder are present and either resolves to OMENative, both components
+// resolve to the same dispatch mode. The per-Component
+// ome.io/deploymentMode annotation wins over spec.deploymentMode, but
+// spec.deploymentMode acts as a uniform default — so a spec that sets
+// spec.deploymentMode=OMENative without per-Component overrides
+// satisfies this check (both Engine and Decoder resolve to OMENative).
+func ValidateEngineDecoderDeploymentMode(spec *v1beta1.InferenceServiceSpec) error {
+	if spec.Engine == nil || spec.Decoder == nil {
+		return nil
+	}
+	engineMode := resolveComponentDeploymentMode(spec.Engine.Annotations, spec.DeploymentMode)
+	decoderMode := resolveComponentDeploymentMode(spec.Decoder.Annotations, spec.DeploymentMode)
+	if engineMode != string(constants.OMENative) && decoderMode != string(constants.OMENative) {
+		return nil
+	}
+	if engineMode != decoderMode {
+		return fmt.Errorf(
+			"InvalidDeploymentModeCombination: engine deploymentMode=%q does not match decoder deploymentMode=%q; when either is OMENative, both must use the same value",
+			engineMode, decoderMode,
+		)
+	}
+	return nil
+}
+
+// resolveComponentDeploymentMode returns the effective dispatch
+// deployment mode for a single Component as a string, applying the
+// resolution chain shared by all admission and reconcile call sites:
+//
+//  1. Per-Component ome.io/deploymentMode annotation (escape hatch).
+//  2. spec.deploymentMode (the typed top-level default).
+//  3. Empty string when neither is set.
+//
+// Shape-derived behavior (Leader/Worker → multi-node OMENative;
+// PDDisaggregated from Engine+Decoder pairing) is intentionally NOT
+// considered here: this helper is consumed by admission rules that only
+// care about the DISPATCH backend (OMENative vs RawDeployment), not the
+// shape.
+func resolveComponentDeploymentMode(annotations map[string]string, specMode *constants.DeploymentModeType) string {
+	if mode, ok := annotations[constants.DeploymentMode]; ok && mode != "" {
+		return mode
+	}
+	if specMode != nil {
+		return string(*specMode)
+	}
+	return ""
+}
+
+func ValidateReplicaBounds(min, max *int) error {
+	if min != nil && *min < 0 {
+		return fmt.Errorf("minReplicas must be >= 0")
+	}
+	if max != nil && *max < 1 {
+		return fmt.Errorf("maxReplicas must be >= 1")
+	}
+	if min != nil && max != nil && *min > *max {
+		return fmt.Errorf("minReplicas (%d) must be <= maxReplicas (%d)", *min, *max)
+	}
+	return nil
+}
+
+// ValidateScaleToZero rejects InferenceServices that explicitly set a
+// Component's MinReplicas=0 unless that Component is KEDA-autoscaled.
+//
+// Before Serverless mode was removed, MinReplicas=0 auto-promoted the
+// engine to Knative-Serving (which natively supports scale-to-zero).
+// After removal, MinReplicas=0 falls through to RawDeployment and the
+// Deployment sits at zero replicas (broken). Operators needing
+// scale-to-zero must opt into KEDA's idleReplicaCount.
+//
+// KEDA opt-in is accepted via either route:
+//
+//   - Typed per-Component field: spec.<component>.autoscaler.class
+//     == KEDA (v1beta1.AutoscalerKEDA, "KEDA"). This is the preferred
+//     surface and is evaluated PER Component — the specific Component that
+//     sets MinReplicas=0 must itself be KEDA-autoscaled.
+//   - Legacy top-level annotation: ome.io/autoscalerClass == "keda"
+//     (constants.AutoscalerClassKEDA). The annotation applies to the
+//     whole ISVC, so it satisfies the gate for every Component. Note the
+//     case mismatch is intentional: the typed enum is "KEDA" while the
+//     legacy annotation value is the lowercase "keda".
+//
+// A Component with MinReplicas=0 that is neither covered by the legacy
+// annotation nor carries a typed KEDA autoscaler block is rejected.
+func ValidateScaleToZero(isvc *v1beta1.InferenceService) error {
+	annotations := isvc.ObjectMeta.Annotations
+	legacyKEDA := constants.AutoscalerClassType(annotations[constants.AutoscalerClass]) == constants.AutoscalerClassKEDA
+
+	// Collect the (MinReplicas, Autoscaler) pair for each present
+	// Component. Engine/Decoder/Router all embed ComponentExtensionSpec,
+	// so MinReplicas and Autoscaler are promoted fields on each.
+	type scaleToZeroCheck struct {
+		name        string
+		minReplicas *int
+		autoscaler  *v1beta1.ComponentAutoscaler
+	}
+	var checks []scaleToZeroCheck
+	if c := isvc.Spec.Engine; c != nil {
+		checks = append(checks, scaleToZeroCheck{"engine", c.MinReplicas, c.Autoscaler})
+	}
+	if c := isvc.Spec.Decoder; c != nil {
+		checks = append(checks, scaleToZeroCheck{"decoder", c.MinReplicas, c.Autoscaler})
+	}
+	if c := isvc.Spec.Router; c != nil {
+		checks = append(checks, scaleToZeroCheck{"router", c.MinReplicas, c.Autoscaler})
+	}
+	for _, c := range checks {
+		if c.minReplicas == nil || *c.minReplicas != 0 {
+			continue
+		}
+		// MinReplicas=0 on this Component. Accept when the whole-ISVC legacy
+		// annotation opts into KEDA, or when this Component carries a typed
+		// KEDA autoscaler block.
+		if legacyKEDA {
+			continue
+		}
+		if c.autoscaler != nil && c.autoscaler.Class == v1beta1.AutoscalerKEDA {
+			continue
+		}
+		return fmt.Errorf(
+			"InvalidScaleToZero: %s.minReplicas=0 requires KEDA autoscaling "+
+				"(set spec.%s.autoscaler.class=%s or the %s=%s annotation); "+
+				"Serverless mode no longer auto-promotes scale-to-zero",
+			c.name, c.name, v1beta1.AutoscalerKEDA,
+			constants.AutoscalerClass, constants.AutoscalerClassKEDA,
+		)
+	}
+	return nil
+}
+
+// ValidateAutoscalerConfig validates autoscaler-related annotations and spec
+// fields. It returns warnings (non-fatal messages) and an error if validation
+// fails.
+func ValidateAutoscalerConfig(isvc *v1beta1.InferenceService) ([]string, error) {
+	annotations := isvc.ObjectMeta.Annotations
+	value, ok := annotations[constants.AutoscalerClass]
+	class := constants.AutoscalerClassType(value)
+	if ok {
+		for _, item := range constants.AutoscalerAllowedClassList {
+			if class == item {
+				switch class {
+				case constants.AutoscalerClassHPA:
+					if metric, ok := annotations[constants.AutoscalerMetrics]; ok {
+						return nil, ValidateHPAMetrics(metric)
+					}
+					return nil, nil
+				case constants.AutoscalerClassKEDA:
+					// Per-Component Autoscaler.Keda shape is validated
+					// by ValidateAutoscaler; the annotation path accepts
+					// class=keda without further validation here.
+					return nil, nil
+				case constants.AutoscalerClassExternal:
+					return nil, nil
+				default:
+					return nil, fmt.Errorf("unknown autoscaler class [%s]", class)
+				}
+			}
+		}
+		return nil, fmt.Errorf("[%s] is not a supported autoscaler class type", value)
+	}
+	return nil, nil
+}
+
+func ValidateAutoscalerTargetUtilizationPercentage(isvc *v1beta1.InferenceService) error {
+	annotations := isvc.ObjectMeta.Annotations
+	if value, ok := annotations[constants.TargetUtilizationPercentage]; ok {
+		t, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("the target utilization percentage should be a [1-100] integer")
+		}
+		if t < 1 || t > 100 {
+			return fmt.Errorf("the target utilization percentage should be a [1-100] integer")
+		}
+	}
+	return nil
+}
+
+// ValidateHPAMetrics validates the legacy ome.io/metrics annotation value
+// against the AutoscalerAllowedMetricsList enum. Accepts the raw string
+// from the annotation — the v1beta1.ScaleMetric enum this used to take is
+// gone.
+func ValidateHPAMetrics(metric string) error {
+	for _, item := range constants.AutoscalerAllowedMetricsList {
+		if string(item) == metric {
+			return nil
+		}
+	}
+	return fmt.Errorf("[%s] is not a supported metric", metric)
+}
+
+// Autoscaler webhook validation reason constants. Operators and the
+// envtest suite (.../webhook/inferenceservice) reference these by
+// name, so they're exported and stable.
+const (
+	// ReasonAutoscalerClassUnknown rejects a ComponentAutoscaler.Class
+	// value that is not in the enum {hpa, keda, external, none}. The
+	// CRD's +kubebuilder:validation:Enum marker enforces this at the
+	// schema level; the webhook is defense-in-depth for clients that
+	// bypass schema validation (e.g., legacy clients with a stale CRD).
+	ReasonAutoscalerClassUnknown = "AutoscalerClassUnknown"
+
+	// ReasonKedaTriggersRequired rejects class=keda blocks with empty
+	// or nil Keda.Triggers. The CRD enforces MinItems=1 at the schema
+	// level; webhook is defense-in-depth and also covers the
+	// nil-Keda-pointer case the marker can't express.
+	ReasonKedaTriggersRequired = "KedaTriggersRequired"
+
+	// ReasonHPAMetricMalformed rejects HPA.Metrics entries whose
+	// declared Type field disagrees with which pointer-field is
+	// populated (e.g., Type=Resource with Resource=nil). Such entries
+	// would silently produce a no-op HPA at apply-time; the webhook
+	// surfaces the bug at admission.
+	ReasonHPAMetricMalformed = "HPAMetricMalformed"
+
+	// ReasonKedaIdleBelowMin rejects KEDA blocks whose IdleReplicaCount
+	// is not strictly less than the effective MinReplicaCount. KEDA's
+	// own admission rejects the same shape; this is a friendlier
+	// up-front error so operators don't get a confusing KEDA-side
+	// rejection after the OME write succeeds.
+	ReasonKedaIdleBelowMin = "KedaIdleBelowMin"
+
+	// ReasonAutoscalerAnnotationConflict rejects an ISVC that carries
+	// both the legacy ome.io/autoscalerClass annotation AND a new
+	// Autoscaler block on any Component. The
+	// per-Component Autoscaler block wins; this validation pre-empts
+	// confusion by forcing operators to remove the annotation.
+	ReasonAutoscalerAnnotationConflict = "AutoscalerAnnotationConflict"
+
+	// ReasonLegacyAutoscalerFieldsRejected is the friendly migration
+	// error returned by ValidateLegacyAutoscalerFieldsRaw when a client
+	// submits an ISVC carrying the deleted scaleTarget / scaleMetric
+	// fields. The Go-struct fields and CRD schema entries are gone; a
+	// modern kubectl against an up-to-date CRD will already prune them
+	// via structural-schema enforcement. This reason is defense-in-depth
+	// for clients with a stale local CRD that bypassed pruning.
+	ReasonLegacyAutoscalerFieldsRejected = "LegacyAutoscalerFieldsRejected"
+)
+
+// validAutoscalerClasses mirrors the CRD enum
+// (+kubebuilder:validation:Enum=hpa;keda;external;none on
+// AutoscalerClass). Used by the webhook defense-in-depth check.
+var validAutoscalerClasses = map[v1beta1.AutoscalerClass]struct{}{
+	v1beta1.AutoscalerHPA:      {},
+	v1beta1.AutoscalerKEDA:     {},
+	v1beta1.AutoscalerExternal: {},
+	v1beta1.AutoscalerNone:     {},
+}
+
+// ComponentAutoscalerCheck names one Component's Autoscaler block for
+// the slice-driven ValidateComponentsAutoscalers helper. Name is the
+// field label used to wrap a per-Component error (e.g., "engine",
+// "engineConfig"). Autoscaler may be nil — skipped silently.
+// MinReplicas is the effective per-Component MinReplicas floor used to
+// gate KEDA.IdleReplicaCount; nil disables that check.
+type ComponentAutoscalerCheck struct {
+	Name        string
+	Autoscaler  *v1beta1.ComponentAutoscaler
+	MinReplicas *int
+}
+
+// ValidateComponentsAutoscalers loops the per-Component checks and
+// returns the first failure wrapped with "<Name>: ". Used by every
+// webhook that dispatches the per-Component Autoscaler shape check
+// across engine/decoder/router (or their ServingRuntime field-path
+// twins) so the engine/decoder/router copy-paste lives in exactly one
+// place. See ValidateAutoscaler for the rule set.
+func ValidateComponentsAutoscalers(checks []ComponentAutoscalerCheck) error {
+	for _, c := range checks {
+		if err := ValidateAutoscaler(c.Autoscaler, c.MinReplicas); err != nil {
+			if c.Name == "" {
+				return err
+			}
+			return fmt.Errorf("%s: %w", c.Name, err)
+		}
+	}
+	return nil
+}
+
+// ValidateAutoscaler is the core per-Component Autoscaler shape check:
+//
+//   - `none` and `external` are status-field twins; both are
+//     accepted at the webhook layer with no Class-specific shape
+//     requirements.
+//   - There is no KEDA-installed probe; the cluster
+//     contract is "KEDA is always present". The webhook does not
+//     validate KEDA availability.
+//
+// Rules enforced:
+//
+//  1. Class must be one of {hpa, keda, external, none} (defense-in-depth
+//     against the CRD enum, in case of a stale-CRD client).
+//  2. class=keda requires Keda.Triggers to be set with at least one
+//     entry (defense-in-depth against MinItems=1 on the CRD, plus the
+//     nil-Keda-pointer case that MinItems can't express).
+//  3. class=hpa with HPA.Metrics: every entry's declared Type must have
+//     the corresponding pointer-field populated (Type=Resource ⇒
+//     Resource != nil, etc.). HPA.Metrics empty/nil is allowed — the
+//     controller defaults to CPU=80%.
+//  4. class=keda with both Keda.IdleReplicaCount and the supplied
+//     minReplicas set: IdleReplicaCount must be strictly less than
+//     minReplicas.
+//
+// Returns nil when autoscaler is nil — every Component-level Autoscaler
+// block is optional.
+//
+// minReplicas is the effective per-Component MinReplicas floor; pass
+// nil if the caller cannot determine it (e.g., the IR webhook may pass
+// the IR's spec.replicas, the ISVC webhook passes
+// ComponentExtensionSpec.MinReplicas). The IdleReplicaCount-vs-MinReplicas
+// check is skipped when either side is nil.
+func ValidateAutoscaler(autoscaler *v1beta1.ComponentAutoscaler, minReplicas *int) error {
+	if autoscaler == nil {
+		return nil
+	}
+	as := autoscaler
+
+	// Rule 1: class enum (defense-in-depth against the CRD marker).
+	if _, ok := validAutoscalerClasses[as.Class]; !ok {
+		return fmt.Errorf(
+			"%s: autoscaler.class %q is not one of HPA|KEDA|External|None",
+			ReasonAutoscalerClassUnknown, as.Class,
+		)
+	}
+
+	// Rule 2: class=keda requires at least one trigger.
+	if as.Class == v1beta1.AutoscalerKEDA {
+		if as.Keda == nil || len(as.Keda.Triggers) == 0 {
+			return fmt.Errorf(
+				"%s: class=keda requires at least 1 trigger",
+				ReasonKedaTriggersRequired,
+			)
+		}
+	}
+
+	// Rule 3: class=hpa with malformed metric entries.
+	if as.Class == v1beta1.AutoscalerHPA && as.HPA != nil {
+		for i, m := range as.HPA.Metrics {
+			if err := validateHPAMetricSpec(i, m); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Rule 4: KEDA IdleReplicaCount < minReplicas.
+	if as.Class == v1beta1.AutoscalerKEDA && as.Keda != nil &&
+		as.Keda.IdleReplicaCount != nil && minReplicas != nil {
+		idle := int(*as.Keda.IdleReplicaCount)
+		min := *minReplicas
+		if idle >= min {
+			return fmt.Errorf(
+				"%s: keda.idleReplicaCount must be < minReplicas (got idleReplicaCount=%d, minReplicas=%d)",
+				ReasonKedaIdleBelowMin, idle, min,
+			)
+		}
+	}
+
+	return nil
+}
+
+// ValidateComponentAutoscaler is a back-compat thin wrapper around
+// ValidateAutoscaler that pulls the Autoscaler block + MinReplicas out
+// of a ComponentExtensionSpec. New callers should prefer
+// ValidateAutoscaler (or ValidateComponentsAutoscalers for the
+// per-Component dispatch) so they don't have to synthesize a parent
+// ComponentExtensionSpec (cf. the IR webhook, which carries Replicas
+// on the IR spec rather than a nested ComponentExtensionSpec).
+func ValidateComponentAutoscaler(componentExt *v1beta1.ComponentExtensionSpec) error {
+	if componentExt == nil {
+		return nil
+	}
+	return ValidateAutoscaler(componentExt.Autoscaler, componentExt.MinReplicas)
+}
+
+// validateHPAMetricSpec checks that a single MetricSpec entry has its
+// Type field populated and the matching pointer field set. Returns a
+// formatted error including the entry index for operator legibility.
+func validateHPAMetricSpec(idx int, m autoscalingv2.MetricSpec) error {
+	if m.Type == "" {
+		return fmt.Errorf(
+			"%s: hpa.metrics[%d].type is empty; must be one of Resource|Pods|Object|External|ContainerResource",
+			ReasonHPAMetricMalformed, idx,
+		)
+	}
+	switch m.Type {
+	case autoscalingv2.ResourceMetricSourceType:
+		if m.Resource == nil {
+			return fmt.Errorf(
+				"%s: hpa.metrics[%d].type=Resource but hpa.metrics[%d].resource is nil",
+				ReasonHPAMetricMalformed, idx, idx,
+			)
+		}
+	case autoscalingv2.PodsMetricSourceType:
+		if m.Pods == nil {
+			return fmt.Errorf(
+				"%s: hpa.metrics[%d].type=Pods but hpa.metrics[%d].pods is nil",
+				ReasonHPAMetricMalformed, idx, idx,
+			)
+		}
+	case autoscalingv2.ObjectMetricSourceType:
+		if m.Object == nil {
+			return fmt.Errorf(
+				"%s: hpa.metrics[%d].type=Object but hpa.metrics[%d].object is nil",
+				ReasonHPAMetricMalformed, idx, idx,
+			)
+		}
+	case autoscalingv2.ExternalMetricSourceType:
+		if m.External == nil {
+			return fmt.Errorf(
+				"%s: hpa.metrics[%d].type=External but hpa.metrics[%d].external is nil",
+				ReasonHPAMetricMalformed, idx, idx,
+			)
+		}
+	case autoscalingv2.ContainerResourceMetricSourceType:
+		if m.ContainerResource == nil {
+			return fmt.Errorf(
+				"%s: hpa.metrics[%d].type=ContainerResource but hpa.metrics[%d].containerResource is nil",
+				ReasonHPAMetricMalformed, idx, idx,
+			)
+		}
+	default:
+		return fmt.Errorf(
+			"%s: hpa.metrics[%d].type %q is not one of Resource|Pods|Object|External|ContainerResource",
+			ReasonHPAMetricMalformed, idx, m.Type,
+		)
+	}
+	return nil
+}
+
+// ValidateAutoscalerAnnotationConflict rejects an InferenceService that
+// declares the legacy ome.io/autoscalerClass annotation AND a new
+// Autoscaler block on any Component. The
+// per-Component Autoscaler block wins; this validator pre-empts confusion
+// by forcing the operator to pick one.
+//
+// Returns nil when the annotation is absent OR when no Component
+// carries an Autoscaler block.
+func ValidateAutoscalerAnnotationConflict(isvc *v1beta1.InferenceService) error {
+	if isvc == nil {
+		return nil
+	}
+	if _, has := isvc.Annotations[constants.AutoscalerClass]; !has {
+		return nil
+	}
+	conflicting := []string{}
+	if isvc.Spec.Engine != nil && isvc.Spec.Engine.Autoscaler != nil {
+		conflicting = append(conflicting, "engine")
+	}
+	if isvc.Spec.Decoder != nil && isvc.Spec.Decoder.Autoscaler != nil {
+		conflicting = append(conflicting, "decoder")
+	}
+	if isvc.Spec.Router != nil && isvc.Spec.Router.Autoscaler != nil {
+		conflicting = append(conflicting, "router")
+	}
+	if len(conflicting) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s: %s annotation is present together with spec.%s.autoscaler; "+
+			"remove the annotation — per-Component autoscaler block wins",
+		ReasonAutoscalerAnnotationConflict,
+		constants.AutoscalerClass, conflicting[0],
+	)
+}
+
+// ValidateLegacyAutoscalerFieldsRaw inspects the raw admission-request
+// JSON for the deleted scaleTarget / scaleMetric fields and returns a
+// friendly migration error if either is set on any Component
+// (spec.engine, spec.decoder, spec.router, spec.engineConfig.*, etc).
+//
+// These fields have been removed from ComponentExtensionSpec; the
+// generated CRD no longer carries them in the OpenAPI schema. A modern
+// kubectl with --validate=true against an up-to-date CRD will reject the
+// unknown fields server-side before they reach the webhook; the API
+// server's structural-schema pruning will silently drop them when
+// --validate=false. This helper exists as defense-in-depth for the
+// narrow window where:
+//
+//   - An operator's local CRD is stale (cluster updated, kubeconfig
+//     points at older CRD), AND
+//   - The client bypasses --validate, AND
+//   - Field pruning fails for any reason (custom admission, intermediate
+//     proxy, etc).
+//
+// In all three cases the field would silently no-op rather than reject;
+// this helper surfaces the migration message at admission time so the
+// operator gets a clear pointer at the Autoscaler block.
+//
+// rawObj is typically req.AdmissionRequest.Object.Raw from the
+// admission.Request — the raw JSON bytes BEFORE the Go decoder strips
+// unknown fields. Returns nil when rawObj is empty / unparseable (the
+// caller's primary validation will surface the parse failure) and when
+// no legacy fields are populated on any Component.
+func ValidateLegacyAutoscalerFieldsRaw(rawObj []byte) error {
+	if len(rawObj) == 0 {
+		return nil
+	}
+	var envelope struct {
+		Spec struct {
+			Engine        json.RawMessage `json:"engine,omitempty"`
+			Decoder       json.RawMessage `json:"decoder,omitempty"`
+			Router        json.RawMessage `json:"router,omitempty"`
+			EngineConfig  json.RawMessage `json:"engineConfig,omitempty"`
+			DecoderConfig json.RawMessage `json:"decoderConfig,omitempty"`
+			RouterConfig  json.RawMessage `json:"routerConfig,omitempty"`
+		} `json:"spec,omitempty"`
+	}
+	if err := json.Unmarshal(rawObj, &envelope); err != nil {
+		// The primary decoder will surface a JSON parse failure; this
+		// helper is best-effort defense-in-depth and must not mask the
+		// real error.
+		return nil
+	}
+	checks := []struct {
+		name string
+		body json.RawMessage
+	}{
+		{"engine", envelope.Spec.Engine},
+		{"decoder", envelope.Spec.Decoder},
+		{"router", envelope.Spec.Router},
+		{"engineConfig", envelope.Spec.EngineConfig},
+		{"decoderConfig", envelope.Spec.DecoderConfig},
+		{"routerConfig", envelope.Spec.RouterConfig},
+	}
+	for _, c := range checks {
+		if len(c.body) == 0 {
+			continue
+		}
+		if field, ok := legacyAutoscalerFieldOn(c.body); ok {
+			return fmt.Errorf(
+				"%s: spec.%s.%s is no longer supported. "+
+					"Use spec.%s.autoscaler.%s instead.",
+				ReasonLegacyAutoscalerFieldsRejected,
+				c.name, field,
+				c.name, legacyAutoscalerReplacement(field),
+			)
+		}
+	}
+	return nil
+}
+
+// legacyAutoscalerFieldOn checks a Component's raw JSON for the deleted
+// legacy autoscaling fields. Returns the offending field name + true on
+// the first match, else "" + false. Both fields are pointer types
+// (*int / *ScaleMetric) in the old API surface, so a null value counts
+// as "not set" — we only reject explicit non-null values.
+func legacyAutoscalerFieldOn(componentBody json.RawMessage) (string, bool) {
+	var probe struct {
+		ScaleTarget *json.RawMessage `json:"scaleTarget,omitempty"`
+		ScaleMetric *json.RawMessage `json:"scaleMetric,omitempty"`
+	}
+	if err := json.Unmarshal(componentBody, &probe); err != nil {
+		return "", false
+	}
+	if isNonNullRaw(probe.ScaleTarget) {
+		return "scaleTarget", true
+	}
+	if isNonNullRaw(probe.ScaleMetric) {
+		return "scaleMetric", true
+	}
+	return "", false
+}
+
+// isNonNullRaw returns true when the raw message is set AND not the
+// literal `null`. JSON `null` for a pointer field is the operator's
+// explicit "unset" marker and must not trigger the rejection.
+func isNonNullRaw(raw *json.RawMessage) bool {
+	if raw == nil {
+		return false
+	}
+	trimmed := string(*raw)
+	return trimmed != "" && trimmed != "null"
+}
+
+// legacyAutoscalerReplacement maps a deleted field name to its
+// Autoscaler-block equivalent so the migration error points the
+// operator at the right replacement.
+func legacyAutoscalerReplacement(field string) string {
+	switch field {
+	case "scaleTarget":
+		return "hpa.metrics[0].resource.target.averageUtilization"
+	case "scaleMetric":
+		return "hpa.metrics[0].resource.name"
+	default:
+		return "<see Autoscaler block>"
+	}
+}

--- a/pkg/validation/isvc.go
+++ b/pkg/validation/isvc.go
@@ -488,7 +488,7 @@ const (
 	// ReasonAutoscalerAnnotationConflict rejects an ISVC that carries
 	// both the legacy ome.io/autoscalerClass annotation AND a new
 	// Autoscaler block on any Component. The
-	// per-Component Autoscaler block wins; this validation pre-empts
+	// per-Component Autoscaler block wins; this validation preempts
 	// confusion by forcing operators to remove the annotation.
 	ReasonAutoscalerAnnotationConflict = "AutoscalerAnnotationConflict"
 
@@ -695,7 +695,7 @@ func validateHPAMetricSpec(idx int, m autoscalingv2.MetricSpec) error {
 // ValidateAutoscalerAnnotationConflict rejects an InferenceService that
 // declares the legacy ome.io/autoscalerClass annotation AND a new
 // Autoscaler block on any Component. The
-// per-Component Autoscaler block wins; this validator pre-empts confusion
+// per-Component Autoscaler block wins; this validator preempts confusion
 // by forcing the operator to pick one.
 //
 // Returns nil when the annotation is absent OR when no Component
@@ -753,7 +753,7 @@ func ValidateAutoscalerAnnotationConflict(isvc *v1beta1.InferenceService) error 
 //
 // rawObj is typically req.AdmissionRequest.Object.Raw from the
 // admission.Request — the raw JSON bytes BEFORE the Go decoder strips
-// unknown fields. Returns nil when rawObj is empty / unparseable (the
+// unknown fields. Returns nil when rawObj is empty / unparsable (the
 // caller's primary validation will surface the parse failure) and when
 // no legacy fields are populated on any Component.
 func ValidateLegacyAutoscalerFieldsRaw(rawObj []byte) error {

--- a/pkg/validation/isvc_test.go
+++ b/pkg/validation/isvc_test.go
@@ -1,0 +1,1503 @@
+package validation
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	kedav1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestValidateInferenceServiceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		isvcName string
+		wantErr  bool
+	}{
+		{name: "valid lowercase", isvcName: "my-model", wantErr: false},
+		{name: "single char", isvcName: "a", wantErr: false},
+		{name: "alphanumeric with hyphens", isvcName: "llama-3-70b", wantErr: false},
+		{name: "starts with number", isvcName: "3model", wantErr: true},
+		{name: "uppercase", isvcName: "MyModel", wantErr: true},
+		{name: "ends with hyphen", isvcName: "model-", wantErr: true},
+		{name: "empty string", isvcName: "", wantErr: true},
+		{name: "underscore", isvcName: "my_model", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateInferenceServiceName(tc.isvcName)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for name %q, got nil", tc.isvcName)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for name %q: %v", tc.isvcName, err)
+			}
+		})
+	}
+}
+
+func TestValidateEngineDecoderConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *v1beta1.InferenceServiceSpec
+		wantErr bool
+	}{
+		{
+			name: "no decoder or engine",
+			spec: &v1beta1.InferenceServiceSpec{},
+		},
+		{
+			name: "engine without decoder",
+			spec: &v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{}},
+		},
+		{
+			name: "engine with decoder",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine:  &v1beta1.EngineSpec{},
+				Decoder: &v1beta1.DecoderSpec{},
+			},
+		},
+		{
+			name:    "decoder without engine",
+			spec:    &v1beta1.InferenceServiceSpec{Decoder: &v1beta1.DecoderSpec{}},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEngineDecoderConfig(tc.spec)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateEngineDecoderDeploymentMode(t *testing.T) {
+	withMode := func(mode string) *v1beta1.ComponentExtensionSpec {
+		return &v1beta1.ComponentExtensionSpec{
+			Annotations: map[string]string{constants.DeploymentMode: mode},
+		}
+	}
+	engineWith := func(ext *v1beta1.ComponentExtensionSpec) *v1beta1.EngineSpec {
+		if ext == nil {
+			return &v1beta1.EngineSpec{}
+		}
+		return &v1beta1.EngineSpec{ComponentExtensionSpec: *ext}
+	}
+	decoderWith := func(ext *v1beta1.ComponentExtensionSpec) *v1beta1.DecoderSpec {
+		if ext == nil {
+			return &v1beta1.DecoderSpec{}
+		}
+		return &v1beta1.DecoderSpec{ComponentExtensionSpec: *ext}
+	}
+
+	tests := []struct {
+		name    string
+		spec    *v1beta1.InferenceServiceSpec
+		wantErr bool
+	}{
+		{
+			name: "no engine, no decoder",
+			spec: &v1beta1.InferenceServiceSpec{},
+		},
+		{
+			name: "engine only (no decoder) — rule does not apply",
+			spec: &v1beta1.InferenceServiceSpec{Engine: engineWith(withMode(string(constants.OMENative)))},
+		},
+		{
+			name: "both present, no annotations — rule does not apply",
+			spec: &v1beta1.InferenceServiceSpec{Engine: engineWith(nil), Decoder: decoderWith(nil)},
+		},
+		{
+			name: "both OMENative — match",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine:  engineWith(withMode(string(constants.OMENative))),
+				Decoder: decoderWith(withMode(string(constants.OMENative))),
+			},
+		},
+		{
+			name: "engine OMENative, decoder unset — mismatch",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine:  engineWith(withMode(string(constants.OMENative))),
+				Decoder: decoderWith(nil),
+			},
+			wantErr: true,
+		},
+		{
+			name: "engine unset, decoder OMENative — mismatch",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine:  engineWith(nil),
+				Decoder: decoderWith(withMode(string(constants.OMENative))),
+			},
+			wantErr: true,
+		},
+		{
+			name: "engine OMENative, decoder RawDeployment — mismatch",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine:  engineWith(withMode(string(constants.OMENative))),
+				Decoder: decoderWith(withMode(string(constants.RawDeployment))),
+			},
+			wantErr: true,
+		},
+		{
+			name: "both RawDeployment (no OMENative) — rule does not apply",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine:  engineWith(withMode(string(constants.RawDeployment))),
+				Decoder: decoderWith(withMode(string(constants.RawDeployment))),
+			},
+		},
+		{
+			name: "engine RawDeployment, decoder RawDeployment (no OMENative) — rule does not apply",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine:  engineWith(withMode(string(constants.RawDeployment))),
+				Decoder: decoderWith(withMode(string(constants.RawDeployment))),
+			},
+		},
+		{
+			name: "spec.deploymentMode=OMENative propagates to both — no mismatch",
+			spec: &v1beta1.InferenceServiceSpec{
+				DeploymentMode: func() *constants.DeploymentModeType {
+					m := constants.OMENative
+					return &m
+				}(),
+				Engine:  engineWith(nil),
+				Decoder: decoderWith(nil),
+			},
+		},
+		{
+			name: "spec.deploymentMode=OMENative; engine annotation pins Raw — mismatch",
+			spec: &v1beta1.InferenceServiceSpec{
+				DeploymentMode: func() *constants.DeploymentModeType {
+					m := constants.OMENative
+					return &m
+				}(),
+				Engine:  engineWith(withMode(string(constants.RawDeployment))),
+				Decoder: decoderWith(nil),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEngineDecoderDeploymentMode(tc.spec)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateLeaderWorkerPairing(t *testing.T) {
+	sizePtr := func(v int) *int { return &v }
+	withWorker := func(size *int) *v1beta1.WorkerSpec { return &v1beta1.WorkerSpec{Size: size} }
+
+	tests := []struct {
+		name    string
+		spec    *v1beta1.InferenceServiceSpec
+		wantErr bool
+		errSub  string
+	}{
+		{
+			name: "no engine, no decoder",
+			spec: &v1beta1.InferenceServiceSpec{},
+		},
+		{
+			name: "engine: neither leader nor worker — single-pod OK",
+			spec: &v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{}},
+		},
+		{
+			name: "engine: leader + worker(size=3) — valid multi-pod",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: withWorker(sizePtr(3)),
+				},
+			},
+		},
+		{
+			name: "engine: leader without worker — rejected",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{Leader: &v1beta1.LeaderSpec{}},
+			},
+			wantErr: true,
+			errSub:  "engine.leader is set but engine.worker is not",
+		},
+		{
+			name: "engine: worker without leader — rejected",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{Worker: withWorker(sizePtr(3))},
+			},
+			wantErr: true,
+			errSub:  "engine.worker is set but engine.leader is not",
+		},
+		{
+			name: "engine: worker with nil size — rejected",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: withWorker(nil),
+				},
+			},
+			wantErr: true,
+			errSub:  "worker.size is not a positive integer",
+		},
+		{
+			name: "engine: worker with size=0 — rejected",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: withWorker(sizePtr(0)),
+				},
+			},
+			wantErr: true,
+			errSub:  "worker.size is not a positive integer",
+		},
+		{
+			name: "decoder: leader without worker — rejected",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine:  &v1beta1.EngineSpec{},
+				Decoder: &v1beta1.DecoderSpec{Leader: &v1beta1.LeaderSpec{}},
+			},
+			wantErr: true,
+			errSub:  "decoder.leader is set but decoder.worker is not",
+		},
+		{
+			name: "engine OK, decoder OK — both single-pod, both pass",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine:  &v1beta1.EngineSpec{},
+				Decoder: &v1beta1.DecoderSpec{},
+			},
+		},
+		{
+			name: "engine fails first — engine error surfaces (decoder not checked)",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine:  &v1beta1.EngineSpec{Leader: &v1beta1.LeaderSpec{}},
+				Decoder: &v1beta1.DecoderSpec{Worker: withWorker(sizePtr(2))},
+			},
+			wantErr: true,
+			errSub:  "engine.leader",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateLeaderWorkerPairing(tc.spec)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tc.errSub != "" && !strings.Contains(err.Error(), tc.errSub) {
+					t.Fatalf("expected error to contain %q, got %v", tc.errSub, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateReplicaBounds(t *testing.T) {
+	intPtr := func(v int) *int { return &v }
+
+	tests := []struct {
+		name    string
+		min     *int
+		max     *int
+		wantErr bool
+	}{
+		{name: "nil both", min: nil, max: nil},
+		{name: "valid range", min: intPtr(1), max: intPtr(3)},
+		{name: "min equals max", min: intPtr(2), max: intPtr(2)},
+		{name: "min zero", min: intPtr(0), max: intPtr(1)},
+		{name: "negative min", min: intPtr(-1), max: intPtr(1), wantErr: true},
+		{name: "zero max", min: intPtr(0), max: intPtr(0), wantErr: true},
+		{name: "min greater than max", min: intPtr(5), max: intPtr(2), wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateReplicaBounds(tc.min, tc.max)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAutoscalerConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantErr     bool
+	}{
+		{
+			name:        "no autoscaler annotation",
+			annotations: map[string]string{},
+		},
+		{
+			name: "valid HPA class",
+			annotations: map[string]string{
+				constants.AutoscalerClass: string(constants.AutoscalerClassHPA),
+			},
+		},
+		{
+			name: "valid HPA with cpu metric",
+			annotations: map[string]string{
+				constants.AutoscalerClass:   string(constants.AutoscalerClassHPA),
+				constants.AutoscalerMetrics: "cpu",
+			},
+		},
+		{
+			name: "HPA with invalid metric",
+			annotations: map[string]string{
+				constants.AutoscalerClass:   string(constants.AutoscalerClassHPA),
+				constants.AutoscalerMetrics: "bogus",
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsupported autoscaler class",
+			annotations: map[string]string{
+				constants.AutoscalerClass: "unsupported",
+			},
+			wantErr: true,
+		},
+		{
+			name: "KEDA class accepted (no validation in phase 1)",
+			annotations: map[string]string{
+				constants.AutoscalerClass: string(constants.AutoscalerClassKEDA),
+			},
+		},
+		{
+			name: "valid external class",
+			annotations: map[string]string{
+				constants.AutoscalerClass: string(constants.AutoscalerClassExternal),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Annotations: tc.annotations},
+			}
+			_, err := ValidateAutoscalerConfig(isvc)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateLeaderWorkerPairing_ReasonConstants confirms the
+// Multi-node validation reason constants appear in the error strings the
+// validator emits. Operators and the webhook test suites grep for
+// these exact tokens.
+func TestValidateLeaderWorkerPairing_ReasonConstants(t *testing.T) {
+	sizePtr := func(v int) *int { return &v }
+
+	tests := []struct {
+		name           string
+		spec           *v1beta1.InferenceServiceSpec
+		wantReasons    []string
+		notWantReasons []string
+	}{
+		{
+			name: "leader without worker — LeaderRequiresWorker",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{Leader: &v1beta1.LeaderSpec{}},
+			},
+			wantReasons: []string{ReasonInvalidLeaderWorkerPairing, ReasonLeaderRequiresWorker},
+		},
+		{
+			name: "worker without leader — WorkerRequiresLeader",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{Worker: &v1beta1.WorkerSpec{Size: sizePtr(3)}},
+			},
+			wantReasons: []string{ReasonInvalidLeaderWorkerPairing, ReasonWorkerRequiresLeader},
+		},
+		{
+			name: "leader + worker(size=0) — WorkerSizeMustBePositive",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: &v1beta1.WorkerSpec{Size: sizePtr(0)},
+				},
+			},
+			wantReasons: []string{ReasonInvalidLeaderWorkerPairing, ReasonWorkerSizeMustBePositive},
+		},
+		{
+			name: "leader + worker(nil size) — WorkerSizeMustBePositive",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: &v1beta1.WorkerSpec{},
+				},
+			},
+			wantReasons: []string{ReasonInvalidLeaderWorkerPairing, ReasonWorkerSizeMustBePositive},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateLeaderWorkerPairing(tc.spec)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			for _, want := range tc.wantReasons {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("expected error to contain %q, got %v", want, err)
+				}
+			}
+			for _, notWant := range tc.notWantReasons {
+				if strings.Contains(err.Error(), notWant) {
+					t.Errorf("expected error to NOT contain %q, got %v", notWant, err)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateLeaderSize is structurally a no-op against the current
+// API surface (LeaderSpec has no Size field; see ValidateLeaderSize
+// doc). The test pins the reason constant + entry point so any
+// future API evolution that adds a leader Size field surfaces a test
+// failure rather than silently passing.
+func TestValidateLeaderSize(t *testing.T) {
+	sizePtr := func(v int) *int { return &v }
+
+	tests := []struct {
+		name    string
+		spec    *v1beta1.InferenceServiceSpec
+		wantErr bool
+	}{
+		{name: "nil spec", spec: nil},
+		{name: "empty spec", spec: &v1beta1.InferenceServiceSpec{}},
+		{name: "single-pod engine", spec: &v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{}}},
+		{
+			name: "multi-pod engine — leader implicitly size=1 by type",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: &v1beta1.WorkerSpec{Size: sizePtr(3)},
+				},
+			},
+		},
+		{
+			name: "multi-pod decoder — leader implicitly size=1 by type",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{},
+				Decoder: &v1beta1.DecoderSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: &v1beta1.WorkerSpec{Size: sizePtr(2)},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateLeaderSize(tc.spec)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), ReasonLeaderSizeMustBeOne) {
+					t.Errorf("expected reason %q, got %v", ReasonLeaderSizeMustBeOne, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateMultiPodLeanRunner covers the rule
+// that a lean (no spec.model, no spec.runtime) multi-pod ISVC must
+// declare both leader.runner.image and worker.runner.image. The
+// controller has no defaulting source for those images.
+func TestValidateMultiPodLeanRunner(t *testing.T) {
+	sizePtr := func(v int) *int { return &v }
+	withRunner := func(img string) *v1beta1.RunnerSpec {
+		if img == "" {
+			return &v1beta1.RunnerSpec{}
+		}
+		return &v1beta1.RunnerSpec{Container: corev1.Container{Image: img}}
+	}
+	modelRef := &v1beta1.ModelRef{Name: "llama"}
+	runtimeRef := &v1beta1.ServingRuntimeRef{Name: "vllm"}
+
+	tests := []struct {
+		name    string
+		spec    *v1beta1.InferenceServiceSpec
+		wantErr bool
+	}{
+		{name: "nil spec", spec: nil},
+		{
+			name: "model set, no leader/worker images — allowed (controller resolves)",
+			spec: &v1beta1.InferenceServiceSpec{
+				Model: modelRef,
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: &v1beta1.WorkerSpec{Size: sizePtr(2)},
+				},
+			},
+		},
+		{
+			name: "runtime set, no leader/worker images — allowed (runtime resolves)",
+			spec: &v1beta1.InferenceServiceSpec{
+				Runtime: runtimeRef,
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: &v1beta1.WorkerSpec{Size: sizePtr(2)},
+				},
+			},
+		},
+		{
+			name: "lean single-pod engine — rule does not fire (no multi-pod)",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{},
+			},
+		},
+		{
+			name: "lean multi-pod engine, both images set — allowed",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{Runner: withRunner("leader:1")},
+					Worker: &v1beta1.WorkerSpec{
+						Size:   sizePtr(2),
+						Runner: withRunner("worker:1"),
+					},
+				},
+			},
+		},
+		{
+			name: "lean multi-pod engine, leader image missing — REJECT",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: &v1beta1.WorkerSpec{
+						Size:   sizePtr(2),
+						Runner: withRunner("worker:1"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "lean multi-pod engine, worker image missing — REJECT",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{Runner: withRunner("leader:1")},
+					Worker: &v1beta1.WorkerSpec{Size: sizePtr(2)},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "lean multi-pod engine, both runner specs but empty images — REJECT",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{Runner: withRunner("")},
+					Worker: &v1beta1.WorkerSpec{
+						Size:   sizePtr(2),
+						Runner: withRunner(""),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "lean multi-pod decoder, missing images — REJECT",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{},
+				Decoder: &v1beta1.DecoderSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: &v1beta1.WorkerSpec{Size: sizePtr(2)},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMultiPodLeanRunner(tc.spec)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), ReasonMultiPodLeanModelNeedsRunner) {
+					t.Errorf("expected reason %q in error, got %v", ReasonMultiPodLeanModelNeedsRunner, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateComponentAutoscaler is the table-driven coverage for
+// Webhook validation of the per-Component Autoscaler block. Two
+// invariants the cases pin:
+//
+//   - `none` and `external` are accepted with no shape requirements —
+//     both mean the controller does not manage scaling itself.
+//   - No KEDA-installed check — KEDA is always required for class=KEDA,
+//     and the webhook does not probe the cluster.
+func TestValidateComponentAutoscaler(t *testing.T) {
+	cpu80 := resource.MustParse("80")
+	validHPAMetrics := []autoscalingv2.MetricSpec{{
+		Type: autoscalingv2.ResourceMetricSourceType,
+		Resource: &autoscalingv2.ResourceMetricSource{
+			Name: corev1.ResourceCPU,
+			Target: autoscalingv2.MetricTarget{
+				Type:         autoscalingv2.UtilizationMetricType,
+				AverageValue: &cpu80,
+			},
+		},
+	}}
+	validKedaTriggers := []kedav1.ScaleTriggers{{
+		Type: "prometheus",
+		Metadata: map[string]string{
+			"serverAddress": "http://prom:9090",
+			"query":         "rate(sglang:num_requests_waiting[1m])",
+			"threshold":     "20",
+		},
+	}}
+
+	tests := []struct {
+		name            string
+		ext             *v1beta1.ComponentExtensionSpec
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name: "valid hpa with nil HPA spec — defaults to CPU=80% downstream",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerHPA},
+			},
+		},
+		{
+			name: "valid hpa with full Metrics",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{
+					Class: v1beta1.AutoscalerHPA,
+					HPA:   &v1beta1.HPAAutoscaler{Metrics: validHPAMetrics},
+				},
+			},
+		},
+		{
+			name: "valid keda with 1 trigger",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{
+					Class: v1beta1.AutoscalerKEDA,
+					Keda:  &v1beta1.KedaAutoscaler{Triggers: validKedaTriggers},
+				},
+			},
+		},
+		{
+			name: "valid external (Q5 status-field twin of none)",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerExternal},
+			},
+		},
+		{
+			name: "valid none (Q5 status-field twin of external)",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerNone},
+			},
+		},
+		{
+			name: "reject keda with empty Triggers",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{
+					Class: v1beta1.AutoscalerKEDA,
+					Keda:  &v1beta1.KedaAutoscaler{Triggers: nil},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "class=keda requires at least 1 trigger",
+		},
+		{
+			name: "reject keda with nil Keda block",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{
+					Class: v1beta1.AutoscalerKEDA,
+				},
+			},
+			wantErr:         true,
+			wantErrContains: ReasonKedaTriggersRequired,
+		},
+		{
+			name: "reject hpa Type=Resource with Resource=nil",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{
+					Class: v1beta1.AutoscalerHPA,
+					HPA: &v1beta1.HPAAutoscaler{Metrics: []autoscalingv2.MetricSpec{{
+						Type:     autoscalingv2.ResourceMetricSourceType,
+						Resource: nil,
+					}}},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "type=Resource but",
+		},
+		{
+			name: "reject hpa Type=Pods with Pods=nil",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{
+					Class: v1beta1.AutoscalerHPA,
+					HPA: &v1beta1.HPAAutoscaler{Metrics: []autoscalingv2.MetricSpec{{
+						Type: autoscalingv2.PodsMetricSourceType,
+					}}},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "type=Pods but",
+		},
+		{
+			name: "reject hpa empty Type",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{
+					Class: v1beta1.AutoscalerHPA,
+					HPA:   &v1beta1.HPAAutoscaler{Metrics: []autoscalingv2.MetricSpec{{Type: ""}}},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "is empty",
+		},
+		{
+			name: "reject hpa Type=External with External=nil",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{
+					Class: v1beta1.AutoscalerHPA,
+					HPA: &v1beta1.HPAAutoscaler{Metrics: []autoscalingv2.MetricSpec{{
+						Type: autoscalingv2.ExternalMetricSourceType,
+					}}},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "type=External but",
+		},
+		{
+			name: "reject keda IdleReplicaCount >= MinReplicaCount",
+			ext: &v1beta1.ComponentExtensionSpec{
+				MinReplicas: ptr.To[int](2),
+				Autoscaler: &v1beta1.ComponentAutoscaler{
+					Class: v1beta1.AutoscalerKEDA,
+					Keda: &v1beta1.KedaAutoscaler{
+						Triggers:         validKedaTriggers,
+						IdleReplicaCount: ptr.To[int32](2),
+					},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "keda.idleReplicaCount must be < minReplicas",
+		},
+		{
+			name: "accept keda IdleReplicaCount=0 with MinReplicaCount=1",
+			ext: &v1beta1.ComponentExtensionSpec{
+				MinReplicas: ptr.To[int](1),
+				Autoscaler: &v1beta1.ComponentAutoscaler{
+					Class: v1beta1.AutoscalerKEDA,
+					Keda: &v1beta1.KedaAutoscaler{
+						Triggers:         validKedaTriggers,
+						IdleReplicaCount: ptr.To[int32](0),
+					},
+				},
+			},
+		},
+		{
+			name: "reject class value not in enum (defense-in-depth)",
+			ext: &v1beta1.ComponentExtensionSpec{
+				Autoscaler: &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerClass("knative")},
+			},
+			wantErr:         true,
+			wantErrContains: "is not one of HPA|KEDA|External|None",
+		},
+		{
+			name: "nil componentExt — no error",
+			ext:  nil,
+		},
+		{
+			name: "nil Autoscaler block — no error",
+			ext: &v1beta1.ComponentExtensionSpec{
+				MinReplicas: ptr.To[int](1),
+				MaxReplicas: 3,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateComponentAutoscaler(tc.ext)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr && tc.wantErrContains != "" {
+				if got := err.Error(); !strings.Contains(got, tc.wantErrContains) {
+					t.Fatalf("error string\n\tgot:  %q\n\twant substring: %q", got, tc.wantErrContains)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateAutoscaler covers the (autoscaler, minReplicas) core
+// signature that lets callers without a parent ComponentExtensionSpec
+// (notably the InferenceReplica webhook) validate without synthesizing
+// one to fit the ValidateComponentAutoscaler shape.
+//
+// The behaviour parity with ValidateComponentAutoscaler is covered by
+// TestValidateComponentAutoscaler above — this test asserts the cases
+// that are only reachable through the direct signature.
+func TestValidateAutoscaler(t *testing.T) {
+	validKedaTriggers := []kedav1.ScaleTriggers{{
+		Type:     "prometheus",
+		Metadata: map[string]string{"serverAddress": "x", "query": "y", "threshold": "1"},
+	}}
+
+	tests := []struct {
+		name            string
+		autoscaler      *v1beta1.ComponentAutoscaler
+		minReplicas     *int
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name: "nil autoscaler is a no-op even with non-nil minReplicas",
+			// IR webhook: spec.autoscaler may be nil while spec.replicas is set;
+			// must return nil rather than panic on nil-deref.
+			minReplicas: ptr.To[int](3),
+		},
+		{
+			name: "keda IdleReplicaCount >= minReplicas — REJECT (IR-style call)",
+			// Equivalent to the IR webhook passing spec.replicas as the floor.
+			autoscaler: &v1beta1.ComponentAutoscaler{
+				Class: v1beta1.AutoscalerKEDA,
+				Keda: &v1beta1.KedaAutoscaler{
+					Triggers:         validKedaTriggers,
+					IdleReplicaCount: ptr.To[int32](2),
+				},
+			},
+			minReplicas:     ptr.To[int](2),
+			wantErr:         true,
+			wantErrContains: "keda.idleReplicaCount must be < minReplicas",
+		},
+		{
+			name: "keda IdleReplicaCount with nil minReplicas — skip check",
+			// IR webhook with spec.replicas nil: skip the idle-vs-min check
+			// rather than reject (controller will pick the default later).
+			autoscaler: &v1beta1.ComponentAutoscaler{
+				Class: v1beta1.AutoscalerKEDA,
+				Keda: &v1beta1.KedaAutoscaler{
+					Triggers:         validKedaTriggers,
+					IdleReplicaCount: ptr.To[int32](5),
+				},
+			},
+			minReplicas: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAutoscaler(tc.autoscaler, tc.minReplicas)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr && tc.wantErrContains != "" {
+				if got := err.Error(); !strings.Contains(got, tc.wantErrContains) {
+					t.Fatalf("error string\n\tgot:  %q\n\twant substring: %q", got, tc.wantErrContains)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateComponentsAutoscalers covers the slice-driven dispatch
+// shared by the ISVC, ServingRuntime, and IR webhooks. Asserts that
+// (a) the first failure short-circuits, (b) the per-Component Name is
+// prepended via %w (so callers can unwrap to ReasonXxx), (c) nil/empty
+// slice + nil Autoscaler entries are no-ops, and (d) an empty Name
+// returns the inner error unwrapped (so the IR site with a single check
+// reads naturally).
+func TestValidateComponentsAutoscalers(t *testing.T) {
+	badKEDA := &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerKEDA}
+	validHPA := &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerHPA}
+
+	t.Run("nil slice is a no-op", func(t *testing.T) {
+		if err := ValidateComponentsAutoscalers(nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty slice is a no-op", func(t *testing.T) {
+		if err := ValidateComponentsAutoscalers([]ComponentAutoscalerCheck{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("all entries with nil Autoscaler — no-op", func(t *testing.T) {
+		err := ValidateComponentsAutoscalers([]ComponentAutoscalerCheck{
+			{Name: "engine"},
+			{Name: "decoder"},
+			{Name: "router"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("all valid — accept", func(t *testing.T) {
+		err := ValidateComponentsAutoscalers([]ComponentAutoscalerCheck{
+			{Name: "engine", Autoscaler: validHPA},
+			{Name: "decoder", Autoscaler: validHPA},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("first failure short-circuits with Name prefix", func(t *testing.T) {
+		// engine is valid, decoder is invalid, router would also be
+		// invalid — assert the error names "decoder" (not "router").
+		err := ValidateComponentsAutoscalers([]ComponentAutoscalerCheck{
+			{Name: "engine", Autoscaler: validHPA},
+			{Name: "decoder", Autoscaler: badKEDA},
+			{Name: "router", Autoscaler: badKEDA},
+		})
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "decoder:") {
+			t.Fatalf("expected 'decoder:' prefix, got %q", err.Error())
+		}
+		if strings.Contains(err.Error(), "router:") {
+			t.Fatalf("expected router not reached, got %q", err.Error())
+		}
+	})
+
+	t.Run("unwrap returns the inner Reason error", func(t *testing.T) {
+		err := ValidateComponentsAutoscalers([]ComponentAutoscalerCheck{
+			{Name: "engine", Autoscaler: badKEDA},
+		})
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		// %w wrapping must preserve the Reason prefix on Unwrap.
+		inner := errors.Unwrap(err)
+		if inner == nil {
+			t.Fatalf("expected unwrappable error, got plain %q", err.Error())
+		}
+		if !strings.Contains(inner.Error(), ReasonKedaTriggersRequired) {
+			t.Fatalf("unwrapped error missing reason: %q", inner.Error())
+		}
+	})
+
+	t.Run("empty Name returns inner error unwrapped", func(t *testing.T) {
+		// Single-Component callers (IR webhook style) pass an empty Name
+		// so the message reads "<reason>: ..." not ": <reason>: ...".
+		err := ValidateComponentsAutoscalers([]ComponentAutoscalerCheck{
+			{Autoscaler: badKEDA},
+		})
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if strings.HasPrefix(err.Error(), ":") {
+			t.Fatalf("empty Name produced bare-colon prefix: %q", err.Error())
+		}
+	})
+
+	t.Run("MinReplicas is per-entry, not shared", func(t *testing.T) {
+		// engine has minReplicas=2 + idleReplica=2 → REJECT.
+		// decoder has minReplicas=3 + idleReplica=2 → accept (but engine
+		// short-circuits first).
+		bad := &v1beta1.ComponentAutoscaler{
+			Class: v1beta1.AutoscalerKEDA,
+			Keda: &v1beta1.KedaAutoscaler{
+				Triggers: []kedav1.ScaleTriggers{{
+					Type:     "prometheus",
+					Metadata: map[string]string{"serverAddress": "x", "query": "y", "threshold": "1"},
+				}},
+				IdleReplicaCount: ptr.To[int32](2),
+			},
+		}
+		err := ValidateComponentsAutoscalers([]ComponentAutoscalerCheck{
+			{Name: "engine", Autoscaler: bad, MinReplicas: ptr.To[int](2)},
+			{Name: "decoder", Autoscaler: bad, MinReplicas: ptr.To[int](3)},
+		})
+		if err == nil || !strings.Contains(err.Error(), "engine:") {
+			t.Fatalf("expected engine reject, got %v", err)
+		}
+	})
+}
+
+// TestValidateAutoscalerAnnotationConflict covers the rule
+// that the legacy ome.io/autoscalerClass annotation cannot coexist
+// with a per-Component Autoscaler block; the validator pre-empts the
+// confused "two sources of truth" state by forcing operators to pick
+// one.
+func TestValidateAutoscalerAnnotationConflict(t *testing.T) {
+	hpaBlock := &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerHPA}
+
+	tests := []struct {
+		name    string
+		isvc    *v1beta1.InferenceService
+		wantErr bool
+	}{
+		{
+			name: "no annotation, no block",
+			isvc: &v1beta1.InferenceService{},
+		},
+		{
+			name: "annotation alone (legacy path)",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.AutoscalerClass: string(constants.AutoscalerClassHPA),
+					},
+				},
+			},
+		},
+		{
+			name: "Autoscaler block on engine, no annotation (new path)",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Autoscaler: hpaBlock},
+					},
+				},
+			},
+		},
+		{
+			name: "annotation + engine.autoscaler block — REJECT",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.AutoscalerClass: string(constants.AutoscalerClassHPA),
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Autoscaler: hpaBlock},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "annotation + decoder.autoscaler block — REJECT",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.AutoscalerClass: string(constants.AutoscalerClassKEDA),
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Decoder: &v1beta1.DecoderSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Autoscaler: hpaBlock},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "annotation + router.autoscaler block — REJECT",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.AutoscalerClass: string(constants.AutoscalerClassExternal),
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Router: &v1beta1.RouterSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{Autoscaler: hpaBlock},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAutoscalerAnnotationConflict(tc.isvc)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr {
+				if !strings.Contains(err.Error(), ReasonAutoscalerAnnotationConflict) {
+					t.Fatalf("error %q did not contain reason %q", err, ReasonAutoscalerAnnotationConflict)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAutoscalerTargetUtilizationPercentage(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantErr     bool
+	}{
+		{name: "no annotation", annotations: map[string]string{}},
+		{name: "valid 50", annotations: map[string]string{constants.TargetUtilizationPercentage: "50"}},
+		{name: "valid 1", annotations: map[string]string{constants.TargetUtilizationPercentage: "1"}},
+		{name: "valid 100", annotations: map[string]string{constants.TargetUtilizationPercentage: "100"}},
+		{name: "zero", annotations: map[string]string{constants.TargetUtilizationPercentage: "0"}, wantErr: true},
+		{name: "101", annotations: map[string]string{constants.TargetUtilizationPercentage: "101"}, wantErr: true},
+		{name: "not a number", annotations: map[string]string{constants.TargetUtilizationPercentage: "abc"}, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Annotations: tc.annotations},
+			}
+			err := ValidateAutoscalerTargetUtilizationPercentage(isvc)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateLegacyAutoscalerFieldsRaw exercises the
+// defense-in-depth check that rejects requests carrying the deleted
+// scaleTarget / scaleMetric fields with a friendly migration message.
+// Most paths NEVER trigger in practice (CRD schema pruning drops the
+// unknown fields server-side), so the test is the canonical operator-
+// facing record of what error a stale client would see.
+func TestValidateLegacyAutoscalerFieldsRaw(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantField string // "" means no error
+	}{
+		{name: "empty raw", raw: ""},
+		{name: "no spec at all", raw: `{}`},
+		{name: "spec without components", raw: `{"spec":{"model":{"name":"m"}}}`},
+		{
+			name: "engine without legacy fields",
+			raw:  `{"spec":{"engine":{"minReplicas":1,"maxReplicas":5}}}`,
+		},
+		{
+			name: "engine.autoscaler block alone is fine",
+			raw:  `{"spec":{"engine":{"autoscaler":{"class":"HPA"}}}}`,
+		},
+		{
+			name:      "engine.scaleTarget=5 rejected",
+			raw:       `{"spec":{"engine":{"scaleTarget":5}}}`,
+			wantField: "engine.scaleTarget",
+		},
+		{
+			name:      "engine.scaleMetric=cpu rejected",
+			raw:       `{"spec":{"engine":{"scaleMetric":"cpu"}}}`,
+			wantField: "engine.scaleMetric",
+		},
+		{
+			name:      "decoder.scaleTarget rejected",
+			raw:       `{"spec":{"decoder":{"scaleTarget":80}}}`,
+			wantField: "decoder.scaleTarget",
+		},
+		{
+			name:      "router.scaleMetric rejected",
+			raw:       `{"spec":{"router":{"scaleMetric":"memory"}}}`,
+			wantField: "router.scaleMetric",
+		},
+		{
+			name:      "engineConfig.scaleTarget rejected (PD-disaggregated shape)",
+			raw:       `{"spec":{"engineConfig":{"scaleTarget":50}}}`,
+			wantField: "engineConfig.scaleTarget",
+		},
+		{
+			name: "explicit null scaleTarget is OK (operator's explicit unset)",
+			raw:  `{"spec":{"engine":{"scaleTarget":null}}}`,
+		},
+		{
+			name: "malformed JSON is silently passed (primary decoder reports)",
+			raw:  `{"spec":{`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateLegacyAutoscalerFieldsRaw([]byte(tc.raw))
+			if tc.wantField == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error mentioning %q; got nil", tc.wantField)
+			}
+			if !strings.Contains(err.Error(), ReasonLegacyAutoscalerFieldsRejected) {
+				t.Errorf("error %q missing reason constant %q", err, ReasonLegacyAutoscalerFieldsRejected)
+			}
+			if !strings.Contains(err.Error(), tc.wantField) {
+				t.Errorf("error %q missing field name %q", err, tc.wantField)
+			}
+			if !strings.Contains(err.Error(), "spec.") {
+				t.Errorf("error %q missing spec.* prefix for operator legibility", err)
+			}
+			if !strings.Contains(err.Error(), "autoscaler") {
+				t.Errorf("error %q missing migration pointer to autoscaler block", err)
+			}
+		})
+	}
+}
+
+// TestValidateScaleToZero covers the MinReplicas=0 KEDA gate. The two
+// accept-paths are (a) the legacy whole-ISVC ome.io/autoscalerClass=keda
+// annotation and (b) the typed per-Component
+// spec.<component>.autoscaler.class=KEDA block. The typed path is
+// evaluated PER Component: a zero-replica Component must itself be
+// KEDA-autoscaled — a KEDA block on a *different* Component does not
+// excuse it. Note the deliberate case mismatch: typed enum "KEDA" vs
+// legacy annotation value "keda".
+func TestValidateScaleToZero(t *testing.T) {
+	kedaAutoscaler := func() *v1beta1.ComponentAutoscaler {
+		return &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerKEDA}
+	}
+	hpaAutoscaler := func() *v1beta1.ComponentAutoscaler {
+		return &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerHPA}
+	}
+
+	tests := []struct {
+		name    string
+		isvc    *v1beta1.InferenceService
+		wantErr bool
+	}{
+		{
+			name: "no component sets MinReplicas=0 — accepted",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: ptr.To(1)},
+					},
+				},
+			},
+		},
+		{
+			name: "nil MinReplicas everywhere — accepted",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine:  &v1beta1.EngineSpec{},
+					Decoder: &v1beta1.DecoderSpec{},
+					Router:  &v1beta1.RouterSpec{},
+				},
+			},
+		},
+		{
+			name: "engine MinReplicas=0 with typed KEDA autoscaler — accepted",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(0),
+							Autoscaler:  kedaAutoscaler(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "decoder MinReplicas=0 with typed KEDA autoscaler — accepted",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Decoder: &v1beta1.DecoderSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(0),
+							Autoscaler:  kedaAutoscaler(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "router MinReplicas=0 with typed KEDA autoscaler — accepted",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Router: &v1beta1.RouterSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(0),
+							Autoscaler:  kedaAutoscaler(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "engine MinReplicas=0 with NO KEDA (no annotation, no typed) — rejected",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: ptr.To(0)},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "engine MinReplicas=0 with typed HPA autoscaler (not KEDA) — rejected",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(0),
+							Autoscaler:  hpaAutoscaler(),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "engine MinReplicas=0 with legacy keda annotation — accepted",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.AutoscalerClass: string(constants.AutoscalerClassKEDA),
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: ptr.To(0)},
+					},
+				},
+			},
+		},
+		{
+			name: "legacy keda annotation covers every zero Component — accepted",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.AutoscalerClass: string(constants.AutoscalerClassKEDA),
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: ptr.To(0)},
+					},
+					Decoder: &v1beta1.DecoderSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: ptr.To(0)},
+					},
+				},
+			},
+		},
+		{
+			name: "legacy hpa annotation does not satisfy the KEDA gate — rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.AutoscalerClass: string(constants.AutoscalerClassHPA),
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: ptr.To(0)},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "per-Component scoping: engine=0 typed-KEDA but decoder=0 without KEDA — rejected",
+			// A typed KEDA block on the engine must NOT excuse a separate
+			// zero-replica decoder that has no KEDA opt-in of its own.
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(0),
+							Autoscaler:  kedaAutoscaler(),
+						},
+					},
+					Decoder: &v1beta1.DecoderSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: ptr.To(0)},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "per-Component scoping: both zero Components carry typed KEDA — accepted",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(0),
+							Autoscaler:  kedaAutoscaler(),
+						},
+					},
+					Decoder: &v1beta1.DecoderSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(0),
+							Autoscaler:  kedaAutoscaler(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateScaleToZero(tc.isvc)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), "InvalidScaleToZero") {
+					t.Errorf("error %q missing InvalidScaleToZero reason", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/validation/isvc_test.go
+++ b/pkg/validation/isvc_test.go
@@ -1070,7 +1070,7 @@ func TestValidateComponentsAutoscalers(t *testing.T) {
 
 // TestValidateAutoscalerAnnotationConflict covers the rule
 // that the legacy ome.io/autoscalerClass annotation cannot coexist
-// with a per-Component Autoscaler block; the validator pre-empts the
+// with a per-Component Autoscaler block; the validator preempts the
 // confused "two sources of truth" state by forcing operators to pick
 // one.
 func TestValidateAutoscalerAnnotationConflict(t *testing.T) {

--- a/pkg/validation/lifecycle.go
+++ b/pkg/validation/lifecycle.go
@@ -1,0 +1,182 @@
+// Per-Component LifecycleSpec.UpdateStrategy.RollingUpdate validation.
+//
+// The CRD schema's XIntOrString marker already gates the structural
+// shape (must parse as integer or string). These helpers add the
+// semantic checks the apiserver can't express: percent strings must
+// match "<n>%" with 0 <= n <= 100, integer values must be >= 0.
+//
+// As of the per-Component MaxSurge/MaxUnavailable wire-up, the rollout
+// budget now reads the per-Component RollingUpdate fields directly
+// (see pkg/controller/v1beta1/workload/budget.go) and composes them
+// with the coordination-group budgets as independent layers — the
+// effective cap is the min of both. Because the per-Component layer
+// now actively gates rollouts, we MUST also reject the unstartable
+// configuration (MaxSurge=0 AND MaxUnavailable=0), mirroring upstream
+// appsv1.Deployment's same rule. Either knob nil (operator unset) is
+// fine — nil means "this layer does not cap" so the rollout falls
+// through to the group layer.
+//
+// The webhook ALSO rejects the equivalent deadlock at the
+// coordination-pacing layer (see validatePacingNotZeroBudget in
+// coordination.go) so the operator-visible blast radius is consistent
+// across both layers.
+package validation
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// Admission rejection reasons for per-Component lifecycle settings.
+const (
+	ReasonInvalidRollingUpdatePercent = "InvalidRollingUpdatePercent"
+	ReasonInvalidRollingUpdateInteger = "InvalidRollingUpdateInteger"
+	// ReasonRollingUpdateZeroBudget rejects MaxSurge=0 AND MaxUnavailable=0
+	// set explicitly on the same Component's rollingUpdate block — the
+	// rollout would be unstartable (no surge headroom, no drain headroom).
+	// Mirrors the upstream appsv1.Deployment validation rule. Either
+	// field nil (defaulted upstream) does NOT trip this check.
+	ReasonRollingUpdateZeroBudget = "RollingUpdateZeroBudget"
+)
+
+// ValidateLifecycle inspects every Component's LifecycleSpec on the
+// InferenceService. Today the only per-Component knobs that need
+// semantic validation past the CRD schema are
+// UpdateStrategy.RollingUpdate.MaxUnavailable and .MaxSurge — both
+// *intstr.IntOrString.
+// Wired into the webhook from inference_service_validation.go.
+func ValidateLifecycle(spec *v1beta1.InferenceServiceSpec) error {
+	if spec == nil {
+		return nil
+	}
+	if spec.Engine != nil {
+		if err := validateComponentLifecycle("engine", spec.Engine.Lifecycle); err != nil {
+			return err
+		}
+	}
+	if spec.Decoder != nil {
+		if err := validateComponentLifecycle("decoder", spec.Decoder.Lifecycle); err != nil {
+			return err
+		}
+	}
+	if spec.Router != nil {
+		if err := validateComponentLifecycle("router", spec.Router.Lifecycle); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateComponentLifecycle(name string, lc *v1beta1.LifecycleSpec) error {
+	if lc == nil || lc.UpdateStrategy == nil || lc.UpdateStrategy.RollingUpdate == nil {
+		return nil
+	}
+	ru := lc.UpdateStrategy.RollingUpdate
+	if err := validateRollingUpdateIntOrString(name, "maxUnavailable", ru.MaxUnavailable); err != nil {
+		return err
+	}
+	if err := validateRollingUpdateIntOrString(name, "maxSurge", ru.MaxSurge); err != nil {
+		return err
+	}
+	if err := validateRollingUpdateNotBothZero(name, ru.MaxSurge, ru.MaxUnavailable); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateRollingUpdateNotBothZero rejects the unstartable configuration
+// where both MaxSurge and MaxUnavailable are EXPLICITLY set to zero on
+// the same Component's rollingUpdate block. With no surge headroom and
+// no drain headroom the rollout can never make progress — the operator
+// almost certainly mistyped one of the two.
+//
+// This applies to in-place strategies too. An in-place update marks the
+// pod not-ready while it patches the running container, which consumes the
+// per-Component MaxUnavailable budget — so maxUnavailable=0 stalls an
+// in-place roll exactly like a surge/drain one: the patch never starts and
+// the pods sit untouched. Exempting in-place on the premise that it
+// "neither surges nor drains" would be wrong — the mark-not-ready does
+// consume the budget, so an exemption only converts a fail-fast
+// admission error into a silent runtime deadlock.
+//
+// Either field nil (operator left it for the layer below to default)
+// does NOT trip this check; the per-Component layer treats nil as "no
+// cap" and defers to the coordination-group ceiling, which has its
+// own non-zero defaults (25% / 25%). The check only fires when the
+// operator wrote 0 on BOTH knobs intentionally.
+//
+// Mirrors the upstream appsv1.Deployment.Strategy.RollingUpdate
+// validation: see k/k pkg/apis/apps/validation/validation.go
+// ValidateRollingUpdateDeployment.
+func validateRollingUpdateNotBothZero(component string, maxSurge, maxUnavailable *intstr.IntOrString) error {
+	if !explicitZero(maxSurge) || !explicitZero(maxUnavailable) {
+		return nil
+	}
+	return fmt.Errorf("spec.%s.lifecycle.updateStrategy.rollingUpdate: maxSurge=0 and maxUnavailable=0 together yield an unstartable rollout (%s)",
+		component, ReasonRollingUpdateZeroBudget)
+}
+
+// explicitZero reports whether v is non-nil AND parses to the integer
+// 0 (either intstr.FromInt(0) or "0%"). A nil pointer is NOT explicit
+// — operator left it unset for upstream defaulting. Any positive
+// integer or percent fails the predicate.
+func explicitZero(v *intstr.IntOrString) bool {
+	if v == nil {
+		return false
+	}
+	if v.Type == intstr.Int {
+		return v.IntValue() == 0
+	}
+	s := v.StrVal
+	if !strings.HasSuffix(s, "%") {
+		return false
+	}
+	pctStr := strings.TrimSuffix(s, "%")
+	pct, err := strconv.Atoi(pctStr)
+	if err != nil {
+		return false
+	}
+	return pct == 0
+}
+
+// validateRollingUpdateIntOrString enforces:
+//   - integer values >= 0
+//   - string values match "<n>%" with 0 <= n <= 100
+//
+// Returns nil for nil inputs (the workload reconciler defaults nil to
+// 25% — both the API documentation and pacingWithDefaults agree on
+// the same fallback).
+func validateRollingUpdateIntOrString(component, field string, v *intstr.IntOrString) error {
+	if v == nil {
+		return nil
+	}
+	if v.Type == intstr.Int {
+		if v.IntValue() < 0 {
+			return fmt.Errorf("spec.%s.lifecycle.updateStrategy.rollingUpdate.%s=%d must be >= 0 (%s)",
+				component, field, v.IntValue(), ReasonInvalidRollingUpdateInteger)
+		}
+		return nil
+	}
+	// String form — must be "<n>%" with 0 <= n <= 100.
+	s := v.StrVal
+	if !strings.HasSuffix(s, "%") {
+		return fmt.Errorf("spec.%s.lifecycle.updateStrategy.rollingUpdate.%s=%q must be an integer count or a percent string like \"25%%\" (%s)",
+			component, field, s, ReasonInvalidRollingUpdatePercent)
+	}
+	pctStr := strings.TrimSuffix(s, "%")
+	pct, err := strconv.Atoi(pctStr)
+	if err != nil {
+		return fmt.Errorf("spec.%s.lifecycle.updateStrategy.rollingUpdate.%s=%q has a malformed percent value (%s)",
+			component, field, s, ReasonInvalidRollingUpdatePercent)
+	}
+	if pct < 0 || pct > 100 {
+		return fmt.Errorf("spec.%s.lifecycle.updateStrategy.rollingUpdate.%s=%q percent must be between 0%% and 100%% (%s)",
+			component, field, s, ReasonInvalidRollingUpdatePercent)
+	}
+	return nil
+}

--- a/pkg/validation/lifecycle_test.go
+++ b/pkg/validation/lifecycle_test.go
@@ -1,0 +1,230 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// TestValidateLifecycle_NilAndEmptyAccepted asserts the validator
+// short-circuits cleanly on nil specs and empty Lifecycle blocks.
+// Every Component is optional and a Lifecycle-less ISVC is valid.
+func TestValidateLifecycle_NilAndEmptyAccepted(t *testing.T) {
+	if err := ValidateLifecycle(nil); err != nil {
+		t.Fatalf("nil spec: unexpected error %v", err)
+	}
+	if err := ValidateLifecycle(&v1beta1.InferenceServiceSpec{}); err != nil {
+		t.Fatalf("empty spec: unexpected error %v", err)
+	}
+	if err := ValidateLifecycle(&v1beta1.InferenceServiceSpec{
+		Engine: &v1beta1.EngineSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{},
+		},
+	}); err != nil {
+		t.Fatalf("empty engine lifecycle: unexpected error %v", err)
+	}
+}
+
+// TestValidateLifecycle_RollingUpdate_AcceptsAllValidShapes runs the
+// happy-path matrix: nil pointers, integer counts, percent strings
+// within 0..100, and zero values on EITHER (but not both) of MaxSurge
+// / MaxUnavailable. The MaxSurge=0 AND MaxUnavailable=0 combination is
+// rejected by ValidateLifecycle_RollingUpdate_RejectsBothZero below.
+func TestValidateLifecycle_RollingUpdate_AcceptsAllValidShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		mu   *intstr.IntOrString
+		ms   *intstr.IntOrString
+	}{
+		{"both-nil", nil, nil},
+		{"int-zero-mu-only", intstrPtr(intstr.FromInt(0)), nil},
+		{"int-zero-ms-only", nil, intstrPtr(intstr.FromInt(0))},
+		{"int-zero-mu-positive-ms", intstrPtr(intstr.FromInt(0)), intstrPtr(intstr.FromInt(1))},
+		{"int-positive-mu-zero-ms", intstrPtr(intstr.FromInt(2)), intstrPtr(intstr.FromInt(0))},
+		{"int-positive", intstrPtr(intstr.FromInt(2)), intstrPtr(intstr.FromInt(1))},
+		{"percent-mid", intstrPtr(intstr.FromString("25%")), intstrPtr(intstr.FromString("50%"))},
+		{"percent-zero-mu-only", intstrPtr(intstr.FromString("0%")), nil},
+		{"percent-zero-mu-positive-ms", intstrPtr(intstr.FromString("0%")), intstrPtr(intstr.FromString("25%"))},
+		{"percent-edge-hundred", intstrPtr(intstr.FromString("100%")), intstrPtr(intstr.FromString("100%"))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := lifecycleSpec(tc.mu, tc.ms)
+			if err := ValidateLifecycle(spec); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateLifecycle_RollingUpdate_RejectsBothZero pins the new rule
+// added when the per-Component layer started actively gating rollouts:
+// MaxSurge=0 AND MaxUnavailable=0 on the same Component is unstartable
+// — no surge headroom, no drain headroom. Mirrors upstream
+// appsv1.Deployment.Strategy.RollingUpdate validation. Both 0% / 0
+// integer combinations and the mixed (0%, 0) combination trip the
+// rejection.
+func TestValidateLifecycle_RollingUpdate_RejectsBothZero(t *testing.T) {
+	cases := []struct {
+		name string
+		mu   *intstr.IntOrString
+		ms   *intstr.IntOrString
+	}{
+		{"int-zero-both", intstrPtr(intstr.FromInt(0)), intstrPtr(intstr.FromInt(0))},
+		{"pct-zero-both", intstrPtr(intstr.FromString("0%")), intstrPtr(intstr.FromString("0%"))},
+		{"int-zero-mu-pct-zero-ms", intstrPtr(intstr.FromInt(0)), intstrPtr(intstr.FromString("0%"))},
+		{"pct-zero-mu-int-zero-ms", intstrPtr(intstr.FromString("0%")), intstrPtr(intstr.FromInt(0))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := lifecycleSpec(tc.mu, tc.ms)
+			err := ValidateLifecycle(spec)
+			if err == nil {
+				t.Fatalf("expected rejection for MaxSurge=0 AND MaxUnavailable=0; got nil")
+			}
+			if !strings.Contains(err.Error(), ReasonRollingUpdateZeroBudget) {
+				t.Fatalf("expected reason %q in error %q", ReasonRollingUpdateZeroBudget, err.Error())
+			}
+		})
+	}
+}
+
+// TestValidateLifecycle_RollingUpdate_RejectsNegativeInteger covers
+// the int-form rejection path — both MaxUnavailable and MaxSurge must
+// reject negative absolute counts with ReasonInvalidRollingUpdateInteger.
+func TestValidateLifecycle_RollingUpdate_RejectsNegativeInteger(t *testing.T) {
+	negative := intstr.FromInt(-1)
+	cases := []struct {
+		name string
+		mu   *intstr.IntOrString
+		ms   *intstr.IntOrString
+	}{
+		{"negative-mu", &negative, nil},
+		{"negative-ms", nil, &negative},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := lifecycleSpec(tc.mu, tc.ms)
+			err := ValidateLifecycle(spec)
+			if err == nil {
+				t.Fatalf("expected error for negative integer; got nil")
+			}
+			if !strings.Contains(err.Error(), ReasonInvalidRollingUpdateInteger) {
+				t.Fatalf("expected reason %q in error %q", ReasonInvalidRollingUpdateInteger, err.Error())
+			}
+		})
+	}
+}
+
+// TestValidateLifecycle_RollingUpdate_RejectsBadPercentString covers
+// the string-form rejection path — non-percent strings, out-of-range
+// percents, and malformed integers in the percent slot must all fail
+// with ReasonInvalidRollingUpdatePercent.
+func TestValidateLifecycle_RollingUpdate_RejectsBadPercentString(t *testing.T) {
+	cases := []struct {
+		name string
+		val  intstr.IntOrString
+	}{
+		{"no-percent-suffix", intstr.FromString("abc")},
+		{"plain-number-string", intstr.FromString("25")},
+		{"negative-percent", intstr.FromString("-25%")},
+		{"over-hundred-percent", intstr.FromString("150%")},
+		{"non-numeric-percent", intstr.FromString("foo%")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := tc.val
+			spec := lifecycleSpec(&v, nil)
+			err := ValidateLifecycle(spec)
+			if err == nil {
+				t.Fatalf("expected error for %+v; got nil", v)
+			}
+			if !strings.Contains(err.Error(), ReasonInvalidRollingUpdatePercent) {
+				t.Fatalf("expected reason %q in error %q", ReasonInvalidRollingUpdatePercent, err.Error())
+			}
+		})
+	}
+}
+
+// TestValidateLifecycle_RollingUpdate_AppliesAcrossAllComponents
+// confirms the validator walks Engine, Decoder, and Router. A bad
+// MaxSurge on any Component triggers rejection — guards against the
+// validator forgetting to recurse into a new Component.
+func TestValidateLifecycle_RollingUpdate_AppliesAcrossAllComponents(t *testing.T) {
+	bad := intstr.FromInt(-3)
+	cases := []struct {
+		name string
+		spec *v1beta1.InferenceServiceSpec
+	}{
+		{
+			name: "engine",
+			spec: &v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						Lifecycle: lifecycleWithRolling(&bad, nil),
+					},
+				},
+			},
+		},
+		{
+			name: "decoder",
+			spec: &v1beta1.InferenceServiceSpec{
+				Decoder: &v1beta1.DecoderSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						Lifecycle: lifecycleWithRolling(nil, &bad),
+					},
+				},
+			},
+		},
+		{
+			name: "router",
+			spec: &v1beta1.InferenceServiceSpec{
+				Router: &v1beta1.RouterSpec{
+					ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+						Lifecycle: lifecycleWithRolling(&bad, nil),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateLifecycle(tc.spec); err == nil {
+				t.Fatalf("expected error for bad %s rollingUpdate", tc.name)
+			}
+		})
+	}
+}
+
+// --- helpers ------------------------------------------------------------
+
+func intstrPtr(v intstr.IntOrString) *intstr.IntOrString { return &v }
+
+// lifecycleSpec returns an InferenceServiceSpec whose Engine carries
+// the supplied MaxUnavailable / MaxSurge on its rollingUpdate block.
+// Most tests only exercise a single Component; the multi-Component
+// matrix uses the dedicated test above.
+func lifecycleSpec(mu, ms *intstr.IntOrString) *v1beta1.InferenceServiceSpec {
+	return &v1beta1.InferenceServiceSpec{
+		Engine: &v1beta1.EngineSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+				Lifecycle: lifecycleWithRolling(mu, ms),
+			},
+		},
+	}
+}
+
+func lifecycleWithRolling(mu, ms *intstr.IntOrString) *v1beta1.LifecycleSpec {
+	return &v1beta1.LifecycleSpec{
+		UpdateStrategy: &v1beta1.UpdateStrategy{
+			Type: v1beta1.UpdateStrategySurgeThenDrain,
+			RollingUpdate: &v1beta1.RollingUpdate{
+				MaxUnavailable: mu,
+				MaxSurge:       ms,
+			},
+		},
+	}
+}

--- a/pkg/validation/names.go
+++ b/pkg/validation/names.go
@@ -1,0 +1,12 @@
+package validation
+
+import "regexp"
+
+const (
+	IsvcNameFmt = "[a-z]([-a-z0-9]*[a-z0-9])?"
+)
+
+var (
+	IsvcNameRegex       = regexp.MustCompile("^" + IsvcNameFmt + "$")
+	ValidNamespaceRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+)

--- a/pkg/validation/placement.go
+++ b/pkg/validation/placement.go
@@ -1,0 +1,58 @@
+package validation
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// ValidatePlacement checks spec.placement at admission — the parts the CRD
+// schema cannot express. The mode enum (Single|All|Split) is already enforced by
+// the CRD, so this covers:
+//
+//   - the requirement / cluster-selector strings must be valid label selectors.
+//     A malformed selector is otherwise not caught until reconcile, where it
+//     silently yields no candidates and the ISVC sits Pending with no obvious
+//     cause; failing fast at admission turns that into a clear error.
+//   - the Split knobs must be self-consistent (non-negative, replicas >= 1 when
+//     set, and minReplicasPerCluster not above a set maxReplicasPerCluster —
+//     otherwise a home could never reach the anti-sliver floor).
+//
+// No-op when spec.placement is unset (single-cluster / annotation-driven ISVCs).
+func ValidatePlacement(spec *v1beta1.InferenceServiceSpec) error {
+	p := spec.Placement
+	if p == nil {
+		return nil
+	}
+	for _, sel := range []struct{ field, value string }{
+		{"requirements", p.Requirements},
+		{"clusterSelector", p.ClusterSelector},
+	} {
+		if sel.value == "" {
+			continue
+		}
+		if _, err := labels.Parse(sel.value); err != nil {
+			return fmt.Errorf("spec.placement.%s is not a valid label selector %q: %w", sel.field, sel.value, err)
+		}
+	}
+	s := p.Split
+	if s == nil {
+		return nil
+	}
+	if s.Replicas != nil && *s.Replicas < 1 {
+		return fmt.Errorf("spec.placement.split.replicas must be >= 1 when set, got %d", *s.Replicas)
+	}
+	if s.MaxReplicasPerCluster < 0 {
+		return fmt.Errorf("spec.placement.split.maxReplicasPerCluster must be >= 0, got %d", s.MaxReplicasPerCluster)
+	}
+	if s.MinReplicasPerCluster < 0 {
+		return fmt.Errorf("spec.placement.split.minReplicasPerCluster must be >= 0, got %d", s.MinReplicasPerCluster)
+	}
+	if s.MaxReplicasPerCluster > 0 && s.MinReplicasPerCluster > s.MaxReplicasPerCluster {
+		return fmt.Errorf("spec.placement.split.minReplicasPerCluster (%d) must not exceed maxReplicasPerCluster (%d)",
+			s.MinReplicasPerCluster, s.MaxReplicasPerCluster)
+	}
+	return nil
+}

--- a/pkg/validation/placement_test.go
+++ b/pkg/validation/placement_test.go
@@ -1,0 +1,61 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestValidatePlacement(t *testing.T) {
+	spec := func(p *v1beta1.PlacementSpec) *v1beta1.InferenceServiceSpec {
+		return &v1beta1.InferenceServiceSpec{Placement: p}
+	}
+
+	t.Run("nil placement is ok", func(t *testing.T) {
+		require.NoError(t, ValidatePlacement(spec(nil)))
+	})
+
+	t.Run("valid selectors + split", func(t *testing.T) {
+		require.NoError(t, ValidatePlacement(spec(&v1beta1.PlacementSpec{
+			Mode:            v1beta1.PlacementModeSplit,
+			Requirements:    "accelerator in (gpu-a100, gpu-h100)",
+			ClusterSelector: "provider=cloud-a",
+			Split:           &v1beta1.SplitSpec{Replicas: ptr.To(int32(4)), MaxReplicasPerCluster: 3, MinReplicasPerCluster: 1},
+		})))
+	})
+
+	t.Run("malformed requirements selector", func(t *testing.T) {
+		err := ValidatePlacement(spec(&v1beta1.PlacementSpec{Requirements: "!!!"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.placement.requirements")
+	})
+
+	t.Run("malformed clusterSelector", func(t *testing.T) {
+		err := ValidatePlacement(spec(&v1beta1.PlacementSpec{ClusterSelector: "="}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.placement.clusterSelector")
+	})
+
+	t.Run("replicas must be >= 1", func(t *testing.T) {
+		err := ValidatePlacement(spec(&v1beta1.PlacementSpec{Split: &v1beta1.SplitSpec{Replicas: ptr.To(int32(0))}}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "replicas")
+	})
+
+	t.Run("min per cluster must not exceed max", func(t *testing.T) {
+		err := ValidatePlacement(spec(&v1beta1.PlacementSpec{
+			Split: &v1beta1.SplitSpec{MaxReplicasPerCluster: 2, MinReplicasPerCluster: 5},
+		}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "minReplicasPerCluster")
+	})
+
+	t.Run("negative caps rejected", func(t *testing.T) {
+		require.Error(t, ValidatePlacement(spec(&v1beta1.PlacementSpec{Split: &v1beta1.SplitSpec{MaxReplicasPerCluster: -1}})))
+		require.Error(t, ValidatePlacement(spec(&v1beta1.PlacementSpec{Split: &v1beta1.SplitSpec{MinReplicasPerCluster: -1}})))
+	})
+}

--- a/pkg/validation/traffic.go
+++ b/pkg/validation/traffic.go
@@ -1,0 +1,117 @@
+// Traffic-management validation.
+//
+// Webhook-level validation for the TrafficSpec typed core (LB
+// algorithm, hash key, endpoint override). Annotation parsing and
+// rollout validation live in sibling files.
+package validation
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// ValidateTrafficSpec runs the typed-core validation rules for
+// InferenceService.spec.traffic. Returns nil when traffic is unset or
+// internally consistent.
+func ValidateTrafficSpec(t *v1beta1.TrafficSpec) error {
+	if t == nil {
+		return nil
+	}
+
+	if err := validateConsistentHashCoupling(t); err != nil {
+		return err
+	}
+	if err := validateConsistentHashShape(t.ConsistentHash); err != nil {
+		return err
+	}
+	if err := validateEndpointOverride(t.EndpointOverride); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateConsistentHashCoupling enforces that ConsistentHash sub-block
+// is present iff Algorithm == ConsistentHash.
+func validateConsistentHashCoupling(t *v1beta1.TrafficSpec) error {
+	isConsistentHash := t.Algorithm != nil && *t.Algorithm == v1beta1.LoadBalancingTypeConsistentHash
+	switch {
+	case isConsistentHash && t.ConsistentHash == nil:
+		return fmt.Errorf("spec.traffic.consistentHash is required when spec.traffic.algorithm=ConsistentHash (MissingConsistentHashSpec)")
+	case !isConsistentHash && t.ConsistentHash != nil:
+		return fmt.Errorf("spec.traffic.consistentHash is only valid when spec.traffic.algorithm=ConsistentHash (UnexpectedConsistentHashSpec)")
+	}
+	return nil
+}
+
+// validateConsistentHashShape enforces the exactly-one-source rule for
+// the ConsistentHash sub-block. Headers (one or more) when
+// Type=Header, Cookie when Type=Cookie, nothing else when
+// Type=SourceIP.
+func validateConsistentHashShape(c *v1beta1.ConsistentHashSpec) error {
+	if c == nil {
+		return nil
+	}
+	switch c.Type {
+	case v1beta1.HashTypeHeader:
+		if len(c.Headers) == 0 {
+			return fmt.Errorf("spec.traffic.consistentHash.headers must be non-empty when type=Header (MissingHashKey)")
+		}
+		if c.Cookie != nil {
+			return fmt.Errorf("spec.traffic.consistentHash.cookie must not be set when type=Header (MultipleHashKeys)")
+		}
+		for i, h := range c.Headers {
+			if h.Name == "" {
+				return fmt.Errorf("spec.traffic.consistentHash.headers[%d].name is empty (MissingHashKey)", i)
+			}
+		}
+	case v1beta1.HashTypeCookie:
+		if c.Cookie == nil {
+			return fmt.Errorf("spec.traffic.consistentHash.cookie is required when type=Cookie (MissingHashKey)")
+		}
+		if c.Cookie.Name == "" {
+			return fmt.Errorf("spec.traffic.consistentHash.cookie.name is empty (MissingHashKey)")
+		}
+		if len(c.Headers) > 0 {
+			return fmt.Errorf("spec.traffic.consistentHash.headers must not be set when type=Cookie (MultipleHashKeys)")
+		}
+	case v1beta1.HashTypeSourceIP:
+		if c.Cookie != nil {
+			return fmt.Errorf("spec.traffic.consistentHash.cookie must not be set when type=SourceIP (MultipleHashKeys)")
+		}
+		if len(c.Headers) > 0 {
+			return fmt.Errorf("spec.traffic.consistentHash.headers must not be set when type=SourceIP (MultipleHashKeys)")
+		}
+	default:
+		// CRD enum tag should reject this before reaching the webhook;
+		// keep a defensive check in case CRD validation is bypassed.
+		return fmt.Errorf("spec.traffic.consistentHash.type=%q is not a valid HashType", string(c.Type))
+	}
+	return nil
+}
+
+// validateEndpointOverride enforces the Headers requirement when
+// Type=Header.
+func validateEndpointOverride(e *v1beta1.EndpointOverrideSpec) error {
+	if e == nil {
+		return nil
+	}
+	switch e.Type {
+	case v1beta1.EndpointOverrideTypeHeader:
+		if len(e.Headers) == 0 {
+			return fmt.Errorf("spec.traffic.endpointOverride.headers must be non-empty when type=Header (MissingEndpointOverrideKey)")
+		}
+		for i, h := range e.Headers {
+			if h.Name == "" {
+				return fmt.Errorf("spec.traffic.endpointOverride.headers[%d].name is empty (MissingEndpointOverrideKey)", i)
+			}
+		}
+	case v1beta1.EndpointOverrideTypeMetadata:
+		// Metadata variant is reserved for future use; no required
+		// sub-fields in alpha.
+	default:
+		return fmt.Errorf("spec.traffic.endpointOverride.type=%q is not a valid EndpointOverrideType", string(e.Type))
+	}
+	return nil
+}

--- a/pkg/validation/traffic_annotations.go
+++ b/pkg/validation/traffic_annotations.go
@@ -1,0 +1,334 @@
+// Traffic annotation validation.
+//
+// Parses, type-coerces, and cross-checks the ome.io/* traffic
+// annotations defined in pkg/constants/traffic_annotations.go.
+// Wired into the InferenceService validating webhook after the
+// typed-core check (ValidateTrafficSpec).
+package validation
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// trafficAnnotationKind classifies an annotation key's expected value
+// type so the webhook can coerce + reject malformed values uniformly.
+type trafficAnnotationKind int
+
+const (
+	kindUnknown trafficAnnotationKind = iota
+	kindInt
+	kindDuration
+	kindBool
+	kindRetryOnList
+	kindPromoteTarget // int >= 0 or "full"
+)
+
+// trafficAnnotationKinds is the authoritative classifier for every
+// documented ome.io/* traffic annotation key. Keys not in this map and not
+// matching a pass-through prefix are unrecognised (subject to the
+// Did-you-mean check).
+//
+// Must stay in lockstep with pkg/constants/traffic_annotations.go.
+var trafficAnnotationKinds = map[string]trafficAnnotationKind{
+	// Circuit breaker — int counts.
+	constants.CircuitBreakerMaxConnectionsAnnotation:            kindInt,
+	constants.CircuitBreakerMaxParallelRequestsAnnotation:       kindInt,
+	constants.CircuitBreakerMaxPendingRequestsAnnotation:        kindInt,
+	constants.CircuitBreakerMaxParallelRetriesAnnotation:        kindInt,
+	constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation: kindInt,
+
+	// Retries.
+	constants.RetryAttemptsAnnotation:      kindInt,
+	constants.RetryOnAnnotation:            kindRetryOnList,
+	constants.RetryPerTryTimeoutAnnotation: kindDuration,
+
+	// Sub-second / connection timeouts.
+	constants.TimeoutIdleAnnotation:                  kindDuration,
+	constants.TimeoutMaxConnectionDurationAnnotation: kindDuration,
+	constants.TimeoutTCPConnectAnnotation:            kindDuration,
+
+	// Operational.
+	constants.ManagedByConflictAckedAnnotation: kindBool,
+	constants.RolloutReadyTimeoutAnnotation:    kindDuration,
+	constants.RevisionHistoryLimitAnnotation:   kindInt,
+	constants.RolloutPromoteAnnotation:         kindPromoteTarget,
+	constants.RolloutRollbackAnnotation:        kindBool,
+}
+
+// validRetryOnTokens enumerates the documented Envoy retry-on
+// tokens. Tokens are case-sensitive (Envoy is case-sensitive).
+var validRetryOnTokens = map[string]struct{}{
+	"5xx":                    {},
+	"reset":                  {},
+	"gateway-error":          {},
+	"connect-failure":        {},
+	"retriable-status-codes": {},
+}
+
+// ValidateTrafficAnnotations is the webhook entry point. It walks
+// every annotation on the object, validates the type-coerced value of
+// known keys, surfaces Did-you-mean for near-miss unknown keys in the
+// ome.io/ namespace, and enforces cross-annotation rules.
+//
+// knownPassthroughPrefixes is the set of ome.io/* pass-through prefixes
+// the active Gateway-implementation translator supports. When
+// non-empty, pass-through keys outside the set are rejected with
+// UnsupportedPassthrough (fast-fail at admission instead of relying on
+// the controller's BackendPolicyUnsupportedFields condition). When
+// empty (legacy / test default), all documented pass-through prefixes
+// are accepted.
+//
+// Returns admission warnings (for non-fatal hints like
+// "perEndpointMaxConnections > 1 with ConsistentHash usually defeats
+// stickiness") alongside the first hard error.
+func ValidateTrafficAnnotations(annotations map[string]string, traffic *v1beta1.TrafficSpec, knownPassthroughPrefixes ...string) (warnings []string, err error) {
+	// Per-key parse + type check.
+	for key, value := range annotations {
+		kind, known := trafficAnnotationKinds[key]
+		if known {
+			if err := validateAnnotationValue(key, value, kind); err != nil {
+				return warnings, err
+			}
+			continue
+		}
+
+		// Pass-through namespaces. Either accept all documented prefixes
+		// (back-compat when knownPassthroughPrefixes is empty) or only
+		// those the active translator can honor.
+		if strings.HasPrefix(key, constants.PassthroughEnvoyGatewayPrefix) ||
+			strings.HasPrefix(key, constants.PassthroughIstioPrefix) {
+			if len(knownPassthroughPrefixes) > 0 && !hasMatchingPrefix(key, knownPassthroughPrefixes) {
+				return warnings, fmt.Errorf(
+					"annotation %q uses a pass-through prefix the active Gateway-implementation translator does not honor; supported prefixes: %v (UnsupportedPassthrough)",
+					key, knownPassthroughPrefixes,
+				)
+			}
+			continue
+		}
+
+		// Did-you-mean for near-miss ome.io/* keys. Only fires for
+		// keys in the ome.io namespace; foreign-namespace annotations
+		// are ignored entirely.
+		if strings.HasPrefix(key, constants.OMEAPIGroupName+"/") {
+			if suggestion, ok := closestTrafficAnnotation(key); ok {
+				return warnings, fmt.Errorf("unknown traffic annotation %q. Did you mean %q? (UnknownTrafficAnnotation)", key, suggestion)
+			}
+		}
+	}
+
+	// Cross-rules — only check if dependencies are present.
+	if w, err := crossRuleRetry(annotations); err != nil {
+		return warnings, err
+	} else if w != "" {
+		warnings = append(warnings, w)
+	}
+	if w, err := crossRuleStickyEndpointCap(annotations, traffic); err != nil {
+		return warnings, err
+	} else if w != "" {
+		warnings = append(warnings, w)
+	}
+	if w, err := crossRuleRolloutTimeoutSanity(annotations); err != nil {
+		return warnings, err
+	} else if w != "" {
+		warnings = append(warnings, w)
+	}
+
+	return warnings, nil
+}
+
+func validateAnnotationValue(key, value string, kind trafficAnnotationKind) error {
+	switch kind {
+	case kindInt:
+		if _, err := strconv.Atoi(value); err != nil {
+			return fmt.Errorf("annotation %q value %q is not a valid integer (InvalidIntValue): %w", key, value, err)
+		}
+	case kindDuration:
+		if _, err := time.ParseDuration(value); err != nil {
+			return fmt.Errorf("annotation %q value %q is not a valid duration (InvalidDuration): %w", key, value, err)
+		}
+	case kindBool:
+		// Only "true" is meaningful; "false" is identical to absence.
+		// We accept either spelling so operators can be explicit.
+		if value != "true" && value != "false" {
+			return fmt.Errorf("annotation %q value %q must be \"true\" or \"false\" (InvalidBoolValue)", key, value)
+		}
+	case kindRetryOnList:
+		if value == "" {
+			return fmt.Errorf("annotation %q must be a non-empty comma-separated list (InvalidRetryOn)", key)
+		}
+		for _, raw := range strings.Split(value, ",") {
+			tok := strings.TrimSpace(raw)
+			if tok == "" {
+				return fmt.Errorf("annotation %q has an empty token (InvalidRetryOn)", key)
+			}
+			if _, ok := validRetryOnTokens[tok]; !ok {
+				return fmt.Errorf("annotation %q token %q is not a supported retry condition (InvalidRetryOn)", key, tok)
+			}
+		}
+	case kindPromoteTarget:
+		// The canary manual-promote verb expects the canary revision hash (the
+		// value copied from status.canary.canaryRevisionHash); "full" is also
+		// accepted. See promotion.shouldAdvanceManual.
+		if value == "full" {
+			return nil
+		}
+		if !isRevisionHashToken(value) {
+			return fmt.Errorf("annotation %q value %q must be a canary revision hash (lowercase alphanumeric, from status.canary.canaryRevisionHash) or \"full\" (InvalidRolloutPromoteTarget)", key, value)
+		}
+	}
+	return nil
+}
+
+// isRevisionHashToken reports whether s looks like a ControllerRevision hash
+// suffix — lowercase alphanumeric, at least 6 chars — the value the canary's
+// manual-promote verb expects (status.canary.canaryRevisionHash).
+func isRevisionHashToken(s string) bool {
+	if len(s) < 6 {
+		return false
+	}
+	for _, r := range s {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			return false
+		}
+	}
+	return true
+}
+
+// crossRuleRetry enforces "retry-attempts > 0 requires retry-on".
+func crossRuleRetry(annotations map[string]string) (string, error) {
+	attemptsStr, hasAttempts := annotations[constants.RetryAttemptsAnnotation]
+	if !hasAttempts {
+		return "", nil
+	}
+	n, _ := strconv.Atoi(attemptsStr) // already validated as int above
+	if n <= 0 {
+		return "", nil
+	}
+	if _, hasOn := annotations[constants.RetryOnAnnotation]; !hasOn {
+		return "", fmt.Errorf("annotation %q set to %d requires %q to specify retry conditions (MissingRetryOn)",
+			constants.RetryAttemptsAnnotation, n, constants.RetryOnAnnotation)
+	}
+	return "", nil
+}
+
+// crossRuleStickyEndpointCap warns when
+// circuit-breaker-per-endpoint-max-connections > 1 with
+// ConsistentHash — this combination usually defeats the purpose of
+// sticky routing.
+func crossRuleStickyEndpointCap(annotations map[string]string, traffic *v1beta1.TrafficSpec) (string, error) {
+	if traffic == nil || traffic.Algorithm == nil || *traffic.Algorithm != v1beta1.LoadBalancingTypeConsistentHash {
+		return "", nil
+	}
+	capStr, ok := annotations[constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation]
+	if !ok {
+		return "", nil
+	}
+	n, _ := strconv.Atoi(capStr) // validated above
+	if n > 1 {
+		return fmt.Sprintf("annotation %q=%d combined with traffic.algorithm=ConsistentHash usually defeats sticky routing; set to 1 to keep sessions on a single pod",
+			constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation, n), nil
+	}
+	return "", nil
+}
+
+// crossRuleRolloutTimeoutSanity warns when rollout-ready-timeout is
+// set to less than 1 minute. Most LLM-runtime warmups need at least
+// minutes; a sub-minute timeout almost guarantees Failed rollouts.
+func crossRuleRolloutTimeoutSanity(annotations map[string]string) (string, error) {
+	v, ok := annotations[constants.RolloutReadyTimeoutAnnotation]
+	if !ok {
+		return "", nil
+	}
+	d, err := time.ParseDuration(v) // validated above
+	if err != nil {
+		return "", nil
+	}
+	if d > 0 && d < time.Minute {
+		return fmt.Sprintf("annotation %q=%s is less than 1 minute; most LLM runtimes need longer to reach Ready (RolloutTimeoutTooShort)",
+			constants.RolloutReadyTimeoutAnnotation, v), nil
+	}
+	return "", nil
+}
+
+// closestTrafficAnnotation returns the documented traffic
+// annotation key closest to the given input under Damerau–Levenshtein
+// distance, capped at 2. Returns "", false when no candidate is
+// within distance 2.
+func closestTrafficAnnotation(input string) (string, bool) {
+	const maxDistance = 2
+	best := ""
+	bestDistance := maxDistance + 1
+	for key := range trafficAnnotationKinds {
+		d := levenshtein(input, key)
+		if d < bestDistance {
+			best = key
+			bestDistance = d
+		}
+	}
+	if bestDistance <= maxDistance {
+		return best, true
+	}
+	return "", false
+}
+
+// levenshtein computes the edit distance between two strings.
+// Standard dynamic-programming algorithm with a two-row buffer.
+func levenshtein(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(
+				prev[j]+1,      // deletion
+				curr[j-1]+1,    // insertion
+				prev[j-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}
+
+// hasMatchingPrefix reports whether key starts with any prefix in the
+// list. Used to gate ome.io/btp.* and ome.io/dr.* pass-throughs against
+// the active translator's SupportedPassthroughPrefixes.
+func hasMatchingPrefix(key string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(key, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/validation/traffic_annotations_test.go
+++ b/pkg/validation/traffic_annotations_test.go
@@ -408,7 +408,7 @@ func TestLevenshtein(t *testing.T) {
 		{"abc", "abc", 0},
 		{"abc", "", 3},
 		{"", "abc", 3},
-		{"abc", "abd", 1},  // substitution
+		{"abc", "abz", 1},  // substitution
 		{"abc", "ab", 1},   // deletion
 		{"abc", "abcd", 1}, // insertion
 		{"kitten", "sitting", 3},

--- a/pkg/validation/traffic_annotations_test.go
+++ b/pkg/validation/traffic_annotations_test.go
@@ -1,0 +1,424 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestValidateTrafficAnnotations_TypedValues(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		wantOK       bool
+		wantContains string
+	}{
+		// Happy paths.
+		{
+			name:        "empty annotations",
+			annotations: nil,
+			wantOK:      true,
+		},
+		{
+			name: "valid circuit breaker int",
+			annotations: map[string]string{
+				constants.CircuitBreakerMaxConnectionsAnnotation: "1024",
+			},
+			wantOK: true,
+		},
+		{
+			name: "valid duration",
+			annotations: map[string]string{
+				constants.TimeoutIdleAnnotation: "60s",
+			},
+			wantOK: true,
+		},
+		{
+			name: "valid retry-on tokens",
+			annotations: map[string]string{
+				constants.RetryAttemptsAnnotation: "0",
+				constants.RetryOnAnnotation:       "5xx,reset,gateway-error",
+			},
+			wantOK: true,
+		},
+		{
+			name: "valid promote target full",
+			annotations: map[string]string{
+				constants.RolloutPromoteAnnotation: "full",
+			},
+			wantOK: true,
+		},
+		{
+			name: "valid promote target revision hash",
+			annotations: map[string]string{
+				constants.RolloutPromoteAnnotation: "e5d6f79d",
+			},
+			wantOK: true,
+		},
+		{
+			name: "valid rollback bool",
+			annotations: map[string]string{
+				constants.RolloutRollbackAnnotation: "true",
+			},
+			wantOK: true,
+		},
+
+		// Type-coercion failures.
+		{
+			name: "int annotation not an int",
+			annotations: map[string]string{
+				constants.CircuitBreakerMaxConnectionsAnnotation: "notanumber",
+			},
+			wantContains: "InvalidIntValue",
+		},
+		{
+			name: "duration annotation not a duration",
+			annotations: map[string]string{
+				constants.TimeoutIdleAnnotation: "10",
+			},
+			wantContains: "InvalidDuration",
+		},
+		{
+			name: "bool annotation not true/false",
+			annotations: map[string]string{
+				constants.RolloutRollbackAnnotation: "yes",
+			},
+			wantContains: "InvalidBoolValue",
+		},
+		{
+			name: "retry-on with unknown token",
+			annotations: map[string]string{
+				constants.RetryAttemptsAnnotation: "1",
+				constants.RetryOnAnnotation:       "5xx,not-a-real-condition",
+			},
+			wantContains: "InvalidRetryOn",
+		},
+		{
+			name: "retry-on empty token in list",
+			annotations: map[string]string{
+				constants.RetryAttemptsAnnotation: "1",
+				constants.RetryOnAnnotation:       "5xx,,reset",
+			},
+			wantContains: "InvalidRetryOn",
+		},
+		{
+			name: "promote target negative",
+			annotations: map[string]string{
+				constants.RolloutPromoteAnnotation: "-1",
+			},
+			wantContains: "InvalidRolloutPromoteTarget",
+		},
+		{
+			name: "promote target garbage",
+			annotations: map[string]string{
+				constants.RolloutPromoteAnnotation: "next",
+			},
+			wantContains: "InvalidRolloutPromoteTarget",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ValidateTrafficAnnotations(tc.annotations, nil)
+			if tc.wantOK {
+				if err != nil {
+					t.Fatalf("expected ok, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantContains)
+			}
+			if !strings.Contains(err.Error(), tc.wantContains) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantContains, err)
+			}
+		})
+	}
+}
+
+func TestValidateTrafficAnnotations_DidYouMean(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		expectError bool
+		expectHint  string
+	}{
+		{
+			name:        "exact known key has no suggestion",
+			key:         constants.CircuitBreakerMaxConnectionsAnnotation,
+			expectError: false,
+		},
+		{
+			name:        "single-char typo gets suggestion",
+			key:         constants.OMEAPIGroupName + "/circut-breaker-max-connections", // missing i
+			expectError: true,
+			expectHint:  constants.CircuitBreakerMaxConnectionsAnnotation,
+		},
+		{
+			name:        "transposition gets suggestion",
+			key:         constants.OMEAPIGroupName + "/circuit-braeker-max-connections", // transposed
+			expectError: true,
+			expectHint:  constants.CircuitBreakerMaxConnectionsAnnotation,
+		},
+		{
+			name:        "far-away key gets no suggestion (ignored)",
+			key:         constants.OMEAPIGroupName + "/this-is-not-related-at-all",
+			expectError: false, // > Levenshtein 2 from every known key → silently ignored
+		},
+		{
+			name:        "non-ome.io annotation is ignored entirely",
+			key:         "foo.example.com/random",
+			expectError: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ann := map[string]string{tc.key: "1"}
+			// For "exact known key", give a valid value for the type.
+			if tc.key == constants.CircuitBreakerMaxConnectionsAnnotation {
+				ann[tc.key] = "1024"
+			}
+			_, err := ValidateTrafficAnnotations(ann, nil)
+			if !tc.expectError {
+				if err != nil {
+					t.Fatalf("expected ok, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error with hint %q, got nil", tc.expectHint)
+			}
+			if !strings.Contains(err.Error(), "UnknownTrafficAnnotation") {
+				t.Fatalf("expected UnknownTrafficAnnotation in error, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.expectHint) {
+				t.Fatalf("expected Did-you-mean hint %q in error, got: %v", tc.expectHint, err)
+			}
+		})
+	}
+}
+
+func TestValidateTrafficAnnotations_PassthroughIgnored(t *testing.T) {
+	// Pass-through namespaces accept any key; the translator validates
+	// the field path at emit time. Webhook must not reject these when
+	// no knownPassthroughPrefixes filter is set (back-compat default).
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{
+			name: "envoy gateway passthrough",
+			key:  constants.PassthroughEnvoyGatewayPrefix + "loadBalancer.slowStart.window",
+		},
+		{
+			name: "istio passthrough",
+			key:  constants.PassthroughIstioPrefix + "trafficPolicy.connectionPool.tcp.tcpKeepalive.time",
+		},
+		{
+			name: "passthrough with deep path",
+			key:  constants.PassthroughEnvoyGatewayPrefix + "deeply.nested.field.with.lots.of.dots",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ValidateTrafficAnnotations(map[string]string{tc.key: "any-value"}, nil)
+			if err != nil {
+				t.Fatalf("pass-through %q must be accepted by webhook, got error: %v", tc.key, err)
+			}
+		})
+	}
+}
+
+func TestValidateTrafficAnnotations_PassthroughGatedByKnownPrefixes(t *testing.T) {
+	// When the validator is wired with the active translator's
+	// SupportedPassthroughPrefixes, pass-through annotations outside
+	// the set must be rejected at admission (UnsupportedPassthrough).
+	tests := []struct {
+		name         string
+		key          string
+		known        []string
+		wantErrMatch string // empty = expect success
+	}{
+		{
+			name:  "btp.* accepted when EG prefix known",
+			key:   constants.PassthroughEnvoyGatewayPrefix + "loadBalancer.slowStart.window",
+			known: []string{constants.PassthroughEnvoyGatewayPrefix},
+		},
+		{
+			name:         "btp.* rejected when only Istio prefix known",
+			key:          constants.PassthroughEnvoyGatewayPrefix + "loadBalancer.slowStart.window",
+			known:        []string{constants.PassthroughIstioPrefix},
+			wantErrMatch: "UnsupportedPassthrough",
+		},
+		{
+			name:  "dr.* accepted when Istio prefix known",
+			key:   constants.PassthroughIstioPrefix + "trafficPolicy.connectionPool.tcp.tcpKeepalive.time",
+			known: []string{constants.PassthroughIstioPrefix},
+		},
+		{
+			name:         "dr.* rejected when only EG prefix known",
+			key:          constants.PassthroughIstioPrefix + "trafficPolicy.connectionPool.tcp.tcpKeepalive.time",
+			known:        []string{constants.PassthroughEnvoyGatewayPrefix},
+			wantErrMatch: "UnsupportedPassthrough",
+		},
+		{
+			name:         "any pass-through rejected when prefix list is non-empty but doesn't match",
+			key:          constants.PassthroughEnvoyGatewayPrefix + "loadBalancer.x",
+			known:        []string{"ome.io/future-translator."},
+			wantErrMatch: "UnsupportedPassthrough",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ValidateTrafficAnnotations(map[string]string{tc.key: "v"}, nil, tc.known...)
+			if tc.wantErrMatch == "" {
+				if err != nil {
+					t.Fatalf("expected accept, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error matching %q, got nil", tc.wantErrMatch)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrMatch) {
+				t.Fatalf("err = %v, want substring %q", err, tc.wantErrMatch)
+			}
+		})
+	}
+}
+
+func TestValidateTrafficAnnotations_CrossRules(t *testing.T) {
+	consistentHash := v1beta1.LoadBalancingTypeConsistentHash
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		traffic      *v1beta1.TrafficSpec
+		wantOK       bool
+		wantContains string
+		wantWarning  string
+	}{
+		{
+			name: "retry-attempts > 0 requires retry-on",
+			annotations: map[string]string{
+				constants.RetryAttemptsAnnotation: "3",
+			},
+			wantContains: "MissingRetryOn",
+		},
+		{
+			name: "retry-attempts=0 doesn't require retry-on",
+			annotations: map[string]string{
+				constants.RetryAttemptsAnnotation: "0",
+			},
+			wantOK: true,
+		},
+		{
+			name: "retry-attempts + retry-on is ok",
+			annotations: map[string]string{
+				constants.RetryAttemptsAnnotation: "3",
+				constants.RetryOnAnnotation:       "5xx",
+			},
+			wantOK: true,
+		},
+		{
+			name: "sticky + per-endpoint cap > 1 warns",
+			annotations: map[string]string{
+				constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation: "10",
+			},
+			traffic: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+				},
+			},
+			wantOK:      true,
+			wantWarning: "defeats sticky routing",
+		},
+		{
+			name: "sticky + per-endpoint cap = 1 no warning",
+			annotations: map[string]string{
+				constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation: "1",
+			},
+			traffic: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "rollout timeout < 1 minute warns",
+			annotations: map[string]string{
+				constants.RolloutReadyTimeoutAnnotation: "30s",
+			},
+			wantOK:      true,
+			wantWarning: "RolloutTimeoutTooShort",
+		},
+		{
+			name: "rollout timeout > 1 minute no warning",
+			annotations: map[string]string{
+				constants.RolloutReadyTimeoutAnnotation: "10m",
+			},
+			wantOK: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			warnings, err := ValidateTrafficAnnotations(tc.annotations, tc.traffic)
+			if tc.wantOK {
+				if err != nil {
+					t.Fatalf("expected ok, got error: %v", err)
+				}
+				if tc.wantWarning != "" {
+					if len(warnings) == 0 {
+						t.Fatalf("expected warning containing %q, got none", tc.wantWarning)
+					}
+					found := false
+					for _, w := range warnings {
+						if strings.Contains(w, tc.wantWarning) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Fatalf("expected warning containing %q in %v", tc.wantWarning, warnings)
+					}
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantContains)
+			}
+			if !strings.Contains(err.Error(), tc.wantContains) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantContains, err)
+			}
+		})
+	}
+}
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"abc", "abd", 1},  // substitution
+		{"abc", "ab", 1},   // deletion
+		{"abc", "abcd", 1}, // insertion
+		{"kitten", "sitting", 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.a+"_"+tc.b, func(t *testing.T) {
+			got := levenshtein(tc.a, tc.b)
+			if got != tc.want {
+				t.Errorf("levenshtein(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/validation/traffic_test.go
+++ b/pkg/validation/traffic_test.go
@@ -1,0 +1,238 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestValidateTrafficSpec(t *testing.T) {
+	consistentHash := v1beta1.LoadBalancingTypeConsistentHash
+	leastRequest := v1beta1.LoadBalancingTypeLeastRequest
+	ttlSecs := int64(3600)
+	tests := []struct {
+		name   string
+		in     *v1beta1.TrafficSpec
+		wantOK bool
+		// Substring of the expected error message. Empty when wantOK.
+		wantContains string
+	}{
+		{
+			name:   "nil traffic",
+			in:     nil,
+			wantOK: true,
+		},
+		{
+			name:   "empty traffic",
+			in:     &v1beta1.TrafficSpec{},
+			wantOK: true,
+		},
+		{
+			name: "round-robin only",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: ptrLB(v1beta1.LoadBalancingTypeRoundRobin),
+			},
+			wantOK: true,
+		},
+		{
+			name: "consistent hash on header — happy path",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "consistent hash on cookie with TTL — happy path",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:   v1beta1.HashTypeCookie,
+					Cookie: &v1beta1.HashCookie{Name: "ome-session", TTLSeconds: &ttlSecs},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "consistent hash on source IP — happy path",
+			in: &v1beta1.TrafficSpec{
+				Algorithm:      &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{Type: v1beta1.HashTypeSourceIP},
+			},
+			wantOK: true,
+		},
+		{
+			name: "consistent hash declared without consistentHash block",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+			},
+			wantContains: "MissingConsistentHashSpec",
+		},
+		{
+			name: "consistent hash block declared without ConsistentHash algorithm",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &leastRequest,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+				},
+			},
+			wantContains: "UnexpectedConsistentHashSpec",
+		},
+		{
+			name: "consistent hash Header without headers",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type: v1beta1.HashTypeHeader,
+				},
+			},
+			wantContains: "MissingHashKey",
+		},
+		{
+			name: "consistent hash Header with empty header name",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: ""}},
+				},
+			},
+			wantContains: "MissingHashKey",
+		},
+		{
+			name: "consistent hash Header with cookie also set",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+					Cookie:  &v1beta1.HashCookie{Name: "ome"},
+				},
+			},
+			wantContains: "MultipleHashKeys",
+		},
+		{
+			name: "consistent hash Cookie without cookie block",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type: v1beta1.HashTypeCookie,
+				},
+			},
+			wantContains: "MissingHashKey",
+		},
+		{
+			name: "consistent hash Cookie with headers also set",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeCookie,
+					Cookie:  &v1beta1.HashCookie{Name: "ome"},
+					Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+				},
+			},
+			wantContains: "MultipleHashKeys",
+		},
+		{
+			name: "consistent hash Cookie with empty name",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:   v1beta1.HashTypeCookie,
+					Cookie: &v1beta1.HashCookie{Name: ""},
+				},
+			},
+			wantContains: "MissingHashKey",
+		},
+		{
+			name: "consistent hash SourceIP with stray headers",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeSourceIP,
+					Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+				},
+			},
+			wantContains: "MultipleHashKeys",
+		},
+		{
+			name: "endpoint override Header without headers",
+			in: &v1beta1.TrafficSpec{
+				EndpointOverride: &v1beta1.EndpointOverrideSpec{
+					Type: v1beta1.EndpointOverrideTypeHeader,
+				},
+			},
+			wantContains: "MissingEndpointOverrideKey",
+		},
+		{
+			name: "endpoint override Header with empty header name",
+			in: &v1beta1.TrafficSpec{
+				EndpointOverride: &v1beta1.EndpointOverrideSpec{
+					Type:    v1beta1.EndpointOverrideTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: ""}},
+				},
+			},
+			wantContains: "MissingEndpointOverrideKey",
+		},
+		{
+			name: "endpoint override Metadata — no required sub-fields",
+			in: &v1beta1.TrafficSpec{
+				EndpointOverride: &v1beta1.EndpointOverrideSpec{
+					Type: v1beta1.EndpointOverrideTypeMetadata,
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "endpoint override Header — happy path",
+			in: &v1beta1.TrafficSpec{
+				EndpointOverride: &v1beta1.EndpointOverrideSpec{
+					Type:    v1beta1.EndpointOverrideTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "X-Endpoint-HostPort"}},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "consistent hash + endpoint override compose",
+			in: &v1beta1.TrafficSpec{
+				Algorithm: &consistentHash,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+				},
+				EndpointOverride: &v1beta1.EndpointOverrideSpec{
+					Type:    v1beta1.EndpointOverrideTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "X-Endpoint-HostPort"}},
+				},
+			},
+			wantOK: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTrafficSpec(tc.in)
+			if tc.wantOK {
+				if err != nil {
+					t.Fatalf("expected ok, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantContains)
+			}
+			if !strings.Contains(err.Error(), tc.wantContains) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantContains, err)
+			}
+		})
+	}
+}
+
+func ptrLB(t v1beta1.LoadBalancingType) *v1beta1.LoadBalancingType {
+	return &t
+}

--- a/pkg/webhook/admission/inferencereplica/validator.go
+++ b/pkg/webhook/admission/inferencereplica/validator.go
@@ -1,0 +1,330 @@
+// Package inferencereplica implements the validating admission webhook
+// for the InferenceReplica CRD. InferenceReplica is a controller-only
+// resource: users only ever write InferenceService, and the ISVC
+// controller is the sole writer of InferenceReplica specs.
+//
+// This webhook enforces the convention by rejecting any Create / Update
+// that lacks the ome.io/controller-write=true annotation, and any
+// spec-field edits the ISVC controller never makes (spec.runners,
+// spec.podTemplate, spec.parentRef, spec.component) from an actor without
+// the annotation. RBAC restricting write on inferencereplicas to the OME
+// ServiceAccount is the actual security boundary — this webhook is the
+// "discouragement" layer that yields clear error messages and stops
+// well-intentioned kubectl edits.
+//
+// Deletion is not gated: operators may kubectl delete an InferenceReplica
+// for debugging, and the controller will recreate it on the next ISVC
+// reconcile.
+package inferencereplica
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/validation"
+)
+
+var log = logf.Log.WithName("inferencereplica-validation-webhook")
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-ome-io-v1beta1-inferencereplica,mutating=false,failurePolicy=fail,groups=ome.io,resources=inferencereplicas,versions=v1beta1,name=inferencereplica.ome-webhook-server.validator,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:object:generate=false
+type Validator struct {
+	Decoder admission.Decoder
+}
+
+// hasControllerWriteAnnotation accepts only the literal "true";
+// truthy variants (yes/True) reject so hand edits can't sneak through.
+func hasControllerWriteAnnotation(annotations map[string]string) bool {
+	if annotations == nil {
+		return false
+	}
+	return annotations[constants.InferenceReplicaControllerWriteAnnotationKey] ==
+		constants.InferenceReplicaControllerWriteAnnotationVal
+}
+
+func denyDirectWrite(op admissionv1.Operation, namespace, name string) admission.Response {
+	return admission.Denied(fmt.Sprintf(
+		"InferenceReplica is a controller-only resource and rejects direct "+
+			"%s on %s/%s: missing %s=%s annotation. Edit the parent "+
+			"InferenceService spec instead; the controller will reconcile "+
+			"the InferenceReplica.",
+		op, namespace, name,
+		constants.InferenceReplicaControllerWriteAnnotationKey,
+		constants.InferenceReplicaControllerWriteAnnotationVal,
+	))
+}
+
+// Handle gates writes per the package doc:
+//   - Create / Update without ome.io/controller-write=true ⇒ Denied.
+//   - Update changing spec.parentRef or spec.component (even from the
+//     controller) ⇒ Denied; recreating the IR is required.
+//   - Update touching nothing but metadata.finalizers ⇒ Allowed
+//     unconditionally (see isFinalizerOnlyUpdate).
+//   - Delete is not registered in the kubebuilder verbs list and
+//     therefore not reached here; operators may delete to recover.
+func (v *Validator) Handle(_ context.Context, req admission.Request) admission.Response {
+	// Defensive: webhook is registered for Create+Update only, but a
+	// future operator misconfig shouldn't surprise us.
+	switch req.Operation {
+	case admissionv1.Create, admissionv1.Update:
+	default:
+		return admission.Allowed("")
+	}
+
+	newObj := &v1beta1.InferenceReplica{}
+	if err := v.Decoder.Decode(req, newObj); err != nil {
+		log.Error(err, "Failed to decode InferenceReplica",
+			"namespace", req.Namespace, "name", req.Name)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Immutability check runs unconditionally on every Update, BEFORE
+	// the controller-write annotation gate. The annotation gates WHO
+	// can write (operator vs. controller), but field immutability is a
+	// stronger contract that applies to ALL writers — a misbehaving
+	// controller (e.g., stale ISVC controller cache) that stamps the
+	// controller-write annotation must NOT also be able to change
+	// spec.parentRef.UID to the wrong parent or move the IR between
+	// Component slots. This is exactly the failure mode webhook gates
+	// exist for.
+	if req.Operation == admissionv1.Update {
+		oldObj := &v1beta1.InferenceReplica{}
+		if err := v.Decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
+			log.Error(err, "Failed to decode old InferenceReplica",
+				"namespace", req.Namespace, "name", req.Name)
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		// Finalizer-only updates are admitted before every gate below.
+		// Such a patch cannot violate any invariant this webhook protects
+		// (spec immutability, controller-write provenance) — but denying
+		// it can manufacture a teardown wedge: this webhook is fail-
+		// closed, so a refused finalizer-removal update leaves a
+		// Terminating IR stuck behind our own admission gate.
+		if isFinalizerOnlyUpdate(oldObj, newObj) {
+			return admission.Allowed("finalizer-only update")
+		}
+
+		if !reflect.DeepEqual(oldObj.Spec.ParentRef, newObj.Spec.ParentRef) {
+			return admission.Denied(fmt.Sprintf(
+				"InferenceReplica %s/%s: spec.parentRef is immutable",
+				req.Namespace, req.Name))
+		}
+		if oldObj.Spec.Component != newObj.Spec.Component {
+			return admission.Denied(fmt.Sprintf(
+				"InferenceReplica %s/%s: spec.component is immutable",
+				req.Namespace, req.Name))
+		}
+	}
+
+	if !hasControllerWriteAnnotation(newObj.Annotations) {
+		log.V(1).Info("Rejecting direct write to InferenceReplica",
+			"op", req.Operation,
+			"namespace", req.Namespace, "name", req.Name,
+			"userInfo", req.UserInfo.Username)
+		return denyDirectWrite(req.Operation, req.Namespace, req.Name)
+	}
+
+	// Validate the projected Autoscaler block shape. The IR
+	// webhook is strict about all spec writes by default (controller-
+	// write annotation gate above); this is defense-in-depth against a
+	// misbehaving controller writing a malformed projection. External
+	// writes to spec.autoscaler are deliberately NOT blocked —
+	// the /scale subresource only mutates spec.replicas, so a successful
+	// write here means either the controller did it or someone forged
+	// the annotation. Either way the shape must be valid.
+	if err := validateIRAutoscaler(newObj); err != nil {
+		return admission.Denied(fmt.Sprintf(
+			"InferenceReplica %s/%s: %s",
+			req.Namespace, req.Name, err.Error()))
+	}
+
+	// Pacing.Partition must be <= effective Replicas, otherwise an
+	// over-Partition silently holds every Instance back forever (the
+	// rollout engine treats Partition as a per-index threshold and
+	// freezes any Instance with index < Partition).
+	if err := validateIRPacing(newObj); err != nil {
+		return admission.Denied(fmt.Sprintf(
+			"InferenceReplica %s/%s: %s",
+			req.Namespace, req.Name, err.Error()))
+	}
+
+	// Every container/initContainer volumeMount in a rendered Runner pod
+	// template must resolve to a volume declared in that same pod spec.
+	// A mount that names an undeclared volume is accepted here but
+	// REJECTED by the kube-apiserver at pod-create time during reconcile
+	// ("spec.containers[0].volumeMounts[0].name: Not found: <name>"),
+	// which surfaces only as a buried InferenceReplica reconcile error
+	// in the manager log — with no signal at kubectl apply. This gate is
+	// defense-in-depth: it turns that silent failure into a clear
+	// admission rejection (and also catches plain volumeMount typos in a
+	// runtime's pod template).
+	if err := validateIRRunnerVolumes(newObj); err != nil {
+		return admission.Denied(fmt.Sprintf(
+			"InferenceReplica %s/%s: %s",
+			req.Namespace, req.Name, err.Error()))
+	}
+
+	return admission.Allowed("")
+}
+
+// isFinalizerOnlyUpdate reports whether the update changes nothing
+// beyond metadata.finalizers. A finalizer-only patch cannot violate any
+// invariant this webhook protects — spec immutability and controller-
+// write provenance both concern content the patch leaves untouched —
+// while refusing it can only manufacture teardown wedges: the webhook
+// is fail-closed, and finalizer add/remove is exactly the write a
+// controller must be able to make for deletion to complete.
+//
+// "Finalizer-only" is judged strictly:
+//   - Spec must be deep-equal.
+//   - Status must be deep-equal. With the status subresource enabled
+//     the apiserver already resets status before validating admission
+//     runs on main-resource updates (and /status updates never reach
+//     this webhook, whose rule covers only the main resource), so this
+//     check is inert today; it keeps the exemption airtight if the
+//     subresource wiring ever changes.
+//   - ObjectMeta must be deep-equal after overwriting, on a copy of the
+//     old metadata, only Finalizers (the field under test) plus the
+//     fields the apiserver itself rewrites on every update and clients
+//     cannot use to smuggle state: ResourceVersion (storage-assigned,
+//     optimistic concurrency enforced by the apiserver), ManagedFields
+//     (server-side field tracking, rewritten on every write), and
+//     Generation (apiserver-stamped; inert here given spec equality).
+//
+// Any other metadata delta — labels, annotations (including stripping
+// the controller-write annotation), ownerReferences, deletion fields —
+// disqualifies the update, which then falls through to the normal
+// gates. Combining a finalizer change with any such edit is therefore
+// not a bypass.
+func isFinalizerOnlyUpdate(oldObj, newObj *v1beta1.InferenceReplica) bool {
+	if !reflect.DeepEqual(oldObj.Spec, newObj.Spec) {
+		return false
+	}
+	if !reflect.DeepEqual(oldObj.Status, newObj.Status) {
+		return false
+	}
+	meta := oldObj.ObjectMeta.DeepCopy()
+	meta.Finalizers = newObj.Finalizers
+	meta.ResourceVersion = newObj.ResourceVersion
+	meta.ManagedFields = newObj.ManagedFields
+	meta.Generation = newObj.Generation
+	return reflect.DeepEqual(*meta, newObj.ObjectMeta)
+}
+
+// validateIRAutoscaler runs the shared Autoscaler shape check against
+// an IR's projected Autoscaler block. The IR spec carries its own
+// Replicas field (not a ComponentExtensionSpec); we pass it as the
+// effective MinReplicas floor for the KEDA idle-vs-min check. Calls
+// validation.ValidateAutoscaler directly — the
+// (*ComponentAutoscaler, *int) signature accepts this shape without
+// synthesizing a parent ComponentExtensionSpec. Shared with the
+// InferenceService and ServingRuntime webhooks.
+func validateIRAutoscaler(ir *v1beta1.InferenceReplica) error {
+	if ir == nil {
+		return nil
+	}
+	var minPtr *int
+	if ir.Spec.Replicas != nil {
+		min := int(*ir.Spec.Replicas)
+		minPtr = &min
+	}
+	return validation.ValidateAutoscaler(ir.Spec.Autoscaler, minPtr)
+}
+
+// validateIRPacing checks that Pacing.Partition <= effective Replicas.
+// An over-Partition (Partition > Replicas) silently holds every
+// Instance back forever — the rollout engine treats Partition as a
+// per-index threshold and freezes any Instance with index < Partition,
+// so Partition >= Replicas freezes the whole replica set. Matches the
+// effective-Replicas default used by convert.desiredFromIR (nil or 0
+// → 1).
+func validateIRPacing(ir *v1beta1.InferenceReplica) error {
+	if ir == nil || ir.Spec.Pacing == nil || ir.Spec.Pacing.Partition == nil {
+		return nil
+	}
+	partition := *ir.Spec.Pacing.Partition
+	// Match convert.desiredFromIR's defaulting: nil OR *r == 0 → 1.
+	replicas := int32(1)
+	if ir.Spec.Replicas != nil && *ir.Spec.Replicas > 0 {
+		replicas = *ir.Spec.Replicas
+	}
+	if partition > replicas {
+		return fmt.Errorf(
+			"spec.pacing.partition (%d) must be <= spec.replicas (%d); "+
+				"an over-partition silently holds every Instance back forever",
+			partition, replicas)
+	}
+	return nil
+}
+
+// validateIRRunnerVolumes checks every Runner's fully-rendered pod
+// template so that each container/initContainer volumeMount references a
+// volume declared in that same pod spec. The IR webhook sees the final
+// rendered leader+worker templates, so this is the most precise place to
+// catch a dangling mount before it reaches the apiserver at pod-create
+// time (where it fails as "spec.containers[i].volumeMounts[j].name: Not
+// found: <name>" and surfaces only as a buried reconcile error). Names
+// the runner, container, and missing volume so the operator can fix the
+// runtime spec — including the multi-node hint, since a dshm/shared
+// volume must be declared under engineConfig.leader.volumes /
+// engineConfig.worker.volumes for the leader+worker templates that mount
+// it.
+func validateIRRunnerVolumes(ir *v1beta1.InferenceReplica) error {
+	if ir == nil {
+		return nil
+	}
+	for i := range ir.Spec.Runners {
+		runner := &ir.Spec.Runners[i]
+		spec := &runner.Template.Spec
+
+		declared := make(map[string]struct{}, len(spec.Volumes))
+		for j := range spec.Volumes {
+			declared[spec.Volumes[j].Name] = struct{}{}
+		}
+
+		// initContainers and containers share the pod's volume set, so
+		// validate both against the same declared map.
+		if err := validateContainerVolumeMounts(
+			string(runner.Name), spec.InitContainers, declared); err != nil {
+			return err
+		}
+		if err := validateContainerVolumeMounts(
+			string(runner.Name), spec.Containers, declared); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateContainerVolumeMounts verifies every volumeMount in the given
+// containers resolves to a name in `declared`. Returns a message naming
+// the runner, container, and missing volume on the first violation.
+func validateContainerVolumeMounts(
+	runnerName string, containers []corev1.Container, declared map[string]struct{},
+) error {
+	for c := range containers {
+		container := &containers[c]
+		for m := range container.VolumeMounts {
+			name := container.VolumeMounts[m].Name
+			if _, ok := declared[name]; !ok {
+				return fmt.Errorf(
+					"runner %q container %q: volumeMount %q has no matching "+
+						"volume in the pod (for a multi-node runtime declare it "+
+						"under engineConfig.leader.volumes / "+
+						"engineConfig.worker.volumes)",
+					runnerName, container.Name, name)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/webhook/admission/inferencereplica/validator_test.go
+++ b/pkg/webhook/admission/inferencereplica/validator_test.go
@@ -1,0 +1,822 @@
+package inferencereplica
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kedav1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func newDecoder(t *testing.T) admission.Decoder {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("v1beta1.AddToScheme: %v", err)
+	}
+	return admission.NewDecoder(s)
+}
+
+func encode(t *testing.T, obj *v1beta1.InferenceReplica) []byte {
+	t.Helper()
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}
+
+// baselineIR returns a syntactically-valid InferenceReplica suitable for
+// cloning into Create / Update fixtures.
+func baselineIR(annotations map[string]string) *v1beta1.InferenceReplica {
+	return &v1beta1.InferenceReplica{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "llama-engine",
+			Namespace:   "prod-models",
+			Annotations: annotations,
+		},
+		Spec: v1beta1.InferenceReplicaSpec{
+			ParentRef: v1beta1.ParentReference{
+				Name: "llama",
+			},
+			Component: v1beta1.EngineComponent,
+			Runners: []v1beta1.Runner{
+				{
+					Name: v1beta1.RunnerNameDefault,
+					Size: 1,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "ome-container",
+								Image: "sgl:1.0",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// withControllerWrite stamps the controller-write annotation, matching
+// what the ISVC controller's client does on every Create/Update.
+func withControllerWrite() map[string]string {
+	return map[string]string{
+		constants.InferenceReplicaControllerWriteAnnotationKey: constants.InferenceReplicaControllerWriteAnnotationVal,
+	}
+}
+
+func createReq(t *testing.T, obj *v1beta1.InferenceReplica) admission.Request {
+	t.Helper()
+	return admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+		Operation: admissionv1.Create,
+		Namespace: obj.Namespace,
+		Name:      obj.Name,
+		UserInfo:  authenticationv1.UserInfo{Username: "alice"},
+		Object:    runtime.RawExtension{Raw: encode(t, obj)},
+	}}
+}
+
+func updateReq(t *testing.T, oldObj, newObj *v1beta1.InferenceReplica) admission.Request {
+	t.Helper()
+	return admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+		Operation: admissionv1.Update,
+		Namespace: newObj.Namespace,
+		Name:      newObj.Name,
+		UserInfo:  authenticationv1.UserInfo{Username: "alice"},
+		OldObject: runtime.RawExtension{Raw: encode(t, oldObj)},
+		Object:    runtime.RawExtension{Raw: encode(t, newObj)},
+	}}
+}
+
+// withReplicas returns a clone of `ir` with Replicas set; convenience
+// for the Update-path table cases that need a spec diff.
+func withReplicas(ir *v1beta1.InferenceReplica, n int32) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	out.Spec.Replicas = &n
+	return out
+}
+
+// withComponent returns a clone with the Component slot changed.
+func withComponent(ir *v1beta1.InferenceReplica, c v1beta1.ComponentType) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	out.Spec.Component = c
+	return out
+}
+
+// withParent returns a clone whose parentRef points at a different ISVC.
+func withParent(ir *v1beta1.InferenceReplica, name string) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	out.Spec.ParentRef.Name = name
+	return out
+}
+
+// withFinalizers returns a clone with metadata.finalizers replaced.
+func withFinalizers(ir *v1beta1.InferenceReplica, finalizers ...string) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	out.Finalizers = finalizers
+	return out
+}
+
+// withLabel returns a clone with one label added.
+func withLabel(ir *v1beta1.InferenceReplica, k, v string) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	if out.Labels == nil {
+		out.Labels = map[string]string{}
+	}
+	out.Labels[k] = v
+	return out
+}
+
+// withOwnerRef returns a clone with one ownerReference added.
+func withOwnerRef(ir *v1beta1.InferenceReplica, name string) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	out.OwnerReferences = append(out.OwnerReferences, metav1.OwnerReference{
+		APIVersion: "ome.io/v1beta1",
+		Kind:       "InferenceService",
+		Name:       name,
+		UID:        "1234",
+	})
+	return out
+}
+
+// withPacingPartition returns a clone with spec.pacing.partition set
+// (creating the Pacing block if nil).
+func withPacingPartition(ir *v1beta1.InferenceReplica, partition int32) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	if out.Spec.Pacing == nil {
+		out.Spec.Pacing = &v1beta1.InferenceReplicaPacing{}
+	}
+	out.Spec.Pacing.Partition = &partition
+	return out
+}
+
+// withReplicasAndPacingPartition returns a clone with both spec.replicas
+// and spec.pacing.partition set. Used by the over-Partition table cases.
+func withReplicasAndPacingPartition(ir *v1beta1.InferenceReplica, replicas, partition int32) *v1beta1.InferenceReplica {
+	out := withReplicas(ir, replicas)
+	if out.Spec.Pacing == nil {
+		out.Spec.Pacing = &v1beta1.InferenceReplicaPacing{}
+	}
+	out.Spec.Pacing.Partition = &partition
+	return out
+}
+
+// withImage returns a clone whose first runner uses a different image.
+func withImage(ir *v1beta1.InferenceReplica, image string) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	out.Spec.Runners[0].Template.Spec.Containers[0].Image = image
+	return out
+}
+
+// withContainerMount returns a clone whose first runner's first
+// container mounts `volName` at /mnt/<volName>. No matching volume is
+// added, so callers exercising the resolve-success path must pair this
+// with withVolume.
+func withContainerMount(ir *v1beta1.InferenceReplica, volName string) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	c := &out.Spec.Runners[0].Template.Spec.Containers[0]
+	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+		Name:      volName,
+		MountPath: "/mnt/" + volName,
+	})
+	return out
+}
+
+// withInitContainerMount returns a clone whose first runner gains an
+// initContainer that mounts `volName`. Used to prove initContainers are
+// validated against the same declared-volume set as containers.
+func withInitContainerMount(ir *v1beta1.InferenceReplica, volName string) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	s := &out.Spec.Runners[0].Template.Spec
+	s.InitContainers = append(s.InitContainers, corev1.Container{
+		Name:  "model-init",
+		Image: "init:1.0",
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      volName,
+			MountPath: "/mnt/" + volName,
+		}},
+	})
+	return out
+}
+
+// withVolume returns a clone declaring an emptyDir volume named
+// `volName` on the first runner's pod spec.
+func withVolume(ir *v1beta1.InferenceReplica, volName string) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	s := &out.Spec.Runners[0].Template.Spec
+	s.Volumes = append(s.Volumes, corev1.Volume{
+		Name:         volName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	})
+	return out
+}
+
+// withModelPVCVolume returns a clone declaring a model-PVC-style volume
+// (the shape UpdatePodSpecVolumes injects for a PVC-backed BaseModel)
+// named `volName`. Used to prove a mount that resolves to an
+// operator-injected volume is admitted.
+func withModelPVCVolume(ir *v1beta1.InferenceReplica, volName string) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	s := &out.Spec.Runners[0].Template.Spec
+	s.Volumes = append(s.Volumes, corev1.Volume{
+		Name: volName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: "model-pvc",
+				ReadOnly:  true,
+			},
+		},
+	})
+	return out
+}
+
+// withAutoscaler returns a clone with the Autoscaler block set on
+// spec.autoscaler. Used by the IR-side webhook autoscaler shape tests.
+func withAutoscaler(ir *v1beta1.InferenceReplica, as *v1beta1.ComponentAutoscaler) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	out.Spec.Autoscaler = as
+	return out
+}
+
+// withReplicasAndAutoscaler returns a clone with both spec.replicas
+// and spec.autoscaler set. Used to test the KEDA
+// IdleReplicaCount-vs-Replicas (IR-side floor) check.
+func withReplicasAndAutoscaler(ir *v1beta1.InferenceReplica, n int32, as *v1beta1.ComponentAutoscaler) *v1beta1.InferenceReplica {
+	out := ir.DeepCopy()
+	out.Spec.Replicas = &n
+	out.Spec.Autoscaler = as
+	return out
+}
+
+// TestHandle covers every gate in pkg/webhook/admission/inferencereplica.
+//
+// Each row builds an admission request from `req(t)`, runs Handle, and
+// asserts Allowed plus optional rejection substring(s). Cases not built
+// via createReq/updateReq use the inline `req` builder; that's how
+// Delete and the malformed-body cases stay in the same table.
+func TestHandle(t *testing.T) {
+	wcw := withControllerWrite() // baseline annotation; "controller write"
+
+	tests := []struct {
+		name         string
+		req          func(t *testing.T) admission.Request
+		wantAllowed  bool
+		wantContains []string // optional substring matches against resp.Result.Message
+	}{
+		{
+			name:         "create without annotation → denied",
+			req:          func(t *testing.T) admission.Request { return createReq(t, baselineIR(nil)) },
+			wantAllowed:  false,
+			wantContains: []string{"controller-only resource", constants.InferenceReplicaControllerWriteAnnotationKey},
+		},
+		{
+			name:        "create with empty annotation map → denied (same as nil)",
+			req:         func(t *testing.T) admission.Request { return createReq(t, baselineIR(map[string]string{})) },
+			wantAllowed: false,
+		},
+		{
+			name: `create with annotation value other than literal "true" → denied`,
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, baselineIR(map[string]string{
+					constants.InferenceReplicaControllerWriteAnnotationKey: "yes",
+				}))
+			},
+			wantAllowed: false,
+		},
+		{
+			name:        "create with controller-write annotation → allowed",
+			req:         func(t *testing.T) admission.Request { return createReq(t, baselineIR(wcw)) },
+			wantAllowed: true,
+		},
+		{
+			name: "update dropping annotation → denied",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw), baselineIR(nil))
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "update with spec change AND dropped annotation → denied",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw), withReplicas(baselineIR(nil), 7))
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "update with spec change (controller write) → allowed",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw), withReplicas(baselineIR(wcw), 3))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "update changing spec.parentRef → denied",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw), withParent(baselineIR(wcw), "different-isvc"))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"spec.parentRef is immutable"},
+		},
+		{
+			name: "update changing spec.component → denied",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw), withComponent(baselineIR(wcw), v1beta1.DecoderComponent))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"spec.component is immutable"},
+		},
+		{
+			name: "update rerendering runners (controller write) → allowed",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw), withImage(baselineIR(wcw), "sgl:2.0"))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "delete (not registered for this webhook) → allowed",
+			req: func(t *testing.T) admission.Request {
+				return admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					Namespace: "prod-models",
+					Name:      "llama-engine",
+				}}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "malformed body → errored (Allowed=false)",
+			req: func(t *testing.T) admission.Request {
+				return admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Namespace: "prod-models",
+					Name:      "llama-engine",
+					Object:    runtime.RawExtension{Raw: []byte(`{not json`)},
+				}}
+			},
+			wantAllowed: false,
+		},
+		// IR-side defense-in-depth on spec.autoscaler shape.
+		// The IR webhook does NOT block external writes
+		// to spec.autoscaler (the /scale subresource only mutates
+		// spec.replicas), but any successful write must carry a
+		// shape-valid Autoscaler block.
+		{
+			name: "create with valid hpa autoscaler → allowed",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withAutoscaler(baselineIR(wcw),
+					&v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerHPA}))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "create with valid keda autoscaler (1 trigger) → allowed",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withAutoscaler(baselineIR(wcw),
+					&v1beta1.ComponentAutoscaler{
+						Class: v1beta1.AutoscalerKEDA,
+						Keda: &v1beta1.KedaAutoscaler{Triggers: []kedav1.ScaleTriggers{{
+							Type:     "prometheus",
+							Metadata: map[string]string{"query": "x", "threshold": "1", "serverAddress": "http://p:9090"},
+						}}},
+					}))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "create with keda + empty Triggers → denied",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withAutoscaler(baselineIR(wcw),
+					&v1beta1.ComponentAutoscaler{
+						Class: v1beta1.AutoscalerKEDA,
+						Keda:  &v1beta1.KedaAutoscaler{Triggers: nil},
+					}))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"class=keda requires at least 1 trigger"},
+		},
+		{
+			name: "create with hpa Type=Resource, Resource=nil → denied",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withAutoscaler(baselineIR(wcw),
+					&v1beta1.ComponentAutoscaler{
+						Class: v1beta1.AutoscalerHPA,
+						HPA: &v1beta1.HPAAutoscaler{Metrics: []autoscalingv2.MetricSpec{{
+							Type: autoscalingv2.ResourceMetricSourceType,
+						}}},
+					}))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"type=Resource but"},
+		},
+		{
+			name: "create with keda IdleReplicaCount >= IR replicas floor → denied",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withReplicasAndAutoscaler(baselineIR(wcw), 2,
+					&v1beta1.ComponentAutoscaler{
+						Class: v1beta1.AutoscalerKEDA,
+						Keda: &v1beta1.KedaAutoscaler{
+							Triggers: []kedav1.ScaleTriggers{{
+								Type:     "prometheus",
+								Metadata: map[string]string{"query": "x", "threshold": "1", "serverAddress": "http://p:9090"},
+							}},
+							IdleReplicaCount: ptr.To[int32](2),
+						},
+					}))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"keda.idleReplicaCount must be < minReplicas"},
+		},
+		{
+			name: "create with bogus class value → denied (defense-in-depth)",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withAutoscaler(baselineIR(wcw),
+					&v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerClass("knative")}))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"is not one of HPA|KEDA|External|None"},
+		},
+		{
+			name: "create with valid external class → allowed",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withAutoscaler(baselineIR(wcw),
+					&v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerExternal}))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "create with valid none class → allowed",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withAutoscaler(baselineIR(wcw),
+					&v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerNone}))
+			},
+			wantAllowed: true,
+		},
+		// The immutability gate runs BEFORE the controller-write
+		// annotation gate. A misbehaving controller (stale ISVC cache)
+		// that stamps the annotation MUST NOT also be able to flip
+		// spec.parentRef.UID to the wrong parent or move the IR between
+		// Component slots: for an annotation-true + UID-rewrite payload
+		// the immutability error wins.
+		{
+			name: "update with annotation, same parentRef → allowed (baseline)",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw), baselineIR(wcw))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "update with annotation, different parentRef.Name → denied (immutability)",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw), withParent(baselineIR(wcw), "different-isvc"))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"spec.parentRef is immutable"},
+		},
+		{
+			name: "update with annotation, different component → denied (immutability)",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw),
+					withComponent(baselineIR(wcw), v1beta1.DecoderComponent))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"spec.component is immutable"},
+		},
+		{
+			name: "update without annotation, same parentRef → denied (annotation gate)",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw), baselineIR(nil))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"controller-only resource"},
+		},
+		{
+			name: "update without annotation, different parentRef.Name → denied (immutability fires first)",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw),
+					withParent(baselineIR(nil), "different-isvc"))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"spec.parentRef is immutable"},
+		},
+		// Pacing.Partition must be <=
+		// effective Replicas. Over-Partition silently freezes the
+		// whole replica set forever (rollout engine treats Partition
+		// as a per-index threshold).
+		{
+			name: "create with pacing nil → allowed (no partition to validate)",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, baselineIR(wcw))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "create with pacing.partition nil → allowed",
+			req: func(t *testing.T) admission.Request {
+				ir := baselineIR(wcw)
+				ir.Spec.Pacing = &v1beta1.InferenceReplicaPacing{}
+				return createReq(t, ir)
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "create with partition == replicas → allowed (boundary)",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withReplicasAndPacingPartition(baselineIR(wcw), 3, 3))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "create with partition < replicas → allowed",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withReplicasAndPacingPartition(baselineIR(wcw), 5, 2))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "create with partition > replicas → denied",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withReplicasAndPacingPartition(baselineIR(wcw), 3, 5))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"spec.pacing.partition", "must be <= spec.replicas"},
+		},
+		{
+			name: "create with partition=2 and replicas nil → denied (defaults to 1)",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withPacingPartition(baselineIR(wcw), 2))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"spec.pacing.partition (2)", "spec.replicas (1)"},
+		},
+		{
+			name: "create with partition=0 (default canary) and replicas=5 → allowed",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withReplicasAndPacingPartition(baselineIR(wcw), 5, 0))
+			},
+			wantAllowed: true,
+		},
+		// volumeMount-resolves-to-a-volume gate. A rendered Runner pod
+		// template whose container mounts an undeclared volume is accepted
+		// by the apiserver here but REJECTED at pod-create time during
+		// reconcile, surfacing only as a buried log error. The webhook
+		// turns that silent failure into a clear admission rejection.
+		{
+			name: "create with container mount of undeclared volume → denied",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withContainerMount(baselineIR(wcw), "dshm"))
+			},
+			wantAllowed: false,
+			wantContains: []string{
+				`runner "default"`,
+				`container "ome-container"`,
+				`volumeMount "dshm" has no matching volume`,
+				"engineConfig.leader.volumes",
+			},
+		},
+		{
+			name: "create with container mount + matching volume → allowed",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withVolume(withContainerMount(baselineIR(wcw), "dshm"), "dshm"))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "create with container mount of model-PVC-style injected volume → allowed",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withModelPVCVolume(withContainerMount(baselineIR(wcw), "llama-model"), "llama-model"))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "create with initContainer mount of undeclared volume → denied",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withInitContainerMount(baselineIR(wcw), "scratch"))
+			},
+			wantAllowed: false,
+			wantContains: []string{
+				`runner "default"`,
+				`container "model-init"`,
+				`volumeMount "scratch" has no matching volume`,
+			},
+		},
+		{
+			name: "create with initContainer mount + matching volume → allowed",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, withVolume(withInitContainerMount(baselineIR(wcw), "scratch"), "scratch"))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "create with no volumeMounts at all → allowed",
+			req: func(t *testing.T) admission.Request {
+				return createReq(t, baselineIR(wcw))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "update rerendering runner with dangling mount → denied",
+			req: func(t *testing.T) admission.Request {
+				return updateReq(t, baselineIR(wcw), withContainerMount(baselineIR(wcw), "dshm"))
+			},
+			wantAllowed: false,
+			wantContains: []string{
+				`volumeMount "dshm" has no matching volume`,
+			},
+		},
+		{
+			name: "create with leader/worker runners, worker mounts undeclared dshm → denied naming worker",
+			req: func(t *testing.T) admission.Request {
+				ir := baselineIR(wcw)
+				// Multi-node shape: leader (declares dshm) + worker (mounts
+				// dshm but forgets to declare it). The leader is fine; the
+				// gate must flag the worker by name.
+				ir.Spec.Runners = []v1beta1.Runner{
+					{
+						Name: v1beta1.RunnerNameLeader,
+						Size: 1,
+						Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:         "ome-container",
+								Image:        "sgl:1.0",
+								VolumeMounts: []corev1.VolumeMount{{Name: "dshm", MountPath: "/dev/shm"}},
+							}},
+							Volumes: []corev1.Volume{{
+								Name:         "dshm",
+								VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+							}},
+						}},
+					},
+					{
+						Name: v1beta1.RunnerNameWorker,
+						Size: 2,
+						Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:         "ome-container",
+								Image:        "sgl:1.0",
+								VolumeMounts: []corev1.VolumeMount{{Name: "dshm", MountPath: "/dev/shm"}},
+							}},
+							// Worker forgets to declare dshm.
+						}},
+					},
+				}
+				return createReq(t, ir)
+			},
+			wantAllowed: false,
+			wantContains: []string{
+				`runner "worker"`,
+				`volumeMount "dshm" has no matching volume`,
+			},
+		},
+		// Finalizer-only-update exemption: a patch that changes nothing
+		// but metadata.finalizers is admitted before the immutability and
+		// controller-write gates — denying it would wedge teardown behind
+		// this fail-closed webhook. Combining a finalizer change with ANY
+		// other edit falls through to the normal gates.
+		{
+			name: "finalizer add without annotation → allowed (exemption)",
+			req: func(t *testing.T) admission.Request {
+				old := baselineIR(nil)
+				return updateReq(t, old, withFinalizers(old, "ome.io/ir-teardown"))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "finalizer remove without annotation → allowed (exemption)",
+			req: func(t *testing.T) admission.Request {
+				old := withFinalizers(baselineIR(nil), "ome.io/ir-teardown")
+				return updateReq(t, old, withFinalizers(old))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "finalizer remove on terminating IR without annotation → allowed",
+			req: func(t *testing.T) admission.Request {
+				old := withFinalizers(baselineIR(nil), "ome.io/ir-teardown")
+				old.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
+				old.DeletionGracePeriodSeconds = ptr.To[int64](0)
+				return updateReq(t, old, withFinalizers(old))
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "finalizer change + apiserver-mutated fields (rv/generation/managedFields) → allowed",
+			req: func(t *testing.T) admission.Request {
+				old := withFinalizers(baselineIR(nil), "ome.io/ir-teardown")
+				old.ResourceVersion = "100"
+				old.Generation = 3
+				newObj := withFinalizers(old)
+				newObj.ResourceVersion = "101"
+				newObj.Generation = 4
+				newObj.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "ome-manager"}}
+				return updateReq(t, old, newObj)
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "finalizer change + spec change → denied (not exempt)",
+			req: func(t *testing.T) admission.Request {
+				old := baselineIR(nil)
+				return updateReq(t, old,
+					withReplicas(withFinalizers(old, "ome.io/ir-teardown"), 7))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"controller-only resource"},
+		},
+		{
+			name: "finalizer change + parentRef change → denied (immutability fires)",
+			req: func(t *testing.T) admission.Request {
+				old := baselineIR(nil)
+				return updateReq(t, old,
+					withParent(withFinalizers(old, "ome.io/ir-teardown"), "different-isvc"))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"spec.parentRef is immutable"},
+		},
+		{
+			name: "finalizer change + label change → denied (not exempt)",
+			req: func(t *testing.T) admission.Request {
+				old := baselineIR(nil)
+				return updateReq(t, old,
+					withLabel(withFinalizers(old, "ome.io/ir-teardown"), "app", "rogue"))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"controller-only resource"},
+		},
+		{
+			name: "finalizer change + annotation change → denied (not exempt)",
+			req: func(t *testing.T) admission.Request {
+				// Stripping the controller-write annotation alongside a
+				// finalizer edit must not ride the exemption: annotations
+				// differ, so the write falls through to the normal gate and
+				// is denied for the missing annotation.
+				old := withFinalizers(baselineIR(wcw), "ome.io/ir-teardown")
+				newObj := withFinalizers(baselineIR(nil), "ome.io/ir-teardown", "extra")
+				return updateReq(t, old, newObj)
+			},
+			wantAllowed:  false,
+			wantContains: []string{"controller-only resource"},
+		},
+		{
+			name: "finalizer change + ownerRef change → denied (not exempt)",
+			req: func(t *testing.T) admission.Request {
+				old := baselineIR(nil)
+				return updateReq(t, old,
+					withOwnerRef(withFinalizers(old, "ome.io/ir-teardown"), "other-parent"))
+			},
+			wantAllowed:  false,
+			wantContains: []string{"controller-only resource"},
+		},
+		{
+			name: "create with leader/worker runners, both declare dshm → allowed",
+			req: func(t *testing.T) admission.Request {
+				ir := baselineIR(wcw)
+				mk := func(name v1beta1.RunnerName, size int32) v1beta1.Runner {
+					return v1beta1.Runner{
+						Name: name,
+						Size: size,
+						Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:         "ome-container",
+								Image:        "sgl:1.0",
+								VolumeMounts: []corev1.VolumeMount{{Name: "dshm", MountPath: "/dev/shm"}},
+							}},
+							Volumes: []corev1.Volume{{
+								Name:         "dshm",
+								VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+							}},
+						}},
+					}
+				}
+				ir.Spec.Runners = []v1beta1.Runner{mk(v1beta1.RunnerNameLeader, 1), mk(v1beta1.RunnerNameWorker, 2)}
+				return createReq(t, ir)
+			},
+			wantAllowed: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			v := &Validator{Decoder: newDecoder(t)}
+			resp := v.Handle(context.Background(), tc.req(t))
+			g.Expect(resp.Allowed).To(gomega.Equal(tc.wantAllowed))
+			for _, sub := range tc.wantContains {
+				g.Expect(resp.Result.Message).To(gomega.ContainSubstring(sub))
+			}
+		})
+	}
+}

--- a/pkg/webhook/admission/isvc/inference_service_defaults.go
+++ b/pkg/webhook/admission/isvc/inference_service_defaults.go
@@ -2,8 +2,11 @@ package isvc
 
 import (
 	"context"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -14,16 +17,12 @@ import (
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
 )
 
-var (
-	// logger for the mutating webhook.
-	mutatorLogger = logf.Log.WithName("inferenceservice-v1beta1-mutating-webhook")
-)
+var mutatorLogger = logf.Log.WithName("inferenceservice-v1beta1-mutating-webhook")
 
-// InferenceServiceDefaulter is responsible for setting default values on the InferenceService
-// when created or updated.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as it is used only for temporary operations and does not need to be deeply copied.
+// InferenceServiceDefaulter wires the webhook framework into the
+// DefaultInferenceService entrypoint. The kubebuilder markers below
+// suppress DeepCopy + OpenAPI codegen since this is a stateless
+// wired-once helper, not a persisted CR.
 // +kubebuilder:object:generate=false
 // +k8s:openapi-gen=false
 type InferenceServiceDefaulter struct {
@@ -40,104 +39,274 @@ func (d *InferenceServiceDefaulter) Default(ctx context.Context, obj runtime.Obj
 		mutatorLogger.Error(err, "Unable to convert object to InferenceService")
 		return err
 	}
-	mutatorLogger.Info("Defaulting InferenceService", "namespace", isvc.Namespace, "name", isvc.Name)
 	deployConfig, err := controllerconfig.NewDeployConfig(d.ClientSet)
 	if err != nil {
 		mutatorLogger.Error(err, "Failed to get deploy config")
 		return err
 	}
-	if err = DefaultInferenceService(ctx, d.Client, isvc, deployConfig); err != nil {
-		return err
-	}
-	return nil
+	return DefaultInferenceService(ctx, d.Client, isvc, deployConfig)
 }
 
-// DefaultInferenceService sets default values on the InferenceService
+// DefaultInferenceService sets default values on the InferenceService.
 func DefaultInferenceService(ctx context.Context, c client.Client, isvc *v1beta1.InferenceService, deployConfig *controllerconfig.DeployConfig) error {
-	// Create annotations map if it doesn't exist
 	if isvc.ObjectMeta.Annotations == nil {
 		isvc.ObjectMeta.Annotations = map[string]string{}
 	}
 
-	// Determine deployment mode based on components
-	_, modeExists := isvc.ObjectMeta.Annotations[constants.DeploymentMode]
-	if !modeExists {
-		// If both Engine and Decoder are specified, set the mode for PD disaggregated deployment
+	if _, modeExists := isvc.ObjectMeta.Annotations[constants.DeploymentMode]; !modeExists {
+		// Engine + Decoder ⇒ PDDisaggregated.
+		// Engine + Leader + Worker (size>0) ⇒ OMENative (native multi-node).
+		// Otherwise fall back to deployConfig.DefaultDeploymentMode
+		// (only RawDeployment is honored — other modes require an
+		// explicit operator annotation).
 		if isvc.Spec.Engine != nil && isvc.Spec.Decoder != nil {
-			// Use the PDDisaggregated deployment mode for PD disaggregated deployments
 			isvc.ObjectMeta.Annotations[constants.DeploymentMode] = string(constants.PDDisaggregated)
 		} else if isvc.Spec.Engine != nil {
-			// Check for MultiNode mode: leader and worker with worker.size > 0
 			if isvc.Spec.Engine.Leader != nil &&
 				isvc.Spec.Engine.Worker != nil &&
 				isvc.Spec.Engine.Worker.Size != nil &&
 				*isvc.Spec.Engine.Worker.Size > 0 {
-				isvc.ObjectMeta.Annotations[constants.DeploymentMode] = string(constants.MultiNode)
+				isvc.ObjectMeta.Annotations[constants.DeploymentMode] = string(constants.OMENative)
 			} else if deployConfig != nil && deployConfig.DefaultDeploymentMode == string(constants.RawDeployment) {
-				// Default to RawDeployment mode if not MultiNode
 				isvc.ObjectMeta.Annotations[constants.DeploymentMode] = deployConfig.DefaultDeploymentMode
 			}
 		} else if deployConfig != nil && deployConfig.DefaultDeploymentMode == string(constants.RawDeployment) {
-			// Apply default deployment mode from config if provided
 			isvc.ObjectMeta.Annotations[constants.DeploymentMode] = deployConfig.DefaultDeploymentMode
 		}
 	}
 
-	// Set default values for Engine component if present
+	// resolvedMode is the effective deployment mode after the ObjectMeta
+	// resolution above: the canonical top-level ome.io/deploymentMode
+	// annotation (set explicitly by the operator or by the leader+worker
+	// heuristic), falling back to spec.DeploymentMode. Components must
+	// resolve OMENative from it so a multi-node engine declared the normal
+	// way (top-level annotation, no spec.deploymentMode) still receives
+	// defaultOMENativeComponent — including the rollout budget defaults
+	// that keep its rollouts capped.
+	resolvedMode := isvc.Spec.DeploymentMode
+	if m := isvc.ObjectMeta.Annotations[constants.DeploymentMode]; m != "" {
+		mm := constants.DeploymentModeType(m)
+		resolvedMode = &mm
+	}
+
 	if isvc.Spec.Engine != nil {
-		defaultEngine(isvc.Spec.Engine)
+		defaultEngine(isvc.Spec.Engine, resolvedMode)
 	}
-
-	// Set default values for Decoder component if present
 	if isvc.Spec.Decoder != nil {
-		defaultDecoder(isvc.Spec.Decoder)
+		defaultDecoder(isvc.Spec.Decoder, resolvedMode)
 	}
-
-	// Set default values for Router component if present
 	if isvc.Spec.Router != nil {
-		defaultRouter(isvc.Spec.Router)
+		defaultRouter(isvc.Spec.Router, resolvedMode)
 	}
+	// Rollout pacing/structure defaults are applied at runtime by the resolve
+	// layer (coordination.ResolveGroups), not at admission.
 	return nil
 }
 
-// defaultEngine sets default values for the Engine component
-func defaultEngine(engine *v1beta1.EngineSpec) {
-	// Set default replica values if not set
+func defaultEngine(engine *v1beta1.EngineSpec, specMode *constants.DeploymentModeType) {
 	if engine.MinReplicas == nil {
-		minReplicas := 1 // MinReplicas is *int, not *int32
+		minReplicas := 1
 		engine.MinReplicas = &minReplicas
 	}
-
-	// MaxReplicas is not a pointer type, so check if it's 0 (default value)
+	// MaxReplicas is a non-pointer int — 0 means "not set".
 	if engine.MaxReplicas == 0 {
 		engine.MaxReplicas = 3
 	}
+	defaultWorkerSize(engine.Leader, engine.Worker)
+	defaultOMENativeComponent(&engine.ComponentExtensionSpec, engineIsMultiPod(engine), specMode)
 }
 
-// defaultDecoder sets default values for the Decoder component
-func defaultDecoder(decoder *v1beta1.DecoderSpec) {
-	// Set default replica values if not set
+func defaultDecoder(decoder *v1beta1.DecoderSpec, specMode *constants.DeploymentModeType) {
 	if decoder.MinReplicas == nil {
-		minReplicas := 1 // MinReplicas is *int, not *int32
+		minReplicas := 1
 		decoder.MinReplicas = &minReplicas
 	}
-
-	// MaxReplicas is not a pointer type, so check if it's 0 (default value)
 	if decoder.MaxReplicas == 0 {
 		decoder.MaxReplicas = 3
 	}
+	defaultWorkerSize(decoder.Leader, decoder.Worker)
+	defaultOMENativeComponent(&decoder.ComponentExtensionSpec, decoderIsMultiPod(decoder), specMode)
 }
 
-// defaultRouter sets default values for the Router component
-func defaultRouter(router *v1beta1.RouterSpec) {
-	// Set default replica values if not set
+// defaultWorkerSize fills Worker.Size=1 when a multi-pod pairing is
+// declared (Leader set AND Worker set) but Worker.Size is nil. Acts
+// only when both halves of the pairing are present — pure
+// leader-without-worker or worker-without-leader specs are left
+// untouched (the validator rejects them later with the appropriate
+// reason).
+//
+// Treats nil Size as the operator-friendly "minimum-viable
+// multi-pod" default; if the operator wants more workers they set
+// Size explicitly. A Size of 0 is preserved (and rejected at
+// validation as WorkerSizeMustBePositive) so we don't quietly turn
+// the operator's "no workers, please" mistake into a 2-pod gang.
+//
+// Must run BEFORE engineIsMultiPod / decoderIsMultiPod so the
+// downstream multi-pod detection sees the defaulted Size and stamps
+// the gang lifecycle policies (RecreateInstance restart, AllPodReady
+// readiness, SurgeThenDrain update).
+func defaultWorkerSize(leader *v1beta1.LeaderSpec, worker *v1beta1.WorkerSpec) {
+	if leader == nil || worker == nil {
+		return
+	}
+	if worker.Size != nil {
+		return
+	}
+	size := 1
+	worker.Size = &size
+}
+
+func defaultRouter(router *v1beta1.RouterSpec, specMode *constants.DeploymentModeType) {
 	if router.MinReplicas == nil {
-		minReplicas := 1 // MinReplicas is *int, not *int32
+		minReplicas := 1
 		router.MinReplicas = &minReplicas
 	}
-
-	// MaxReplicas is not a pointer type, so check if it's 0 (default value)
 	if router.MaxReplicas == 0 {
 		router.MaxReplicas = 2
 	}
+	// Router has no Leader/Worker; always single-pod.
+	defaultOMENativeComponent(&router.ComponentExtensionSpec, false, specMode)
+}
+
+// engineIsMultiPod reports whether the Engine spawns more than one pod per
+// Instance — true when a Leader is declared or when Worker.Size > 0.
+func engineIsMultiPod(engine *v1beta1.EngineSpec) bool {
+	if engine == nil {
+		return false
+	}
+	if engine.Leader != nil {
+		return true
+	}
+	return engine.Worker != nil && engine.Worker.Size != nil && *engine.Worker.Size > 0
+}
+
+// decoderIsMultiPod reports whether the Decoder spawns more than one pod per
+// Instance — true when a Leader is declared or when Worker.Size > 0.
+func decoderIsMultiPod(decoder *v1beta1.DecoderSpec) bool {
+	if decoder == nil {
+		return false
+	}
+	if decoder.Leader != nil {
+		return true
+	}
+	return decoder.Worker != nil && decoder.Worker.Size != nil && *decoder.Worker.Size > 0
+}
+
+// defaultOMENativeComponent fills in lifecycle-policy defaults on
+// the Component's omenative sub-block. Only acts when the Component
+// resolves to OMENative — either via its own
+// ome.io/deploymentMode annotation or via the top-level
+// spec.deploymentMode field (per-Component annotation wins). For any
+// other mode the block is left untouched. multiPod toggles the
+// restart/ready policy defaults: a multi-pod Instance defaults to group
+// restart + AllPodReady aggregation; a single-pod Instance defaults to
+// None for both.
+//
+// Multi-pod defaults:
+//
+//   - RestartPolicy = RecreateInstanceOnPodRestart (gang restart)
+//   - ReadyPolicy = AllPodReady (Instance Ready iff every pod Ready)
+//   - UpdateStrategy.Type = SurgeThenDrain (same default as single-pod;
+//     multi-pod gangs surge as a unit via the gang-surge path)
+func defaultOMENativeComponent(ext *v1beta1.ComponentExtensionSpec, multiPod bool, specMode *constants.DeploymentModeType) {
+	if ext == nil {
+		return
+	}
+	if !componentResolvesToOMENative(ext.Annotations, specMode) {
+		return
+	}
+	if ext.Lifecycle == nil {
+		ext.Lifecycle = &v1beta1.LifecycleSpec{}
+	}
+	spec := ext.Lifecycle
+
+	if spec.RestartPolicy == nil {
+		rp := v1beta1.InstanceRestartPolicyNone
+		if multiPod {
+			rp = v1beta1.InstanceRestartPolicyRecreateInstance
+		}
+		spec.RestartPolicy = &rp
+	}
+
+	if spec.UpdateStrategy == nil {
+		spec.UpdateStrategy = &v1beta1.UpdateStrategy{}
+	}
+	if spec.UpdateStrategy.Type == "" {
+		// SurgeThenDrain is the default. Single-pod Instances get a real
+		// zero-downtime surge (new pod at the alternate ordinal, drain
+		// the old, promote); multi-pod gangs surge a whole replacement
+		// gang at a fresh surge index before the source drains. Either
+		// way it is safer than in-place because the MaxUnavailable gate
+		// throttles drains.
+		spec.UpdateStrategy.Type = v1beta1.UpdateStrategySurgeThenDrain
+	}
+	if spec.UpdateStrategy.InPlaceUpdateStrategy == nil {
+		spec.UpdateStrategy.InPlaceUpdateStrategy = &v1beta1.InPlaceUpdateStrategy{}
+	}
+	if spec.UpdateStrategy.InPlaceUpdateStrategy.GracePeriodSeconds == nil {
+		grace := int32(30)
+		spec.UpdateStrategy.InPlaceUpdateStrategy.GracePeriodSeconds = &grace
+	}
+	if spec.UpdateStrategy.InPlaceUpdateStrategy.MarkNotReadyDuringLifecycle == nil {
+		mark := true
+		spec.UpdateStrategy.InPlaceUpdateStrategy.MarkNotReadyDuringLifecycle = &mark
+	}
+
+	// Default the per-Component rollout budgets so an unset RollingUpdate
+	// never resolves to the uncapped BudgetNoLimit. Without a cap the
+	// dispatcher can start every Instance's surge/drain in a single
+	// reconcile pass, draining an entire fleet at once on a spec bump.
+	// 25% mirrors the upstream appsv1.Deployment RollingUpdate defaults and
+	// paces both the surge path (gated on MaxSurge) and the recreate path
+	// (gated on MaxUnavailable). Percent values scale with replica count at
+	// reconcile time, so this is safe from tiny to large Components.
+	if spec.UpdateStrategy.RollingUpdate == nil {
+		spec.UpdateStrategy.RollingUpdate = &v1beta1.RollingUpdate{}
+	}
+	if spec.UpdateStrategy.RollingUpdate.MaxSurge == nil {
+		ms := intstr.FromString("25%")
+		spec.UpdateStrategy.RollingUpdate.MaxSurge = &ms
+	}
+	if spec.UpdateStrategy.RollingUpdate.MaxUnavailable == nil {
+		mu := intstr.FromString("25%")
+		spec.UpdateStrategy.RollingUpdate.MaxUnavailable = &mu
+	}
+
+	if spec.ReadyPolicy == nil {
+		rp := v1beta1.InstanceReadyPolicyNone
+		if multiPod {
+			rp = v1beta1.InstanceReadyPolicyAllPodReady
+		}
+		spec.ReadyPolicy = &rp
+	}
+
+	if spec.InstanceReadyTimeout == nil {
+		spec.InstanceReadyTimeout = &metav1.Duration{Duration: 30 * time.Minute}
+	}
+
+	if spec.MigrationPolicy == nil {
+		spec.MigrationPolicy = &v1beta1.MigrationPolicy{}
+	}
+	if spec.MigrationPolicy.Mode == "" {
+		spec.MigrationPolicy.Mode = v1beta1.MigrationPolicyModeAuto
+	}
+}
+
+// componentResolvesToOMENative reports whether a Component dispatches
+// to the OMENative backend after applying the precedence chain:
+//  1. Per-Component ome.io/deploymentMode annotation (escape hatch).
+//  2. Top-level spec.deploymentMode (typed default).
+//
+// Returns false when neither resolves to OMENative. Used by the
+// lifecycle-policy defaulter so spec.deploymentMode=OMENative also
+// triggers the OMENative defaults without forcing operators to repeat
+// the annotation on every Component.
+func componentResolvesToOMENative(annotations map[string]string, specMode *constants.DeploymentModeType) bool {
+	if annotations[constants.DeploymentMode] != "" {
+		return annotations[constants.DeploymentMode] == string(constants.OMENative)
+	}
+	if specMode != nil {
+		return *specMode == constants.OMENative
+	}
+	return false
 }

--- a/pkg/webhook/admission/isvc/inference_service_defaults_test.go
+++ b/pkg/webhook/admission/isvc/inference_service_defaults_test.go
@@ -3,12 +3,14 @@ package isvc
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -48,11 +50,6 @@ func intPtr(i int) *int {
 	return &i
 }
 
-// Helper function to create int64 pointers
-func int64Ptr(i int64) *int64 {
-	return &i
-}
-
 // createBasicInferenceService creates a basic InferenceService for testing
 func createBasicInferenceService(name, namespace string) *v1beta1.InferenceService {
 	return &v1beta1.InferenceService{
@@ -61,6 +58,48 @@ func createBasicInferenceService(name, namespace string) *v1beta1.InferenceServi
 			Namespace: namespace,
 		},
 		Spec: v1beta1.InferenceServiceSpec{},
+	}
+}
+
+// =============================================================================
+// Main DefaultInferenceService Tests
+// =============================================================================
+
+func TestDefaultInferenceService(t *testing.T) {
+	tests := []struct {
+		name            string
+		isvc            *v1beta1.InferenceService
+		deployConfig    *controllerconfig.DeployConfig
+		wantAnnotations map[string]string
+	}{
+		{
+			name:            "empty InferenceService should have no annotations",
+			isvc:            createBasicInferenceService("test-isvc", "default"),
+			deployConfig:    nil,
+			wantAnnotations: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			c := createFakeClient(t)
+			err := DefaultInferenceService(ctx, c, tt.isvc, tt.deployConfig)
+			require.NoError(t, err)
+
+			if tt.wantAnnotations == nil {
+				if tt.isvc.Annotations != nil {
+					assert.Empty(t, tt.isvc.Annotations, "Expected no annotations")
+				}
+				return
+			}
+			require.NotNil(t, tt.isvc.Annotations)
+			for key, expectedVal := range tt.wantAnnotations {
+				actualVal, exists := tt.isvc.Annotations[key]
+				assert.True(t, exists, "expected annotation %q", key)
+				assert.Equal(t, expectedVal, actualVal)
+			}
+		})
 	}
 }
 
@@ -87,7 +126,7 @@ func TestDeploymentModeDetection(t *testing.T) {
 			expectedMode: string(constants.PDDisaggregated),
 		},
 		{
-			name: "engine with leader and worker should set MultiNode",
+			name: "engine with leader and worker should set OMENative",
 			isvc: &v1beta1.InferenceService{
 				Spec: v1beta1.InferenceServiceSpec{
 					Engine: &v1beta1.EngineSpec{
@@ -97,7 +136,7 @@ func TestDeploymentModeDetection(t *testing.T) {
 				},
 			},
 			deployConfig: nil,
-			expectedMode: string(constants.MultiNode),
+			expectedMode: string(constants.OMENative),
 		},
 		{
 			name: "engine without leader/worker should default to RawDeployment",
@@ -123,11 +162,15 @@ func TestDeploymentModeDetection(t *testing.T) {
 			expectedMode: string(constants.RawDeployment),
 		},
 		{
+			// A pre-existing annotation is preserved verbatim — even a
+			// legacy "MultiNode" value the defaulter itself never stamps.
+			// This pins the upgrade-safety contract: admission does not
+			// rewrite or reject persisted annotations.
 			name: "existing deployment mode should not be overridden",
 			isvc: &v1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						constants.DeploymentMode: string(constants.MultiNode),
+						constants.DeploymentMode: "MultiNode",
 					},
 				},
 				Spec: v1beta1.InferenceServiceSpec{
@@ -136,7 +179,7 @@ func TestDeploymentModeDetection(t *testing.T) {
 				},
 			},
 			deployConfig: nil,
-			expectedMode: string(constants.MultiNode),
+			expectedMode: "MultiNode",
 		},
 	}
 
@@ -155,9 +198,62 @@ func TestDeploymentModeDetection(t *testing.T) {
 	}
 }
 
-// =============================================================================
-// Component Default Value Tests
-// =============================================================================
+// TestDefaultInferenceService_OMENativeBudgetViaAnnotationAndHeuristic pins
+// that a multi-node engine resolving to OMENative via the canonical top-level
+// ome.io/deploymentMode annotation OR via the leader+worker heuristic (no
+// spec.deploymentMode, no per-component annotation) still gets the rollout
+// budget defaults. If componentResolvesToOMENative saw only the per-component
+// annotation + spec field, the whole defaulter (including the 25% budgets)
+// would be skipped for these shapes, leaving the rollout uncapped.
+func TestDefaultInferenceService_OMENativeBudgetViaAnnotationAndHeuristic(t *testing.T) {
+	mnEngine := func() *v1beta1.EngineSpec {
+		return &v1beta1.EngineSpec{
+			Leader: &v1beta1.LeaderSpec{},
+			Worker: &v1beta1.WorkerSpec{Size: intPtr(2)},
+		}
+	}
+	tests := []struct {
+		name string
+		isvc *v1beta1.InferenceService
+	}{
+		{
+			name: "top-level ome.io/deploymentMode=OMENative annotation",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{constants.DeploymentMode: string(constants.OMENative)},
+				},
+				Spec: v1beta1.InferenceServiceSpec{Engine: mnEngine()},
+			},
+		},
+		{
+			name: "leader+worker heuristic (no annotation, no spec.deploymentMode)",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{Engine: mnEngine()},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			c := createFakeClient(t)
+			require.NoError(t, DefaultInferenceService(ctx, c, tt.isvc, nil))
+
+			// Sanity: it resolved to OMENative.
+			assert.Equal(t, string(constants.OMENative),
+				tt.isvc.ObjectMeta.Annotations[constants.DeploymentMode])
+
+			// The defaulter ran → budgets are set to 25% (not left nil/uncapped).
+			lc := tt.isvc.Spec.Engine.Lifecycle
+			require.NotNil(t, lc, "OMENative lifecycle must be defaulted")
+			require.NotNil(t, lc.UpdateStrategy)
+			require.NotNil(t, lc.UpdateStrategy.RollingUpdate)
+			require.NotNil(t, lc.UpdateStrategy.RollingUpdate.MaxSurge)
+			assert.Equal(t, intstr.FromString("25%"), *lc.UpdateStrategy.RollingUpdate.MaxSurge)
+			require.NotNil(t, lc.UpdateStrategy.RollingUpdate.MaxUnavailable)
+			assert.Equal(t, intstr.FromString("25%"), *lc.UpdateStrategy.RollingUpdate.MaxUnavailable)
+		})
+	}
+}
 
 func TestDefaultComponents(t *testing.T) {
 	t.Run("defaultEngine", func(t *testing.T) {
@@ -188,7 +284,7 @@ func TestDefaultComponents(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				defaultEngine(tt.engine)
+				defaultEngine(tt.engine, nil)
 				require.NotNil(t, tt.engine.MinReplicas)
 				assert.Equal(t, tt.wantMinReplicas, *tt.engine.MinReplicas)
 				assert.Equal(t, tt.wantMaxReplicas, tt.engine.MaxReplicas)
@@ -224,7 +320,7 @@ func TestDefaultComponents(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				defaultDecoder(tt.decoder)
+				defaultDecoder(tt.decoder, nil)
 				require.NotNil(t, tt.decoder.MinReplicas)
 				assert.Equal(t, tt.wantMinReplicas, *tt.decoder.MinReplicas)
 				assert.Equal(t, tt.wantMaxReplicas, tt.decoder.MaxReplicas)
@@ -260,7 +356,7 @@ func TestDefaultComponents(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				defaultRouter(tt.router)
+				defaultRouter(tt.router, nil)
 				require.NotNil(t, tt.router.MinReplicas)
 				assert.Equal(t, tt.wantMinReplicas, *tt.router.MinReplicas)
 				assert.Equal(t, tt.wantMaxReplicas, tt.router.MaxReplicas)
@@ -268,6 +364,358 @@ func TestDefaultComponents(t *testing.T) {
 		}
 	})
 }
+
+func int32Ptr(v int32) *int32 { return &v }
+
+func TestDefaultOMENativeComponent(t *testing.T) {
+	omenativeMode := map[string]string{constants.DeploymentMode: string(constants.OMENative)}
+
+	t.Run("not OMENative — omenative block untouched", func(t *testing.T) {
+		ext := &v1beta1.ComponentExtensionSpec{
+			Annotations: map[string]string{constants.DeploymentMode: string(constants.RawDeployment)},
+		}
+		defaultOMENativeComponent(ext, true, nil)
+		assert.Nil(t, ext.Lifecycle)
+	})
+
+	t.Run("no annotation — omenative block untouched", func(t *testing.T) {
+		ext := &v1beta1.ComponentExtensionSpec{}
+		defaultOMENativeComponent(ext, true, nil)
+		assert.Nil(t, ext.Lifecycle)
+	})
+
+	t.Run("OMENative + multi-pod — full defaults applied", func(t *testing.T) {
+		ext := &v1beta1.ComponentExtensionSpec{Annotations: omenativeMode}
+		defaultOMENativeComponent(ext, true, nil)
+
+		require.NotNil(t, ext.Lifecycle)
+		spec := ext.Lifecycle
+
+		require.NotNil(t, spec.RestartPolicy)
+		assert.Equal(t, v1beta1.InstanceRestartPolicyRecreateInstance, *spec.RestartPolicy)
+
+		require.NotNil(t, spec.UpdateStrategy)
+		assert.Equal(t, v1beta1.UpdateStrategySurgeThenDrain, spec.UpdateStrategy.Type)
+		require.NotNil(t, spec.UpdateStrategy.InPlaceUpdateStrategy)
+		require.NotNil(t, spec.UpdateStrategy.InPlaceUpdateStrategy.GracePeriodSeconds)
+		assert.Equal(t, int32(30), *spec.UpdateStrategy.InPlaceUpdateStrategy.GracePeriodSeconds)
+		require.NotNil(t, spec.UpdateStrategy.InPlaceUpdateStrategy.MarkNotReadyDuringLifecycle)
+		assert.True(t, *spec.UpdateStrategy.InPlaceUpdateStrategy.MarkNotReadyDuringLifecycle)
+
+		// Rollout budgets default to 25% so an unset RollingUpdate never
+		// resolves to the uncapped BudgetNoLimit that would let a rollout
+		// drain a whole fleet at once. Both surge and drain paths are paced.
+		require.NotNil(t, spec.UpdateStrategy.RollingUpdate)
+		require.NotNil(t, spec.UpdateStrategy.RollingUpdate.MaxSurge)
+		assert.Equal(t, intstr.FromString("25%"), *spec.UpdateStrategy.RollingUpdate.MaxSurge)
+		require.NotNil(t, spec.UpdateStrategy.RollingUpdate.MaxUnavailable)
+		assert.Equal(t, intstr.FromString("25%"), *spec.UpdateStrategy.RollingUpdate.MaxUnavailable)
+
+		require.NotNil(t, spec.ReadyPolicy)
+		assert.Equal(t, v1beta1.InstanceReadyPolicyAllPodReady, *spec.ReadyPolicy)
+
+		require.NotNil(t, spec.InstanceReadyTimeout)
+		assert.Equal(t, 30*time.Minute, spec.InstanceReadyTimeout.Duration)
+
+		require.NotNil(t, spec.MigrationPolicy)
+		assert.Equal(t, v1beta1.MigrationPolicyModeAuto, spec.MigrationPolicy.Mode)
+	})
+
+	t.Run("OMENative + single-pod — restart/ready default to None", func(t *testing.T) {
+		ext := &v1beta1.ComponentExtensionSpec{Annotations: omenativeMode}
+		defaultOMENativeComponent(ext, false, nil)
+
+		require.NotNil(t, ext.Lifecycle)
+		require.NotNil(t, ext.Lifecycle.RestartPolicy)
+		assert.Equal(t, v1beta1.InstanceRestartPolicyNone, *ext.Lifecycle.RestartPolicy)
+		require.NotNil(t, ext.Lifecycle.ReadyPolicy)
+		assert.Equal(t, v1beta1.InstanceReadyPolicyNone, *ext.Lifecycle.ReadyPolicy)
+	})
+
+	t.Run("OMENative + existing values — preserved, nil siblings filled", func(t *testing.T) {
+		customRestart := v1beta1.InstanceRestartPolicyNone
+		customTimeout := metav1.Duration{Duration: 5 * time.Minute}
+		ext := &v1beta1.ComponentExtensionSpec{
+			Annotations: omenativeMode,
+			Lifecycle: &v1beta1.LifecycleSpec{
+				RestartPolicy:        &customRestart,
+				InstanceReadyTimeout: &customTimeout,
+			},
+		}
+		defaultOMENativeComponent(ext, true, nil)
+
+		// preserved
+		require.NotNil(t, ext.Lifecycle.RestartPolicy)
+		assert.Equal(t, v1beta1.InstanceRestartPolicyNone, *ext.Lifecycle.RestartPolicy)
+		assert.Equal(t, 5*time.Minute, ext.Lifecycle.InstanceReadyTimeout.Duration)
+
+		// filled
+		require.NotNil(t, ext.Lifecycle.UpdateStrategy)
+		assert.Equal(t, v1beta1.UpdateStrategySurgeThenDrain, ext.Lifecycle.UpdateStrategy.Type)
+		require.NotNil(t, ext.Lifecycle.ReadyPolicy)
+		assert.Equal(t, v1beta1.InstanceReadyPolicyAllPodReady, *ext.Lifecycle.ReadyPolicy)
+		require.NotNil(t, ext.Lifecycle.MigrationPolicy)
+		assert.Equal(t, v1beta1.MigrationPolicyModeAuto, ext.Lifecycle.MigrationPolicy.Mode)
+	})
+
+	t.Run("OMENative + partial UpdateStrategy — only nil leaves filled", func(t *testing.T) {
+		customType := v1beta1.UpdateStrategyRecreatePod
+		customGrace := int32(60)
+		ext := &v1beta1.ComponentExtensionSpec{
+			Annotations: omenativeMode,
+			Lifecycle: &v1beta1.LifecycleSpec{
+				UpdateStrategy: &v1beta1.UpdateStrategy{
+					Type: customType,
+					InPlaceUpdateStrategy: &v1beta1.InPlaceUpdateStrategy{
+						GracePeriodSeconds: &customGrace,
+					},
+				},
+			},
+		}
+		defaultOMENativeComponent(ext, true, nil)
+
+		assert.Equal(t, v1beta1.UpdateStrategyRecreatePod, ext.Lifecycle.UpdateStrategy.Type)
+		assert.Equal(t, int32(60), *ext.Lifecycle.UpdateStrategy.InPlaceUpdateStrategy.GracePeriodSeconds)
+		// MarkNotReadyDuringLifecycle was nil → defaulted to true
+		require.NotNil(t, ext.Lifecycle.UpdateStrategy.InPlaceUpdateStrategy.MarkNotReadyDuringLifecycle)
+		assert.True(t, *ext.Lifecycle.UpdateStrategy.InPlaceUpdateStrategy.MarkNotReadyDuringLifecycle)
+		// RollingUpdate was nil → both budgets defaulted to 25%.
+		require.NotNil(t, ext.Lifecycle.UpdateStrategy.RollingUpdate)
+		require.NotNil(t, ext.Lifecycle.UpdateStrategy.RollingUpdate.MaxSurge)
+		assert.Equal(t, intstr.FromString("25%"), *ext.Lifecycle.UpdateStrategy.RollingUpdate.MaxSurge)
+		require.NotNil(t, ext.Lifecycle.UpdateStrategy.RollingUpdate.MaxUnavailable)
+		assert.Equal(t, intstr.FromString("25%"), *ext.Lifecycle.UpdateStrategy.RollingUpdate.MaxUnavailable)
+	})
+
+	t.Run("OMENative + operator-set RollingUpdate budgets — preserved, nil sibling filled", func(t *testing.T) {
+		// An operator who sets only MaxSurge keeps that value; the nil
+		// MaxUnavailable sibling is filled with the 25% default.
+		customSurge := intstr.FromInt(1)
+		ext := &v1beta1.ComponentExtensionSpec{
+			Annotations: omenativeMode,
+			Lifecycle: &v1beta1.LifecycleSpec{
+				UpdateStrategy: &v1beta1.UpdateStrategy{
+					RollingUpdate: &v1beta1.RollingUpdate{
+						MaxSurge: &customSurge,
+					},
+				},
+			},
+		}
+		defaultOMENativeComponent(ext, true, nil)
+
+		require.NotNil(t, ext.Lifecycle.UpdateStrategy.RollingUpdate.MaxSurge)
+		assert.Equal(t, intstr.FromInt(1), *ext.Lifecycle.UpdateStrategy.RollingUpdate.MaxSurge)
+		// nil sibling filled with the default.
+		require.NotNil(t, ext.Lifecycle.UpdateStrategy.RollingUpdate.MaxUnavailable)
+		assert.Equal(t, intstr.FromString("25%"), *ext.Lifecycle.UpdateStrategy.RollingUpdate.MaxUnavailable)
+	})
+}
+
+func TestEngineIsMultiPod(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *v1beta1.EngineSpec
+		want bool
+	}{
+		{name: "nil", spec: nil, want: false},
+		{name: "empty", spec: &v1beta1.EngineSpec{}, want: false},
+		{name: "leader only", spec: &v1beta1.EngineSpec{Leader: &v1beta1.LeaderSpec{}}, want: true},
+		{
+			name: "worker size 0",
+			spec: &v1beta1.EngineSpec{Worker: &v1beta1.WorkerSpec{Size: func() *int { v := 0; return &v }()}},
+			want: false,
+		},
+		{
+			name: "worker size 1",
+			spec: &v1beta1.EngineSpec{Worker: &v1beta1.WorkerSpec{Size: func() *int { v := 1; return &v }()}},
+			want: true,
+		},
+		{
+			name: "worker size nil",
+			spec: &v1beta1.EngineSpec{Worker: &v1beta1.WorkerSpec{}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, engineIsMultiPod(tt.spec))
+		})
+	}
+}
+
+func TestDefaultEngine_OMENativeAnnotationTriggersDefaults(t *testing.T) {
+	engine := &v1beta1.EngineSpec{
+		ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+			Annotations: map[string]string{constants.DeploymentMode: string(constants.OMENative)},
+		},
+		Worker: &v1beta1.WorkerSpec{Size: func() *int { v := 3; return &v }()},
+	}
+	defaultEngine(engine, nil)
+	require.NotNil(t, engine.Lifecycle)
+	require.NotNil(t, engine.Lifecycle.RestartPolicy)
+	assert.Equal(t, v1beta1.InstanceRestartPolicyRecreateInstance, *engine.Lifecycle.RestartPolicy)
+}
+
+func TestDefaultRouter_OMENativeAlwaysSinglePod(t *testing.T) {
+	router := &v1beta1.RouterSpec{
+		ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+			Annotations: map[string]string{constants.DeploymentMode: string(constants.OMENative)},
+		},
+	}
+	defaultRouter(router, nil)
+	require.NotNil(t, router.Lifecycle)
+	require.NotNil(t, router.Lifecycle.RestartPolicy)
+	assert.Equal(t, v1beta1.InstanceRestartPolicyNone, *router.Lifecycle.RestartPolicy)
+}
+
+// TestDefaultWorkerSize_MultiPodWithoutSize covers the
+// defaulter rule that Worker.Size = nil with Leader set is
+// treated as "minimum-viable multi-pod" (Size=1). The downstream
+// engineIsMultiPod / decoderIsMultiPod detection sees the defaulted
+// Size and the gang lifecycle policies kick in.
+func TestDefaultWorkerSize_MultiPodWithoutSize(t *testing.T) {
+	t.Run("engine leader + worker without size — defaults Size=1", func(t *testing.T) {
+		engine := &v1beta1.EngineSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+				Annotations: map[string]string{constants.DeploymentMode: string(constants.OMENative)},
+			},
+			Leader: &v1beta1.LeaderSpec{},
+			Worker: &v1beta1.WorkerSpec{},
+		}
+		defaultEngine(engine, nil)
+		require.NotNil(t, engine.Worker.Size)
+		assert.Equal(t, 1, *engine.Worker.Size)
+		// downstream multi-pod detection should kick in:
+		require.NotNil(t, engine.Lifecycle)
+		require.NotNil(t, engine.Lifecycle.RestartPolicy)
+		assert.Equal(t, v1beta1.InstanceRestartPolicyRecreateInstance, *engine.Lifecycle.RestartPolicy)
+		require.NotNil(t, engine.Lifecycle.ReadyPolicy)
+		assert.Equal(t, v1beta1.InstanceReadyPolicyAllPodReady, *engine.Lifecycle.ReadyPolicy)
+	})
+
+	t.Run("engine leader + worker with size=3 — preserved", func(t *testing.T) {
+		engine := &v1beta1.EngineSpec{
+			Leader: &v1beta1.LeaderSpec{},
+			Worker: &v1beta1.WorkerSpec{Size: intPtr(3)},
+		}
+		defaultEngine(engine, nil)
+		require.NotNil(t, engine.Worker.Size)
+		assert.Equal(t, 3, *engine.Worker.Size)
+	})
+
+	t.Run("engine leader + worker with size=0 — preserved (validator rejects)", func(t *testing.T) {
+		// The defaulter must NOT silently turn a 0 into a 1; that
+		// would erase a clear operator mistake. Validator rejects
+		// Size <= 0 with WorkerSizeMustBePositive.
+		engine := &v1beta1.EngineSpec{
+			Leader: &v1beta1.LeaderSpec{},
+			Worker: &v1beta1.WorkerSpec{Size: intPtr(0)},
+		}
+		defaultEngine(engine, nil)
+		require.NotNil(t, engine.Worker.Size)
+		assert.Equal(t, 0, *engine.Worker.Size)
+	})
+
+	t.Run("engine leader-only — no worker created (validator rejects)", func(t *testing.T) {
+		// Pure leader-without-worker is not the multi-pod pairing the
+		// defaulter handles. The validator catches it with
+		// LeaderRequiresWorker.
+		engine := &v1beta1.EngineSpec{Leader: &v1beta1.LeaderSpec{}}
+		defaultEngine(engine, nil)
+		assert.Nil(t, engine.Worker)
+	})
+
+	t.Run("engine worker-only — Size left untouched (validator rejects)", func(t *testing.T) {
+		// Pure worker-without-leader: the defaulter sees no pairing
+		// to fill. The validator catches it with
+		// WorkerRequiresLeader; the malformed Size remains for the
+		// error message to surface.
+		engine := &v1beta1.EngineSpec{Worker: &v1beta1.WorkerSpec{}}
+		defaultEngine(engine, nil)
+		assert.Nil(t, engine.Worker.Size)
+	})
+
+	t.Run("decoder leader + worker without size — defaults Size=1", func(t *testing.T) {
+		decoder := &v1beta1.DecoderSpec{
+			ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+				Annotations: map[string]string{constants.DeploymentMode: string(constants.OMENative)},
+			},
+			Leader: &v1beta1.LeaderSpec{},
+			Worker: &v1beta1.WorkerSpec{},
+		}
+		defaultDecoder(decoder, nil)
+		require.NotNil(t, decoder.Worker.Size)
+		assert.Equal(t, 1, *decoder.Worker.Size)
+		require.NotNil(t, decoder.Lifecycle)
+		require.NotNil(t, decoder.Lifecycle.RestartPolicy)
+		assert.Equal(t, v1beta1.InstanceRestartPolicyRecreateInstance, *decoder.Lifecycle.RestartPolicy)
+	})
+
+	t.Run("single-pod engine — Worker field unset, no panic", func(t *testing.T) {
+		engine := &v1beta1.EngineSpec{}
+		defaultEngine(engine, nil)
+		assert.Nil(t, engine.Worker)
+		assert.Nil(t, engine.Leader)
+	})
+}
+
+// TestDefaultOMENativeComponent_MultiPodDefaults pins the
+// multi-pod defaulter rules as a single explicit before/after
+// test, complementing TestDefaultOMENativeComponent which already
+// covers the underlying mechanic.
+//
+// Rules pinned:
+//   - RestartPolicy → RecreateInstanceOnPodRestart
+//   - ReadyPolicy   → AllPodReady
+//   - UpdateStrategy.Type → SurgeThenDrain (same as single-pod;
+//     multi-pod gangs surge as a unit via the gang-surge path)
+func TestDefaultOMENativeComponent_MultiPodDefaults(t *testing.T) {
+	ext := &v1beta1.ComponentExtensionSpec{
+		Annotations: map[string]string{constants.DeploymentMode: string(constants.OMENative)},
+	}
+
+	// before
+	assert.Nil(t, ext.Lifecycle)
+
+	defaultOMENativeComponent(ext, true /* multiPod */, nil)
+
+	// after
+	require.NotNil(t, ext.Lifecycle)
+	require.NotNil(t, ext.Lifecycle.RestartPolicy)
+	assert.Equal(t, v1beta1.InstanceRestartPolicyRecreateInstance, *ext.Lifecycle.RestartPolicy,
+		"multi-pod must default to RecreateInstanceOnPodRestart (gang restart)")
+
+	require.NotNil(t, ext.Lifecycle.ReadyPolicy)
+	assert.Equal(t, v1beta1.InstanceReadyPolicyAllPodReady, *ext.Lifecycle.ReadyPolicy,
+		"multi-pod must default to AllPodReady so Instance Ready iff every gang pod Ready")
+
+	require.NotNil(t, ext.Lifecycle.UpdateStrategy)
+	assert.Equal(t, v1beta1.UpdateStrategySurgeThenDrain, ext.Lifecycle.UpdateStrategy.Type,
+		"multi-pod must default to SurgeThenDrain — same as single-pod")
+}
+
+// TestDefaultOMENativeComponent_SinglePodDefaults confirms the
+// multi-pod rules do NOT affect single-pod defaulting.
+func TestDefaultOMENativeComponent_SinglePodDefaults(t *testing.T) {
+	ext := &v1beta1.ComponentExtensionSpec{
+		Annotations: map[string]string{constants.DeploymentMode: string(constants.OMENative)},
+	}
+	defaultOMENativeComponent(ext, false /* singlePod */, nil)
+
+	require.NotNil(t, ext.Lifecycle)
+	require.NotNil(t, ext.Lifecycle.RestartPolicy)
+	assert.Equal(t, v1beta1.InstanceRestartPolicyNone, *ext.Lifecycle.RestartPolicy,
+		"single-pod must keep RestartPolicy=None — no gang restart needed for one pod")
+	require.NotNil(t, ext.Lifecycle.ReadyPolicy)
+	assert.Equal(t, v1beta1.InstanceReadyPolicyNone, *ext.Lifecycle.ReadyPolicy,
+		"single-pod must keep ReadyPolicy=None — no aggregation needed for one pod")
+	require.NotNil(t, ext.Lifecycle.UpdateStrategy)
+	assert.Equal(t, v1beta1.UpdateStrategySurgeThenDrain, ext.Lifecycle.UpdateStrategy.Type,
+		"single-pod UpdateStrategy must stay SurgeThenDrain")
+}
+
+// silence unused-helper lint if int32Ptr isn't referenced elsewhere
+var _ = int32Ptr
 
 // =============================================================================
 // Webhook Integration Tests

--- a/pkg/webhook/admission/isvc/inference_service_validation.go
+++ b/pkg/webhook/admission/isvc/inference_service_validation.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -19,66 +19,72 @@ import (
 	isvcutils "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils"
 	"sigs.k8s.io/ome/pkg/runtimerevision"
 	"sigs.k8s.io/ome/pkg/runtimeselector"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+	"sigs.k8s.io/ome/pkg/validation"
 )
 
-// regular expressions for validation of isvc name
-const (
-	IsvcNameFmt                string = "[a-z]([-a-z0-9]*[a-z0-9])?"
-	InvalidISVCNameFormatError string = "invalid InferenceService name %q, must match %q"
-)
+var validatorLogger = logf.Log.WithName("inferenceservice-v1beta1-validation-webhook")
 
-var (
-	// logger for the validation webhook.
-	validatorLogger = logf.Log.WithName("inferenceservice-v1beta1-validation-webhook")
-	// IsvcRegexp regular expressions for validation of isvc name
-	IsvcRegexp = regexp.MustCompile("^" + IsvcNameFmt + "$")
-)
-
-// InferenceServiceValidator is responsible for validating the InferenceService resource
-// when it is created, updated, or deleted.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as this struct is used only for temporary operations and does not need to be deeply copied.
+// InferenceServiceValidator wires the webhook framework into the
+// per-rule validators in pkg/validation. The kubebuilder markers below
+// suppress DeepCopy + OpenAPI codegen since this is a stateless
+// wired-once helper, not a persisted CR.
 // +kubebuilder:object:generate=false
 // +k8s:openapi-gen=false
 type InferenceServiceValidator struct {
 	Client          client.Client
 	RuntimeSelector runtimeselector.Selector
+
+	// KnownPassthroughPrefixes lists the ome.io/* pass-through
+	// annotation prefixes the active Gateway-implementation translator
+	// supports (e.g. ["ome.io/btp."] when Envoy Gateway is loaded).
+	// When non-empty, the validator rejects pass-through annotations
+	// whose prefix is not in the set with `UnsupportedPassthrough`,
+	// surfacing the misconfiguration at admission instead of letting
+	// the controller catch it at runtime via the
+	// BackendPolicyUnsupportedFields condition.
+	//
+	// Empty (default) keeps the prior permissive behavior — all
+	// documented pass-through prefixes are accepted. Production
+	// (cmd/manager/main.go) populates this from the active translator's
+	// SupportedPassthroughPrefixes(); test wiring may leave it empty
+	// unless explicitly exercising the rejection path.
+	KnownPassthroughPrefixes []string
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-ome-io-v1beta1-inferenceservice,mutating=false,failurePolicy=fail,groups=ome.io,resources=inferenceservices,versions=v1beta1,name=inferenceservice.ome-webhook-server.validator
 var _ webhook.CustomValidator = &InferenceServiceValidator{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (v *InferenceServiceValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	isvc, err := convertToInferenceService(obj)
 	if err != nil {
 		validatorLogger.Error(err, "Unable to convert object to InferenceService")
 		return nil, err
 	}
-	validatorLogger.Info("validate create", "name", isvc.Name)
 	return v.validateInferenceService(ctx, isvc)
 }
-
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (v *InferenceServiceValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	isvc, err := convertToInferenceService(newObj)
 	if err != nil {
 		validatorLogger.Error(err, "Unable to convert object to InferenceService")
 		return nil, err
 	}
-	validatorLogger.Info("validate update", "name", isvc.Name)
+	oldIsvc, err := convertToInferenceService(oldObj)
+	if err != nil {
+		validatorLogger.Error(err, "Unable to convert prior object to InferenceService")
+		return nil, err
+	}
+	if err := validation.ValidateCoordinationUpdate(&oldIsvc.Spec, &isvc.Spec); err != nil {
+		return nil, err
+	}
 	return v.validateInferenceService(ctx, isvc)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (v *InferenceServiceValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	isvc, err := convertToInferenceService(obj)
-	if err != nil {
+func (v *InferenceServiceValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if _, err := convertToInferenceService(obj); err != nil {
 		validatorLogger.Error(err, "Unable to convert object to InferenceService")
 		return nil, err
 	}
-	validatorLogger.Info("validate delete", "name", isvc.Name)
 	return nil, nil
 }
 
@@ -88,56 +94,430 @@ func GetIntReference(number int) *int {
 	return &num
 }
 
+// deploymentStrategyWarnings flags components that set deploymentStrategy while
+// resolving to a non-Raw deployment mode. deploymentStrategy is the k8s-native
+// appsv1.DeploymentStrategy and is honored only by RawDeployment (createRawDeployment
+// copies it onto the Deployment); OMENative and PD-disaggregated manage pods
+// directly and ignore it, so it is a silent no-op there. Point operators at
+// lifecycle.updateStrategy, which OMENative reads for rollout pacing.
+func deploymentStrategyWarnings(isvc *v1beta1.InferenceService) admission.Warnings {
+	mode := isvc.Annotations[constants.DeploymentMode]
+	if mode == "" && isvc.Spec.DeploymentMode != nil {
+		mode = string(*isvc.Spec.DeploymentMode)
+	}
+	// Unknown mode (defaulter hasn't run, e.g. a unit test) or Raw: nothing to warn.
+	if mode == "" || mode == string(constants.RawDeployment) {
+		return nil
+	}
+	var warnings admission.Warnings
+	check := func(name string, ext *v1beta1.ComponentExtensionSpec) {
+		if ext != nil && ext.DeploymentStrategy != nil {
+			warnings = append(warnings, fmt.Sprintf(
+				"%s.deploymentStrategy is set but deploymentMode is %q; deploymentStrategy applies only to RawDeployment and is ignored here — use %s.lifecycle.updateStrategy.rollingUpdate for rollout pacing",
+				name, mode, name))
+		}
+	}
+	if isvc.Spec.Engine != nil {
+		check("engine", &isvc.Spec.Engine.ComponentExtensionSpec)
+	}
+	if isvc.Spec.Decoder != nil {
+		check("decoder", &isvc.Spec.Decoder.ComponentExtensionSpec)
+	}
+	if isvc.Spec.Router != nil {
+		check("router", &isvc.Spec.Router.ComponentExtensionSpec)
+	}
+	return warnings
+}
 func (v *InferenceServiceValidator) validateInferenceService(ctx context.Context, isvc *v1beta1.InferenceService) (admission.Warnings, error) {
 	var allWarnings admission.Warnings
 
-	if err := validateInferenceServiceName(isvc); err != nil {
+	if err := validation.ValidateInferenceServiceName(isvc.Name); err != nil {
 		return allWarnings, err
 	}
 
+	autoscalerWarnings, err := validation.ValidateAutoscalerConfig(isvc)
+	if err != nil {
+		return allWarnings, err
+	}
+	allWarnings = append(allWarnings, autoscalerWarnings...)
+
+	// Per-Component Autoscaler block shape validation: class enum,
+	// required fields, IdleReplicaCount vs MinReplicas, plus
+	// annotation/block conflict. The per-Component dispatch is shared
+	// with the ServingRuntime and InferenceReplica webhooks via
+	// validation.ValidateComponentsAutoscalers.
+	if err := validation.ValidateComponentsAutoscalers(isvcAutoscalerChecks(isvc)); err != nil {
+		return allWarnings, err
+	}
+	if err := validation.ValidateAutoscalerAnnotationConflict(isvc); err != nil {
+		return allWarnings, err
+	}
+
+	// Legacy autoscaler surfaces (annotation class + spec.kedaConfig /
+	// per-Component scaleMetric) remain supported; validate them alongside
+	// the typed Autoscaler block.
 	if err := validateInferenceServiceAutoscaler(isvc); err != nil {
 		return allWarnings, err
 	}
 
-	if err := validateAutoscalerTargetUtilizationPercentage(isvc); err != nil {
+	if err := validation.ValidateAutoscalerTargetUtilizationPercentage(isvc); err != nil {
+		return allWarnings, err
+	}
+	if err := validation.ValidateEngineDecoderConfig(&isvc.Spec); err != nil {
+		return allWarnings, err
+	}
+	if err := validation.ValidateLeaderWorkerPairing(&isvc.Spec); err != nil {
+		return allWarnings, err
+	}
+	// Forward-looking guard that the leader Runner stays at size=1
+	// (today enforced structurally by LeaderSpec having no Size field;
+	// see ValidateLeaderSize).
+	if err := validation.ValidateLeaderSize(&isvc.Spec); err != nil {
+		return allWarnings, err
+	}
+	// Lean (no-model, no-runtime) multi-pod specs must declare both
+	// leader.runner.image and worker.runner.image — the controller has
+	// no way to fill them in without a runtime or model.
+	if err := validation.ValidateMultiPodLeanRunner(&isvc.Spec); err != nil {
+		return allWarnings, err
+	}
+	if err := validation.ValidateEngineDecoderDeploymentMode(&isvc.Spec); err != nil {
+		return allWarnings, err
+	}
+	if err := validation.ValidateScaleToZero(isvc); err != nil {
+		return allWarnings, err
+	}
+	if err := validation.ValidatePlacement(&isvc.Spec); err != nil {
 		return allWarnings, err
 	}
 
-	// New validation logic for Engine/Decoder architecture
-	if err := validateEngineDecoderConfiguration(isvc); err != nil {
+	// Traffic block: typed core load-balancing config + ome.io/* annotations.
+	if err := validation.ValidateTrafficSpec(isvc.Spec.Traffic); err != nil {
+		return allWarnings, err
+	}
+	trafficWarnings, err := validation.ValidateTrafficAnnotations(isvc.Annotations, isvc.Spec.Traffic, v.KnownPassthroughPrefixes...)
+	if err != nil {
+		return allWarnings, err
+	}
+	allWarnings = append(allWarnings, trafficWarnings...)
+
+	// spec.rollout.canary: validate the progressive-traffic rollout plan.
+	if err := validation.ValidateCanary(&isvc.Spec); err != nil {
 		return allWarnings, err
 	}
 
-	// Reject malformed explicit runtime-revision pins early.
+	// Cross-Component rollout coordination: structural + RatioBalanced
+	// tolerance warning.
+	if err := validation.ValidateCoordination(&isvc.Spec); err != nil {
+		return allWarnings, err
+	}
+	if warning := validation.CoordinationRatioToleranceWarning(&isvc.Spec); warning != "" {
+		allWarnings = append(allWarnings, warning)
+	}
+
+	// Per-Component LifecycleSpec.UpdateStrategy.RollingUpdate semantic
+	// validation: percent strings must be "<n>%" with 0 <= n <= 100;
+	// integer values must be >= 0. The CRD XIntOrString marker handles
+	// the structural "must be int or string" check; this validator adds
+	// the range / format check.
+	if err := validation.ValidateLifecycle(&isvc.Spec); err != nil {
+		return allWarnings, err
+	}
+
+	// deploymentStrategy (k8s appsv1) is honored only by RawDeployment; on
+	// OMENative / PD it is silently ignored. Warn so operators move rollout
+	// pacing to lifecycle.updateStrategy, which OMENative actually reads.
+	allWarnings = append(allWarnings, deploymentStrategyWarnings(isvc)...)
+
+	// At least one of spec.model or spec.runtime must be set. When
+	// spec.model is omitted (lean path), spec.runtime must name the
+	// runtime to use — the controller skips model-fetch and runtime
+	// auto-selection in that mode.
+	modelSet := isvc.Spec.Model != nil && isvc.Spec.Model.Name != ""
+	runtimeSet := isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Name != ""
+	if !modelSet && !runtimeSet {
+		return allWarnings, fmt.Errorf("at least one of spec.model or spec.runtime must be set")
+	}
+
 	if err := validateRuntimePin(isvc); err != nil {
 		return allWarnings, err
 	}
-
-	// Validate that referenced model exists (for new Engine architecture using isvc.Spec.Model)
 	if err := v.validateModelExists(ctx, isvc); err != nil {
 		return allWarnings, err
 	}
+	if err := v.validateOverlays(isvc); err != nil {
+		return allWarnings, err
+	}
 
-	// Validate runtime and model resolution for new architecture
 	if isvc.Spec.Engine != nil {
-		warnings, err := v.validateRuntimeAndModelResolution(ctx, isvc)
+		resWarnings, err := v.validateRuntimeAndModelResolution(ctx, isvc)
 		if err != nil {
 			return allWarnings, err
 		}
-		allWarnings = append(allWarnings, warnings...)
+		allWarnings = append(allWarnings, resWarnings...)
 	}
 	return allWarnings, nil
 }
+func convertToInferenceService(obj runtime.Object) (*v1beta1.InferenceService, error) {
+	isvc, ok := obj.(*v1beta1.InferenceService)
+	if !ok {
+		return nil, fmt.Errorf("expected an InferenceService object but got %T", obj)
+	}
+	return isvc, nil
+}
 
-// Validation of isvc name
-func validateInferenceServiceName(isvc *v1beta1.InferenceService) error {
-	if !IsvcRegexp.MatchString(isvc.Name) {
-		return fmt.Errorf(InvalidISVCNameFormatError, isvc.Name, IsvcNameFmt)
+// validateModelExists ensures the referenced BaseModel/ClusterBaseModel
+// (and each overlay) is reachable in the ISVC's namespace, and that
+// cross-namespace PVC rules pass per-overlay.
+func (v *InferenceServiceValidator) validateModelExists(ctx context.Context, isvc *v1beta1.InferenceService) error {
+	if isvc.Spec.Model == nil || isvc.Spec.Model.Name == "" {
+		return nil
+	}
+	spec, meta, err := isvcutils.GetBaseModel(v.Client, isvc.Spec.Model.Name, isvc.Namespace)
+	if err != nil {
+		return fmt.Errorf("referenced model %q not found in namespace %q: ensure a BaseModel exists in this namespace or a ClusterBaseModel exists cluster-wide with this name",
+			isvc.Spec.Model.Name, isvc.Namespace)
+	}
+	if err := validateClusterBaseModelPVCNamespace(spec, meta, isvc); err != nil {
+		return err
+	}
+	for _, ov := range isvc.Spec.Model.Overlays {
+		ovSpec, ovMeta, err := isvcutils.GetBaseModel(v.Client, ov.Name, isvc.Namespace)
+		if err != nil {
+			return fmt.Errorf("overlay %q not found in namespace %q: %w", ov.Name, isvc.Namespace, err)
+		}
+		if err := validateClusterBaseModelPVCNamespace(ovSpec, ovMeta, isvc); err != nil {
+			return fmt.Errorf("overlay %q: %w", ov.Name, err)
+		}
 	}
 	return nil
 }
 
-// Validation of isvc autoscaler class
+// validateClusterBaseModelPVCNamespace rejects InferenceServices that
+// reference a ClusterBaseModel whose PVC URI points to a namespace other
+// than the InferenceService's own namespace. Kubernetes does not allow a
+// pod to mount a PVC from a different namespace, so without this check the
+// generated ISVC pods would fail at scheduling with a confusing
+// "persistentvolumeclaim ... not found" error and no upstream signal.
+//
+// Skipped for namespaced BaseModel (already same-namespace by construction)
+// and for non-PVC URIs.
+func validateClusterBaseModelPVCNamespace(spec *v1beta1.BaseModelSpec, meta *metav1.ObjectMeta, isvc *v1beta1.InferenceService) error {
+	// namespaced BaseModel ⇒ same-namespace by construction; skip
+	if meta == nil || meta.Namespace != "" {
+		return nil
+	}
+	if spec == nil || spec.Storage == nil || spec.Storage.StorageUri == nil {
+		return nil
+	}
+	uri := *spec.Storage.StorageUri
+	storageType, err := storage.GetStorageType(uri)
+	if err != nil || storageType != storage.StorageTypePVC {
+		return nil
+	}
+	components, err := storage.ParsePVCStorageURI(uri)
+	if err != nil || components.Namespace == "" || components.Namespace == isvc.Namespace {
+		return nil
+	}
+	return fmt.Errorf(
+		"ClusterBaseModel %q references PVC in namespace %q, but InferenceService is in namespace %q; "+
+			"Kubernetes does not allow pods to mount PVCs from another namespace. "+
+			"Either move the InferenceService to namespace %q or replicate the PVC into namespace %q.",
+		isvc.Spec.Model.Name, components.Namespace, isvc.Namespace, components.Namespace, isvc.Namespace)
+}
+
+// validateOverlays rejects overlay sets that would produce a broken
+// pod spec: duplicate Name, env-var name collision after sanitization
+// (foo-bar and foo_bar both → FOO_BAR), or self-reference.
+// Per-overlay existence + runtime compatibility live in
+// validateRuntimeAndModelResolution.
+func (v *InferenceServiceValidator) validateOverlays(isvc *v1beta1.InferenceService) error {
+	if isvc.Spec.Model == nil || len(isvc.Spec.Model.Overlays) == 0 {
+		return nil
+	}
+	primary := isvc.Spec.Model.Name
+	seenName := map[string]bool{}
+	seenEnv := map[string]string{} // sanitized → original name
+	for _, ov := range isvc.Spec.Model.Overlays {
+		if ov.Name == "" {
+			return fmt.Errorf("overlay name cannot be empty")
+		}
+		if ov.Name == primary {
+			return fmt.Errorf("overlay %q must not reference the primary model of the same kind/apiGroup", ov.Name)
+		}
+		if seenName[ov.Name] {
+			return fmt.Errorf("overlay %q is declared more than once", ov.Name)
+		}
+		seenName[ov.Name] = true
+
+		envName := isvcutils.OverlayEnvVarName(ov.Name)
+		if prev, ok := seenEnv[envName]; ok {
+			return fmt.Errorf("overlays %q and %q both sanitize to env var %s; rename one (hyphens and underscores collapse to the same form)",
+				prev, ov.Name, envName)
+		}
+		seenEnv[envName] = ov.Name
+	}
+	return nil
+}
+
+// validateRuntimeAndModelResolution gates runtime/model resolution on
+// the Engine-architecture path. Lean specs (full runner config + no
+// model) short-circuit; everything else needs the runtime selector.
+func (v *InferenceServiceValidator) validateRuntimeAndModelResolution(ctx context.Context, isvc *v1beta1.InferenceService) (admission.Warnings, error) {
+	var warnings admission.Warnings
+
+	if isvc.Spec.Engine == nil {
+		return warnings, nil
+	}
+	if isvc.Spec.Model == nil {
+		if isvc.Spec.Runtime == nil && !hasFullRunnerConfig(isvc.Spec.Engine) {
+			return warnings, fmt.Errorf("model reference is required when runtime is not specified and engine does not have complete runner configuration")
+		}
+		return warnings, nil
+	}
+	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Name != "" {
+		return v.resolveModelAndRuntime(ctx, isvc, warnings)
+	}
+	if !hasFullRunnerConfig(isvc.Spec.Engine) {
+		return v.resolveModelAndRuntime(ctx, isvc, warnings)
+	}
+	return warnings, nil
+}
+func (v *InferenceServiceValidator) resolveModelAndRuntime(ctx context.Context, isvc *v1beta1.InferenceService, warnings admission.Warnings) (admission.Warnings, error) {
+	baseModel, _, err := isvcutils.GetBaseModel(v.Client, isvc.Spec.Model.Name, isvc.Namespace)
+	if err != nil {
+		return warnings, fmt.Errorf("failed to resolve model %s: %w", isvc.Spec.Model.Name, err)
+	}
+	if baseModel.Disabled != nil && *baseModel.Disabled {
+		return warnings, fmt.Errorf("model %s is disabled", isvc.Spec.Model.Name)
+	}
+
+	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Name != "" {
+		if err := v.RuntimeSelector.ValidateRuntime(ctx, isvc.Spec.Runtime.Name, baseModel, isvc); err != nil {
+			// The operator named this runtime explicitly, so OME should
+			// not block on the runtime's *declared* supportedModelFormats:
+			// a generic runtime (e.g. sglang) can serve many architectures
+			// it never enumerates. Downgrade a pure compatibility mismatch
+			// (format / architecture / framework) to an advisory warning
+			// and admit — the deliberate choice wins over the declaration.
+			//
+			// Everything else stays a hard error: runtime not found /
+			// disabled / malformed model means the runtime genuinely
+			// cannot run, so admitting would only produce a broken ISVC.
+			if runtimeselector.IsRuntimeCompatibilityError(err) {
+				warnings = append(warnings, fmt.Sprintf(
+					"runtime %q does not declare support for model %q (%v); proceeding because the runtime was named explicitly",
+					isvc.Spec.Runtime.Name, isvc.Spec.Model.Name, err))
+				return warnings, nil
+			}
+			return warnings, fmt.Errorf("runtime %s does not support model %s: %w",
+				isvc.Spec.Runtime.Name, isvc.Spec.Model.Name, err)
+		}
+		// Success is the common case and emits nothing — a bare "is valid"
+		// admission Warning showed up as `Warning:` in kubectl and read as
+		// if something were wrong.
+		return warnings, nil
+	}
+	selection, err := v.RuntimeSelector.SelectRuntime(ctx, baseModel, isvc)
+	if err != nil {
+		return warnings, fmt.Errorf("no supporting runtime found for model %s and engine does not have complete runner configuration: %w", isvc.Spec.Model.Name, err)
+	}
+	warnings = append(warnings, fmt.Sprintf("Runtime %s will be auto-selected for model %s",
+		selection.Name, isvc.Spec.Model.Name))
+	return warnings, nil
+}
+
+// validateRuntimePin rejects malformed explicit ControllerRevision pins
+// at admission. The full existence check is left to reconcile (the
+// webhook can't reliably reach across cluster scope), but the cheap
+// shape checks happen here:
+//
+//   - spec.runtime.revision is meaningful only when autoSync is false;
+//     setting it with autoSync=true (default) is a confused-user
+//     signal worth surfacing immediately.
+//   - The revision name must conform to the convention for the named
+//     runtime's kind + scope; an obviously-wrong name (e.g., pinning
+//     to runtime A but naming a revision of runtime B) is rejected
+//     before the controller ever sees it.
+func validateRuntimePin(isvc *v1beta1.InferenceService) error {
+	if isvc.Spec.Runtime == nil || isvc.Spec.Runtime.Revision == nil || *isvc.Spec.Runtime.Revision == "" {
+		return nil
+	}
+	if isvc.Spec.Runtime.AutoSync == nil || *isvc.Spec.Runtime.AutoSync {
+		return fmt.Errorf(
+			"spec.runtime.revision requires spec.runtime.autoSync=false; AutoSync=true would silently ignore the pin")
+	}
+	kind := runtimerevision.KindClusterServingRuntime
+	sourceNS := ""
+	if isvc.Spec.Runtime.Kind != nil && *isvc.Spec.Runtime.Kind == string(runtimerevision.KindServingRuntime) {
+		kind = runtimerevision.KindServingRuntime
+		sourceNS = isvc.Namespace
+	}
+	revName := *isvc.Spec.Runtime.Revision
+	if !runtimerevision.MatchesRuntime(revName, kind, sourceNS, isvc.Spec.Runtime.Name) {
+		return fmt.Errorf(
+			"spec.runtime.revision %q does not match the expected naming convention for runtime %q (%s); "+
+				"expected the form %s",
+			revName, isvc.Spec.Runtime.Name, kind, expectedPinPattern(kind, sourceNS, isvc.Spec.Runtime.Name))
+	}
+	return nil
+}
+func expectedPinPattern(kind runtimerevision.SourceKind, sourceNS, runtimeName string) string {
+	switch kind {
+	case runtimerevision.KindClusterServingRuntime:
+		return fmt.Sprintf("cr-%s-<8 lowercase hex chars>", runtimeName)
+	case runtimerevision.KindServingRuntime:
+		return fmt.Sprintf("r-%s-%s-<8 lowercase hex chars>", sourceNS, runtimeName)
+	default:
+		return "<unknown kind>"
+	}
+}
+
+// isvcAutoscalerChecks projects each declared Component (Engine,
+// Decoder, Router) into the per-Component slice consumed by
+// validation.ValidateComponentsAutoscalers. Nil Components are skipped
+// so an absent Component never produces a spurious "<name>:" error.
+func isvcAutoscalerChecks(isvc *v1beta1.InferenceService) []validation.ComponentAutoscalerCheck {
+	var checks []validation.ComponentAutoscalerCheck
+	if isvc.Spec.Engine != nil {
+		checks = append(checks, validation.ComponentAutoscalerCheck{
+			Name:        "engine",
+			Autoscaler:  isvc.Spec.Engine.Autoscaler,
+			MinReplicas: isvc.Spec.Engine.MinReplicas,
+		})
+	}
+	if isvc.Spec.Decoder != nil {
+		checks = append(checks, validation.ComponentAutoscalerCheck{
+			Name:        "decoder",
+			Autoscaler:  isvc.Spec.Decoder.Autoscaler,
+			MinReplicas: isvc.Spec.Decoder.MinReplicas,
+		})
+	}
+	if isvc.Spec.Router != nil {
+		checks = append(checks, validation.ComponentAutoscalerCheck{
+			Name:        "router",
+			Autoscaler:  isvc.Spec.Router.Autoscaler,
+			MinReplicas: isvc.Spec.Router.MinReplicas,
+		})
+	}
+	return checks
+}
+
+func hasFullRunnerConfig(engine *v1beta1.EngineSpec) bool {
+	if engine == nil {
+		return false
+	}
+	if engine.Runner != nil && engine.Runner.Image != "" {
+		return true
+	}
+	if engine.Leader != nil && engine.Worker != nil {
+		leaderHasRunner := engine.Leader.Runner != nil && engine.Leader.Runner.Image != ""
+		workerHasRunner := engine.Worker.Runner != nil && engine.Worker.Runner.Image != ""
+		return leaderHasRunner && workerHasRunner
+	}
+	return false
+}
+
 func validateInferenceServiceAutoscaler(isvc *v1beta1.InferenceService) error {
 	annotations := isvc.ObjectMeta.Annotations
 	value, ok := annotations[constants.AutoscalerClass]
@@ -169,6 +549,7 @@ func validateInferenceServiceAutoscaler(isvc *v1beta1.InferenceService) error {
 }
 
 // Validate of autoscaler HPA metrics
+
 func validateHPAMetrics(metric v1beta1.ScaleMetric) error {
 	for _, item := range constants.AutoscalerAllowedMetricsList {
 		if item == constants.AutoscalerMetricsType(metric) {
@@ -179,6 +560,7 @@ func validateHPAMetrics(metric v1beta1.ScaleMetric) error {
 }
 
 // kedaValidScalingOperators defines the valid KEDA scaling operators
+
 var kedaValidScalingOperators = []string{
 	"GreaterThan",
 	"GreaterThanOrEqual",
@@ -187,6 +569,7 @@ var kedaValidScalingOperators = []string{
 }
 
 // kedaValidAuthModes defines the valid KEDA authentication modes
+
 var kedaValidAuthModes = []string{
 	"basic",
 	"tls",
@@ -195,6 +578,7 @@ var kedaValidAuthModes = []string{
 }
 
 // validateKEDAConfig validates KEDA-specific configuration in KedaConfig and annotations
+
 func validateKEDAConfig(isvc *v1beta1.InferenceService) (admission.Warnings, error) {
 	var warnings admission.Warnings
 	kedaConfig := isvc.Spec.KedaConfig
@@ -258,6 +642,7 @@ func validateKEDAConfig(isvc *v1beta1.InferenceService) (admission.Warnings, err
 }
 
 // validateKEDAScalingOperator validates that the scaling operator is one of the valid KEDA operators
+
 func validateKEDAScalingOperator(operator string) error {
 	for _, valid := range kedaValidScalingOperators {
 		if operator == valid {
@@ -268,6 +653,7 @@ func validateKEDAScalingOperator(operator string) error {
 }
 
 // validateKEDAScalingThreshold validates that the scaling threshold is a valid number
+
 func validateKEDAScalingThreshold(threshold string) error {
 	_, err := strconv.ParseFloat(threshold, 64)
 	if err != nil {
@@ -277,6 +663,7 @@ func validateKEDAScalingThreshold(threshold string) error {
 }
 
 // validateKEDAPrometheusServerAddress validates that the Prometheus server address is a valid URL
+
 func validateKEDAPrometheusServerAddress(address string) error {
 	parsedURL, err := url.Parse(address)
 	if err != nil {
@@ -297,6 +684,7 @@ func validateKEDAPrometheusServerAddress(address string) error {
 }
 
 // validateKEDAAuthModes validates that all auth modes are valid
+
 func validateKEDAAuthModes(authModes string) error {
 	modes := strings.Split(authModes, ",")
 	for _, mode := range modes {
@@ -319,193 +707,3 @@ func validateKEDAAuthModes(authModes string) error {
 }
 
 // Validate of autoscaler targetUtilizationPercentage
-func validateAutoscalerTargetUtilizationPercentage(isvc *v1beta1.InferenceService) error {
-	annotations := isvc.ObjectMeta.Annotations
-	if value, ok := annotations[constants.TargetUtilizationPercentage]; ok {
-		t, err := strconv.Atoi(value)
-		if err != nil {
-			return fmt.Errorf("the target utilization percentage should be a [1-100] integer")
-		} else if t < 1 || t > 100 {
-			return fmt.Errorf("the target utilization percentage should be a [1-100] integer")
-		}
-	}
-
-	return nil
-}
-
-// Convert runtime.Object into InferenceService
-func convertToInferenceService(obj runtime.Object) (*v1beta1.InferenceService, error) {
-	isvc, ok := obj.(*v1beta1.InferenceService)
-	if !ok {
-		return nil, fmt.Errorf("expected an InferenceService object but got %T", obj)
-	}
-	return isvc, nil
-}
-
-// validateEngineDecoderConfiguration validates Engine/Decoder configuration rules
-func validateEngineDecoderConfiguration(isvc *v1beta1.InferenceService) error {
-	// Rule 1: If inference service has decoder defined, but not engine, fail
-	if isvc.Spec.Decoder != nil && isvc.Spec.Engine == nil {
-		return fmt.Errorf("decoder cannot be specified without engine")
-	}
-
-	return nil
-}
-
-// validateModelExists validates that the referenced model (BaseModel or ClusterBaseModel) exists
-func (v *InferenceServiceValidator) validateModelExists(ctx context.Context, isvc *v1beta1.InferenceService) error {
-	// Check new architecture model reference (isvc.Spec.Model)
-	if isvc.Spec.Model != nil && isvc.Spec.Model.Name != "" {
-		_, _, err := isvcutils.GetBaseModel(v.Client, isvc.Spec.Model.Name, isvc.Namespace)
-		if err != nil {
-			return fmt.Errorf("referenced model %q not found in namespace %q: ensure a BaseModel exists in this namespace or a ClusterBaseModel exists cluster-wide with this name",
-				isvc.Spec.Model.Name, isvc.Namespace)
-		}
-	}
-
-	return nil
-}
-
-// validateRuntimePin rejects malformed explicit ControllerRevision pins
-// at admission. The full existence check is left to reconcile (the
-// webhook can't reliably reach across cluster scope), but the cheap
-// shape checks happen here:
-//
-//   - spec.runtime.revision is meaningful only when autoSync is false;
-//     setting it with autoSync=true (default) is a confused-user
-//     signal worth surfacing immediately.
-//   - The revision name must conform to the convention for the named
-//     runtime's kind + scope; an obviously-wrong name (e.g., pinning
-//     to runtime A but naming a revision of runtime B) is rejected
-//     before the controller ever sees it.
-func validateRuntimePin(isvc *v1beta1.InferenceService) error {
-	if isvc.Spec.Runtime == nil || isvc.Spec.Runtime.Revision == nil || *isvc.Spec.Runtime.Revision == "" {
-		return nil
-	}
-	if isvc.Spec.Runtime.AutoSync == nil || *isvc.Spec.Runtime.AutoSync {
-		return fmt.Errorf(
-			"spec.runtime.revision requires spec.runtime.autoSync=false; AutoSync=true would silently ignore the pin")
-	}
-	kind := runtimerevision.KindClusterServingRuntime
-	sourceNS := ""
-	if isvc.Spec.Runtime.Kind != nil && *isvc.Spec.Runtime.Kind == string(runtimerevision.KindServingRuntime) {
-		kind = runtimerevision.KindServingRuntime
-		sourceNS = isvc.Namespace
-	}
-	revName := *isvc.Spec.Runtime.Revision
-	if !runtimerevision.MatchesRuntime(revName, kind, sourceNS, isvc.Spec.Runtime.Name) {
-		return fmt.Errorf(
-			"spec.runtime.revision %q does not match the expected naming convention for runtime %q (%s); "+
-				"expected the form %s",
-			revName, isvc.Spec.Runtime.Name, kind, expectedPinPattern(kind, sourceNS, isvc.Spec.Runtime.Name))
-	}
-	return nil
-}
-
-func expectedPinPattern(kind runtimerevision.SourceKind, sourceNS, runtimeName string) string {
-	switch kind {
-	case runtimerevision.KindClusterServingRuntime:
-		return fmt.Sprintf("cr-%s-<8 lowercase hex chars>", runtimeName)
-	case runtimerevision.KindServingRuntime:
-		return fmt.Sprintf("r-%s-%s-<8 lowercase hex chars>", sourceNS, runtimeName)
-	default:
-		return "<unknown kind>"
-	}
-}
-
-// validateRuntimeAndModelResolution validates runtime and model resolution for new architecture
-func (v *InferenceServiceValidator) validateRuntimeAndModelResolution(ctx context.Context, isvc *v1beta1.InferenceService) (admission.Warnings, error) {
-	var warnings admission.Warnings
-
-	// Only validate new architecture if Engine is specified (focusing on new spec)
-	if isvc.Spec.Engine == nil {
-		return warnings, nil
-	}
-
-	// Rule 2: If inference service does not have runtime defined in isvc.runtime
-	if isvc.Spec.Runtime == nil {
-		// Check if engine has full runner config
-		if !hasFullRunnerConfig(isvc.Spec.Engine) {
-			// Model reference is required when runtime is not specified and engine doesn't have full config
-			if isvc.Spec.Model == nil {
-				return warnings, fmt.Errorf("model reference is required when runtime is not specified and engine does not have complete runner configuration")
-			}
-
-			return v.resolveModelAndRuntime(ctx, isvc, warnings)
-		}
-	}
-
-	return warnings, nil
-}
-
-// resolveModelAndRuntime performs actual model and runtime resolution
-func (v *InferenceServiceValidator) resolveModelAndRuntime(ctx context.Context, isvc *v1beta1.InferenceService, warnings admission.Warnings) (admission.Warnings, error) {
-	// Resolve model using the new architecture approach
-	baseModel, _, err := isvcutils.GetBaseModel(v.Client, isvc.Spec.Model.Name, isvc.Namespace)
-	if err != nil {
-		return warnings, fmt.Errorf("failed to resolve model %s: %w", isvc.Spec.Model.Name, err)
-	}
-
-	// Validate model is not disabled
-	if baseModel.Disabled != nil && *baseModel.Disabled {
-		return warnings, fmt.Errorf("model %s is disabled", isvc.Spec.Model.Name)
-	}
-
-	// Check runtime selection/validation
-	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Name != "" {
-		// Validate specified runtime
-		if err := v.RuntimeSelector.ValidateRuntime(ctx, isvc.Spec.Runtime.Name, baseModel, isvc); err != nil {
-			// The operator named this runtime explicitly, so OME should not
-			// block on the runtime's *declared* supportedModelFormats: a
-			// generic runtime (e.g. sglang) can serve many architectures it
-			// never enumerates. Downgrade a pure compatibility mismatch
-			// (format / architecture / framework) to an advisory warning and
-			// admit — the deliberate choice wins over the declaration.
-			//
-			// Everything else stays a hard error: a not-found / disabled
-			// runtime or a malformed model genuinely cannot run, so admitting
-			// would only produce a broken ISVC.
-			if runtimeselector.IsRuntimeCompatibilityError(err) {
-				warnings = append(warnings, fmt.Sprintf(
-					"runtime %q does not declare support for model %q (%v); proceeding because the runtime was named explicitly",
-					isvc.Spec.Runtime.Name, isvc.Spec.Model.Name, err))
-				return warnings, nil
-			}
-			return warnings, fmt.Errorf("runtime %s does not support model %s: %w",
-				isvc.Spec.Runtime.Name, isvc.Spec.Model.Name, err)
-		}
-		warnings = append(warnings, fmt.Sprintf("Runtime %s is valid for model %s",
-			isvc.Spec.Runtime.Name, isvc.Spec.Model.Name))
-	} else {
-		// Check if runtime can be auto-selected
-		selection, err := v.RuntimeSelector.SelectRuntime(ctx, baseModel, isvc)
-		if err != nil {
-			return warnings, fmt.Errorf("no supporting runtime found for model %s and engine does not have complete runner configuration: %w", isvc.Spec.Model.Name, err)
-		}
-		// Success - runtime will be auto-selected
-		warnings = append(warnings, fmt.Sprintf("Runtime %s will be auto-selected for model %s",
-			selection.Name, isvc.Spec.Model.Name))
-	}
-	return warnings, nil
-}
-
-// hasFullRunnerConfig checks if the engine has complete runner configuration
-func hasFullRunnerConfig(engine *v1beta1.EngineSpec) bool {
-	if engine == nil {
-		return false
-	}
-
-	// Check if main runner is defined with required fields
-	if engine.Runner != nil && engine.Runner.Image != "" {
-		return true
-	}
-
-	// Check if both leader and worker runners are defined for multi-node
-	if engine.Leader != nil && engine.Worker != nil {
-		leaderHasRunner := engine.Leader.Runner != nil && engine.Leader.Runner.Image != ""
-		workerHasRunner := engine.Worker.Runner != nil && engine.Worker.Runner.Image != ""
-		return leaderHasRunner && workerHasRunner
-	}
-
-	return false
-}

--- a/pkg/webhook/admission/isvc/inference_service_validation_test.go
+++ b/pkg/webhook/admission/isvc/inference_service_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,7 +16,184 @@ import (
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
 	"sigs.k8s.io/ome/pkg/runtimeselector"
+	"sigs.k8s.io/ome/pkg/validation"
 )
+
+// =============================================================================
+// VALIDATOR INTERFACE TESTS
+// =============================================================================
+
+func TestValidateClusterBaseModelPVCNamespace(t *testing.T) {
+	pvc := func(uri string) *v1beta1.BaseModelSpec {
+		return &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{StorageUri: stringPtr(uri)}}
+	}
+	clusterMeta := &metav1.ObjectMeta{Name: "shared-llama"}
+	namespacedMeta := &metav1.ObjectMeta{Name: "llama", Namespace: "models"}
+	isvc := func(ns string) *v1beta1.InferenceService {
+		return &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: ns},
+			Spec:       v1beta1.InferenceServiceSpec{Model: &v1beta1.ModelRef{Name: "shared-llama"}},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		spec    *v1beta1.BaseModelSpec
+		meta    *metav1.ObjectMeta
+		isvc    *v1beta1.InferenceService
+		wantErr bool
+	}{
+		{name: "namespaced BaseModel: skip", spec: pvc("pvc://my-pvc/p"), meta: namespacedMeta, isvc: isvc("models")},
+		{name: "ClusterBaseModel non-PVC: skip", spec: pvc("oci://n/ns/b/bucket/o/path"), meta: clusterMeta, isvc: isvc("team-foo")},
+		{name: "ClusterBaseModel PVC same ns: ok", spec: pvc("pvc://team-foo:my-pvc/p"), meta: clusterMeta, isvc: isvc("team-foo")},
+		{name: "ClusterBaseModel PVC missing ns prefix: defer to BaseModel webhook", spec: pvc("pvc://my-pvc/p"), meta: clusterMeta, isvc: isvc("team-foo")},
+		{name: "ClusterBaseModel PVC cross-ns: reject", spec: pvc("pvc://shared:my-pvc/p"), meta: clusterMeta, isvc: isvc("team-foo"), wantErr: true},
+		{name: "spec nil: skip", spec: nil, meta: clusterMeta, isvc: isvc("team-foo")},
+		{name: "spec storage nil: skip", spec: &v1beta1.BaseModelSpec{}, meta: clusterMeta, isvc: isvc("team-foo")},
+		{name: "spec storage uri nil: skip", spec: &v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{}}, meta: clusterMeta, isvc: isvc("team-foo")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateClusterBaseModelPVCNamespace(tc.spec, tc.meta, tc.isvc)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestInferenceServiceValidator_ValidateCreate(t *testing.T) {
+	tests := []struct {
+		name    string
+		isvc    *v1beta1.InferenceService
+		wantErr bool
+	}{
+		{
+			name: "valid inference service",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "test-runtime"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid name format",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "Test-ISVC", // Invalid name format
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "test-runtime"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &InferenceServiceValidator{}
+			warnings, err := v.ValidateCreate(context.Background(), tt.isvc)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Nil(t, warnings)
+			}
+		})
+	}
+}
+
+func TestInferenceServiceValidator_ValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name    string
+		oldIsvc *v1beta1.InferenceService
+		newIsvc *v1beta1.InferenceService
+		wantErr bool
+	}{
+		{
+			name: "valid update",
+			oldIsvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "test-runtime"},
+				},
+			},
+			newIsvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "test-runtime"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &InferenceServiceValidator{}
+			warnings, err := v.ValidateUpdate(context.Background(), tt.oldIsvc, tt.newIsvc)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Nil(t, warnings)
+			}
+		})
+	}
+}
+
+func TestInferenceServiceValidator_ValidateDelete(t *testing.T) {
+	tests := []struct {
+		name    string
+		isvc    *v1beta1.InferenceService
+		wantErr bool
+	}{
+		{
+			name: "valid inference service",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &InferenceServiceValidator{}
+			warnings, err := v.ValidateDelete(context.Background(), tt.isvc)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Nil(t, warnings)
+			}
+		})
+	}
+}
 
 // Test error paths in ValidateCreate, ValidateUpdate, ValidateDelete
 func TestValidatorErrorPaths(t *testing.T) {
@@ -90,7 +268,7 @@ func TestInferenceService_NameValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateInferenceServiceName(tt.isvc)
+			err := validation.ValidateInferenceServiceName(tt.isvc.Name)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -188,7 +366,7 @@ func TestInferenceService_AutoscalerValidation(t *testing.T) {
 				},
 			}
 
-			err := validateInferenceServiceAutoscaler(isvc)
+			err := func() error { _, err := validation.ValidateAutoscalerConfig(isvc); return err }()
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -253,7 +431,7 @@ func TestInferenceService_TargetUtilizationValidation(t *testing.T) {
 				},
 			}
 
-			err := validateAutoscalerTargetUtilizationPercentage(isvc)
+			err := validation.ValidateAutoscalerTargetUtilizationPercentage(isvc)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -266,20 +444,20 @@ func TestInferenceService_TargetUtilizationValidation(t *testing.T) {
 
 // Test missing branches in validateHPAMetrics
 func TestValidateHPAMetrics_AllMetrics(t *testing.T) {
-	validMetrics := []v1beta1.ScaleMetric{
-		v1beta1.ScaleMetric(constants.AutoScalerMetricsCPU),
-		v1beta1.ScaleMetric(constants.AutoScalerMetricsMemory),
+	validMetrics := []string{
+		string(constants.AutoScalerMetricsCPU),
+		string(constants.AutoScalerMetricsMemory),
 	}
 
 	for _, metric := range validMetrics {
-		t.Run(string(metric), func(t *testing.T) {
-			err := validateHPAMetrics(metric)
+		t.Run(metric, func(t *testing.T) {
+			err := validation.ValidateHPAMetrics(metric)
 			assert.NoError(t, err)
 		})
 	}
 
 	t.Run("invalid metric", func(t *testing.T) {
-		err := validateHPAMetrics("invalid-metric")
+		err := validation.ValidateHPAMetrics("invalid-metric")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "is not a supported metric")
 	})
@@ -338,12 +516,176 @@ func TestInferenceService_EngineDecoderValidation(t *testing.T) {
 				isvc.Spec.Decoder = &v1beta1.DecoderSpec{}
 			}
 
-			err := validateEngineDecoderConfiguration(isvc)
+			err := validation.ValidateEngineDecoderConfig(&isvc.Spec)
 
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errMsg != "" {
 					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInferenceService_OMENativeEngineDecoderCoupling(t *testing.T) {
+	annot := func(mode string) v1beta1.ComponentExtensionSpec {
+		return v1beta1.ComponentExtensionSpec{
+			Annotations: map[string]string{constants.DeploymentMode: mode},
+		}
+	}
+	withRunner := &v1beta1.RunnerSpec{Container: v1.Container{Image: "test-image:latest"}}
+
+	tests := []struct {
+		name    string
+		isvc    *v1beta1.InferenceService
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "engine and decoder both OMENative - passes",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "test-runtime"},
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: annot(string(constants.OMENative)),
+						Runner:                 withRunner,
+					},
+					Decoder: &v1beta1.DecoderSpec{
+						ComponentExtensionSpec: annot(string(constants.OMENative)),
+					},
+				},
+			},
+		},
+		{
+			name: "engine OMENative, decoder unset - rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: annot(string(constants.OMENative)),
+						Runner:                 withRunner,
+					},
+					Decoder: &v1beta1.DecoderSpec{},
+				},
+			},
+			wantErr: true,
+			errMsg:  "InvalidDeploymentModeCombination",
+		},
+		{
+			name: "engine OMENative, decoder RawDeployment - rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						ComponentExtensionSpec: annot(string(constants.OMENative)),
+						Runner:                 withRunner,
+					},
+					Decoder: &v1beta1.DecoderSpec{
+						ComponentExtensionSpec: annot(string(constants.RawDeployment)),
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "InvalidDeploymentModeCombination",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &InferenceServiceValidator{}
+			_, err := v.ValidateCreate(context.Background(), tt.isvc)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInferenceService_LeaderWorkerPairing(t *testing.T) {
+	sizePtr := func(v int) *int { return &v }
+	withRunner := &v1beta1.RunnerSpec{Container: v1.Container{Image: "test-image:latest"}}
+
+	tests := []struct {
+		name    string
+		isvc    *v1beta1.InferenceService
+		wantErr bool
+		errSub  string
+	}{
+		{
+			name: "engine: leader + worker(size=3) - valid",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "test-runtime"},
+					Engine: &v1beta1.EngineSpec{
+						Runner: withRunner,
+						Leader: &v1beta1.LeaderSpec{},
+						Worker: &v1beta1.WorkerSpec{Size: sizePtr(3)},
+					},
+				},
+			},
+		},
+		{
+			name: "engine: leader only - rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						Runner: withRunner,
+						Leader: &v1beta1.LeaderSpec{},
+					},
+				},
+			},
+			wantErr: true,
+			errSub:  "InvalidLeaderWorkerPairing",
+		},
+		{
+			name: "engine: worker only - rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{
+						Runner: withRunner,
+						Worker: &v1beta1.WorkerSpec{Size: sizePtr(3)},
+					},
+				},
+			},
+			wantErr: true,
+			errSub:  "InvalidLeaderWorkerPairing",
+		},
+		{
+			name: "decoder: leader only - rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Engine: &v1beta1.EngineSpec{Runner: withRunner},
+					Decoder: &v1beta1.DecoderSpec{
+						Leader: &v1beta1.LeaderSpec{},
+					},
+				},
+			},
+			wantErr: true,
+			errSub:  "decoder.leader",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &InferenceServiceValidator{}
+			_, err := v.ValidateCreate(context.Background(), tt.isvc)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errSub != "" {
+					assert.Contains(t, err.Error(), tt.errSub)
 				}
 			} else {
 				assert.NoError(t, err)
@@ -595,11 +937,7 @@ func TestInferenceService_RuntimeResolution(t *testing.T) {
 					Name:      "test-isvc",
 					Namespace: "default",
 				},
-				Spec: v1beta1.InferenceServiceSpec{
-					Model: &v1beta1.ModelRef{
-						Name: "enabled-model",
-					},
-				},
+				Spec: v1beta1.InferenceServiceSpec{},
 			},
 			wantErr: false,
 		},
@@ -922,7 +1260,155 @@ func TestValidateInferenceService_ComprehensiveErrorPaths(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "model reference is required",
+			errMsg:  "at least one of spec.model or spec.runtime must be set",
+		},
+		{
+			// Lean path: model omitted, runtime named explicitly. The
+			// validator must accept this — model parsing + runtime
+			// auto-select is skipped by the controller, and the runtime
+			// is fetched as-is.
+			name: "no model + runtime named (lean path) - passes",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-lean", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "test-runtime"},
+					Engine:  &v1beta1.EngineSpec{},
+				},
+			},
+		},
+		{
+			// Lean path failure: only spec.runtime.name=="" — caught by
+			// the same Model-OR-Runtime rule.
+			name: "no model + empty runtime name should fail",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-lean-bad", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: ""},
+					Engine:  &v1beta1.EngineSpec{},
+				},
+			},
+			wantErr: true,
+			errMsg:  "at least one of spec.model or spec.runtime must be set",
+		},
+		// Explicit-pin admission validation.
+		{
+			name: "explicit revision pin with autoSync=false (cluster) passes",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "pin-ok", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name:     "srt-llama-pd",
+						AutoSync: boolPtr(false),
+						Revision: stringPtr("cr-srt-llama-pd-abc12345"),
+					},
+					Engine: &v1beta1.EngineSpec{},
+				},
+			},
+		},
+		{
+			name: "explicit revision pin with autoSync=true rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "pin-conflict", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name:     "srt-llama-pd",
+						AutoSync: boolPtr(true),
+						Revision: stringPtr("cr-srt-llama-pd-abc12345"),
+					},
+					Engine: &v1beta1.EngineSpec{},
+				},
+			},
+			wantErr: true,
+			errMsg:  "AutoSync=true would silently ignore the pin",
+		},
+		{
+			name: "explicit revision pin with autoSync omitted (defaults true) rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "pin-defaultsync", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name:     "srt-llama-pd",
+						Revision: stringPtr("cr-srt-llama-pd-abc12345"),
+					},
+					Engine: &v1beta1.EngineSpec{},
+				},
+			},
+			wantErr: true,
+			errMsg:  "AutoSync=true would silently ignore the pin",
+		},
+		{
+			name: "explicit revision pin naming a DIFFERENT runtime rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "pin-wrong-runtime", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name:     "srt-llama-pd",
+						AutoSync: boolPtr(false),
+						Revision: stringPtr("cr-srt-other-abc12345"),
+					},
+					Engine: &v1beta1.EngineSpec{},
+				},
+			},
+			wantErr: true,
+			errMsg:  "does not match the expected naming convention",
+		},
+		{
+			name: "explicit revision pin with malformed hash rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "pin-bad-hash", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name:     "srt-llama-pd",
+						AutoSync: boolPtr(false),
+						Revision: stringPtr("cr-srt-llama-pd-XYZ"),
+					},
+					Engine: &v1beta1.EngineSpec{},
+				},
+			},
+			wantErr: true,
+			errMsg:  "does not match the expected naming convention",
+		},
+		{
+			name: "explicit revision pin for namespaced runtime (correct scope) passes",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "pin-ns-ok", Namespace: "team-a"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name:     "srt-foo",
+						Kind:     stringPtr("ServingRuntime"),
+						AutoSync: boolPtr(false),
+						Revision: stringPtr("r-team-a-srt-foo-abc12345"),
+					},
+					Engine: &v1beta1.EngineSpec{},
+				},
+			},
+		},
+		{
+			name: "explicit revision pin for namespaced runtime, wrong namespace prefix rejected",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "pin-ns-bad", Namespace: "team-a"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{
+						Name:     "srt-foo",
+						Kind:     stringPtr("ServingRuntime"),
+						AutoSync: boolPtr(false),
+						Revision: stringPtr("r-team-b-srt-foo-abc12345"),
+					},
+					Engine: &v1beta1.EngineSpec{},
+				},
+			},
+			wantErr: true,
+			errMsg:  "does not match the expected naming convention",
+		},
+		{
+			name: "no explicit revision pin → validator no-op",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "no-pin", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Runtime: &v1beta1.ServingRuntimeRef{Name: "srt-llama-pd", AutoSync: boolPtr(false)},
+					Engine:  &v1beta1.EngineSpec{},
+				},
+			},
 		},
 	}
 
@@ -1149,7 +1635,154 @@ func TestResolveModelAndRuntime_Comprehensive(t *testing.T) {
 	}
 }
 
-// Test edge cases and warning scenarios
+func TestResolveModelAndRuntime_ExplicitRuntimeCompatIsAdvisory(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+
+	// llama model.
+	llamaModel := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-model"},
+		Spec: v1beta1.BaseModelSpec{
+			ModelArchitecture:  stringPtr("llama"),
+			ModelParameterSize: stringPtr("7B"),
+			ModelFormat: v1beta1.ModelFormat{
+				Name:    "llama",
+				Version: stringPtr("1.0.0"),
+			},
+		},
+	}
+
+	// A generic runtime that only *declares* support for a different
+	// architecture/format ("gpt"). It does not enumerate "llama", so the
+	// compatibility matcher reports a mismatch — but the operator named it
+	// explicitly, so admission should warn-and-admit rather than reject.
+	genericRuntime := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "generic-runtime"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFormat:       &v1beta1.ModelFormat{Name: "gpt", Version: stringPtr("1.0.0")},
+					ModelArchitecture: stringPtr("gpt"),
+					AutoSelect:        boolPtr(true),
+				},
+			},
+		},
+	}
+
+	// A runtime that genuinely declares support for llama.
+	matchingRuntime := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching-runtime"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFormat:       &v1beta1.ModelFormat{Name: "llama", Version: stringPtr("1.0.0"), Weight: int64(1)},
+					ModelArchitecture: stringPtr("llama"),
+					AutoSelect:        boolPtr(true),
+				},
+			},
+		},
+	}
+
+	t.Run("explicit runtime + format mismatch is admitted with advisory warning", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(llamaModel.DeepCopy(), genericRuntime.DeepCopy()).
+			Build()
+		validator := &InferenceServiceValidator{
+			Client:          fakeClient,
+			RuntimeSelector: runtimeselector.New(fakeClient),
+		}
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-isvc", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Model:   &v1beta1.ModelRef{Name: "llama-model"},
+				Runtime: &v1beta1.ServingRuntimeRef{Name: "generic-runtime"},
+			},
+		}
+
+		warnings, err := validator.resolveModelAndRuntime(context.Background(), isvc, admission.Warnings{})
+
+		assert.NoError(t, err, "explicit-runtime compat mismatch must be admitted, not rejected")
+		assert.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "does not declare support for model")
+		assert.Contains(t, warnings[0], "proceeding because the runtime was named explicitly")
+		// The dropped success-warning phrasing must not reappear.
+		assert.NotContains(t, warnings[0], "is valid for model")
+	})
+
+	t.Run("explicit runtime that matches is admitted with no warning", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(llamaModel.DeepCopy(), matchingRuntime.DeepCopy()).
+			Build()
+		validator := &InferenceServiceValidator{
+			Client:          fakeClient,
+			RuntimeSelector: runtimeselector.New(fakeClient),
+		}
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-isvc", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Model:   &v1beta1.ModelRef{Name: "llama-model"},
+				Runtime: &v1beta1.ServingRuntimeRef{Name: "matching-runtime"},
+			},
+		}
+
+		warnings, err := validator.resolveModelAndRuntime(context.Background(), isvc, admission.Warnings{})
+
+		assert.NoError(t, err)
+		assert.Empty(t, warnings, "a matching explicit runtime emits no advisory warning")
+	})
+
+	t.Run("explicit runtime not found still hard-fails", func(t *testing.T) {
+		// A non-existent runtime is not a declared-format mismatch; it must
+		// stay a hard error even on the explicit path.
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(llamaModel.DeepCopy()).
+			Build()
+		validator := &InferenceServiceValidator{
+			Client:          fakeClient,
+			RuntimeSelector: runtimeselector.New(fakeClient),
+		}
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-isvc", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Model:   &v1beta1.ModelRef{Name: "llama-model"},
+				Runtime: &v1beta1.ServingRuntimeRef{Name: "does-not-exist"},
+			},
+		}
+
+		_, err := validator.resolveModelAndRuntime(context.Background(), isvc, admission.Warnings{})
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("auto-select with no matching runtime still hard-fails", func(t *testing.T) {
+		// Same model, only the non-matching generic runtime present, and NO
+		// explicit runtime named: OME is choosing, so compat MUST gate.
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(llamaModel.DeepCopy(), genericRuntime.DeepCopy()).
+			Build()
+		validator := &InferenceServiceValidator{
+			Client:          fakeClient,
+			RuntimeSelector: runtimeselector.New(fakeClient),
+		}
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-isvc", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Model: &v1beta1.ModelRef{Name: "llama-model"},
+			},
+		}
+
+		_, err := validator.resolveModelAndRuntime(context.Background(), isvc, admission.Warnings{})
+
+		assert.Error(t, err, "auto-select must still reject when nothing supports the model")
+		assert.Contains(t, err.Error(), "no supporting runtime found for model llama-model")
+	})
+}
+
 func TestResolveModelAndRuntime_EdgeCases(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = v1beta1.AddToScheme(scheme)
@@ -1811,7 +2444,155 @@ func TestValidateInferenceService_ModelExistsIntegration(t *testing.T) {
 }
 
 // =============================================================================
-// KEDA VALIDATION TESTS
+// HELPER FUNCTIONS
+// =============================================================================
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+// TestValidateOverlays_StructuralChecks covers the schema-level overlay
+// rejections (duplicates, self-reference, env-name collision) that fire
+// before any apiserver lookups happen — no fake client needed.
+func TestValidateOverlays_StructuralChecks(t *testing.T) {
+	v := &InferenceServiceValidator{}
+	clusterKind := "ClusterBaseModel"
+	apiGroup := "ome.io"
+	tests := []struct {
+		name     string
+		overlays []v1beta1.ModelOverlayRef
+		wantErr  string // empty = expect success
+	}{
+		{
+			name:     "empty overlays accepted",
+			overlays: nil,
+		},
+		{
+			name: "single overlay accepted",
+			overlays: []v1beta1.ModelOverlayRef{
+				{Name: "foo-pvc", Kind: &clusterKind, APIGroup: &apiGroup},
+			},
+		},
+		{
+			name: "empty overlay name rejected",
+			overlays: []v1beta1.ModelOverlayRef{
+				{Name: "", Kind: &clusterKind, APIGroup: &apiGroup},
+			},
+			wantErr: "overlay name cannot be empty",
+		},
+		{
+			name: "overlay matching primary rejected",
+			overlays: []v1beta1.ModelOverlayRef{
+				{Name: "primary", Kind: &clusterKind, APIGroup: &apiGroup},
+			},
+			wantErr: "must not reference the primary model",
+		},
+		{
+			name: "duplicate overlay name rejected",
+			overlays: []v1beta1.ModelOverlayRef{
+				{Name: "foo-pvc"}, {Name: "foo-pvc"},
+			},
+			wantErr: "declared more than once",
+		},
+		{
+			name: "sanitized env-var collision rejected",
+			overlays: []v1beta1.ModelOverlayRef{
+				{Name: "foo-bar"}, {Name: "foo_bar"},
+			},
+			wantErr: "both sanitize to env var OVERLAY_FOO_BAR_MODEL_PATH",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "default"},
+				Spec: v1beta1.InferenceServiceSpec{
+					Model: &v1beta1.ModelRef{Name: "primary", Overlays: tc.overlays},
+				},
+			}
+			err := v.validateOverlays(isvc)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestDeploymentStrategyWarnings pins the footgun warning: deploymentStrategy is
+// raw-only, so setting it on an OMENative/PD component is a silent no-op and must
+// warn (pointing at lifecycle.updateStrategy); raw and no-strategy must not warn.
+func TestDeploymentStrategyWarnings(t *testing.T) {
+	strategy := func() *appsv1.DeploymentStrategy {
+		return &appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType}
+	}
+	engineWith := &v1beta1.EngineSpec{
+		ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{DeploymentStrategy: strategy()},
+	}
+	modeAnn := func(m constants.DeploymentModeType) map[string]string {
+		return map[string]string{constants.DeploymentMode: string(m)}
+	}
+
+	tests := []struct {
+		name    string
+		isvc    *v1beta1.InferenceService
+		wantLen int
+	}{
+		{
+			name: "OMENative engine with deploymentStrategy warns",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Annotations: modeAnn(constants.OMENative)},
+				Spec:       v1beta1.InferenceServiceSpec{Engine: engineWith},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "RawDeployment engine with deploymentStrategy does not warn (honored)",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Annotations: modeAnn(constants.RawDeployment)},
+				Spec:       v1beta1.InferenceServiceSpec{Engine: engineWith},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "OMENative without deploymentStrategy does not warn",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Annotations: modeAnn(constants.OMENative)},
+				Spec:       v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{}},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "no resolved mode does not warn",
+			isvc: &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{Engine: engineWith},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "PD decoder with deploymentStrategy warns",
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Annotations: modeAnn(constants.PDDisaggregated)},
+				Spec: v1beta1.InferenceServiceSpec{
+					Decoder: &v1beta1.DecoderSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{DeploymentStrategy: strategy()},
+					},
+				},
+			},
+			wantLen: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Len(t, deploymentStrategyWarnings(tt.isvc), tt.wantLen)
+		})
+	}
+}
+
+// =============================================================================
+// MIGRATION-REQUEST ANNOTATION VALIDATION (mailbox admission)
 // =============================================================================
 
 func TestValidateKEDAConfig(t *testing.T) {
@@ -2341,7 +3122,3 @@ func TestInferenceService_KEDAAutoscalerIntegration(t *testing.T) {
 // =============================================================================
 // HELPER FUNCTIONS
 // =============================================================================
-
-func boolPtr(b bool) *bool {
-	return &b
-}


### PR DESCRIPTION
## What this PR does

Adds admission-time enforcement for the API surfaces introduced in the recent `[API]` series (lifecycle, autoscaler, rollout, traffic, InferenceReplica, placement):

- **`pkg/validation`** grows pure, client-free rule modules shared across webhooks: canary/rollout group invariants (at most one canary group, step shape), rollout-coordination update rules, per-Component `Autoscaler` block shape (class enum, required fields, `IdleReplicaCount` vs `MinReplicas`, annotation/block conflicts), lifecycle policy shape, placement spec rules, traffic spec + `ome.io/*` traffic-annotation validation, leader/worker pairing, scale-to-zero rules, and InferenceService naming.
- **InferenceService validator/defaulter** rewired onto those modules. Defaulting now understands `spec.deploymentMode` (OMENative-aware component defaulting, worker sizing). The legacy autoscaler surfaces — annotation class, `spec.kedaConfig`, per-Component `scaleMetric` — **remain fully supported and validated** alongside the typed `Autoscaler` block; explicit-runtime compatibility mismatches downgrade to admission warnings instead of hard failures.
- **InferenceReplica validating webhook**: InferenceReplica is a controller-only CRD — the webhook rejects direct user writes unless the `ome.io/controller-write=true` annotation is present (stamped by the ISVC controller on writes it owns; RBAC remains the actual security boundary). Registered in the manager, added to `config/webhook/manifests.yaml`, and shipped as a chart webhook template with a `skip-deletion` matchCondition so finalizer-only patches during GC are never blocked.
- **`pkg/constants`**: typed `ome.io/*` traffic/circuit-breaker/retry/timeout annotation keys (+tests) and the InferenceReplica controller-write annotation.
- Overlay naming helpers (`OVERLAY_<NAME>_MODEL_PATH`, mount path) backing overlay validation.

Controllers for these surfaces land in follow-ups; this PR ensures objects persisted in the meantime already satisfy the invariants those controllers assume.

## Why we need it

The new API fields currently accept any shape — a malformed rollout group or an out-of-range traffic percent persists silently and would surface as a controller error much later. Validating at admission keeps feedback at `kubectl apply` time and guarantees the controller series can trust stored objects.

## How to test

- `make test` — includes ported unit tests for every validation module, the rewired ISVC webhook tests (KEDA/HPA legacy-surface tests retained), and the InferenceReplica validator tests.
- `helm lint` / `helm template` clean; `kubectl apply -k config/webhook` installs the new webhook configuration.

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally