### PR TITLE
[CI/Tests] use Go 1.26 across workflows

### DIFF
--- a/.github/workflows/dev-images.yaml
+++ b/.github/workflows/dev-images.yaml
@@ -16,7 +16,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_ORG: moirai-internal
   # Go version
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   build-and-push-images:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pr-push-validation.yml
+++ b/.github/workflows/pr-push-validation.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Run fmt check
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Setup Rust
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Setup Rust
@@ -157,7 +157,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Setup Rust
@@ -222,7 +222,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Check licenses

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Cache Go modules
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Setup Rust
@@ -156,7 +156,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Setup Rust
@@ -206,7 +206,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Setup Rust
@@ -263,7 +263,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Run golangci-lint
@@ -280,7 +280,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Regenerate manifests and code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_ORG: moirai-internal
   # Go version
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   prepare:

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Install syft
         uses: anchore/sbom-action/download-syft@v0

--- a/.github/workflows/sync-dependabot.yaml
+++ b/.github/workflows/sync-dependabot.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Update dependencies


### PR DESCRIPTION
## What this PR does

Bumps every workflow's Go toolchain pin from 1.25 to 1.26 (`setup-go` inputs and the `GO_VERSION` env in dev-images/release).

## Why we need it

`hack/internal/doctools` requires `go >= 1.26.0` (helm 3.20's floor). `setup-go` runs with `GOTOOLCHAIN=local`, so on workflows pinned to 1.25 any target that resolves versions from that module fails — currently breaking the `PR Push Validation` run on `main` at the helm install step (`HELM_VERSION` resolves empty and `go install helm.sh/helm/v3/cmd/helm@` errors). The PR-validation workflow only avoided it because its jobs never touch the docs tooling.

Root `go.mod` (1.25.0) and the codegen tools module are unaffected — 1.26 satisfies every module in the repository.

## How to test

- This PR's own checks run under 1.26.
- After merge, the `PR Push Validation` workflow on `main` goes green again (its Lint job reaches `make helm` and installs v3.20.2).

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally