### PR TITLE
[CI/Tests] Add codecov coverage ratchet

### DIFF
--- a/.github/workflows/pr-push-validation.yml
+++ b/.github/workflows/pr-push-validation.yml
@@ -97,6 +97,15 @@ jobs:
             coverage-pkg.out
             coverage-internal.out
 
+      - name: Upload coverage to Codecov
+        if: matrix.test-suite == 'unit'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage-cmd.out,coverage-pkg.out,coverage-internal.out
+          flags: unit
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -533,6 +533,9 @@ artifacts: kustomize ## Generate artifacts for release.
 GOTOOLCHAIN      ?= go1.25.0+auto # https://github.com/golang/go/issues/75031
 XET_LIB_PATH     := $(shell pwd)/pkg/xet/target/release
 EXCLUDE_PATTERNS := "pkg/testing/|pkg/testutils/|_generated\.go|zz_generated|pkg/apis/|pkg/openapi/|pkg/client/|pkg/modelconfig/examples/|pkg/hfutil/hub/samples/"
+# Keep this floor moving toward the 85% coverage goal. Override it locally with
+# `make coverage COVER_MIN=<percent>` when evaluating an incremental increase.
+COVER_MIN        ?= 65
 
 # Define test packages
 TEST_PACKAGES     := $(shell go list ./... | grep -v -E '(pkg/apis|pkg/testing|pkg/openapi|pkg/client)')
@@ -584,8 +587,10 @@ test-no-xet: fmt vet manifests envtest ## 🧪 Run tests excluding ome-agent
 	$(call run_go_test,$(INTERNAL_PACKAGES),internal,-no-xet)
 	@echo "\n🎉 All tests completed successfully (excluding ome-agent)!"
 
-.PHONY: coverage
-coverage: ## Show coverage summary and enforce threshold
+.PHONY: coverage cover-check
+coverage: cover-check ## Show coverage summary and enforce threshold
+
+cover-check: ## Enforce the minimum average coverage (COVER_MIN, currently 65)
 	@echo "\n---------- Coverage Summary ----------"
 	@for part in cmd pkg internal; do \
 		echo "\n$$part Coverage:"; \
@@ -598,8 +603,8 @@ coverage: ## Show coverage summary and enforce threshold
 	echo "CMD: $$cmd_cov%"; echo "PKG: $$pkg_cov%"; echo "Internal: $$int_cov%"; \
 	avg_cov=$$(awk "BEGIN {printf \"%.2f\", ($$cmd_cov + $$pkg_cov + $$int_cov) / 3}"); \
 	echo "\nAverage Coverage: $$avg_cov%"; \
-	if awk "BEGIN {exit !($$avg_cov < 48)}"; then \
-		echo "❌ Average coverage $$avg_cov% is below threshold of 48%"; \
+	if awk "BEGIN {exit !($$avg_cov < $(COVER_MIN))}"; then \
+		echo "❌ Average coverage $$avg_cov% is below threshold of $(COVER_MIN)%"; \
 		exit 1; \
 	fi
 .PHONY: integration-test

--- a/Makefile
+++ b/Makefile
@@ -535,7 +535,7 @@ XET_LIB_PATH     := $(shell pwd)/pkg/xet/target/release
 EXCLUDE_PATTERNS := "pkg/testing/|pkg/testutils/|_generated\.go|zz_generated|pkg/apis/|pkg/openapi/|pkg/client/|pkg/modelconfig/examples/|pkg/hfutil/hub/samples/"
 # Keep this floor moving toward the 85% coverage goal. Override it locally with
 # `make coverage COVER_MIN=<percent>` when evaluating an incremental increase.
-COVER_MIN        ?= 65
+COVER_MIN        ?= 50
 
 # Define test packages
 TEST_PACKAGES     := $(shell go list ./... | grep -v -E '(pkg/apis|pkg/testing|pkg/openapi|pkg/client)')
@@ -590,7 +590,7 @@ test-no-xet: fmt vet manifests envtest ## 🧪 Run tests excluding ome-agent
 .PHONY: coverage cover-check
 coverage: cover-check ## Show coverage summary and enforce threshold
 
-cover-check: ## Enforce the minimum average coverage (COVER_MIN, currently 65)
+cover-check: ## Enforce the minimum average coverage (COVER_MIN, currently 50)
 	@echo "\n---------- Coverage Summary ----------"
 	@for part in cmd pkg internal; do \
 		echo "\n$$part Coverage:"; \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OME (Open Model Engine) — Kubernetes Operator for LLM Serving
 
 [![Go Report](https://goreportcard.com/badge/sigs.k8s.io/ome)](https://goreportcard.com/report/sigs.k8s.io/ome)
+[![codecov](https://codecov.io/gh/ome-projects/ome/graph/badge.svg)](https://codecov.io/gh/ome-projects/ome)
 [![Latest Release](https://img.shields.io/github/v/release/ome-projects/ome?include_prereleases)](https://github.com/ome-projects/ome/releases/latest)
 [![API Reference](https://img.shields.io/badge/API-v1beta1-blue)](https://ome-projects.github.io/ome/docs/reference/ome.v1beta1/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)


### PR DESCRIPTION
## What this PR does

- Adds a visible Codecov badge to the README.
- Uploads main-branch unit coverage reports to Codecov.
- Adds an explicit `cover-check` target with configurable `COVER_MIN`.
- Raises the enforced coverage floor from 48% to 50%, toward the 85% goal.

## Why we need it

Coverage is now visible to contributors, and regressions below the current attainable floor are rejected. Follow-up sweeps can keep raising `COVER_MIN` as coverage improves.

Related issue: N/A — none provided.

## How to test

- `make fmt`
- `make vet`
- `make tidy`
- `pre-commit run --all-files`
- `git diff --check`
- PR validation, including unit tests, builds, CodeQL, and Docker builds
- Coverage ratchet: 50.27% measured average against a 50% floor

All CI checks passed.

## Checklist

- [ ] Tests added/updated — N/A; CI/configuration and documentation only
- [x] Docs updated
- [ ] `make test` passes locally — passed in PR CI; full local suite not repeated
