### PR TITLE
[Bugfix] tolerate lean isvc in runtime selection

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -239,32 +239,36 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 			rt = pin.spec
 		} else {
-			if err := r.RuntimeSelector.ValidateRuntime(ctx, rtName, baseModel, isvc); err != nil {
-				// The operator named this runtime explicitly, so OME should not
-				// block on the runtime's *declared* supportedModelFormats: a
-				// generic runtime (e.g. sglang) can serve many architectures it
-				// never enumerates. Downgrade a pure compatibility mismatch
-				// (format / architecture / framework) to an advisory event and
-				// proceed — the deliberate choice wins over the declaration.
-				//
-				// This mirrors the admission webhook (explicit-runtime compat
-				// is advisory). Without the same downgrade here, the webhook
-				// admits the ISVC but this reconcile hard-fails, so it never
-				// gets pods.
-				//
-				// Everything else stays a hard error: a not-found / disabled
-				// runtime or a malformed model genuinely cannot run.
-				if runtimeselector.IsRuntimeCompatibilityError(err) {
-					r.Log.Info("Runtime named explicitly; proceeding despite declared-format mismatch",
-						"runtime", rtName, "model", isvc.Spec.Model.Name, "details", err.Error())
-					r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeCompatibilityAdvisory",
-						"Runtime %s does not declare support for model %s (%v); proceeding because the runtime was named explicitly",
-						rtName, isvc.Spec.Model.Name, err)
-				} else {
-					r.Log.Error(err, "Runtime validation failed", "runtime", rtName, "model", isvc.Spec.Model.Name)
-					r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeValidationError",
-						"Runtime %s does not support model %s: %v", rtName, isvc.Spec.Model.Name, err)
-					return reconcile.Result{}, err
+			// A lean InferenceService (no spec.model) can still name a
+			// runtime explicitly; there is no model to validate against.
+			if baseModel != nil {
+				if err := r.RuntimeSelector.ValidateRuntime(ctx, rtName, baseModel, isvc); err != nil {
+					// The operator named this runtime explicitly, so OME should not
+					// block on the runtime's *declared* supportedModelFormats: a
+					// generic runtime (e.g. sglang) can serve many architectures it
+					// never enumerates. Downgrade a pure compatibility mismatch
+					// (format / architecture / framework) to an advisory event and
+					// proceed — the deliberate choice wins over the declaration.
+					//
+					// This mirrors the admission webhook (explicit-runtime compat
+					// is advisory). Without the same downgrade here, the webhook
+					// admits the ISVC but this reconcile hard-fails, so it never
+					// gets pods.
+					//
+					// Everything else stays a hard error: a not-found / disabled
+					// runtime or a malformed model genuinely cannot run.
+					if runtimeselector.IsRuntimeCompatibilityError(err) {
+						r.Log.Info("Runtime named explicitly; proceeding despite declared-format mismatch",
+							"runtime", rtName, "model", isvc.Spec.Model.Name, "details", err.Error())
+						r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeCompatibilityAdvisory",
+							"Runtime %s does not declare support for model %s (%v); proceeding because the runtime was named explicitly",
+							rtName, isvc.Spec.Model.Name, err)
+					} else {
+						r.Log.Error(err, "Runtime validation failed", "runtime", rtName, "model", isvc.Spec.Model.Name)
+						r.Recorder.Eventf(isvc, v1.EventTypeWarning, "RuntimeValidationError",
+							"Runtime %s does not support model %s: %v", rtName, isvc.Spec.Model.Name, err)
+						return reconcile.Result{}, err
+					}
 				}
 			}
 
@@ -277,7 +281,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 			rt = rtSpec
 		}
-	} else {
+	} else if baseModel != nil {
 		// Auto-select runtime
 		selection, err := r.RuntimeSelector.SelectRuntime(ctx, baseModel, isvc)
 		if err != nil {
@@ -289,6 +293,14 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		rt = selection.Spec
 		rtName = selection.Name
 		r.Log.Info("Auto-selected runtime", "runtime", rtName, "model", isvc.Spec.Model.Name)
+	} else {
+		// No model and no runtime: nothing to select from. The admission
+		// webhook rejects the shapes that cannot work; this is a defensive
+		// guard for direct writes that bypass admission.
+		err := fmt.Errorf("InferenceService must specify spec.runtime when spec.model is omitted")
+		r.Log.Error(err, "Cannot reconcile", "Name", isvc.Name)
+		r.Recorder.Event(isvc, v1.EventTypeWarning, "RuntimeSelectionError", err.Error())
+		return reconcile.Result{}, err
 	}
 
 	// Step 3: Merge rt and isvc specs to get final engine, decoder, and router specs

--- a/pkg/runtimeselector/selector.go
+++ b/pkg/runtimeselector/selector.go
@@ -39,14 +39,15 @@ func NewWithConfig(config *Config) Selector {
 func (s *defaultSelector) SelectRuntime(ctx context.Context, model *v1beta1.BaseModelSpec, isvc *v1beta1.InferenceService) (*RuntimeSelection, error) {
 	namespace := isvc.Namespace
 	logger := log.FromContext(ctx)
-	logger.Info("Selecting runtime for model",
-		"model", model.ModelFormat.Name,
-		"namespace", namespace)
 
-	// Validate model
+	// Validate model before anything dereferences it (a lean
+	// InferenceService carries no model at all).
 	if err := s.validateModel(model); err != nil {
 		return nil, err
 	}
+	logger.Info("Selecting runtime for model",
+		"model", model.ModelFormat.Name,
+		"namespace", namespace)
 
 	// Get all compatible runtimes
 	matches, err := s.GetCompatibleRuntimes(ctx, model, isvc, namespace)
@@ -150,15 +151,16 @@ func (s *defaultSelector) GetCompatibleRuntimes(ctx context.Context, model *v1be
 func (s *defaultSelector) ValidateRuntime(ctx context.Context, runtimeName string, model *v1beta1.BaseModelSpec, isvc *v1beta1.InferenceService) error {
 	namespace := isvc.Namespace
 	logger := log.FromContext(ctx)
+
+	// Validate model before anything dereferences it (a lean
+	// InferenceService carries no model at all).
+	if err := s.validateModel(model); err != nil {
+		return err
+	}
 	logger.V(1).Info("Validating runtime",
 		"runtime", runtimeName,
 		"model", model.ModelFormat.Name,
 		"namespace", namespace)
-
-	// Validate model
-	if err := s.validateModel(model); err != nil {
-		return err
-	}
 
 	// Get the specific runtime
 	runtimeSpec, isCluster, err := s.fetcher.GetRuntime(ctx, runtimeName, namespace)

--- a/pkg/runtimeselector/selector_test.go
+++ b/pkg/runtimeselector/selector_test.go
@@ -1568,3 +1568,24 @@ func TestSupportedRuntimeWithAC(t *testing.T) {
 		})
 	}
 }
+
+// A lean InferenceService carries no model at all; both selector entry
+// points must reject a nil model with a typed error instead of
+// dereferencing it.
+func TestSelectRuntime_NilModelReturnsError(t *testing.T) {
+	selector := New(fake.NewClientBuilder().Build())
+	isvc := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "lean", Namespace: "default"}}
+
+	_, err := selector.SelectRuntime(context.Background(), nil, isvc)
+	assert.Error(t, err)
+	assert.IsType(t, &ModelValidationError{}, err)
+}
+
+func TestValidateRuntime_NilModelReturnsError(t *testing.T) {
+	selector := New(fake.NewClientBuilder().Build())
+	isvc := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "lean", Namespace: "default"}}
+
+	err := selector.ValidateRuntime(context.Background(), "some-runtime", nil, isvc)
+	assert.Error(t, err)
+	assert.IsType(t, &ModelValidationError{}, err)
+}


### PR DESCRIPTION
## What this PR does

Makes the reconcile path safe for lean InferenceServices — specs with no `spec.model` — which admission accepts (a lean ISVC can run from a fully-specified runner image, with `spec.runtime` named explicitly):

- `runtimeselector`: `SelectRuntime` / `ValidateRuntime` validate the model **before** the logging that dereferences it; a nil model now returns a typed `ModelValidationError` instead of panicking. Regression tests added for both entry points.
- ISVC controller: explicit-runtime validation is skipped when there is no model to validate against; auto-selection only runs when a model exists; a spec with neither model nor runtime gets a clear error event ("must specify spec.runtime when spec.model is omitted") as a defensive guard for writes that bypass admission.

## Why we need it

`spec.model` is optional in the API, and the admission chain supports the lean shape — but the reconciler assumed a model everywhere: a lean ISVC panicked in `SelectRuntime` (nil dereference in the entry log) or in the controller's error paths. The webhook admitted objects the controller then crashed on.

## How to test

- New tests: `go test ./pkg/runtimeselector/ -run NilModel` — previously panicked, now typed errors.
- `make test` — full suite green.
- A lean ISVC with `spec.runtime.name` set reconciles past runtime resolution; one with neither model nor runtime surfaces a `RuntimeSelectionError` event instead of a controller panic.

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally