### PR TITLE
[Bugfix] runtime pin and router env fixes

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/router.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/router.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"context"
+	"sort"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -229,9 +230,7 @@ func (r *Router) reconcilePodSpec(isvc *v1beta1.InferenceService, objectMeta *me
 	if r.routerSpec.Runner != nil {
 		if r.routerSpec.Config != nil {
 			r.Log.Info("Adding config to router env", "inference service", isvc.Name, "namespace", isvc.Namespace)
-			for k, v := range r.routerSpec.Config {
-				r.routerSpec.Runner.Env = append(r.routerSpec.Runner.Env, v1.EnvVar{Name: k, Value: v})
-			}
+			r.routerSpec.Runner.Env = append(r.routerSpec.Runner.Env, configEnvVars(r.routerSpec.Config)...)
 		}
 	}
 	// Use common pod spec reconciler for base logic
@@ -271,4 +270,20 @@ func (r *Router) ValidateSpec() error {
 	}
 	// Add more validation logic as needed
 	return nil
+}
+
+// configEnvVars converts a component config map to env vars in sorted
+// key order — map iteration order would churn the pod template hash
+// across reconciles and trigger spurious rollouts.
+func configEnvVars(config map[string]string) []v1.EnvVar {
+	keys := make([]string, 0, len(config))
+	for k := range config {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	envs := make([]v1.EnvVar, 0, len(keys))
+	for _, k := range keys {
+		envs = append(envs, v1.EnvVar{Name: k, Value: config[k]})
+	}
+	return envs
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/router_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/router_test.go
@@ -1,0 +1,54 @@
+package components
+
+import (
+	"testing"
+)
+
+// TestConfigEnvVars_SortedDeterministic pins the env order derived from
+// the router config map: map iteration order is randomized per run, and
+// an order change churns the pod template hash, rolling the router
+// deployment for no spec change.
+func TestConfigEnvVars_SortedDeterministic(t *testing.T) {
+	config := map[string]string{
+		"ZED":       "3",
+		"ALPHA":     "1",
+		"MIDDLE":    "2",
+		"OME_DEBUG": "true",
+		"B_FLAG":    "x",
+	}
+
+	want := []string{"ALPHA", "B_FLAG", "MIDDLE", "OME_DEBUG", "ZED"}
+	first := configEnvVars(config)
+	if len(first) != len(want) {
+		t.Fatalf("configEnvVars returned %d vars, want %d", len(first), len(want))
+	}
+	for i, name := range want {
+		if first[i].Name != name {
+			t.Errorf("env[%d].Name = %q, want %q (sorted key order)", i, first[i].Name, name)
+		}
+		if first[i].Value != config[name] {
+			t.Errorf("env[%d].Value = %q, want %q", i, first[i].Value, config[name])
+		}
+	}
+
+	// Repeated conversion of the same map must produce the identical
+	// sequence — the property the pod template hash depends on.
+	for run := 0; run < 20; run++ {
+		again := configEnvVars(config)
+		for i := range want {
+			if again[i] != first[i] {
+				t.Fatalf("run %d: env[%d] = %+v, want %+v (order must be stable)", run, i, again[i], first[i])
+			}
+		}
+	}
+}
+
+// TestConfigEnvVars_Empty covers nil and empty maps.
+func TestConfigEnvVars_Empty(t *testing.T) {
+	if got := configEnvVars(nil); len(got) != 0 {
+		t.Errorf("configEnvVars(nil) = %v, want empty", got)
+	}
+	if got := configEnvVars(map[string]string{}); len(got) != 0 {
+		t.Errorf("configEnvVars(empty) = %v, want empty", got)
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/pinning.go
+++ b/pkg/controller/v1beta1/inferenceservice/pinning.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
 	"sigs.k8s.io/ome/pkg/runtimerevision"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
 )
 
 // pinResult tells the caller how to proceed after the pinning helper
@@ -37,6 +38,8 @@ type pinResult struct {
 //   - Otherwise → set RuntimeDrifted=True, skip children.
 //   - Explicit spec.runtime.revision set → fetch that revision; if
 //     missing, RuntimeDrifted=True (Reason=RevisionMissing) + skip.
+//   - Source runtime deleted but a pin resolves → keep serving the
+//     pinned revision, RuntimeDrifted=True (Reason=SourceRuntimeMissing).
 func (r *InferenceServiceReconciler) resolvePinnedRuntime(
 	ctx context.Context,
 	isvc *v1beta1.InferenceService,
@@ -47,14 +50,21 @@ func (r *InferenceServiceReconciler) resolvePinnedRuntime(
 	omeNS := constants.OMENamespace
 
 	// Resolve the LIVE spec once — needed for hash compare, and to
-	// seed the first-reconcile pin / advance on ack.
-	liveSpec, _, err := r.RuntimeSelector.GetRuntime(ctx, runtimeName, isvc.Namespace)
-	if err != nil {
-		return pinResult{}, fmt.Errorf("resolve live runtime %s: %w", runtimeName, err)
+	// seed the first-reconcile pin / advance on ack. A deleted source
+	// runtime is tolerated when a pin exists: pinning's whole point is
+	// that the ISVC keeps serving the pinned revision, so the gap
+	// surfaces as RuntimeDrifted instead of a hard reconcile error.
+	liveSpec, _, liveErr := r.RuntimeSelector.GetRuntime(ctx, runtimeName, isvc.Namespace)
+	sourceMissing := runtimeselector.IsRuntimeNotFoundError(liveErr)
+	if liveErr != nil && !sourceMissing {
+		return pinResult{}, fmt.Errorf("resolve live runtime %s: %w", runtimeName, liveErr)
 	}
-	_, liveHash, err := runtimerevision.Hash(liveSpec)
-	if err != nil {
-		return pinResult{}, err
+	var liveHash string
+	if !sourceMissing {
+		var err error
+		if _, liveHash, err = runtimerevision.Hash(liveSpec); err != nil {
+			return pinResult{}, err
+		}
 	}
 
 	// Explicit revision pin overrides everything else.
@@ -81,12 +91,21 @@ func (r *InferenceServiceReconciler) resolvePinnedRuntime(
 			return pinResult{}, err
 		}
 		isvc.Status.PinnedRevisionName = pinName
-		clearRuntimeDriftedCondition(isvc)
+		if sourceMissing {
+			setRuntimeDriftedCondition(isvc, v1.ConditionTrue, "SourceRuntimeMissing",
+				fmt.Sprintf("runtime %s not found; serving from pinned revision %s", runtimeName, pinName))
+		} else {
+			clearRuntimeDriftedCondition(isvc)
+		}
 		return pinResult{spec: pinned}, nil
 	}
 
 	// First reconcile: nothing pinned yet → create-or-find from live.
+	// With no pin AND no live source there is nothing to serve from.
 	if isvc.Status.PinnedRevisionName == "" {
+		if sourceMissing {
+			return pinResult{}, fmt.Errorf("resolve live runtime %s: %w", runtimeName, liveErr)
+		}
 		revName, err := runtimerevision.FindOrCreate(ctx, r.Client, omeNS, kind, sourceNS, runtimeName, liveSpec)
 		if err != nil {
 			return pinResult{}, fmt.Errorf("create initial pin for %s: %w", runtimeName, err)
@@ -106,6 +125,16 @@ func (r *InferenceServiceReconciler) resolvePinnedRuntime(
 		}
 		return pinResult{}, err
 	}
+
+	// Source deleted but the pin resolves: keep serving it. Hash compare
+	// and sync-ack advance are meaningless without a live spec.
+	if sourceMissing {
+		setRuntimeDriftedCondition(isvc, v1.ConditionTrue, "SourceRuntimeMissing",
+			fmt.Sprintf("runtime %s not found; serving from pinned revision %s",
+				runtimeName, isvc.Status.PinnedRevisionName))
+		return pinResult{spec: pinned}, nil
+	}
+
 	_, pinnedHash, err := runtimerevision.Hash(pinned)
 	if err != nil {
 		return pinResult{}, err

--- a/pkg/controller/v1beta1/inferenceservice/pinning_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/pinning_test.go
@@ -1,0 +1,186 @@
+package inferenceservice
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	knapis "knative.dev/pkg/apis"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+// stubRuntimeSelector overrides GetRuntime only; the embedded nil
+// Selector panics on any other call, which no pinning path makes.
+type stubRuntimeSelector struct {
+	runtimeselector.Selector
+	spec *v1beta1.ServingRuntimeSpec
+	err  error
+}
+
+func (s *stubRuntimeSelector) GetRuntime(_ context.Context, _, _ string) (*v1beta1.ServingRuntimeSpec, bool, error) {
+	return s.spec, false, s.err
+}
+
+// pinnedRevisionObj serializes spec into a ControllerRevision named
+// revName in the OME namespace, labeled as a revision of runtimeName.
+func pinnedRevisionObj(t *testing.T, revName, runtimeName string, spec *v1beta1.ServingRuntimeSpec) *appsv1.ControllerRevision {
+	t.Helper()
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal pinned spec: %v", err)
+	}
+	return &appsv1.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      revName,
+			Namespace: constants.OMENamespace,
+			Labels: map[string]string{
+				constants.RuntimeRevisionOfLabelKey: runtimeName,
+			},
+		},
+		Data: runtime.RawExtension{Raw: raw},
+	}
+}
+
+func pinningReconciler(t *testing.T, selector runtimeselector.Selector, objs ...*appsv1.ControllerRevision) *InferenceServiceReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add appsv1 to scheme: %v", err)
+	}
+	builder := ctrlclientfake.NewClientBuilder().WithScheme(scheme)
+	for _, o := range objs {
+		builder = builder.WithObjects(o)
+	}
+	return &InferenceServiceReconciler{
+		Client:          builder.Build(),
+		RuntimeSelector: selector,
+	}
+}
+
+func pinnedISVC(runtimeName string) *v1beta1.InferenceService {
+	autoSync := false
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama", Namespace: "prod"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: runtimeName, AutoSync: &autoSync},
+		},
+	}
+}
+
+func findCondition(isvc *v1beta1.InferenceService, condType string) *knapis.Condition {
+	for i := range isvc.Status.Conditions {
+		if string(isvc.Status.Conditions[i].Type) == condType {
+			return &isvc.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// TestResolvePinnedRuntime_SourceDeleted_ServesPin is the regression
+// test for the deleted-source wedge: a NotFound on the live runtime
+// used to hard-fail the reconcile even though the pinned revision was
+// intact, wedging the ISVC. The pin must keep serving with drift
+// surfaced as a condition.
+func TestResolvePinnedRuntime_SourceDeleted_ServesPin(t *testing.T) {
+	const runtimeName = "vllm-rt"
+	const revName = "csr-vllm-rt-abc123"
+
+	rev := pinnedRevisionObj(t, revName, runtimeName, &v1beta1.ServingRuntimeSpec{})
+	r := pinningReconciler(t, &stubRuntimeSelector{
+		err: &runtimeselector.RuntimeNotFoundError{RuntimeName: runtimeName, Namespace: "prod"},
+	}, rev)
+
+	isvc := pinnedISVC(runtimeName)
+	isvc.Status.PinnedRevisionName = revName
+
+	pin, err := r.resolvePinnedRuntime(context.Background(), isvc)
+	if err != nil {
+		t.Fatalf("resolvePinnedRuntime returned error %v, want the pin to keep serving", err)
+	}
+	if pin.skipChildren {
+		t.Error("skipChildren = true, want children reconciled from the pinned spec")
+	}
+	if pin.spec == nil {
+		t.Fatal("pin.spec is nil, want the decoded pinned revision spec")
+	}
+	cond := findCondition(isvc, constants.RuntimeDriftedConditionType)
+	if cond == nil {
+		t.Fatal("RuntimeDrifted condition not set")
+	}
+	if cond.Status != v1.ConditionTrue || cond.Reason != "SourceRuntimeMissing" {
+		t.Errorf("RuntimeDrifted = %s/%s, want True/SourceRuntimeMissing", cond.Status, cond.Reason)
+	}
+}
+
+// TestResolvePinnedRuntime_SourceDeleted_ExplicitRevision covers the
+// explicit spec.runtime.revision path: the named revision resolves, so
+// a deleted source runtime must not block it either.
+func TestResolvePinnedRuntime_SourceDeleted_ExplicitRevision(t *testing.T) {
+	const runtimeName = "vllm-rt"
+	const revName = "csr-vllm-rt-def456"
+
+	rev := pinnedRevisionObj(t, revName, runtimeName, &v1beta1.ServingRuntimeSpec{})
+	r := pinningReconciler(t, &stubRuntimeSelector{
+		err: &runtimeselector.RuntimeNotFoundError{RuntimeName: runtimeName, Namespace: "prod"},
+	}, rev)
+
+	isvc := pinnedISVC(runtimeName)
+	pin := revName
+	isvc.Spec.Runtime.Revision = &pin
+
+	res, err := r.resolvePinnedRuntime(context.Background(), isvc)
+	if err != nil {
+		t.Fatalf("resolvePinnedRuntime returned error %v, want the explicit pin to serve", err)
+	}
+	if res.skipChildren || res.spec == nil {
+		t.Errorf("got skipChildren=%v spec=%v, want a served pin", res.skipChildren, res.spec)
+	}
+	if isvc.Status.PinnedRevisionName != revName {
+		t.Errorf("PinnedRevisionName = %q, want %q", isvc.Status.PinnedRevisionName, revName)
+	}
+	cond := findCondition(isvc, constants.RuntimeDriftedConditionType)
+	if cond == nil || cond.Reason != "SourceRuntimeMissing" {
+		t.Errorf("RuntimeDrifted condition = %+v, want Reason=SourceRuntimeMissing", cond)
+	}
+}
+
+// TestResolvePinnedRuntime_SourceDeleted_NoPin: with no pin and no live
+// source there is nothing to serve from — the error must propagate.
+func TestResolvePinnedRuntime_SourceDeleted_NoPin(t *testing.T) {
+	const runtimeName = "vllm-rt"
+	r := pinningReconciler(t, &stubRuntimeSelector{
+		err: &runtimeselector.RuntimeNotFoundError{RuntimeName: runtimeName, Namespace: "prod"},
+	})
+
+	if _, err := r.resolvePinnedRuntime(context.Background(), pinnedISVC(runtimeName)); err == nil {
+		t.Fatal("resolvePinnedRuntime succeeded with no pin and no live runtime, want error")
+	}
+}
+
+// TestResolvePinnedRuntime_LiveError_Propagates: only NotFound is
+// tolerated — transient live-resolution failures still error so the
+// reconcile retries.
+func TestResolvePinnedRuntime_LiveError_Propagates(t *testing.T) {
+	const runtimeName = "vllm-rt"
+	const revName = "csr-vllm-rt-abc123"
+
+	rev := pinnedRevisionObj(t, revName, runtimeName, &v1beta1.ServingRuntimeSpec{})
+	r := pinningReconciler(t, &stubRuntimeSelector{
+		err: &runtimeselector.ConfigurationError{Component: "fetcher", Message: "boom"},
+	}, rev)
+
+	isvc := pinnedISVC(runtimeName)
+	isvc.Status.PinnedRevisionName = revName
+
+	if _, err := r.resolvePinnedRuntime(context.Background(), isvc); err == nil {
+		t.Fatal("resolvePinnedRuntime swallowed a non-NotFound live-resolution error")
+	}
+}


### PR DESCRIPTION
## What this PR does

Two verified reconciler fixes:

1. **A pinned ISVC survives deletion of its source runtime.** Previously, `resolvePinnedRuntime` hard-failed the reconcile when the live runtime lookup returned not-found — even though a resolvable pinned ControllerRevision was the whole reason the ISVC could keep serving. Now: with a pin present, a missing source runtime keeps serving the pinned revision and surfaces `RuntimeDrifted=True` with `Reason=SourceRuntimeMissing` (hash-compare and sync-ack advance are skipped — meaningless without a live spec); with no pin AND no live source, the hard error remains. Extensive `pinning_test.go` coverage added (first-reconcile seed, drift, ack advance, source-missing with and without pin).

2. **Router config env vars are emitted in sorted key order.** They were appended by ranging over a map — iteration order is randomized per process, so the pod template hash churned across reconciles and triggered spurious rollouts of the router deployment. `configEnvVars` now sorts keys; a determinism test pins the behavior.

## Why we need it

Both are silent operational failures: the first turns a routine runtime cleanup into a broken pinned ISVC; the second causes no-op spec changes to roll router pods at random.

## How to test

- `go test ./pkg/controller/v1beta1/inferenceservice/... ` — new pinning and env-determinism tests included; full suite green.
- Manually: pin an ISVC (`spec.runtime.autoSync=false`), delete the ServingRuntime → pods keep serving, `RuntimeDrifted=True/SourceRuntimeMissing`; recreate the runtime → drift clears on next reconcile.

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally