### PR TITLE
[Bugfix] fan runtime changes out to referencing isvcs

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -27,6 +27,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/network"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -528,6 +529,11 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	if err = r.updateStatus(isvc, deploymentMode); err != nil {
+		// A terminal status conflict is benign — requeue and re-reconcile
+		// off fresh state instead of surfacing an ERROR-level failure.
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		r.Recorder.Event(isvc, v1.EventTypeWarning, "InternalError", err.Error())
 		return reconcile.Result{}, err
 	}
@@ -564,6 +570,11 @@ func (r *InferenceServiceReconciler) handleVirtualDeployment(isvc *v1beta1.Infer
 	}})
 
 	if err := r.updateStatus(isvc, constants.VirtualDeployment); err != nil {
+		// A terminal status conflict is benign — requeue and re-reconcile
+		// off fresh state instead of surfacing an ERROR-level failure.
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		r.Recorder.Event(isvc, v1.EventTypeWarning, "InternalError", err.Error())
 		return reconcile.Result{}, err
 	}
@@ -672,6 +683,14 @@ func (r *InferenceServiceReconciler) ensureIngressDisableAnnotation(isvc *v1beta
 func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployConfig *controllerconfig.DeployConfig, ingressConfig *controllerconfig.IngressConfig) error {
 	r.ClientConfig = mgr.GetConfig()
 
+	// Register the spec.runtime.name cache index so runtime events
+	// fan out to referencing ISVCs through the cache index instead of
+	// scanning every cached InferenceService — see
+	// isvcsReferencingRuntime.
+	if err := registerISVCRuntimeNameIndex(context.Background(), mgr.GetFieldIndexer()); err != nil {
+		return err
+	}
+
 	// NEW: Initialize StatusReconciler
 	r.StatusManager = status.NewStatusReconciler()
 
@@ -697,17 +716,17 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 	}
 
 	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(&v1beta1.InferenceService{}).
+		For(&v1beta1.InferenceService{}, builder.WithPredicates(isvcReconcileTriggerPredicate())).
 		Owns(&appsv1.Deployment{}).
 		Owns(&v1.Service{}).
 		Owns(&v1.ConfigMap{}).
 		Owns(&v1.PersistentVolume{}).
 		Owns(&v1.PersistentVolumeClaim{}).
-		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}, builder.WithPredicates(ownedStatusIgnoringPredicate())).
 		Owns(&policyv1.PodDisruptionBudget{})
 
 	if kedaFound {
-		ctrlBuilder = ctrlBuilder.Owns(&kedav1.ScaledObject{})
+		ctrlBuilder = ctrlBuilder.Owns(&kedav1.ScaledObject{}, builder.WithPredicates(ownedStatusIgnoringPredicate()))
 	} else {
 		r.Log.Info("The InferenceService controller won't watch keda.sh/v1/ScaledObject resources because the CRD is not available.")
 	}
@@ -724,16 +743,17 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 		r.Log.Info("The InferenceService controller won't watch networking.istio.io/v1beta1/VirtualService resources because the CRD is not available.")
 	}
 
-	// Add watches for ServingRuntime and ClusterServingRuntime to populate cache
+	// Add watches for ServingRuntime and ClusterServingRuntime. Runtime
+	// events fan out to EVERY ISVC referencing the runtime: autoSync=true
+	// (float) ISVCs re-render from the live runtime and roll forward;
+	// autoSync=false (pinned) ISVCs run drift detection and warn. Without
+	// this fan-out a runtime change never triggers a float ISVC's reconcile,
+	// so the edit silently fails to propagate — see isvcsReferencingRuntime.
 	ctrlBuilder = ctrlBuilder.
 		Watches(&v1beta1.ServingRuntime{},
-			handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []reconcile.Request {
-				return nil // Just populate cache
-			})).
+			handler.EnqueueRequestsFromMapFunc(r.isvcsReferencingRuntime)).
 		Watches(&v1beta1.ClusterServingRuntime{},
-			handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []reconcile.Request {
-				return nil // Just populate cache
-			}))
+			handler.EnqueueRequestsFromMapFunc(r.isvcsReferencingRuntime))
 
 	return ctrlBuilder.Complete(r)
 }
@@ -767,4 +787,136 @@ func (r *InferenceServiceReconciler) setExternalServiceURL(ctx context.Context, 
 	}
 
 	return nil
+}
+
+// referencing the runtime; with it MatchingFields narrows the list to
+// the referencing ISVCs in O(matched). Registered on the manager cache
+// in SetupWithManager (see registerISVCRuntimeNameIndex).
+//
+// The field name is an internal index identifier (a code constant), not
+// a behavioral/user-facing value — no config surface is required.
+const isvcRuntimeNameIndexField = "spec.runtime.name"
+
+// isvcRuntimeNameIndexExtractor is the cache IndexerFunc registered for
+// isvcRuntimeNameIndexField. It returns the ISVC's spec.runtime.name, or
+// nil when the runtime ref (or its name) is absent — the unindexed
+// match below skips those identically.
+func isvcRuntimeNameIndexExtractor(obj client.Object) []string {
+	isvc, ok := obj.(*v1beta1.InferenceService)
+	if !ok {
+		return nil
+	}
+	if isvc.Spec.Runtime == nil || isvc.Spec.Runtime.Name == "" {
+		return nil
+	}
+	return []string{isvc.Spec.Runtime.Name}
+}
+
+// isvcRuntimeUnresolvedIndexField indexes auto-select ISVCs (no
+// spec.runtime.name) currently stuck with RuntimeReady=False. The name
+// index above cannot cover them — they reference no runtime by name — so
+// without this index a runtime created AFTER the ISVC never re-triggers
+// its reconcile and markRuntimeUnresolved becomes an absorbing state.
+// Internal index identifier, like isvcRuntimeNameIndexField.
+const isvcRuntimeUnresolvedIndexField = "status.runtimeUnresolved"
+
+// isvcRuntimeUnresolvedIndexValue is the single bucket value for
+// isvcRuntimeUnresolvedIndexField (membership index, not a lookup key).
+const isvcRuntimeUnresolvedIndexValue = "true"
+
+func isvcRuntimeUnresolvedIndexExtractor(obj client.Object) []string {
+	isvc, ok := obj.(*v1beta1.InferenceService)
+	if !ok {
+		return nil
+	}
+	if isvc.Spec.Runtime != nil && isvc.Spec.Runtime.Name != "" {
+		// Named references fan out via the name index.
+		return nil
+	}
+	cond := isvc.Status.GetCondition(v1beta1.RuntimeReady)
+	if cond == nil || cond.Status != v1.ConditionFalse {
+		return nil
+	}
+	return []string{isvcRuntimeUnresolvedIndexValue}
+}
+
+// registerISVCRuntimeNameIndex installs the runtime fan-out indexes on the
+// supplied indexer (mgr.GetFieldIndexer()). Call once during manager
+// setup, before Start, so isvcsReferencingRuntime resolves
+// referencing ISVCs through the indexes instead of scanning every cached
+// InferenceService.
+func registerISVCRuntimeNameIndex(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx, &v1beta1.InferenceService{}, isvcRuntimeNameIndexField, isvcRuntimeNameIndexExtractor); err != nil {
+		return err
+	}
+	return indexer.IndexField(ctx, &v1beta1.InferenceService{}, isvcRuntimeUnresolvedIndexField, isvcRuntimeUnresolvedIndexExtractor)
+}
+
+// isvcsReferencingRuntime returns reconcile requests for EVERY ISVC whose
+// spec.runtime.name matches obj (respecting namespaced-SR scope), regardless
+// of autoSync. Both float and pinned consumers must be re-reconciled on a
+// runtime change:
+//
+//   - autoSync=true (default, "float"): the reconcile re-renders the pod
+//     spec from the LIVE runtime, so a runtime edit rolls the ISVC forward.
+//     Fanning these out is the whole point — without it a runtime change
+//     never triggers the float ISVC's reconcile, so it silently fails to
+//     propagate until some unrelated event happens to wake the ISVC. That
+//     used to be masked by frequent incidental reconciles; once those were
+//     trimmed (event-filter predicates, scoped informers), runtime edits
+//     stopped reaching float ISVCs entirely.
+//
+//   - autoSync=false ("pinned"): the reconcile runs drift detection and
+//     warns the operator that the runtime edit was rejected; it does not roll.
+//
+// NOTE: fanning out float ISVCs means a runtime edit rolls them. For
+// RawDeployment that is a safe native rolling update; for OMENative it
+// rolls per the Component's updateStrategy — an OMENative ISVC on
+// RecreatePod with no rollout budget is recreated wholesale.
+func (r *InferenceServiceReconciler) isvcsReferencingRuntime(ctx context.Context, obj client.Object) []reconcile.Request {
+	runtimeName := obj.GetName()
+	runtimeNamespace := obj.GetNamespace() // empty for cluster-scoped
+
+	// Narrow to ISVCs whose spec.runtime.name matches via the field index;
+	// the in-memory kind/namespace-scope filter below still applies.
+	var isvcs v1beta1.InferenceServiceList
+	if err := r.List(ctx, &isvcs, client.MatchingFields{isvcRuntimeNameIndexField: runtimeName}); err != nil {
+		r.Log.Error(err, "fan-out runtime event: list InferenceServices failed")
+		return nil
+	}
+
+	var reqs []reconcile.Request
+	for i := range isvcs.Items {
+		isvc := &isvcs.Items[i]
+		if isvc.Spec.Runtime == nil || isvc.Spec.Runtime.Name != runtimeName {
+			continue
+		}
+		// Namespaced SR only matches same-namespace ISVCs; a cluster-scoped
+		// runtime (empty namespace) matches ISVCs in any namespace.
+		if runtimeNamespace != "" && isvc.Namespace != runtimeNamespace {
+			continue
+		}
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: isvc.Namespace, Name: isvc.Name,
+		}})
+	}
+
+	// Also wake auto-select ISVCs parked on RuntimeReady=False: the new or
+	// edited runtime may be the compatible one they are waiting for, and no
+	// name reference exists to fan them out through the index above.
+	var unresolved v1beta1.InferenceServiceList
+	if err := r.List(ctx, &unresolved, client.MatchingFields{isvcRuntimeUnresolvedIndexField: isvcRuntimeUnresolvedIndexValue}); err != nil {
+		r.Log.Error(err, "fan-out runtime event: list unresolved InferenceServices failed")
+		return reqs
+	}
+	for i := range unresolved.Items {
+		isvc := &unresolved.Items[i]
+		if runtimeNamespace != "" && isvc.Namespace != runtimeNamespace {
+			continue
+		}
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: isvc.Namespace, Name: isvc.Name,
+		}})
+	}
+	return reqs
 }

--- a/pkg/controller/v1beta1/inferenceservice/runtime_watch_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/runtime_watch_test.go
@@ -1,0 +1,80 @@
+package inferenceservice
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func rtRefISVC(ns, name, runtimeName string, autoSync *bool) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec: v1beta1.InferenceServiceSpec{
+			Runtime: &v1beta1.ServingRuntimeRef{Name: runtimeName, AutoSync: autoSync},
+		},
+	}
+}
+
+func reqNames(reqs []reconcile.Request) []string {
+	out := make([]string, 0, len(reqs))
+	for _, r := range reqs {
+		out = append(out, r.Namespace+"/"+r.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestIsvcsReferencingRuntime_EnqueuesAutoSyncTrue is the regression guard
+// for the fix: a runtime change must fan out to EVERY referencing ISVC,
+// including autoSync=true (float) ones — previously they were skipped, so
+// runtime edits silently never reached them.
+func TestIsvcsReferencingRuntime_EnqueuesAutoSyncTrue(t *testing.T) {
+	s := runtime.NewScheme()
+	assert.NoError(t, v1beta1.AddToScheme(s))
+	c := ctrlclientfake.NewClientBuilder().WithScheme(s).
+		WithIndex(&v1beta1.InferenceService{}, isvcRuntimeNameIndexField, isvcRuntimeNameIndexExtractor).
+		WithObjects(
+			rtRefISVC("prod", "float-default", "rt-a", nil),          // default float -> enqueue
+			rtRefISVC("prod", "float-true", "rt-a", ptr.To(true)),    // explicit float -> enqueue (the fix)
+			rtRefISVC("prod", "pinned", "rt-a", ptr.To(false)),       // pinned -> enqueue (unchanged)
+			rtRefISVC("prod", "other-runtime", "rt-b", ptr.To(true)), // different runtime -> skip
+		).Build()
+	r := &InferenceServiceReconciler{Client: c, Log: logr.Discard()}
+
+	// Cluster-scoped runtime event (empty namespace) matches any namespace.
+	got := r.isvcsReferencingRuntime(context.Background(), &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "rt-a"},
+	})
+	assert.Equal(t, []string{"prod/float-default", "prod/float-true", "prod/pinned"}, reqNames(got),
+		"every ISVC referencing rt-a must enqueue regardless of autoSync; the rt-b consumer must not")
+}
+
+// TestIsvcsReferencingRuntime_NamespacedScope pins that a namespaced
+// ServingRuntime only fans out to same-namespace ISVCs.
+func TestIsvcsReferencingRuntime_NamespacedScope(t *testing.T) {
+	s := runtime.NewScheme()
+	assert.NoError(t, v1beta1.AddToScheme(s))
+	c := ctrlclientfake.NewClientBuilder().WithScheme(s).
+		WithIndex(&v1beta1.InferenceService{}, isvcRuntimeNameIndexField, isvcRuntimeNameIndexExtractor).
+		WithObjects(
+			rtRefISVC("prod", "same-ns", "rt-ns", ptr.To(true)),
+			rtRefISVC("dev", "other-ns", "rt-ns", ptr.To(true)),
+		).Build()
+	r := &InferenceServiceReconciler{Client: c, Log: logr.Discard()}
+
+	got := r.isvcsReferencingRuntime(context.Background(), &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "rt-ns"},
+	})
+	assert.Equal(t, []string{"prod/same-ns"}, reqNames(got),
+		"a namespaced ServingRuntime must only enqueue ISVCs in its own namespace")
+}

--- a/pkg/controller/v1beta1/inferenceservice/watches.go
+++ b/pkg/controller/v1beta1/inferenceservice/watches.go
@@ -1,0 +1,93 @@
+package inferenceservice
+
+import (
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// isvcReconcileTriggerPredicate gates the controller's For(&InferenceService{})
+// watch so the reconciler reacts to spec and metadata changes but NOT to its
+// own status writes.
+//
+// Why this exists: the autoscaler-status mirror copies the live HPA's
+// conditions onto status.components.<comp>.autoscaler.conditions. When a
+// Component's HPA can't read a metric (e.g. a CPU-utilization HPA on pods with
+// no CPU request) the HPA controller perpetually rewrites a
+// ScalingActive=False / FailedGetResourceMetric condition. Even after we
+// normalize the rotating pod name out of the message, any status write the
+// reconciler makes still bumps resourceVersion — and an unfiltered For() watch
+// re-enqueues on every such self-write, producing a reconcile + status-write
+// storm.
+//
+// We deliberately do NOT use predicate.GenerationChangedPredicate: OME drives
+// rollouts (canary promote/rollback, etc.) through annotations that do not bump
+// .metadata.generation. Dropping those would break rollouts. Instead we enqueue
+// when generation changed OR labels/annotations changed, and drop updates that
+// only touched status / resourceVersion / managedFields.
+//
+// Create / Delete / Generic always pass — they are not status-churn sources and
+// the reconciler must see object lifecycle transitions.
+func isvcReconcileTriggerPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return true
+			}
+			return metaOrSpecChanged(e.ObjectOld, e.ObjectNew)
+		},
+	}
+}
+
+// ownedStatusIgnoringPredicate gates an Owns() watch so the reconciler reacts
+// to spec/generation and metadata changes on the owned object but ignores
+// status-only churn.
+//
+// This is used for the HPA (and KEDA ScaledObject) Owns() watches. The HPA
+// controller continuously rewrites the HPA's .status.conditions when it can't
+// fetch a metric; without this filter every such rewrite re-enqueues the owning
+// ISVC. We still react to HPA spec changes (e.g. min/max replicas) and metadata
+// changes via the generation-or-metadata comparison below.
+//
+// Create / Delete / Generic always pass.
+func ownedStatusIgnoringPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return true
+			}
+			return metaOrSpecChanged(e.ObjectOld, e.ObjectNew)
+		},
+	}
+}
+
+// metaOrSpecChanged reports whether an old→new object transition touched
+// .metadata.generation (a proxy for spec changes on a CRD/built-in with a
+// status subresource), .metadata.deletionTimestamp, labels, or annotations.
+// Status-only writes leave all of these untouched (generation only bumps on
+// spec changes; the apiserver does not advance generation for status
+// subresource writes), so they return false and are dropped.
+//
+// The deletionTimestamp check is load-bearing: deleting an object that
+// carries a finalizer surfaces as an UPDATE event (deletionTimestamp set),
+// not a Delete event — the Delete event only fires when the object is
+// actually removed, after every finalizer drops. Without the check the
+// reconciler never learns the deletion started and finalizer processing
+// stalls until some unrelated event happens to wake it.
+func metaOrSpecChanged(oldObj, newObj client.Object) bool {
+	if oldObj.GetGeneration() != newObj.GetGeneration() {
+		return true
+	}
+	if (oldObj.GetDeletionTimestamp() == nil) != (newObj.GetDeletionTimestamp() == nil) {
+		return true
+	}
+	if !reflect.DeepEqual(oldObj.GetLabels(), newObj.GetLabels()) {
+		return true
+	}
+	if !reflect.DeepEqual(oldObj.GetAnnotations(), newObj.GetAnnotations()) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## What this PR does

Three reconcile-behavior fixes in the InferenceService controller:

1. **Runtime edits now propagate.** The ServingRuntime / ClusterServingRuntime watches previously enqueued nothing (`return nil // Just populate cache`), so editing a runtime never re-reconciled any ISVC referencing it — float (`autoSync=true`) ISVCs silently didn't roll forward, and pinned ones didn't run drift detection until an unrelated event. Runtime events now fan out through a `spec.runtime.name` cache index to every referencing ISVC (namespaced-scope respected), and additionally wake auto-select ISVCs parked on `RuntimeReady=False` — a newly created runtime may be exactly what they're waiting for. Covered by `runtime_watch_test.go`.

2. **Reconcile-churn predicates.** The ISVC `For()` watch now ignores pure status/metadata-bookkeeping updates (`isvcReconcileTriggerPredicate`), and owned HPA/KEDA objects ignore status-only changes (`ownedStatusIgnoringPredicate`) — HPA status flaps (e.g. `FailedGetResourceMetric` message churn) no longer drive reconcile storms. These land together with the fan-out deliberately: reducing incidental reconciles removes the accidental masking that made the missing fan-out look harmless.

3. **Benign status-write conflicts requeue quietly.** A conflict on the terminal status update means a concurrent writer bumped the object; the next reconcile reads fresh state. That now requeues instead of surfacing an ERROR-level reconciler failure.

## Why we need it

The fan-out gap is a silent correctness bug (runtime edits appearing to take effect but not propagating); the predicates and conflict handling remove the noise that both masked it and burned reconcile cycles.

## How to test

- `go test ./pkg/controller/v1beta1/inferenceservice/...` — new watch fan-out tests included; full suite green.
- Manually: edit a ServingRuntime referenced by a float ISVC → the ISVC re-reconciles and rolls forward immediately; a pinned ISVC reports drift; an ISVC waiting on `RuntimeReady=False` wakes when a compatible runtime is created.

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `make test` passes locally