### PR TITLE
[Bugfix] propagate runtime schedulerName to pods

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/utils/merging.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/merging.go
@@ -218,6 +218,47 @@ func MergeNodeSelector(runtime *v1beta1.ServingRuntimeSpec, acceleratorClass *v1
 	return mergedNodeSelector
 }
 
+// MergeSchedulerName back-fills the runtime's top-level schedulerName
+// into every pod-spec level of the merged component specs (component,
+// leader, worker) so whichever template the renderer selects carries
+// it. Fill-only — a name set at any of those levels (by the
+// InferenceService or the runtime's component config) always wins, and
+// with nothing set anywhere the field stays empty so the cluster's
+// default scheduler applies.
+func MergeSchedulerName(runtime *v1beta1.ServingRuntimeSpec, engine *v1beta1.EngineSpec, decoder *v1beta1.DecoderSpec, router *v1beta1.RouterSpec) {
+	if runtime == nil || runtime.ServingRuntimePodSpec.SchedulerName == "" {
+		return
+	}
+	name := runtime.ServingRuntimePodSpec.SchedulerName
+
+	fill := func(spec *v1beta1.PodSpec) {
+		if spec.SchedulerName == "" {
+			spec.SchedulerName = name
+		}
+	}
+	if engine != nil {
+		fill(&engine.PodSpec)
+		if engine.Leader != nil {
+			fill(&engine.Leader.PodSpec)
+		}
+		if engine.Worker != nil {
+			fill(&engine.Worker.PodSpec)
+		}
+	}
+	if decoder != nil {
+		fill(&decoder.PodSpec)
+		if decoder.Leader != nil {
+			fill(&decoder.Leader.PodSpec)
+		}
+		if decoder.Worker != nil {
+			fill(&decoder.Worker.PodSpec)
+		}
+	}
+	if router != nil {
+		fill(&router.PodSpec)
+	}
+}
+
 // MergeResource merges resource requests and limits from runtime, accelerator class, and container spec.
 // It only merges resources from the runtime and accelerator class when the user has not explicitly specified resources in the InferenceService spec.
 // The acceleratorClass takes precedence and overrides the runtime resource, if it existed.

--- a/pkg/controller/v1beta1/inferenceservice/utils/merging_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/merging_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 )
 
 func TestMergeArgs(t *testing.T) {
@@ -556,4 +558,66 @@ func TestOverrideKeyValueInSlice(t *testing.T) {
 			assert.Equal(t, tt.expectedArgs, result)
 		})
 	}
+}
+
+// TestMergeSchedulerName pins the fill-only contract of the top-level
+// schedulerName back-fill: empty levels gain the runtime's top-level
+// name, already-set levels keep theirs, and absent inputs are no-ops.
+func TestMergeSchedulerName(t *testing.T) {
+	runtimeWithScheduler := func() *v1beta1.ServingRuntimeSpec {
+		return &v1beta1.ServingRuntimeSpec{
+			ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{SchedulerName: "custom-scheduler"},
+		}
+	}
+
+	t.Run("fills every empty pod-spec level", func(t *testing.T) {
+		engine := &v1beta1.EngineSpec{
+			Leader: &v1beta1.LeaderSpec{},
+			Worker: &v1beta1.WorkerSpec{Size: ptrInt(2)},
+		}
+		decoder := &v1beta1.DecoderSpec{
+			Leader: &v1beta1.LeaderSpec{},
+			Worker: &v1beta1.WorkerSpec{Size: ptrInt(1)},
+		}
+		router := &v1beta1.RouterSpec{}
+
+		MergeSchedulerName(runtimeWithScheduler(), engine, decoder, router)
+
+		assert.Equal(t, "custom-scheduler", engine.SchedulerName)
+		assert.Equal(t, "custom-scheduler", engine.Leader.SchedulerName)
+		assert.Equal(t, "custom-scheduler", engine.Worker.SchedulerName)
+		assert.Equal(t, "custom-scheduler", decoder.SchedulerName)
+		assert.Equal(t, "custom-scheduler", decoder.Leader.SchedulerName)
+		assert.Equal(t, "custom-scheduler", decoder.Worker.SchedulerName)
+		assert.Equal(t, "custom-scheduler", router.SchedulerName)
+	})
+
+	t.Run("set levels always win", func(t *testing.T) {
+		engine := &v1beta1.EngineSpec{
+			PodSpec: v1beta1.PodSpec{SchedulerName: "component-scheduler"},
+			Leader:  &v1beta1.LeaderSpec{PodSpec: v1beta1.PodSpec{SchedulerName: "leader-scheduler"}},
+			Worker:  &v1beta1.WorkerSpec{Size: ptrInt(2)},
+		}
+
+		MergeSchedulerName(runtimeWithScheduler(), engine, nil, nil)
+
+		assert.Equal(t, "component-scheduler", engine.SchedulerName)
+		assert.Equal(t, "leader-scheduler", engine.Leader.SchedulerName)
+		assert.Equal(t, "custom-scheduler", engine.Worker.SchedulerName,
+			"an unset worker level must still gain the top-level name")
+	})
+
+	t.Run("empty top-level name is a no-op", func(t *testing.T) {
+		engine := &v1beta1.EngineSpec{Leader: &v1beta1.LeaderSpec{}}
+
+		MergeSchedulerName(&v1beta1.ServingRuntimeSpec{}, engine, nil, nil)
+
+		assert.Empty(t, engine.SchedulerName)
+		assert.Empty(t, engine.Leader.SchedulerName)
+	})
+
+	t.Run("nil runtime and nil components do not panic", func(t *testing.T) {
+		MergeSchedulerName(nil, &v1beta1.EngineSpec{}, nil, nil)
+		MergeSchedulerName(runtimeWithScheduler(), nil, nil, nil)
+	})
 }

--- a/pkg/controller/v1beta1/inferenceservice/utils/reconciliation.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/reconciliation.go
@@ -96,5 +96,12 @@ func MergeRuntimeSpecs(isvc *v1beta1.InferenceService, runtime *v1beta1.ServingR
 		return nil, nil, nil, goerrors.Wrap(err, "failed to merge router specs")
 	}
 
+	// The renderers read only the merged component specs, so this is the
+	// one seam where the runtime's top-level schedulerName can reach a
+	// pod. Applied after the component merges so every more specific
+	// level (component / leader / worker, from either side) keeps
+	// precedence.
+	MergeSchedulerName(runtime, mergedEngine, mergedDecoder, mergedRouter)
+
 	return mergedEngine, mergedDecoder, mergedRouter, nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/utils/reconciliation_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/reconciliation_test.go
@@ -1,0 +1,151 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func ptrInt(i int) *int { return &i }
+
+// TestMergeRuntimeSpecs_SchedulerNamePrecedence pins the schedulerName
+// resolution order across the full merge pipeline (component merge +
+// top-level back-fill): ISVC pod-spec levels beat
+// runtime component-config levels, which beat the runtime's top-level
+// schedulerName; with nothing set anywhere the field stays empty.
+func TestMergeRuntimeSpecs_SchedulerNamePrecedence(t *testing.T) {
+	log := logr.Discard()
+
+	t.Run("top-level name reaches component, leader, worker, and router levels", func(t *testing.T) {
+		runtime := &v1beta1.ServingRuntimeSpec{
+			ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{SchedulerName: "custom-scheduler"},
+			EngineConfig: &v1beta1.EngineSpec{
+				Leader: &v1beta1.LeaderSpec{},
+				Worker: &v1beta1.WorkerSpec{Size: ptrInt(2)},
+			},
+			DecoderConfig: &v1beta1.DecoderSpec{
+				Leader: &v1beta1.LeaderSpec{},
+				Worker: &v1beta1.WorkerSpec{Size: ptrInt(1)},
+			},
+			RouterConfig: &v1beta1.RouterSpec{},
+		}
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Engine:  &v1beta1.EngineSpec{},
+				Decoder: &v1beta1.DecoderSpec{},
+				Router:  &v1beta1.RouterSpec{},
+			},
+		}
+
+		engine, decoder, router, err := MergeRuntimeSpecs(isvc, runtime, log)
+		require.NoError(t, err)
+		require.NotNil(t, engine)
+		require.NotNil(t, decoder)
+		require.NotNil(t, router)
+
+		assert.Equal(t, "custom-scheduler", engine.SchedulerName)
+		require.NotNil(t, engine.Leader)
+		assert.Equal(t, "custom-scheduler", engine.Leader.SchedulerName,
+			"rendered leader pods source their template from Leader.PodSpec — it must carry the runtime-level name")
+		require.NotNil(t, engine.Worker)
+		assert.Equal(t, "custom-scheduler", engine.Worker.SchedulerName,
+			"rendered worker pods source their template from Worker.PodSpec — it must carry the runtime-level name")
+		assert.Equal(t, "custom-scheduler", decoder.SchedulerName)
+		assert.Equal(t, "custom-scheduler", decoder.Leader.SchedulerName)
+		assert.Equal(t, "custom-scheduler", decoder.Worker.SchedulerName)
+		assert.Equal(t, "custom-scheduler", router.SchedulerName)
+	})
+
+	t.Run("runtime leader and worker levels override top-level", func(t *testing.T) {
+		runtime := &v1beta1.ServingRuntimeSpec{
+			ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{SchedulerName: "top-scheduler"},
+			EngineConfig: &v1beta1.EngineSpec{
+				Leader: &v1beta1.LeaderSpec{PodSpec: v1beta1.PodSpec{SchedulerName: "leader-scheduler"}},
+				Worker: &v1beta1.WorkerSpec{Size: ptrInt(2)},
+			},
+		}
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{}},
+		}
+
+		engine, _, _, err := MergeRuntimeSpecs(isvc, runtime, log)
+		require.NoError(t, err)
+
+		assert.Equal(t, "leader-scheduler", engine.Leader.SchedulerName)
+		assert.Equal(t, "top-scheduler", engine.Worker.SchedulerName,
+			"a worker level left unset must still fall back to the top-level name")
+	})
+
+	t.Run("ISVC levels override every runtime level", func(t *testing.T) {
+		runtime := &v1beta1.ServingRuntimeSpec{
+			ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{SchedulerName: "top-scheduler"},
+			EngineConfig: &v1beta1.EngineSpec{
+				Leader: &v1beta1.LeaderSpec{PodSpec: v1beta1.PodSpec{SchedulerName: "runtime-leader-scheduler"}},
+				Worker: &v1beta1.WorkerSpec{Size: ptrInt(2)},
+			},
+			RouterConfig: &v1beta1.RouterSpec{},
+		}
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{PodSpec: v1beta1.PodSpec{SchedulerName: "isvc-leader-scheduler"}},
+					Worker: &v1beta1.WorkerSpec{PodSpec: v1beta1.PodSpec{SchedulerName: "isvc-worker-scheduler"}},
+				},
+				Router: &v1beta1.RouterSpec{
+					PodSpec: v1beta1.PodSpec{SchedulerName: "isvc-router-scheduler"},
+				},
+			},
+		}
+
+		engine, _, router, err := MergeRuntimeSpecs(isvc, runtime, log)
+		require.NoError(t, err)
+
+		assert.Equal(t, "isvc-leader-scheduler", engine.Leader.SchedulerName)
+		assert.Equal(t, "isvc-worker-scheduler", engine.Worker.SchedulerName)
+		assert.Equal(t, "isvc-router-scheduler", router.SchedulerName)
+	})
+
+	t.Run("nothing set leaves every level empty", func(t *testing.T) {
+		runtime := &v1beta1.ServingRuntimeSpec{
+			EngineConfig: &v1beta1.EngineSpec{
+				Leader: &v1beta1.LeaderSpec{},
+				Worker: &v1beta1.WorkerSpec{Size: ptrInt(2)},
+			},
+		}
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{}},
+		}
+
+		engine, _, _, err := MergeRuntimeSpecs(isvc, runtime, log)
+		require.NoError(t, err)
+
+		assert.Empty(t, engine.SchedulerName)
+		assert.Empty(t, engine.Leader.SchedulerName)
+		assert.Empty(t, engine.Worker.SchedulerName)
+	})
+
+	t.Run("top-level name applies when the runtime has no engine config", func(t *testing.T) {
+		runtime := &v1beta1.ServingRuntimeSpec{
+			ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{SchedulerName: "custom-scheduler"},
+		}
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Leader: &v1beta1.LeaderSpec{},
+					Worker: &v1beta1.WorkerSpec{Size: ptrInt(2)},
+				},
+			},
+		}
+
+		engine, _, _, err := MergeRuntimeSpecs(isvc, runtime, log)
+		require.NoError(t, err)
+
+		assert.Equal(t, "custom-scheduler", engine.SchedulerName)
+		assert.Equal(t, "custom-scheduler", engine.Leader.SchedulerName)
+		assert.Equal(t, "custom-scheduler", engine.Worker.SchedulerName)
+	})
+}


### PR DESCRIPTION
## What

A `schedulerName` set at the runtime's top level (`ServingRuntimePodSpec.SchedulerName`) never reached rendered pods. The renderers read only the merged component specs, and the merge pipeline dropped the top-level field — pods silently landed on the default scheduler, which breaks any setup relying on a custom scheduler (gang scheduling, queueing, bin-packing schedulers).

## How

`MergeSchedulerName` back-fills the runtime's top-level `schedulerName` into every pod-spec level of the merged component specs (component, leader, worker for engine/decoder, plus router), applied as the last step of `MergeRuntimeSpecs`.

Fill-only semantics:
- a name set at any more specific level — by the InferenceService or the runtime's component config — always wins;
- with nothing set anywhere the field stays empty, so the cluster's default scheduler applies (no behavior change for specs that never set it).

## Testing

- `TestMergeSchedulerName` (`merging_test.go`) pins the fill-only contract per level: empty levels gain the top-level name, already-set levels keep theirs, absent inputs are no-ops.
- `TestMergeRuntimeSpecs_SchedulerNamePrecedence` (new `reconciliation_test.go`) pins the resolution order across the full pipeline: ISVC pod-spec levels beat runtime component-config levels, which beat the runtime top level; nothing set leaves every level empty.
- `go test ./pkg/controller/v1beta1/inferenceservice/...`: all pass.