### PR TITLE
[Helm] add modelAgent.enabled install flag

### DIFF
--- a/charts/ome-resources/templates/model-agent-daemonset/clusterrole.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.modelAgent.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -20,3 +21,4 @@ rules:
   - apiGroups: [ "ome.io" ]
     resources: [ "clusterbasemodels" ]
     verbs: [ "get", "list", "watch", "patch", "update" ]
+{{- end }}

--- a/charts/ome-resources/templates/model-agent-daemonset/clusterrolebinding.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.modelAgent.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.modelAgent.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.modelAgent.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,3 +8,4 @@ data:
   # Instance-type -> short-name map. Source of truth: values.yaml
   # modelAgent.instanceTypeMap (rendered via the ome.instanceTypeMap helper).
   instance-type-map: {{ include "ome.instanceTypeMap" . | quote }}
+{{- end }}

--- a/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.modelAgent.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -109,3 +110,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/ome-resources/templates/model-agent-daemonset/serviceaccount.yaml
+++ b/charts/ome-resources/templates/model-agent-daemonset/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.modelAgent.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: "ome-model-agent-daemonset"
+{{- end }}

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -90,6 +90,10 @@ ome:
     scalingThreshold: "10"
     scalingOperator: "GreaterThanOrEqual"
 modelAgent:
+  # Deploy the model-agent DaemonSet (node-local model download/cache).
+  # Disable for installs whose runtimes fetch models themselves and that
+  # run InferenceServices without a BaseModel reference.
+  enabled: true
   hostPath: /mnt/data/models
   priorityClassName: system-node-critical
   serviceAccountName: ome-model-agent

--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -91,9 +91,9 @@ ome:
     scalingOperator: "GreaterThanOrEqual"
 modelAgent:
   # Deploy the model-agent DaemonSet (node-local model download/cache).
-  # Disable for installs whose runtimes fetch models themselves and that
-  # run InferenceServices without a BaseModel reference.
-  enabled: true
+  # Required for BaseModel/ClusterBaseModel-backed model resolution.
+  # Installs whose runtimes fetch models themselves can leave this off.
+  enabled: false
   hostPath: /mnt/data/models
   priorityClassName: system-node-critical
   serviceAccountName: ome-model-agent


### PR DESCRIPTION
## What

Adds `modelAgent.enabled` (default **`false`**) to the `ome-resources` chart, gating the entire `model-agent-daemonset/` template group (DaemonSet, ClusterRole, ClusterRoleBinding, ConfigMap, ServiceAccount).

## Why

The model-agent DaemonSet deployed unconditionally. The most common install profile is just InferenceService + ServingRuntime — the runtime image downloads its model itself and no BaseModel objects exist — and those clusters still got a `system-node-critical` DaemonSet on every node with nothing to do.

Model-agent is now opt-in: installs that use BaseModel/ClusterBaseModel-backed model resolution (node-local download/cache) set `modelAgent.enabled=true`.

> **Upgrade note:** installs relying on the model-agent DaemonSet must set `modelAgent.enabled=true` when upgrading — the default no longer deploys it.

The controller ConfigMap's use of `modelAgent.instanceTypeMap` (shared value source for the init-container instance map) is independent of the DaemonSet and intentionally not gated.

## Testing

- `helm lint charts/ome-resources`: pass.
- `helm template charts/ome-resources` (defaults): no model-agent resources rendered; everything else unchanged.
- `helm template charts/ome-resources --set modelAgent.enabled=true`: DaemonSet + RBAC render exactly as the pre-flag chart did.