### PR TITLE
[Bugfix] let InferenceService omit spec.model

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/utils/reconciliation.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/reconciliation.go
@@ -47,10 +47,13 @@ func GetFineTunedWeight(cl client.Client, name string) (*v1beta1.FineTunedWeight
 	return nil, goerrors.New("No FineTunedWeight with the name: " + name)
 }
 
-// ReconcileBaseModel retrieves and validates the base model for an InferenceService
+// ReconcileBaseModel retrieves and validates the base model for an
+// InferenceService. Returns (nil, nil, nil) when the ISVC has no model
+// reference — the lean path where the operator specifies the runtime
+// directly and skips model-parsing/auto-selection.
 func ReconcileBaseModel(cl client.Client, isvc *v1beta1.InferenceService) (*v1beta1.BaseModelSpec, *metav1.ObjectMeta, error) {
 	if isvc.Spec.Model == nil || isvc.Spec.Model.Name == "" {
-		return nil, nil, goerrors.New("model reference is required")
+		return nil, nil, nil
 	}
 
 	baseModel, baseModelMeta, err := GetBaseModel(cl, isvc.Spec.Model.Name, isvc.Namespace)

--- a/pkg/controller/v1beta1/inferenceservice/utils/reconciliation_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/reconciliation_test.go
@@ -149,3 +149,27 @@ func TestMergeRuntimeSpecs_SchedulerNamePrecedence(t *testing.T) {
 		assert.Equal(t, "custom-scheduler", engine.Worker.SchedulerName)
 	})
 }
+
+// TestReconcileBaseModel_LeanPath pins that an InferenceService without
+// a model reference resolves to no base model and no error — the lean
+// path where the operator names the runtime directly. A nil client
+// proves the path returns before any API access.
+func TestReconcileBaseModel_LeanPath(t *testing.T) {
+	t.Run("nil model", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{}
+		spec, meta, err := ReconcileBaseModel(nil, isvc)
+		require.NoError(t, err)
+		assert.Nil(t, spec)
+		assert.Nil(t, meta)
+	})
+
+	t.Run("empty model name", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{Model: &v1beta1.ModelRef{Name: ""}},
+		}
+		spec, meta, err := ReconcileBaseModel(nil, isvc)
+		require.NoError(t, err)
+		assert.Nil(t, spec)
+		assert.Nil(t, meta)
+	})
+}


### PR DESCRIPTION
## What

Fixes the last gap in the lean-InferenceService path: an ISVC with `spec.runtime` set and no `spec.model` passed admission (the webhook explicitly allows it: "at least one of spec.model or spec.runtime"), but then wedged in reconcile — `ReconcileBaseModel` returned `model reference is required` before the runtime-resolution step ever ran, so the service never got pods.

`ReconcileBaseModel` now returns `(nil, nil, nil)` when no model is referenced.

## Why it's safe

Every downstream consumer already handles a nil base model:
- explicit-runtime validation is guarded (`if baseModel != nil`) and documents the lean case;
- runtime auto-selection only runs `if baseModel != nil`;
- the no-model-no-runtime shape keeps its defensive `spec.runtime is required when spec.model is omitted` error (admission-bypass guard);
- component reconcilers and modelconfig skip model-derived wiring on nil.

This makes the model-less profile (runtime image fetches its own model — no BaseModel objects, and with #714, no model-agent DaemonSet) work end to end.

## Testing

- New `TestReconcileBaseModel_LeanPath`: nil model and empty model name both resolve to no base model, no error — with a nil client, proving the path returns before any API access.
- `go test ./pkg/controller/v1beta1/inferenceservice/...`: all pass.