### PR TITLE
[Bugfix] isvc status URLs honor urlScheme config

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -538,13 +538,22 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 func (r *InferenceServiceReconciler) handleVirtualDeployment(isvc *v1beta1.InferenceService) (ctrl.Result, error) {
 	// We directly set URL and inference service status to Ready in VirtualDeployment mode
 
+	// Honor the configured urlScheme rather than hardcoding http.
+	ingressConfig, err := controllerconfig.NewIngressConfig(r.Clientset)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Set URL across all Status components
 	host := network.GetServiceHostname(isvc.Name, isvc.Namespace)
-	openAIURL := knapis.HTTP(host)
+	openAIURL := &knapis.URL{
+		Host:   host,
+		Scheme: ingressConfig.UrlScheme,
+	}
 	addressURL := &duckv1.Addressable{
 		URL: &knapis.URL{
 			Host:   host,
-			Scheme: "http",
+			Scheme: ingressConfig.UrlScheme,
 		},
 	}
 	isvc.Status.URL = openAIURL
@@ -755,14 +764,15 @@ func (r *InferenceServiceReconciler) setExternalServiceURL(ctx context.Context, 
 	host := network.GetServiceHostname(externalService.Name, externalService.Namespace)
 	hostWithPort := fmt.Sprintf("%s:%d", host, port)
 
+	// Honor the configured urlScheme rather than hardcoding http.
 	isvc.Status.URL = &knapis.URL{
 		Host:   hostWithPort,
-		Scheme: "http",
+		Scheme: ingressConfig.UrlScheme,
 	}
 	isvc.Status.Address = &duckv1.Addressable{
 		URL: &knapis.URL{
 			Host:   hostWithPort,
-			Scheme: "http",
+			Scheme: ingressConfig.UrlScheme,
 		},
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -67,7 +67,9 @@ func createRawURL(clientset kubernetes.Interface, metadata metav1.ObjectMeta) (*
 	}
 	domainService := services.NewDomainService()
 	url := &knapis.URL{}
-	url.Scheme = "http"
+	// Honor the configured urlScheme rather than hardcoding http;
+	// NewIngressConfig defaults UrlScheme when unset, so this is never empty.
+	url.Scheme = ingressConfig.UrlScheme
 	url.Host, err = domainService.GenerateDomainName(metadata.Name, metadata, ingressConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler_test.go
@@ -1,0 +1,59 @@
+package raw
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
+)
+
+// ingressConfigMap builds the inferenceservice-config ConfigMap the ingress
+// config loader reads, with the given urlScheme (empty ⇒ omitted so the loader
+// applies its own default).
+func ingressConfigMap(urlScheme string) *corev1.ConfigMap {
+	ingress := `{"ingressGateway":"knative-serving/knative-ingress-gateway","ingressService":"istio-ingressgateway.istio-system.svc.cluster.local","ingressDomain":"example.com","domainTemplate":"{{.Name}}.{{.Namespace}}.{{.IngressDomain}}"`
+	if urlScheme != "" {
+		ingress += `,"urlScheme":"` + urlScheme + `"`
+	}
+	ingress += `}`
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.InferenceServiceConfigMapName,
+			Namespace: constants.OMENamespace,
+		},
+		Data: map[string]string{
+			controllerconfig.IngressConfigKeyName: ingress,
+		},
+	}
+}
+
+// TestCreateRawURL_HonorsUrlScheme guards that the raw
+// per-component status URL must carry the configured urlScheme, not a hardcoded
+// http.
+func TestCreateRawURL_HonorsUrlScheme(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		urlScheme  string
+		wantScheme string
+	}{
+		{name: "https is honored", urlScheme: "https", wantScheme: "https"},
+		{name: "http is honored", urlScheme: "http", wantScheme: "http"},
+		{name: "empty falls back to loader default", urlScheme: "", wantScheme: controllerconfig.DefaultUrlScheme},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(ingressConfigMap(tc.urlScheme))
+			meta := metav1.ObjectMeta{Name: "my-isvc", Namespace: "my-ns"}
+
+			url, err := createRawURL(clientset, meta)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantScheme, url.Scheme)
+			assert.Equal(t, "my-isvc.my-ns.example.com", url.Host)
+		})
+	}
+}


### PR DESCRIPTION
## What

Three status-URL construction sites hardcoded `http`, ignoring the `urlScheme` field already present in the ingress config (`IngressConfig.UrlScheme`, defaulted by the loader):

1. `handleVirtualDeployment` — `status.url` / `status.address` in VirtualDeployment mode;
2. `setExternalServiceURL` — external-service URL (the function already received the ingress config, then ignored its scheme);
3. `createRawURL` (raw reconciler) — per-component status URLs.

Clusters fronted by TLS ingress advertised `http://` endpoints in status. All three now use `ingressConfig.UrlScheme`.

## Behavior

- `urlScheme` unset: loader defaults apply (`http`) — rendered status is byte-identical to today.
- `urlScheme: https`: status URLs carry `https://`.

## Testing

- New `TestCreateRawURL_HonorsUrlScheme`: https honored, http honored, empty falls back to the loader default — built on the real config loader reading the `inferenceservice-config` ConfigMap.
- `go vet` + `go test ./pkg/controller/v1beta1/inferenceservice/...`: pass.