### PR TITLE
[Core] wire ServicePortAppProtocols into Services

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -40,7 +40,7 @@ func NewServiceReconciler(client client.Client,
 	return &ServiceReconciler{
 		client:       client,
 		scheme:       scheme,
-		Service:      buildService(componentMeta, podSpec, Selector),
+		Service:      buildService(componentMeta, componentExt, podSpec, Selector),
 		componentExt: componentExt,
 	}
 }
@@ -98,6 +98,7 @@ func buildServiceWithLoadBalancer(
 // that should not be applied to Services. These annotations are defined in component specs
 // (like engineConfig.annotations) for pod-level configurations but have no effect on Services.
 func buildService(componentMeta metav1.ObjectMeta,
+	componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec,
 	selector map[string]string,
 ) *corev1.Service {
@@ -106,7 +107,11 @@ func buildService(componentMeta metav1.ObjectMeta,
 	serviceMeta := componentMeta.DeepCopy()
 	serviceMeta.Annotations = utils.FilterPodOnlyAnnotations(componentMeta.Annotations)
 
-	servicePorts := buildServicePorts(podSpec)
+	var appProtocols map[string]string
+	if componentExt != nil {
+		appProtocols = componentExt.ServicePortAppProtocols
+	}
+	servicePorts := buildServicePorts(podSpec, appProtocols)
 	serviceType := determineServiceType(*serviceMeta)
 	if selector == nil {
 		selector = map[string]string{"app": constants.TruncateNameWithMaxLength(serviceMeta.Name, 63)}
@@ -116,31 +121,31 @@ func buildService(componentMeta metav1.ObjectMeta,
 }
 
 // buildServicePorts creates service ports configuration from pod spec
-func buildServicePorts(podSpec *corev1.PodSpec) []corev1.ServicePort {
+func buildServicePorts(podSpec *corev1.PodSpec, appProtocols map[string]string) []corev1.ServicePort {
 	if len(podSpec.Containers) == 0 {
 		return nil
 	}
 
 	container := podSpec.Containers[0]
 	if len(container.Ports) == 0 {
-		return []corev1.ServicePort{buildDefaultServicePort(container.Name)}
+		return []corev1.ServicePort{buildDefaultServicePort(container.Name, appProtocols[container.Name])}
 	}
 
 	servicePorts := make([]corev1.ServicePort, 0, len(container.Ports))
 	for _, port := range container.Ports {
-		servicePorts = append(servicePorts, buildServicePort(port))
+		servicePorts = append(servicePorts, buildServicePort(port, appProtocols[port.Name]))
 	}
 	return servicePorts
 }
 
 // buildServicePort creates a ServicePort from a ContainerPort
-func buildServicePort(containerPort corev1.ContainerPort) corev1.ServicePort {
+func buildServicePort(containerPort corev1.ContainerPort, appProtocol string) corev1.ServicePort {
 	protocol := containerPort.Protocol
 	if protocol == "" {
 		protocol = corev1.ProtocolTCP
 	}
 
-	return corev1.ServicePort{
+	servicePort := corev1.ServicePort{
 		Name: containerPort.Name,
 		Port: containerPort.ContainerPort,
 		TargetPort: intstr.IntOrString{
@@ -149,12 +154,16 @@ func buildServicePort(containerPort corev1.ContainerPort) corev1.ServicePort {
 		},
 		Protocol: protocol,
 	}
+	if appProtocol != "" {
+		servicePort.AppProtocol = &appProtocol
+	}
+	return servicePort
 }
 
 // buildDefaultServicePort creates a default ServicePort
-func buildDefaultServicePort(name string) corev1.ServicePort {
+func buildDefaultServicePort(name, appProtocol string) corev1.ServicePort {
 	port, _ := strconv.Atoi(constants.InferenceServiceDefaultHttpPort)
-	return corev1.ServicePort{
+	servicePort := corev1.ServicePort{
 		Name: name,
 		Port: constants.CommonISVCPort,
 		TargetPort: intstr.IntOrString{
@@ -163,6 +172,10 @@ func buildDefaultServicePort(name string) corev1.ServicePort {
 		},
 		Protocol: corev1.ProtocolTCP,
 	}
+	if appProtocol != "" {
+		servicePort.AppProtocol = &appProtocol
+	}
+	return servicePort
 }
 
 // Reconcile ensures the Service matches the desired state
@@ -218,11 +231,13 @@ func (r *ServiceReconciler) handleReconcileAction(checkResult constants.CheckRes
 		}
 		return r.Service, nil
 	case constants.CheckResultUpdate:
-		if err := r.client.Update(ctx, r.Service); err != nil {
+		existingService.Spec.Ports = r.Service.Spec.Ports
+		existingService.Spec.Selector = r.Service.Spec.Selector
+		if err := r.client.Update(ctx, existingService); err != nil {
 			log.Error(err, "Failed to update Service", "namespace", r.Service.Namespace, "name", r.Service.Name)
 			return nil, err
 		}
-		return r.Service, nil
+		return existingService, nil
 	default:
 		return existingService, nil
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
@@ -1,12 +1,17 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
 )
 
@@ -173,7 +178,7 @@ func TestBuildServiceFiltersAnnotations(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			service := buildService(scenario.componentMeta, podSpec, nil)
+			service := buildService(scenario.componentMeta, nil, podSpec, nil)
 
 			// Check that expected annotations are present
 			for key, expectedValue := range scenario.expectedAnnotations {
@@ -218,7 +223,7 @@ func TestBuildServicePreservesOtherMetadata(t *testing.T) {
 		}},
 	}
 
-	service := buildService(componentMeta, podSpec, nil)
+	service := buildService(componentMeta, nil, podSpec, nil)
 
 	// Name and Namespace should be preserved
 	if service.Name != "test-service" {
@@ -265,7 +270,7 @@ func TestBuildServiceWithNilAnnotations(t *testing.T) {
 	}
 
 	// Should not panic with nil annotations
-	service := buildService(componentMeta, podSpec, nil)
+	service := buildService(componentMeta, nil, podSpec, nil)
 
 	if service == nil {
 		t.Error("Expected service to be created, got nil")
@@ -288,12 +293,88 @@ func TestBuildServiceWithEmptyAnnotations(t *testing.T) {
 		}},
 	}
 
-	service := buildService(componentMeta, podSpec, nil)
+	service := buildService(componentMeta, nil, podSpec, nil)
 
 	if service == nil {
 		t.Fatal("Expected service to be created, got nil")
 	}
 	if len(service.Annotations) != 0 {
 		t.Errorf("Expected empty annotations, got %v", service.Annotations)
+	}
+}
+func TestBuildServiceSetsConfiguredPortAppProtocols(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name: "router",
+			Ports: []corev1.ContainerPort{
+				{Name: "http", ContainerPort: 8000},
+				{Name: "metrics", ContainerPort: 29000},
+			},
+		}},
+	}
+	componentExt := &v1beta1.ComponentExtensionSpec{
+		ServicePortAppProtocols: map[string]string{
+			"http": "kubernetes.io/h2c",
+		},
+	}
+
+	service := buildService(metav1.ObjectMeta{Name: "test-service"}, componentExt, podSpec, nil)
+
+	if got := service.Spec.Ports[0].AppProtocol; got == nil || *got != "kubernetes.io/h2c" {
+		t.Errorf("http appProtocol: got %v, want kubernetes.io/h2c", got)
+	}
+	if got := service.Spec.Ports[1].AppProtocol; got != nil {
+		t.Errorf("metrics appProtocol: got %q, want nil", *got)
+	}
+}
+
+func TestServiceReconcilerAddsAppProtocolToExistingService(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	existing := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-service", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Selector:  map[string]string{"app": "test-service"},
+			Ports: []corev1.ServicePort{{
+				Name: "http",
+				Port: 8000,
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	podSpec := &corev1.PodSpec{Containers: []corev1.Container{{
+		Name: "router",
+		Ports: []corev1.ContainerPort{{
+			Name:          "http",
+			ContainerPort: 8000,
+		}},
+	}}}
+	componentExt := &v1beta1.ComponentExtensionSpec{
+		ServicePortAppProtocols: map[string]string{"http": "kubernetes.io/h2c"},
+	}
+	reconciler := NewServiceReconciler(
+		c,
+		scheme,
+		metav1.ObjectMeta{Name: "test-service", Namespace: "default"},
+		componentExt,
+		podSpec,
+		nil,
+	)
+
+	if _, err := reconciler.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	got := &corev1.Service{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "test-service", Namespace: "default"}, got); err != nil {
+		t.Fatalf("get Service after reconcile: %v", err)
+	}
+	if got.Spec.ClusterIP != existing.Spec.ClusterIP {
+		t.Errorf("ClusterIP: got %q, want %q", got.Spec.ClusterIP, existing.Spec.ClusterIP)
+	}
+	if got.Spec.Ports[0].AppProtocol == nil || *got.Spec.Ports[0].AppProtocol != "kubernetes.io/h2c" {
+		t.Errorf("appProtocol: got %v, want kubernetes.io/h2c", got.Spec.Ports[0].AppProtocol)
 	}
 }

--- a/pkg/controller/v1beta1/inferenceservice/utils/merging_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/merging_test.go
@@ -621,3 +621,16 @@ func TestMergeSchedulerName(t *testing.T) {
 		MergeSchedulerName(runtimeWithScheduler(), nil, nil, nil)
 	})
 }
+
+func TestMergeEngineSpecPreservesRuntimeServicePortAppProtocols(t *testing.T) {
+	runtimeEngine := &v1beta1.EngineSpec{
+		ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+			ServicePortAppProtocols: map[string]string{"http": "kubernetes.io/h2c"},
+		},
+	}
+
+	merged, err := MergeEngineSpec(runtimeEngine, &v1beta1.EngineSpec{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, runtimeEngine.ServicePortAppProtocols, merged.ServicePortAppProtocols)
+}


### PR DESCRIPTION
## What

`ComponentExtensionSpec.ServicePortAppProtocols` exists in the API (and CRDs) but the Service reconciler never read it — generated Services always omitted `appProtocol`. Mesh and ingress implementations that key protocol handling off `appProtocol` (`kubernetes.io/h2c`, gRPC) fell back to protocol sniffing.

- `buildService` now receives the component extension spec and stamps `AppProtocol` onto service ports by port name — declared container ports and the synthesized default port both honor it; unlisted ports stay untouched.
- The service update path now writes ports/selector into the **live** Service object rather than blind-updating the built object, so cluster-assigned fields (ClusterIP and friends) survive the update. The new reconciler test pins exactly that: an existing Service gains the appProtocol while keeping its ClusterIP.

## Testing

- `TestBuildServiceSetsConfiguredPortAppProtocols`: configured port gets the protocol, unconfigured port stays nil.
- `TestServiceReconcilerAddsAppProtocolToExistingService`: update path adds appProtocol and preserves ClusterIP.
- `TestMergeEngineSpecPreservesRuntimeServicePortAppProtocols`: runtime-level config survives the engine merge.
- `go vet` + `go test ./pkg/controller/v1beta1/inferenceservice/...`: pass.