### PR TITLE
[Bugfix] webhook and pod-path panic guards

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/base.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base.go
@@ -434,11 +434,18 @@ func ProcessBaseAnnotations(b *BaseComponentFields, isvc *v1beta1.InferenceServi
 
 		// Add fine-tuned weight ft strategy
 		fineTunedWeightFTStrategy, err := isvcutils.GetValueFromRawExtension(b.FineTunedWeights[0].Spec.HyperParameters, constants.StrategyConfigKey)
-		if err != nil || fineTunedWeightFTStrategy == nil {
+		if err != nil {
 			b.Log.Error(err, "Error getting hyper-parameter strategy from FineTunedWeight", "FineTunedWeight", b.FineTunedWeights[0].Name, "namespace", isvc.Namespace)
 			return nil, err
 		}
-		annotations[constants.FineTunedWeightFTStrategyKey] = fineTunedWeightFTStrategy.(string)
+		if fineTunedWeightFTStrategy == nil {
+			return nil, fmt.Errorf("hyper-parameter %q not set on FineTunedWeight %s", constants.StrategyConfigKey, b.FineTunedWeights[0].Name)
+		}
+		strategy, ok := fineTunedWeightFTStrategy.(string)
+		if !ok {
+			return nil, fmt.Errorf("hyper-parameter %q on FineTunedWeight %s must be a string, got %T", constants.StrategyConfigKey, b.FineTunedWeights[0].Name, fineTunedWeightFTStrategy)
+		}
+		annotations[constants.FineTunedWeightFTStrategyKey] = strategy
 	}
 
 	if b.FineTunedServingWithMergedWeights {
@@ -523,7 +530,11 @@ func ProcessBaseLabels(b *BaseComponentFields, isvc *v1beta1.InferenceService, c
 
 		fineTunedWeightFTStrategy := ""
 		if ftStrategyParameter != nil {
-			fineTunedWeightFTStrategy = ftStrategyParameter.(string)
+			s, ok := ftStrategyParameter.(string)
+			if !ok {
+				return nil, fmt.Errorf("hyper-parameter %q on FineTunedWeight %s must be a string, got %T", constants.StrategyConfigKey, b.FineTunedWeights[0].Name, ftStrategyParameter)
+			}
+			fineTunedWeightFTStrategy = s
 		}
 		labels[constants.FineTunedWeightFTStrategyLabelKey] = fineTunedWeightFTStrategy
 

--- a/pkg/controller/v1beta1/inferenceservice/components/base_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/base_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
@@ -393,4 +394,92 @@ func TestMergeRuntimeArgumentsOverride(t *testing.T) {
 			g.Expect(container.Command).To(gomega.Equal(tt.expectedCommand))
 		})
 	}
+}
+
+// TestProcessBaseAnnotationsFTStrategy pins the fine-tuned strategy
+// annotation contract: a string strategy is stamped; an absent or
+// non-string strategy is a loud error (never a silent nil annotations
+// map, never a type-assertion panic).
+func TestProcessBaseAnnotationsFTStrategy(t *testing.T) {
+	mkFields := func(hyperParameters string) *BaseComponentFields {
+		return &BaseComponentFields{
+			FineTunedServing: true,
+			FineTunedWeights: []*v1beta1.FineTunedWeight{{
+				ObjectMeta: metav1.ObjectMeta{Name: "ftw-1"},
+				Spec: v1beta1.FineTunedWeightSpec{
+					HyperParameters: runtime.RawExtension{Raw: []byte(hyperParameters)},
+				},
+			}},
+			Log: logr.Discard(),
+		}
+	}
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-isvc", Namespace: "default"},
+	}
+
+	tests := []struct {
+		name            string
+		hyperParameters string
+		wantErr         bool
+		wantStrategy    string
+	}{
+		{
+			name:            "string strategy stamped",
+			hyperParameters: `{"strategy":"tfew"}`,
+			wantStrategy:    "tfew",
+		},
+		{
+			name:            "absent strategy is an error, not silent success",
+			hyperParameters: `{"other":"x"}`,
+			wantErr:         true,
+		},
+		{
+			name:            "non-string strategy is an error, not a panic",
+			hyperParameters: `{"strategy":42}`,
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			var annotations map[string]string
+			var err error
+			g.Expect(func() {
+				annotations, err = ProcessBaseAnnotations(mkFields(tt.hyperParameters), isvc, map[string]string{})
+			}).NotTo(gomega.Panic())
+			if tt.wantErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(annotations).To(gomega.BeNil())
+			} else {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(annotations).To(gomega.HaveKeyWithValue(constants.FineTunedWeightFTStrategyKey, tt.wantStrategy))
+			}
+		})
+	}
+}
+
+// TestProcessBaseLabelsNonStringStrategy verifies a non-string strategy
+// hyper-parameter is a returned error rather than a reconcile panic.
+func TestProcessBaseLabelsNonStringStrategy(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	b := &BaseComponentFields{
+		FineTunedServing: true,
+		FineTunedWeights: []*v1beta1.FineTunedWeight{{
+			ObjectMeta: metav1.ObjectMeta{Name: "ftw-1"},
+			Spec: v1beta1.FineTunedWeightSpec{
+				HyperParameters: runtime.RawExtension{Raw: []byte(`{"strategy":{"nested":true}}`)},
+			},
+		}},
+		Log: logr.Discard(),
+	}
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-isvc", Namespace: "default"},
+	}
+
+	var err error
+	g.Expect(func() {
+		_, err = ProcessBaseLabels(b, isvc, v1beta1.EngineComponent, nil)
+	}).NotTo(gomega.Panic())
+	g.Expect(err).To(gomega.HaveOccurred())
 }

--- a/pkg/webhook/admission/pod/mutator.go
+++ b/pkg/webhook/admission/pod/mutator.go
@@ -44,7 +44,7 @@ func (mutator *Mutator) Handle(ctx context.Context, req admission.Request) admis
 
 	log.Info("mutating pod", "name", podName)
 
-	configMap, err := mutator.Clientset.CoreV1().ConfigMaps(constants.OMENamespace).Get(context.TODO(),
+	configMap, err := mutator.Clientset.CoreV1().ConfigMaps(constants.OMENamespace).Get(ctx,
 		constants.InferenceServiceConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		log.Error(err, "Failed to find config map", "name", constants.InferenceServiceConfigMapName)

--- a/pkg/webhook/admission/pod/rdma_injector.go
+++ b/pkg/webhook/admission/pod/rdma_injector.go
@@ -173,8 +173,17 @@ func (ri *RDMAInjector) injectContainerConfig(container *v1.Container, profile R
 	// Sort keys for stable ordering
 	sort.Strings(keys)
 
-	// Add environment variables in sorted order
+	// Add environment variables in sorted order. Existing env vars are
+	// authoritative: skip profile entries already present so operator
+	// overrides survive and webhook reinvocation doesn't stack duplicates.
+	existingEnv := make(map[string]struct{}, len(container.Env))
+	for _, env := range container.Env {
+		existingEnv[env.Name] = struct{}{}
+	}
 	for _, name := range keys {
+		if _, ok := existingEnv[name]; ok {
+			continue
+		}
 		container.Env = append(container.Env, v1.EnvVar{
 			Name:  name,
 			Value: profile.EnvVars[name],
@@ -186,6 +195,11 @@ func (ri *RDMAInjector) injectContainerConfig(container *v1.Container, profile R
 		if !ri.volumeMountExists(container, mount.Name) {
 			container.VolumeMounts = append(container.VolumeMounts, mount)
 		}
+	}
+
+	// Profiles without a securityContext leave the container's untouched.
+	if profile.SecurityContext == nil {
+		return
 	}
 
 	// Set security context if not already set

--- a/pkg/webhook/admission/pod/rdma_injector_test.go
+++ b/pkg/webhook/admission/pod/rdma_injector_test.go
@@ -827,3 +827,66 @@ func getExpectedEnvVars() []v1.EnvVar {
 	}
 	return envVars
 }
+
+// TestRDMAInjector_injectContainerConfig_NilProfileSecurityContext verifies
+// that a profile without a securityContext does not panic or alter the
+// container's existing security context.
+func TestRDMAInjector_injectContainerConfig_NilProfileSecurityContext(t *testing.T) {
+	injector := NewRDMAInjector()
+	profile := RDMAProfile{EnvVars: map[string]string{"NCCL_DEBUG": "INFO"}}
+
+	tests := []struct {
+		name            string
+		securityContext *v1.SecurityContext
+	}{
+		{name: "container_without_security_context", securityContext: nil},
+		{name: "container_with_nil_capabilities", securityContext: &v1.SecurityContext{}},
+		{
+			name: "container_with_capabilities",
+			securityContext: &v1.SecurityContext{
+				Capabilities: &v1.Capabilities{Add: []v1.Capability{"IPC_LOCK"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			container := &v1.Container{
+				Name:            "ome-container",
+				SecurityContext: tt.securityContext.DeepCopy(),
+			}
+			assert.NotPanics(t, func() {
+				injector.injectContainerConfig(container, profile)
+			})
+			assert.Equal(t, tt.securityContext, container.SecurityContext,
+				"a profile without a securityContext must not change the container's")
+		})
+	}
+}
+
+// TestRDMAInjector_injectContainerConfig_EnvDedup verifies that env vars
+// already present on the container win over profile values and that
+// re-running the injector (webhook reinvocation) does not stack duplicates.
+func TestRDMAInjector_injectContainerConfig_EnvDedup(t *testing.T) {
+	injector := NewRDMAInjector()
+	profile := RDMAProfiles["oci-roce"]
+
+	container := &v1.Container{
+		Name: "ome-container",
+		Env:  []v1.EnvVar{{Name: "NCCL_DEBUG", Value: "WARN"}},
+	}
+
+	injector.injectContainerConfig(container, profile)
+	injector.injectContainerConfig(container, profile)
+
+	assert.Len(t, container.Env, len(profile.EnvVars),
+		"each env name must appear exactly once after repeated injection")
+	count := 0
+	for _, env := range container.Env {
+		if env.Name == "NCCL_DEBUG" {
+			count++
+			assert.Equal(t, "WARN", env.Value, "pre-existing env value must be preserved")
+		}
+	}
+	assert.Equal(t, 1, count, "NCCL_DEBUG must not be duplicated")
+}

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
@@ -74,15 +74,16 @@ func (sr *ServingRuntimeValidator) Handle(ctx context.Context, req admission.Req
 		return admission.Denied(err.Error())
 	}
 
+	// Spec-only checks run outside the loop so they still apply when the
+	// namespace has no other runtimes.
+	if err := validateModelFormatPrioritySame(&servingRuntime.Spec); err != nil {
+		return admission.Denied(fmt.Sprintf(PriorityIsNotSameServingRuntimeError, err.Error(), servingRuntime.Name))
+	}
+	if err := validateServingRuntimeAnnotations(&servingRuntime.Spec); err != nil {
+		return admission.Denied(ChainsawInjectAnnotationNotAllowError)
+	}
+
 	for i := range ExistingRuntimes.Items {
-		if err := validateModelFormatPrioritySame(&servingRuntime.Spec); err != nil {
-			return admission.Denied(fmt.Sprintf(PriorityIsNotSameServingRuntimeError, err.Error(), servingRuntime.Name))
-		}
-
-		if err := validateServingRuntimeAnnotations(&servingRuntime.Spec); err != nil {
-			return admission.Denied(ChainsawInjectAnnotationNotAllowError)
-		}
-
 		if err := validateServingRuntimePriority(&servingRuntime.Spec, &ExistingRuntimes.Items[i].Spec, servingRuntime.Name, ExistingRuntimes.Items[i].Name); err != nil {
 			return admission.Denied(fmt.Sprintf(InvalidPriorityServingRuntimeError, err.Error(), ExistingRuntimes.Items[i].Name, servingRuntime.Name, servingRuntime.Namespace))
 		}
@@ -120,15 +121,16 @@ func (csr *ClusterServingRuntimeValidator) Handle(ctx context.Context, req admis
 		return admission.Denied(err.Error())
 	}
 
+	// Spec-only checks run outside the loop so they still apply when no
+	// other ClusterServingRuntimes exist.
+	if err := validateModelFormatPrioritySame(&clusterServingRuntime.Spec); err != nil {
+		return admission.Denied(fmt.Sprintf(PriorityIsNotSameClusterServingRuntimeError, err.Error(), clusterServingRuntime.Name))
+	}
+	if err := validateServingRuntimeAnnotations(&clusterServingRuntime.Spec); err != nil {
+		return admission.Denied(ChainsawInjectAnnotationNotAllowError)
+	}
+
 	for i := range ExistingRuntimes.Items {
-		if err := validateModelFormatPrioritySame(&clusterServingRuntime.Spec); err != nil {
-			return admission.Denied(fmt.Sprintf(PriorityIsNotSameClusterServingRuntimeError, err.Error(), clusterServingRuntime.Name))
-		}
-
-		if err := validateServingRuntimeAnnotations(&clusterServingRuntime.Spec); err != nil {
-			return admission.Denied(ChainsawInjectAnnotationNotAllowError)
-		}
-
 		if err := validateServingRuntimePriority(&clusterServingRuntime.Spec, &ExistingRuntimes.Items[i].Spec, clusterServingRuntime.Name, ExistingRuntimes.Items[i].Name); err != nil {
 			return admission.Denied(fmt.Sprintf(InvalidPriorityClusterServingRuntimeError, err.Error(), ExistingRuntimes.Items[i].Name, clusterServingRuntime.Name))
 		}

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook_test.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook_test.go
@@ -2,16 +2,19 @@ package servingruntime
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
@@ -2198,4 +2201,76 @@ func TestValidateAcceleratorClasses(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidator_SpecOnlyChecksRunWithNoExistingRuntimes verifies that
+// the spec-only model-format priority check is enforced even when no
+// other runtime exists (the check used to live inside the loop over
+// existing runtimes, so the first runtime admitted escaped it).
+func TestValidator_SpecOnlyChecksRunWithNoExistingRuntimes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	decoder := admission.NewDecoder(scheme)
+
+	// Same auto-selected format name at two different priorities —
+	// invalid per validateModelFormatPrioritySame.
+	spec := v1beta1.ServingRuntimeSpec{
+		SupportedModelFormats: []v1beta1.SupportedModelFormat{
+			{Name: "safetensors", AutoSelect: proto.Bool(true), Priority: proto.Int32(1)},
+			{Name: "safetensors", AutoSelect: proto.Bool(true), Priority: proto.Int32(2)},
+		},
+		ServingRuntimePodSpec: v1beta1.ServingRuntimePodSpec{
+			Containers: []corev1.Container{{Name: "ome-container"}},
+		},
+	}
+
+	t.Run("clusterservingruntime", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		csr := &v1beta1.ClusterServingRuntime{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "ome.io/v1beta1", Kind: "ClusterServingRuntime"},
+			ObjectMeta: metav1.ObjectMeta{Name: "rt-solo"},
+			Spec:       spec,
+		}
+		raw, err := json.Marshal(csr)
+		g.Expect(err).To(gomega.BeNil())
+
+		validator := &ClusterServingRuntimeValidator{
+			Client:  fake.NewClientBuilder().WithScheme(scheme).Build(),
+			Decoder: decoder,
+		}
+		resp := validator.Handle(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: raw},
+		}})
+
+		g.Expect(resp.Allowed).To(gomega.BeFalse(),
+			"conflicting per-format priorities must be rejected even with no existing CSRs")
+		g.Expect(resp.Result.Message).To(gomega.ContainSubstring("safetensors"))
+	})
+
+	t.Run("servingruntime", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		sr := &v1beta1.ServingRuntime{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "ome.io/v1beta1", Kind: "ServingRuntime"},
+			ObjectMeta: metav1.ObjectMeta{Name: "rt-solo", Namespace: "test"},
+			Spec:       spec,
+		}
+		raw, err := json.Marshal(sr)
+		g.Expect(err).To(gomega.BeNil())
+
+		validator := &ServingRuntimeValidator{
+			Client:  fake.NewClientBuilder().WithScheme(scheme).Build(),
+			Decoder: decoder,
+		}
+		resp := validator.Handle(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: raw},
+		}})
+
+		g.Expect(resp.Allowed).To(gomega.BeFalse(),
+			"conflicting per-format priorities must be rejected even with no existing SRs in the namespace")
+		g.Expect(resp.Result.Message).To(gomega.ContainSubstring("safetensors"))
+	})
 }


### PR DESCRIPTION
## What

Hardens four admission/pod-construction paths that could panic or silently misbehave:

**components (`base.go`)** — the fine-tuned strategy hyper-parameter was read with unchecked `.(string)` type assertions in both the annotations and labels paths. A FineTunedWeight whose `strategy` hyper-parameter is a number, object, or absent panicked the reconcile goroutine. Both paths now return descriptive errors.

**RDMA injector** — two fixes:
- Env injection appended profile values unconditionally: webhook reinvocation stacked duplicates, and operator-set values were shadowed. Existing container env is authoritative now — profile entries already present are skipped.
- The security-context merge dereferenced `profile.SecurityContext` without a nil check; a profile with no securityContext panicked when the container already had one. Such profiles now leave the container's context untouched.

**ServingRuntime / ClusterServingRuntime webhook** — the spec-only checks (`validateModelFormatPrioritySame`, annotation denylist) ran *inside* the loop over existing runtimes, so the **first** runtime admitted in a namespace (or the first CSR in the cluster) escaped both checks. Hoisted above the loop; the pairwise priority check stays inside.

**Pod mutator** — the ConfigMap read used `context.TODO()` instead of the handler's context.

## Testing

- `TestProcessBaseAnnotationsFTStrategy` / `TestProcessBaseLabelsNonStringStrategy`: string stamped; absent/non-string strategy is an error, never a panic.
- `TestRDMAInjector_injectContainerConfig_EnvDedup`: repeated injection yields each env exactly once, operator value preserved.
- `TestRDMAInjector_injectContainerConfig_NilProfileSecurityContext`: no panic, container context untouched.
- `TestValidator_SpecOnlyChecksRunWithNoExistingRuntimes`: conflicting per-format priorities rejected with zero existing runtimes, for both SR and CSR.
- Full `pkg/webhook/...` + components suites pass.