### PR TITLE
[CI/Tests] ignore KEDA minor bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,11 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "sigs.k8s.io/*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # KEDA tracks the k8s minor: its controller-runtime floor moves with
+      # each minor, so standalone bumps resolve an incompatible module graph.
+      # KEDA minors ride the k8s matrix migration instead.
+      - dependency-name: "github.com/kedacore/keda/v2"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   # Tools Go module
   - package-ecosystem: "gomod"


### PR DESCRIPTION
## What

Adds `github.com/kedacore/keda/v2` to dependabot's semver-major/minor ignore list, matching the existing `k8s.io/*` / `sigs.k8s.io/*` pattern. Patch updates stay enabled.

## Why

KEDA tracks the Kubernetes minor: each KEDA minor raises its controller-runtime floor, so a standalone KEDA bump resolves a module graph where controller-runtime and client-go are mutually incompatible. #708 (KEDA 2.12 → 2.20) fails Lint/Drift/Test for exactly this reason and cannot pass without a coordinated k8s dependency-matrix migration — no patch to that branch fixes it.

KEDA minors ride the future k8s matrix migration (controller-runtime + client-go + api machinery moved together); until then this stops dependabot from re-opening doomed KEDA bumps.

After merging, #708 gets `@dependabot ignore this minor version` to close it.