### PR TITLE
[Core] traffic-policy engine for spec.traffic

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -43,6 +43,8 @@ import (
 	v1beta1benchmarkjobcontroller "sigs.k8s.io/ome/pkg/controller/v1beta1/benchmark"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
 	v1beta1isvccontroller "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic"
+	trafficfactory "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/factory"
 	v1beta1runtimerevisioncontroller "sigs.k8s.io/ome/pkg/controller/v1beta1/runtimerevision"
 	"sigs.k8s.io/ome/pkg/runtimeselector"
 	"sigs.k8s.io/ome/pkg/utils"
@@ -256,16 +258,31 @@ func main() {
 	}
 
 	// Setup Event Broadcaster
+	// Select the active traffic translator based on
+	// installed backend-policy CRDs (Envoy Gateway BackendTrafficPolicy,
+	// Istio DestinationRule, else Noop). The selection is process-
+	// level — the translator stays stable for the controller's
+	// lifetime — so we build it once at startup.
+	setupLog.Info("Selecting traffic translator")
+	trafficTranslator, err := trafficfactory.New(cfg)
+	if err != nil {
+		setupLog.Error(err, "Failed to select traffic translator")
+		os.Exit(1)
+	}
+	setupLog.Info("Selected traffic translator", "translator", trafficTranslator.Name())
+	trafficReconciler := traffic.NewReconciler(mgr.GetClient(), mgr.GetScheme(), trafficTranslator)
+
 	setupLog.Info("Configuring event broadcaster")
 	eventBroadcaster := record.NewBroadcaster()
 	setupLog.Info("Setting up InferenceService controller")
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
 	if err = (&v1beta1isvccontroller.InferenceServiceReconciler{
-		Client:    mgr.GetClient(),
-		Clientset: clientSet,
-		Log:       ctrl.Log.WithName("InferenceService"),
-		Scheme:    mgr.GetScheme(),
-		Recorder:  eventBroadcaster.NewRecorder(mgr.GetScheme(), v1.EventSource{Component: "v1beta1Controllers"}),
+		Client:            mgr.GetClient(),
+		Clientset:         clientSet,
+		Log:               ctrl.Log.WithName("InferenceService"),
+		Scheme:            mgr.GetScheme(),
+		Recorder:          eventBroadcaster.NewRecorder(mgr.GetScheme(), v1.EventSource{Component: "v1beta1Controllers"}),
+		TrafficReconciler: trafficReconciler,
 	}).SetupWithManager(mgr, deployConfig, ingressConfig); err != nil {
 		setupLog.Error(err, "Failed to create InferenceService controller")
 		os.Exit(1)

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/external_service"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress"
 	multimodelconfig "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/modelconfig"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/status"
 	isvcutils "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils"
 	"sigs.k8s.io/ome/pkg/runtimeselector"
@@ -117,6 +118,11 @@ type InferenceServiceReconciler struct {
 	StatusManager            *status.StatusReconciler
 	RuntimeSelector          runtimeselector.Selector
 	AcceleratorClassSelector acceleratorclassselector.Selector
+	// TrafficReconciler is the backend-policy reconciler.
+	// Built from the active translator at controller startup; the
+	// active translator is selected by traffic/factory.New based on
+	// installed Gateway-implementation CRDs.
+	TrafficReconciler *traffic.Reconciler
 }
 
 func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -482,6 +488,30 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	r.Log.Info("Reconciling external service for inference service", "isvc", isvc.Name)
 	if err := externalServiceReconciler.Reconcile(ctx, isvc); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "fails to reconcile external service")
+	}
+
+	// Traffic management reconciler. Skipped when the InferenceService
+	// declares no traffic intent (spec.traffic or ome.io/* annotation).
+	// The reconciler invokes the active translator (chosen at startup
+	// by the factory), applies the emitted backend policy resource,
+	// and returns the TrafficStatus to write back. A nil reconciler
+	// means the controller was set up without traffic management
+	// (legitimate for tests / minimal configurations).
+	if r.TrafficReconciler != nil {
+		targetRoutes := traffic.ComputeTargetHTTPRoutes(isvc, mergedDecoder != nil, mergedRouter != nil)
+		trafficStatus, err := r.TrafficReconciler.Reconcile(ctx, isvc, targetRoutes)
+		if err != nil {
+			r.Log.Error(err, "Failed to reconcile traffic policy",
+				"namespace", isvc.Namespace, "inferenceService", isvc.Name,
+				"translator", r.TrafficReconciler.TranslatorName())
+			r.Recorder.Event(isvc, v1.EventTypeWarning, "TrafficReconcileError", err.Error())
+			// Surface the status even on error so operators see the
+			// TranslationFailed reason without waiting for the next
+			// successful reconcile.
+			isvc.Status.Traffic = trafficStatus
+			return reconcile.Result{}, errors.Wrapf(err, "fails to reconcile traffic policy")
+		}
+		isvc.Status.Traffic = trafficStatus
 	}
 
 	// Set Status.Address for external service and add ingress disable annotation when ingress is disabled

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/factory/factory.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/factory/factory.go
@@ -1,0 +1,93 @@
+// Package factory selects the active traffic translator at controller
+// startup.
+//
+// Exactly one Translator is active per controller process. The
+// selection rules (highest priority wins):
+//
+//  1. Envoy Gateway — gateway.envoyproxy.io/v1alpha1.BackendTrafficPolicy
+//     CRD is installed in the cluster.
+//  2. Istio — networking.istio.io/v1.DestinationRule CRD is installed.
+//  3. Noop — fallback when no supported policy CRD is available.
+//
+// Order is meaningful: Envoy Gateway BackendTrafficPolicy is the most
+// expressive supported back end, so we prefer it whenever it's present.
+// Operators on clusters that ship both Envoy Gateway and Istio (rare,
+// but legal) get Envoy Gateway behavior. The factory does not honor
+// runtime overrides — translator selection is a process-level decision,
+// not a per-ISVC one, to keep the produced policy resource type stable
+// across reconciles.
+//
+// Both the Envoy Gateway translator (BackendTrafficPolicy) and the
+// Istio translator (DestinationRule) build their resources as
+// unstructured.Unstructured to avoid vendoring the gateway.envoyproxy.io
+// and Istio Go modules.
+package factory
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/envoygateway"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/istio"
+	"sigs.k8s.io/ome/pkg/utils"
+)
+
+// Well-known GroupVersionKinds for backend-policy CRDs. Listed in
+// translator-priority order — the factory probes each in turn and
+// picks the first match.
+var (
+	envoyGatewayBackendTrafficPolicyGVK = schema.GroupVersionKind{
+		Group:   "gateway.envoyproxy.io",
+		Version: "v1alpha1",
+		Kind:    "BackendTrafficPolicy",
+	}
+	istioDestinationRuleGVK = schema.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1",
+		Kind:    "DestinationRule",
+	}
+)
+
+// crdProbe abstracts utils.IsCrdAvailable for test injection. The
+// signature mirrors IsCrdAvailable exactly so the production wiring is
+// a one-liner.
+type crdProbe func(cfg *rest.Config, groupVersion, kind string) (bool, error)
+
+// New returns the Translator selected for the cluster reachable via
+// cfg. It probes the well-known backend-policy CRDs in priority order
+// and returns the highest-priority match. Falls back to the Noop
+// translator when no probe succeeds.
+//
+// An error is returned only when a CRD probe itself fails (e.g.
+// network error talking to the API server). A clean "CRD not present"
+// answer is not an error; it advances to the next probe.
+func New(cfg *rest.Config) (traffic.Translator, error) {
+	return newWithProbe(cfg, utils.IsCrdAvailable)
+}
+
+func newWithProbe(cfg *rest.Config, probe crdProbe) (traffic.Translator, error) {
+	// 1. Envoy Gateway BackendTrafficPolicy (preferred).
+	found, err := probe(cfg, envoyGatewayBackendTrafficPolicyGVK.GroupVersion().String(), envoyGatewayBackendTrafficPolicyGVK.Kind)
+	if err != nil {
+		return nil, fmt.Errorf("probe %s: %w", envoyGatewayBackendTrafficPolicyGVK.String(), err)
+	}
+	if found {
+		return envoygateway.New(), nil
+	}
+
+	// 2. Istio DestinationRule.
+	found, err = probe(cfg, istioDestinationRuleGVK.GroupVersion().String(), istioDestinationRuleGVK.Kind)
+	if err != nil {
+		return nil, fmt.Errorf("probe %s: %w", istioDestinationRuleGVK.String(), err)
+	}
+	if found {
+		return istio.New(), nil
+	}
+
+	// 3. Noop fallback.
+	return translators.NewNoop(), nil
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/factory/factory_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/factory/factory_test.go
@@ -1,0 +1,136 @@
+package factory
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/envoygateway"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/istio"
+)
+
+// fakeProbe returns the next value from results on each call, recording
+// the (groupVersion, kind) it was queried with. Useful for asserting
+// probe ordering as well as outcome.
+type fakeProbe struct {
+	calls   []probeCall
+	results []probeResult
+}
+
+type probeCall struct {
+	groupVersion string
+	kind         string
+}
+
+type probeResult struct {
+	found bool
+	err   error
+}
+
+func (f *fakeProbe) probe(_ *rest.Config, groupVersion, kind string) (bool, error) {
+	f.calls = append(f.calls, probeCall{groupVersion: groupVersion, kind: kind})
+	if len(f.results) == 0 {
+		return false, nil
+	}
+	r := f.results[0]
+	f.results = f.results[1:]
+	return r.found, r.err
+}
+
+func TestNew_NoBackendPolicyCRD_ReturnsNoop(t *testing.T) {
+	// No backend-policy CRDs installed — both probes return (false, nil).
+	f := &fakeProbe{results: []probeResult{
+		{found: false},
+		{found: false},
+	}}
+	got, err := newWithProbe(&rest.Config{}, f.probe)
+	if err != nil {
+		t.Fatalf("newWithProbe err = %v, want nil", err)
+	}
+	if got.Name() != translators.NoopName {
+		t.Fatalf("Name() = %q, want %q", got.Name(), translators.NoopName)
+	}
+	// Both probes must have been attempted in priority order.
+	if len(f.calls) != 2 {
+		t.Fatalf("expected 2 probes, got %d: %#v", len(f.calls), f.calls)
+	}
+	if f.calls[0].kind != "BackendTrafficPolicy" {
+		t.Fatalf("expected first probe BackendTrafficPolicy, got %q", f.calls[0].kind)
+	}
+	if f.calls[1].kind != "DestinationRule" {
+		t.Fatalf("expected second probe DestinationRule, got %q", f.calls[1].kind)
+	}
+}
+
+func TestNew_EnvoyGatewayDetected_SelectsEnvoyTranslator(t *testing.T) {
+	// First probe hits — the factory must stop and not also probe Istio,
+	// and it must return the Envoy Gateway translator (not Noop).
+	f := &fakeProbe{results: []probeResult{
+		{found: true},
+	}}
+	got, err := newWithProbe(&rest.Config{}, f.probe)
+	if err != nil {
+		t.Fatalf("newWithProbe err = %v, want nil", err)
+	}
+	if got.Name() != envoygateway.Name {
+		t.Fatalf("Name() = %q, want %q", got.Name(), envoygateway.Name)
+	}
+	if len(f.calls) != 1 {
+		t.Fatalf("expected exactly 1 probe (short-circuit), got %d: %#v", len(f.calls), f.calls)
+	}
+}
+
+func TestNew_IstioDetected_SelectsIstioTranslator(t *testing.T) {
+	// Envoy Gateway absent, Istio present.
+	f := &fakeProbe{results: []probeResult{
+		{found: false},
+		{found: true},
+	}}
+	got, err := newWithProbe(&rest.Config{}, f.probe)
+	if err != nil {
+		t.Fatalf("newWithProbe err = %v, want nil", err)
+	}
+	if got.Name() != istio.Name {
+		t.Fatalf("Name() = %q, want %q", got.Name(), istio.Name)
+	}
+	if len(f.calls) != 2 {
+		t.Fatalf("expected 2 probes, got %d: %#v", len(f.calls), f.calls)
+	}
+}
+
+func TestNew_ProbeError_PropagatedWithGVKContext(t *testing.T) {
+	sentinel := errors.New("simulated discovery failure")
+	f := &fakeProbe{results: []probeResult{
+		{err: sentinel},
+	}}
+	_, err := newWithProbe(&rest.Config{}, f.probe)
+	if err == nil {
+		t.Fatalf("newWithProbe err = nil, want error")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("newWithProbe err = %v, want wraps %v", err, sentinel)
+	}
+}
+
+func TestNew_PrefersEnvoyOverIstioWhenBothPresent(t *testing.T) {
+	// Both CRDs installed (rare but legal). Envoy Gateway must win
+	// because of priority order, so Istio must NOT be probed.
+	f := &fakeProbe{results: []probeResult{
+		{found: true},
+		// Second result is intentionally not consumed — if the factory
+		// keeps probing, the test will fail on call count below.
+		{found: true},
+	}}
+	got, err := newWithProbe(&rest.Config{}, f.probe)
+	if err != nil {
+		t.Fatalf("newWithProbe err = %v, want nil", err)
+	}
+	if got.Name() != envoygateway.Name {
+		t.Fatalf("Name() = %q, want %q (Envoy must win over Istio)", got.Name(), envoygateway.Name)
+	}
+	if len(f.calls) != 1 {
+		t.Fatalf("expected exactly 1 probe (Envoy short-circuits Istio), got %d", len(f.calls))
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/intent.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/intent.go
@@ -1,0 +1,271 @@
+// Package traffic translates an InferenceService's traffic policy into
+// gateway-specific routing resources.
+//
+// The translator reads the operator's intent (TrafficSpec typed core +
+// ome.io/* annotation extension) from an InferenceService, resolves it
+// into a ResolvedIntent struct, and hands that to a per-Gateway-
+// implementation translator. The translator emits one backend policy
+// resource (e.g. Envoy Gateway BackendTrafficPolicy) targeting every
+// OME-managed HTTPRoute for the ISVC.
+//
+// This file defines the resolved-intent data model and the resolve
+// function. The Translator interface lives in interfaces/translator.go.
+// Translator implementations live under translators/.
+package traffic
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// ResolvedIntent is the per-ISVC traffic-management intent after
+// merging the typed core (spec.traffic.*) and the ome.io/* annotation
+// extension. Translators receive a ResolvedIntent and decide how to
+// represent it in their implementation's policy CRD.
+//
+// An intent is "empty" (HasIntent() == false) when the operator has
+// not declared any traffic-management knobs on the InferenceService.
+// In that case the reconciler skips translation entirely — no backend
+// policy resource is emitted.
+type ResolvedIntent struct {
+	// Traffic is the typed core from spec.traffic. Nil when unset.
+	// Note: this is a pointer to the live TrafficSpec on the ISVC;
+	// translators must treat it as read-only.
+	Traffic *v1beta1.TrafficSpec
+
+	// CircuitBreaker holds the resolved circuit-breaker knobs from
+	// the ome.io/circuit-breaker-* annotation extension. Nil when
+	// none are set.
+	CircuitBreaker *CircuitBreakerIntent
+
+	// Retry holds the resolved retry knobs from ome.io/retry-*.
+	// Nil when none are set.
+	Retry *RetryIntent
+
+	// Timeout holds the resolved sub-second / connection timeouts
+	// from ome.io/timeout-*. The request-level timeout stays on
+	// the per-Component ComponentExtensionSpec.TimeoutSeconds and is
+	// applied by the HTTPRoute builder, not by the translator. Nil
+	// when no annotations are set.
+	Timeout *TimeoutIntent
+
+	// PassthroughEnvoyGateway is the set of raw
+	// ome.io/btp.<path>=<value> annotations, with the prefix
+	// stripped. The Envoy Gateway translator stitches these
+	// verbatim into the emitted BackendTrafficPolicy. Other
+	// translators surface them as UnsupportedField.
+	//
+	// Map key is the dotted path (e.g. "loadBalancer.slowStart.window")
+	// and value is the raw annotation value (e.g. "30s"). Always
+	// non-nil but possibly empty.
+	PassthroughEnvoyGateway map[string]string
+
+	// PassthroughIstio is the equivalent for ome.io/dr.<path>.
+	// Always non-nil but possibly empty.
+	PassthroughIstio map[string]string
+}
+
+// CircuitBreakerIntent holds resolved circuit-breaker values. Each
+// field is a pointer so the translator can distinguish "operator
+// asked for this value" from "operator did not set this knob".
+type CircuitBreakerIntent struct {
+	MaxConnections            *int32
+	MaxParallelRequests       *int32
+	MaxPendingRequests        *int32
+	MaxParallelRetries        *int32
+	PerEndpointMaxConnections *int32
+}
+
+// RetryIntent holds resolved retry-related values. RetryOn is the
+// parsed (and validated, by the webhook) list of retry-condition
+// tokens.
+type RetryIntent struct {
+	Attempts      *int32
+	RetryOn       []string
+	PerTryTimeout *time.Duration
+}
+
+// TimeoutIntent holds resolved non-request-level timeout values.
+type TimeoutIntent struct {
+	Idle                  *time.Duration
+	MaxConnectionDuration *time.Duration
+	TCPConnect            *time.Duration
+}
+
+// HasIntent reports whether the operator has declared any
+// traffic-management intent on the ISVC. Translators should not be
+// invoked when this returns false — the reconciler skips emission
+// entirely in that case (the per-mode reconciler may still populate
+// status.components[*].traffic[] for rollouts, but that's HTTPRoute-
+// builder territory, not translator territory).
+func (r *ResolvedIntent) HasIntent() bool {
+	if r == nil {
+		return false
+	}
+	if r.Traffic != nil && (r.Traffic.Algorithm != nil ||
+		r.Traffic.ConsistentHash != nil ||
+		r.Traffic.EndpointOverride != nil) {
+		return true
+	}
+	if r.CircuitBreaker != nil {
+		return true
+	}
+	if r.Retry != nil {
+		return true
+	}
+	if r.Timeout != nil {
+		return true
+	}
+	if len(r.PassthroughEnvoyGateway) > 0 || len(r.PassthroughIstio) > 0 {
+		return true
+	}
+	return false
+}
+
+// Resolve produces a ResolvedIntent from an InferenceService spec.
+// It merges the typed core with the ome.io/* annotation extension and
+// extracts pass-through namespaces into their dedicated maps.
+//
+// Values that fail to parse are silently skipped — the validating
+// webhook (pkg/validation/traffic_annotations.go) rejects malformed
+// values at admission time, so a Resolve call here on a valid ISVC
+// will not lose data.
+func Resolve(isvc *v1beta1.InferenceService) *ResolvedIntent {
+	intent := &ResolvedIntent{
+		PassthroughEnvoyGateway: map[string]string{},
+		PassthroughIstio:        map[string]string{},
+	}
+	if isvc.Spec.Traffic != nil {
+		intent.Traffic = isvc.Spec.Traffic
+	}
+
+	cb := resolveCircuitBreaker(isvc.Annotations)
+	if cb != nil {
+		intent.CircuitBreaker = cb
+	}
+	retry := resolveRetry(isvc.Annotations)
+	if retry != nil {
+		intent.Retry = retry
+	}
+	timeout := resolveTimeout(isvc.Annotations)
+	if timeout != nil {
+		intent.Timeout = timeout
+	}
+
+	for k, v := range isvc.Annotations {
+		if path, ok := strings.CutPrefix(k, constants.PassthroughEnvoyGatewayPrefix); ok {
+			intent.PassthroughEnvoyGateway[path] = v
+			continue
+		}
+		if path, ok := strings.CutPrefix(k, constants.PassthroughIstioPrefix); ok {
+			intent.PassthroughIstio[path] = v
+		}
+	}
+
+	return intent
+}
+
+func resolveCircuitBreaker(annotations map[string]string) *CircuitBreakerIntent {
+	if annotations == nil {
+		return nil
+	}
+	keys := []string{
+		constants.CircuitBreakerMaxConnectionsAnnotation,
+		constants.CircuitBreakerMaxParallelRequestsAnnotation,
+		constants.CircuitBreakerMaxPendingRequestsAnnotation,
+		constants.CircuitBreakerMaxParallelRetriesAnnotation,
+		constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation,
+	}
+	if !anyKeySet(annotations, keys) {
+		return nil
+	}
+	out := &CircuitBreakerIntent{}
+	out.MaxConnections = parseInt32(annotations[constants.CircuitBreakerMaxConnectionsAnnotation])
+	out.MaxParallelRequests = parseInt32(annotations[constants.CircuitBreakerMaxParallelRequestsAnnotation])
+	out.MaxPendingRequests = parseInt32(annotations[constants.CircuitBreakerMaxPendingRequestsAnnotation])
+	out.MaxParallelRetries = parseInt32(annotations[constants.CircuitBreakerMaxParallelRetriesAnnotation])
+	out.PerEndpointMaxConnections = parseInt32(annotations[constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation])
+	return out
+}
+
+func resolveRetry(annotations map[string]string) *RetryIntent {
+	if annotations == nil {
+		return nil
+	}
+	keys := []string{
+		constants.RetryAttemptsAnnotation,
+		constants.RetryOnAnnotation,
+		constants.RetryPerTryTimeoutAnnotation,
+	}
+	if !anyKeySet(annotations, keys) {
+		return nil
+	}
+	out := &RetryIntent{
+		Attempts:      parseInt32(annotations[constants.RetryAttemptsAnnotation]),
+		PerTryTimeout: parseDuration(annotations[constants.RetryPerTryTimeoutAnnotation]),
+	}
+	if raw, ok := annotations[constants.RetryOnAnnotation]; ok && raw != "" {
+		for _, tok := range strings.Split(raw, ",") {
+			tok = strings.TrimSpace(tok)
+			if tok != "" {
+				out.RetryOn = append(out.RetryOn, tok)
+			}
+		}
+	}
+	return out
+}
+
+func resolveTimeout(annotations map[string]string) *TimeoutIntent {
+	if annotations == nil {
+		return nil
+	}
+	keys := []string{
+		constants.TimeoutIdleAnnotation,
+		constants.TimeoutMaxConnectionDurationAnnotation,
+		constants.TimeoutTCPConnectAnnotation,
+	}
+	if !anyKeySet(annotations, keys) {
+		return nil
+	}
+	return &TimeoutIntent{
+		Idle:                  parseDuration(annotations[constants.TimeoutIdleAnnotation]),
+		MaxConnectionDuration: parseDuration(annotations[constants.TimeoutMaxConnectionDurationAnnotation]),
+		TCPConnect:            parseDuration(annotations[constants.TimeoutTCPConnectAnnotation]),
+	}
+}
+
+func anyKeySet(annotations map[string]string, keys []string) bool {
+	for _, k := range keys {
+		if _, ok := annotations[k]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func parseInt32(value string) *int32 {
+	if value == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return nil
+	}
+	out := int32(n)
+	return &out
+}
+
+func parseDuration(value string) *time.Duration {
+	if value == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return nil
+	}
+	return &d
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/intent.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/intent.go
@@ -251,7 +251,7 @@ func parseInt32(value string) *int32 {
 	if value == "" {
 		return nil
 	}
-	n, err := strconv.Atoi(value)
+	n, err := strconv.ParseInt(value, 10, 32)
 	if err != nil {
 		return nil
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/intent_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/intent_test.go
@@ -1,0 +1,273 @@
+package traffic
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestResolve_Empty(t *testing.T) {
+	isvc := &v1beta1.InferenceService{}
+	got := Resolve(isvc)
+	if got == nil {
+		t.Fatalf("Resolve must always return a non-nil ResolvedIntent")
+	}
+	if got.HasIntent() {
+		t.Fatalf("empty ISVC must produce no intent: %#v", got)
+	}
+	// Pass-through maps must be initialized (non-nil) even when empty,
+	// so translators can range over them without nil checks.
+	if got.PassthroughEnvoyGateway == nil {
+		t.Fatalf("PassthroughEnvoyGateway map must be non-nil")
+	}
+	if got.PassthroughIstio == nil {
+		t.Fatalf("PassthroughIstio map must be non-nil")
+	}
+}
+
+func TestResolve_TypedTrafficOnly(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	isvc := &v1beta1.InferenceService{
+		Spec: v1beta1.InferenceServiceSpec{
+			Traffic: &v1beta1.TrafficSpec{
+				Algorithm: &alg,
+				ConsistentHash: &v1beta1.ConsistentHashSpec{
+					Type:    v1beta1.HashTypeHeader,
+					Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+				},
+			},
+		},
+	}
+	got := Resolve(isvc)
+	if !got.HasIntent() {
+		t.Fatalf("typed traffic must count as intent: %#v", got)
+	}
+	if got.Traffic == nil || got.Traffic.Algorithm == nil || *got.Traffic.Algorithm != v1beta1.LoadBalancingTypeConsistentHash {
+		t.Fatalf("typed traffic not propagated: %#v", got.Traffic)
+	}
+	if got.CircuitBreaker != nil || got.Retry != nil || got.Timeout != nil {
+		t.Fatalf("annotation extension fields must be nil when no annotations set: %#v", got)
+	}
+}
+
+func TestResolve_CircuitBreakerAnnotations(t *testing.T) {
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.CircuitBreakerMaxConnectionsAnnotation:            "1024",
+				constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation: "1",
+			},
+		},
+	}
+	got := Resolve(isvc)
+	if got.CircuitBreaker == nil {
+		t.Fatalf("expected CircuitBreaker populated")
+	}
+	if got.CircuitBreaker.MaxConnections == nil || *got.CircuitBreaker.MaxConnections != 1024 {
+		t.Fatalf("MaxConnections wrong: %v", got.CircuitBreaker.MaxConnections)
+	}
+	if got.CircuitBreaker.PerEndpointMaxConnections == nil || *got.CircuitBreaker.PerEndpointMaxConnections != 1 {
+		t.Fatalf("PerEndpointMaxConnections wrong: %v", got.CircuitBreaker.PerEndpointMaxConnections)
+	}
+	// Unset knobs must be nil.
+	if got.CircuitBreaker.MaxParallelRequests != nil {
+		t.Fatalf("MaxParallelRequests must be nil when annotation absent, got: %v", got.CircuitBreaker.MaxParallelRequests)
+	}
+}
+
+func TestResolve_RetryAnnotations(t *testing.T) {
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.RetryAttemptsAnnotation:      "3",
+				constants.RetryOnAnnotation:            "5xx,reset,gateway-error",
+				constants.RetryPerTryTimeoutAnnotation: "30s",
+			},
+		},
+	}
+	got := Resolve(isvc)
+	if got.Retry == nil {
+		t.Fatalf("expected Retry populated")
+	}
+	if got.Retry.Attempts == nil || *got.Retry.Attempts != 3 {
+		t.Fatalf("Attempts wrong: %v", got.Retry.Attempts)
+	}
+	wantOn := []string{"5xx", "reset", "gateway-error"}
+	if !reflect.DeepEqual(got.Retry.RetryOn, wantOn) {
+		t.Fatalf("RetryOn wrong: got %v want %v", got.Retry.RetryOn, wantOn)
+	}
+	if got.Retry.PerTryTimeout == nil || *got.Retry.PerTryTimeout != 30*time.Second {
+		t.Fatalf("PerTryTimeout wrong: %v", got.Retry.PerTryTimeout)
+	}
+}
+
+func TestResolve_RetryOn_TrimsAndSkipsEmpty(t *testing.T) {
+	// The webhook rejects empty-token retry-on lists, but Resolve is
+	// defensive: empty tokens are skipped so a degenerate annotation
+	// doesn't produce a malformed RetryOn slice.
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.RetryAttemptsAnnotation: "1",
+				constants.RetryOnAnnotation:       " 5xx , , reset  ",
+			},
+		},
+	}
+	got := Resolve(isvc)
+	wantOn := []string{"5xx", "reset"}
+	if !reflect.DeepEqual(got.Retry.RetryOn, wantOn) {
+		t.Fatalf("RetryOn whitespace/empty handling wrong: got %v want %v", got.Retry.RetryOn, wantOn)
+	}
+}
+
+func TestResolve_TimeoutAnnotations(t *testing.T) {
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.TimeoutIdleAnnotation:                  "60s",
+				constants.TimeoutMaxConnectionDurationAnnotation: "5m",
+				constants.TimeoutTCPConnectAnnotation:            "5s",
+			},
+		},
+	}
+	got := Resolve(isvc)
+	if got.Timeout == nil {
+		t.Fatalf("expected Timeout populated")
+	}
+	if got.Timeout.Idle == nil || *got.Timeout.Idle != 60*time.Second {
+		t.Fatalf("Idle wrong: %v", got.Timeout.Idle)
+	}
+	if got.Timeout.MaxConnectionDuration == nil || *got.Timeout.MaxConnectionDuration != 5*time.Minute {
+		t.Fatalf("MaxConnectionDuration wrong: %v", got.Timeout.MaxConnectionDuration)
+	}
+	if got.Timeout.TCPConnect == nil || *got.Timeout.TCPConnect != 5*time.Second {
+		t.Fatalf("TCPConnect wrong: %v", got.Timeout.TCPConnect)
+	}
+}
+
+func TestResolve_PassthroughNamespaces(t *testing.T) {
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.PassthroughEnvoyGatewayPrefix + "loadBalancer.slowStart.window":               "30s",
+				constants.PassthroughEnvoyGatewayPrefix + "loadBalancer.slowStart.aggression":           "1.5",
+				constants.PassthroughIstioPrefix + "trafficPolicy.connectionPool.tcp.tcpKeepalive.time": "30s",
+				// Foreign-namespace annotations must be ignored.
+				"foo.example.com/anything": "ignored",
+			},
+		},
+	}
+	got := Resolve(isvc)
+	if len(got.PassthroughEnvoyGateway) != 2 {
+		t.Fatalf("expected 2 envoy passthroughs, got %d: %v", len(got.PassthroughEnvoyGateway), got.PassthroughEnvoyGateway)
+	}
+	if got.PassthroughEnvoyGateway["loadBalancer.slowStart.window"] != "30s" {
+		t.Fatalf("envoy passthrough path stripping wrong: %v", got.PassthroughEnvoyGateway)
+	}
+	if got.PassthroughIstio["trafficPolicy.connectionPool.tcp.tcpKeepalive.time"] != "30s" {
+		t.Fatalf("istio passthrough not captured: %v", got.PassthroughIstio)
+	}
+}
+
+func TestResolve_PassthroughCountsAsIntent(t *testing.T) {
+	// HasIntent must report true when pass-through annotations are
+	// the only thing set, otherwise the translator never runs for
+	// pass-through-only operators.
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.PassthroughEnvoyGatewayPrefix + "loadBalancer.slowStart.window": "30s",
+			},
+		},
+	}
+	got := Resolve(isvc)
+	if !got.HasIntent() {
+		t.Fatalf("pass-through-only intent must count as HasIntent: %#v", got)
+	}
+}
+
+func TestResolve_MalformedAnnotationsSilentlySkipped(t *testing.T) {
+	// The webhook rejects these at admission, so production never
+	// hits this path. Resolve is defensive: an unparseable value
+	// produces nil rather than a panic. This protects controllers
+	// that observe the API in a half-applied state (e.g. just after
+	// CRD upgrade) from crash-looping.
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.CircuitBreakerMaxConnectionsAnnotation: "not-a-number",
+				constants.TimeoutIdleAnnotation:                  "not-a-duration",
+			},
+		},
+	}
+	got := Resolve(isvc)
+	// Annotations are present so the parent struct is created, but
+	// the malformed fields are nil.
+	if got.CircuitBreaker == nil {
+		t.Fatalf("CircuitBreaker should be allocated when any cb-* key is present")
+	}
+	if got.CircuitBreaker.MaxConnections != nil {
+		t.Fatalf("malformed int must yield nil, got: %v", got.CircuitBreaker.MaxConnections)
+	}
+	if got.Timeout == nil {
+		t.Fatalf("Timeout should be allocated when any timeout-* key is present")
+	}
+	if got.Timeout.Idle != nil {
+		t.Fatalf("malformed duration must yield nil, got: %v", got.Timeout.Idle)
+	}
+}
+
+func TestHasIntent_Cases(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeRoundRobin
+	cases := []struct {
+		name string
+		in   *ResolvedIntent
+		want bool
+	}{
+		{"nil", nil, false},
+		{"zero", &ResolvedIntent{}, false},
+		{
+			"traffic typed",
+			&ResolvedIntent{Traffic: &v1beta1.TrafficSpec{Algorithm: &alg}},
+			true,
+		},
+		{
+			"empty traffic struct does not count",
+			&ResolvedIntent{Traffic: &v1beta1.TrafficSpec{}},
+			false,
+		},
+		{"circuit breaker", &ResolvedIntent{CircuitBreaker: &CircuitBreakerIntent{}}, true},
+		{"retry", &ResolvedIntent{Retry: &RetryIntent{}}, true},
+		{"timeout", &ResolvedIntent{Timeout: &TimeoutIntent{}}, true},
+		{
+			"envoy passthrough",
+			&ResolvedIntent{PassthroughEnvoyGateway: map[string]string{"a": "b"}},
+			true,
+		},
+		{
+			"istio passthrough",
+			&ResolvedIntent{PassthroughIstio: map[string]string{"a": "b"}},
+			true,
+		},
+		{
+			"empty passthrough maps don't count",
+			&ResolvedIntent{
+				PassthroughEnvoyGateway: map[string]string{},
+				PassthroughIstio:        map[string]string{},
+			},
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.in.HasIntent(); got != tc.want {
+				t.Fatalf("HasIntent() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/intent_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/intent_test.go
@@ -193,7 +193,7 @@ func TestResolve_PassthroughCountsAsIntent(t *testing.T) {
 
 func TestResolve_MalformedAnnotationsSilentlySkipped(t *testing.T) {
 	// The webhook rejects these at admission, so production never
-	// hits this path. Resolve is defensive: an unparseable value
+	// hits this path. Resolve is defensive: an unparsable value
 	// produces nil rather than a panic. This protects controllers
 	// that observe the API in a half-applied state (e.g. just after
 	// CRD upgrade) from crash-looping.

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/reconciler.go
@@ -1,0 +1,319 @@
+// Per-InferenceService traffic-management reconciler — top-level entry
+// point that resolves the operator's intent, invokes the active
+// translator, applies the emitted backend policy resource, and returns
+// the TrafficStatus to write back to the ISVC.
+//
+// Construction lives in package factory; the InferenceServiceReconciler
+// holds a *Reconciler and calls Reconcile after the ingress reconciler
+// has materialized the OME-managed HTTPRoutes.
+package traffic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/status"
+)
+
+// ErrConflictingPolicy is returned by applyPolicy when a backend
+// policy resource with the name OME would emit already exists but is
+// not owned by the InferenceService being reconciled — either it has
+// a different controller, no controller-ref at all (hand-authored),
+// or a controller-ref to a different InferenceService. Caller surfaces
+// this as BackendPolicyReady=False/ConflictingPolicy in the status and
+// must NOT overwrite the pre-existing object.
+var ErrConflictingPolicy = errors.New("backend policy with the OME-managed name exists but is not owned by this InferenceService")
+
+// Reconciler turns operator intent into a backend policy resource via
+// the active Translator and surfaces a TrafficStatus the caller can
+// assign to the InferenceService's status subresource.
+type Reconciler struct {
+	client     client.Client
+	scheme     *runtime.Scheme
+	translator Translator
+	// now lets tests inject a stable timestamp.
+	now func() metav1.Time
+}
+
+// NewReconciler builds a Reconciler around the active translator.
+// translator must be non-nil; callers obtain it from the factory at
+// controller startup.
+func NewReconciler(c client.Client, scheme *runtime.Scheme, translator Translator) *Reconciler {
+	return &Reconciler{
+		client:     c,
+		scheme:     scheme,
+		translator: translator,
+		now:        metav1.Now,
+	}
+}
+
+// TranslatorName returns the active translator's stable identifier.
+// Useful for log fields and metrics labels on the caller side.
+func (r *Reconciler) TranslatorName() string {
+	return r.translator.Name()
+}
+
+// Watches returns a zero-value of the resource type the active
+// translator emits, or nil when the translator emits nothing. The
+// caller's SetupWithManager passes this to .Owns() so policy changes
+// re-enqueue the owning ISVC.
+func (r *Reconciler) Watches() client.Object {
+	return r.translator.Watches()
+}
+
+// Reconcile resolves intent, invokes the translator, applies the
+// emitted policy resource (if any), and returns the TrafficStatus the
+// caller should write back. Returns (nil, nil) when no intent is
+// declared — caller should clear or leave isvc.Status.Traffic alone in
+// that case (Build is what produces nil; ownership of the prior status
+// is the caller's call).
+//
+// targetHTTPRoutes lists the OME-managed HTTPRoute names the backend
+// policy should target. Callers compute this from the ISVC + which
+// components are present (Engine always; Decoder/Router conditional).
+func (r *Reconciler) Reconcile(
+	ctx context.Context,
+	isvc *v1beta1.InferenceService,
+	targetHTTPRoutes []string,
+) (*v1beta1.TrafficStatus, error) {
+	intent := Resolve(isvc)
+	if !intent.HasIntent() {
+		if err := r.cleanupPriorPolicy(ctx, isvc); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	emitted, passthroughs, translateErr := r.translator.Translate(isvc, targetHTTPRoutes, intent)
+
+	// Apply the emitted resource only when the translator succeeded
+	// and produced something to apply. An apply failure folds into the
+	// translateErr surface for the status writer.
+	var conflictMessage string
+	if translateErr == nil && emitted != nil {
+		if applyErr := r.applyPolicy(ctx, isvc, emitted); applyErr != nil {
+			translateErr = applyErr
+			if errors.Is(applyErr, ErrConflictingPolicy) {
+				conflictMessage = applyErr.Error()
+			}
+		}
+	}
+
+	// Observe gateway acceptance from the post-apply state on the
+	// server. Only meaningful when we successfully applied something
+	// — on first reconcile we usually get Pending (gateway hasn't
+	// run yet) and the next .Owns()-driven re-enqueue surfaces the
+	// real signal. Skip the observe step when we hit a conflict
+	// (we didn't write anything; existing object's status is not
+	// ours to interpret).
+	acceptance := AcceptanceObservation{State: AcceptancePending}
+	if translateErr == nil && emitted != nil {
+		acceptance = r.observeAcceptance(ctx, emitted)
+	}
+
+	out := status.Build(status.BuildArgs{
+		TranslatorName:           r.translator.Name(),
+		HasIntent:                true,
+		Algorithm:                algorithmOf(intent),
+		EmittedPolicy:            emitted,
+		TargetedRoutes:           targetHTTPRoutes,
+		Passthroughs:             passthroughs,
+		TranslateErr:             translateErr,
+		ConflictDetected:         conflictMessage != "",
+		ConflictMessage:          conflictMessage,
+		ObservedGeneration:       isvc.Generation,
+		Now:                      r.now(),
+		GatewayAcceptance:        toStatusAcceptance(acceptance.State),
+		GatewayAcceptanceReason:  acceptance.Reason,
+		GatewayAcceptanceMessage: acceptance.Message,
+		UnsupportedAnnotations:   ComputeUnsupportedAnnotations(isvc.Annotations, r.translator),
+	})
+
+	return out, translateErr
+}
+
+// cleanupPriorPolicy deletes the previously-emitted backend policy
+// resource when the operator has removed all traffic intent. Owner
+// references handle ISVC deletion; this handles the "intent removed
+// but ISVC remains" case.
+//
+// Gated on isvc.Status.Traffic.BackendPolicyResource so the common
+// case (ISVC never had traffic intent) costs no extra API call. The
+// gate has a small leak window — if a previous reconcile applied a
+// policy but crashed before writing status, and then the operator
+// removes intent, we'd skip the Delete. Operators can recover by
+// re-adding intent and removing it again, or by deleting the BTP by
+// hand. Trading that edge case for not pestering the API server with
+// a no-op Delete on every reconcile of every intent-free ISVC.
+func (r *Reconciler) cleanupPriorPolicy(ctx context.Context, isvc *v1beta1.InferenceService) error {
+	if isvc.Status.Traffic == nil || isvc.Status.Traffic.BackendPolicyResource == nil {
+		return nil
+	}
+	// Noop translator never emits anything, so there's nothing to
+	// clean up. Defensive — in practice the gate above already short-
+	// circuits because the noop branch never sets BackendPolicyResource.
+	watch := r.translator.Watches()
+	if watch == nil {
+		return nil
+	}
+	obj, ok := watch.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("translator.Watches() did not produce a client.Object")
+	}
+	// Translator emits with isvc.Name; the status mirrors that, so
+	// either works. Going through status keeps us robust to future
+	// translators that pick a different name convention.
+	obj.SetName(isvc.Status.Traffic.BackendPolicyResource.Name)
+	obj.SetNamespace(isvc.Namespace)
+	if err := r.client.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete prior backend policy %s/%s: %w", isvc.Namespace, obj.GetName(), err)
+	}
+	return nil
+}
+
+// observeAcceptance fetches the freshly-applied policy resource and
+// asks the translator to interpret its status. Errors fetching the
+// object degrade silently to Pending — the next reconcile will retry.
+func (r *Reconciler) observeAcceptance(ctx context.Context, desired client.Object) AcceptanceObservation {
+	fetched, ok := desired.DeepCopyObject().(client.Object)
+	if !ok {
+		return AcceptanceObservation{State: AcceptancePending}
+	}
+	// Strip the desired spec; Get fills it in (including status).
+	fetched.SetName(desired.GetName())
+	fetched.SetNamespace(desired.GetNamespace())
+	if err := r.client.Get(ctx, client.ObjectKeyFromObject(desired), fetched); err != nil {
+		return AcceptanceObservation{State: AcceptancePending}
+	}
+	return r.translator.ObserveAcceptance(fetched)
+}
+
+// toStatusAcceptance bridges the translator-side AcceptanceState to
+// the status-package primitive type. Keeping the two enums separate
+// is what lets the status package avoid importing the parent traffic
+// package (and the import cycle that would create).
+func toStatusAcceptance(s AcceptanceState) status.GatewayAcceptance {
+	switch s {
+	case AcceptanceAccepted:
+		return status.GatewayAcceptanceAccepted
+	case AcceptanceRejected:
+		return status.GatewayAcceptanceRejected
+	default:
+		return status.GatewayAcceptancePending
+	}
+}
+
+func algorithmOf(intent *ResolvedIntent) string {
+	if intent == nil || intent.Traffic == nil || intent.Traffic.Algorithm == nil {
+		return ""
+	}
+	return string(*intent.Traffic.Algorithm)
+}
+
+// applyPolicy sets controller reference and create-or-updates the
+// emitted policy resource. The translator guarantees deterministic
+// output, so the update path can be a coarse Update; finer
+// reconciliation lives in the translator (e.g. semantic equality
+// helpers) when needed.
+func (r *Reconciler) applyPolicy(ctx context.Context, isvc *v1beta1.InferenceService, desired client.Object) error {
+	if err := controllerutil.SetControllerReference(isvc, desired, r.scheme); err != nil {
+		return fmt.Errorf("set controller reference on backend policy: %w", err)
+	}
+
+	// We need an empty instance of the same type to fetch into.
+	existingObj, ok := desired.DeepCopyObject().(client.Object)
+	if !ok {
+		return errors.New("backend policy resource does not implement client.Object")
+	}
+	// Strip the desired fields out of the fetch target — Get fills it
+	// in from the API server. Leaving the desired spec in place would
+	// shadow the live state on a not-found path.
+	existingObj.SetName(desired.GetName())
+	existingObj.SetNamespace(desired.GetNamespace())
+
+	key := client.ObjectKeyFromObject(desired)
+	err := r.client.Get(ctx, key, existingObj)
+	switch {
+	case apierrors.IsNotFound(err):
+		if createErr := r.client.Create(ctx, desired); createErr != nil {
+			return fmt.Errorf("create backend policy %s: %w", key, createErr)
+		}
+		return nil
+	case err != nil:
+		return fmt.Errorf("get backend policy %s: %w", key, err)
+	}
+
+	// ConflictingPolicy guard: if the existing object isn't owned by
+	// this InferenceService, refuse to overwrite. This defers to hand-
+	// authored policies of the same name (alpha-phase behavior); later
+	// phases will warn (beta) or reject without an ack annotation (GA).
+	if !ownedBy(existingObj, isvc) {
+		return fmt.Errorf(
+			"%w: %s already exists with %s",
+			ErrConflictingPolicy, key, describeController(existingObj),
+		)
+	}
+
+	// Update path. Preserve ResourceVersion so the Update doesn't lose
+	// the optimistic-concurrency token. The translator's deterministic-
+	// output contract means identical desired states across reconciles
+	// — Update is idempotent for our purposes.
+	desired.SetResourceVersion(existingObj.GetResourceVersion())
+	if updateErr := r.client.Update(ctx, desired); updateErr != nil {
+		return fmt.Errorf("update backend policy %s: %w", key, updateErr)
+	}
+	return nil
+}
+
+// ownedBy reports whether obj's controller owner reference points at
+// isvc. Returns false when there is no controller-ref (hand-authored)
+// or the controller-ref names a different object.
+func ownedBy(obj client.Object, isvc *v1beta1.InferenceService) bool {
+	ctrl := metav1.GetControllerOf(obj)
+	if ctrl == nil {
+		return false
+	}
+	return ctrl.UID == isvc.UID || (ctrl.Name == isvc.Name && ctrl.Kind == "InferenceService")
+}
+
+// describeController returns a human-readable description of obj's
+// controller owner for use in the ConflictingPolicy error message.
+func describeController(obj client.Object) string {
+	ctrl := metav1.GetControllerOf(obj)
+	if ctrl == nil {
+		return "no controller owner reference (hand-authored)"
+	}
+	return fmt.Sprintf("controller=%s/%s", ctrl.Kind, ctrl.Name)
+}
+
+// ComputeTargetHTTPRoutes returns the OME-managed HTTPRoute names the
+// backend policy should target for the given InferenceService. Always
+// includes the top-level route (isvc.Name) and the engine route; adds
+// the decoder route when hasDecoder is true and the router route when
+// hasRouter is true.
+//
+// Callers (the InferenceService reconciler) pass hasDecoder /
+// hasRouter from the merged runtime spec, so a decoder/router added
+// by the runtime template participates in traffic management even
+// when not declared on the ISVC itself.
+func ComputeTargetHTTPRoutes(isvc *v1beta1.InferenceService, hasDecoder, hasRouter bool) []string {
+	out := make([]string, 0, 4)
+	out = append(out, isvc.Name)
+	out = append(out, constants.EngineServiceName(isvc.Name))
+	if hasDecoder {
+		out = append(out, constants.DecoderServiceName(isvc.Name))
+	}
+	if hasRouter {
+		out = append(out, constants.RouterServiceName(isvc.Name))
+	}
+	return out
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/reconciler_test.go
@@ -1,0 +1,685 @@
+package traffic
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/status"
+)
+
+var fixedNow = metav1.NewTime(time.Date(2026, time.May, 17, 12, 0, 0, 0, time.UTC))
+
+// stubTranslator records what it was called with and returns a
+// pre-programmed response. Avoids a dependency on any real translator
+// implementation so this test stays self-contained.
+type stubTranslator struct {
+	name string
+
+	gotISVC   *v1beta1.InferenceService
+	gotRoutes []string
+	gotIntent *ResolvedIntent
+
+	respObj          client.Object
+	respPassthroughs []string
+	respErr          error
+
+	supports         sets.Set[string]
+	supportedPrefixs []string
+	watches          client.Object
+
+	// observeFunc lets individual tests script gateway-acceptance
+	// observations. When nil, ObserveAcceptance returns Pending.
+	observeFunc  func(obj client.Object) AcceptanceObservation
+	observedWith client.Object
+}
+
+func (s *stubTranslator) Name() string { return s.name }
+func (s *stubTranslator) SupportedAnnotations() sets.Set[string] {
+	if s.supports == nil {
+		return sets.New[string]()
+	}
+	return s.supports
+}
+func (s *stubTranslator) Watches() client.Object                 { return s.watches }
+func (s *stubTranslator) SupportedPassthroughPrefixes() []string { return s.supportedPrefixs }
+func (s *stubTranslator) Translate(
+	isvc *v1beta1.InferenceService,
+	targetHTTPRoutes []string,
+	intent *ResolvedIntent,
+) (client.Object, []string, error) {
+	s.gotISVC = isvc
+	s.gotRoutes = targetHTTPRoutes
+	s.gotIntent = intent
+	return s.respObj, s.respPassthroughs, s.respErr
+}
+func (s *stubTranslator) ObserveAcceptance(obj client.Object) AcceptanceObservation {
+	s.observedWith = obj
+	if s.observeFunc == nil {
+		return AcceptanceObservation{State: AcceptancePending}
+	}
+	return s.observeFunc(obj)
+}
+
+func newReconcilerWithStub(t *testing.T, tr *stubTranslator, seed ...client.Object) (*Reconciler, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add clientgo scheme: %v", err)
+	}
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1beta1 scheme: %v", err)
+	}
+	c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(seed...).Build()
+	r := NewReconciler(c, scheme, tr)
+	r.now = func() metav1.Time { return fixedNow }
+	return r, c
+}
+
+func newISVC(name string) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Generation: 4},
+	}
+}
+
+func TestReconcile_NoIntent_ReturnsNilSkipsTranslator(t *testing.T) {
+	tr := &stubTranslator{name: status.NoopTranslatorName}
+	r, _ := newReconcilerWithStub(t, tr)
+
+	got, err := r.Reconcile(context.Background(), newISVC("isvc"), []string{"isvc"})
+	if err != nil {
+		t.Fatalf("Reconcile err = %v, want nil", err)
+	}
+	if got != nil {
+		t.Fatalf("Reconcile must return nil when no intent declared, got %+v", got)
+	}
+	if tr.gotISVC != nil {
+		t.Fatalf("translator must NOT be invoked when HasIntent=false (called with %+v)", tr.gotISVC)
+	}
+}
+
+func TestReconcile_Noop_ReturnsNoTranslatorAvailableStatus(t *testing.T) {
+	// Intent declared (retry annotation), noop translator active.
+	tr := &stubTranslator{name: status.NoopTranslatorName}
+	r, _ := newReconcilerWithStub(t, tr)
+
+	isvc := newISVC("isvc")
+	alg := v1beta1.LoadBalancingTypeRoundRobin
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{Algorithm: &alg}
+
+	got, err := r.Reconcile(context.Background(), isvc, []string{"isvc", "isvc-engine"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected TrafficStatus, got nil")
+	}
+	if got.Conditions[0].Reason != v1beta1.TrafficReasonNoTranslatorAvailable {
+		t.Fatalf("Reason = %q, want NoTranslatorAvailable", got.Conditions[0].Reason)
+	}
+	if got.Conditions[0].ObservedGeneration != isvc.Generation {
+		t.Fatalf("ObservedGeneration = %d, want %d", got.Conditions[0].ObservedGeneration, isvc.Generation)
+	}
+}
+
+func TestReconcile_RealTranslator_AppliesPolicyAndReturnsPendingStatus(t *testing.T) {
+	// Use a registered scheme type (ConfigMap) as a stand-in for the
+	// emitted backend policy. The reconciler is generic over
+	// client.Object so this is sufficient to exercise the apply path
+	// without depending on the Envoy Gateway types.
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+		Data:       map[string]string{"mock": "policy"},
+	}
+	tr := &stubTranslator{
+		name:             "envoy-gateway",
+		respObj:          desired,
+		respPassthroughs: []string{"loadBalancer.slowStart.window"},
+	}
+	r, c := newReconcilerWithStub(t, tr)
+
+	isvc := newISVC("isvc")
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{Algorithm: &alg}
+
+	got, err := r.Reconcile(context.Background(), isvc, []string{"isvc", "isvc-engine"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+
+	// Status checks.
+	if got.Algorithm != string(v1beta1.LoadBalancingTypeConsistentHash) {
+		t.Fatalf("LoadBalancingType = %q", got.Algorithm)
+	}
+	if got.Conditions[0].Reason != v1beta1.TrafficReasonPending {
+		t.Fatalf("Reason = %q, want Pending", got.Conditions[0].Reason)
+	}
+
+	// Verify the policy was created and the owner reference points at
+	// the InferenceService.
+	got2 := &corev1.ConfigMap{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "isvc-btp"}, got2); err != nil {
+		t.Fatalf("policy not created: %v", err)
+	}
+	if len(got2.OwnerReferences) != 1 || got2.OwnerReferences[0].Name != isvc.Name {
+		t.Fatalf("owner reference not set on policy: %+v", got2.OwnerReferences)
+	}
+	if got2.Data["mock"] != "policy" {
+		t.Fatalf("policy data not preserved: %+v", got2.Data)
+	}
+}
+
+func TestReconcile_RealTranslator_UpdatesExistingPolicy(t *testing.T) {
+	// Seed an existing policy resource — Reconcile must Update
+	// instead of Create and the new Data must win. The existing object
+	// carries OME's controller-ref so the ConflictingPolicy guard
+	// recognizes it as OME-managed.
+	isvc := newISVC("isvc")
+	isvc.UID = "isvc-uid"
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "isvc-btp",
+			Namespace:       "default",
+			ResourceVersion: "1",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "ome.io/v1beta1",
+				Kind:       "InferenceService",
+				Name:       isvc.Name,
+				UID:        isvc.UID,
+				Controller: ptr.To(true),
+			}},
+		},
+		Data: map[string]string{"mock": "stale"},
+	}
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+		Data:       map[string]string{"mock": "fresh"},
+	}
+	tr := &stubTranslator{name: "envoy-gateway", respObj: desired}
+	r, c := newReconcilerWithStub(t, tr, existing)
+
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{
+		Algorithm: ptrAlg(v1beta1.LoadBalancingTypeRoundRobin),
+	}
+
+	if _, err := r.Reconcile(context.Background(), isvc, []string{"isvc"}); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+
+	updated := &corev1.ConfigMap{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "isvc-btp"}, updated); err != nil {
+		t.Fatalf("policy missing: %v", err)
+	}
+	if updated.Data["mock"] != "fresh" {
+		t.Fatalf("policy not updated: %+v", updated.Data)
+	}
+}
+
+func TestReconcile_ConflictingPolicy_RefusesOverwriteAndSurfacesReason(t *testing.T) {
+	// Pre-existing same-name policy with NO controller-ref simulates a
+	// hand-authored BTP. Reconcile must refuse to Update and surface
+	// BackendPolicyReady=False/ConflictingPolicy (alpha-phase coexistence
+	// behavior).
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "isvc-btp",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+		Data: map[string]string{"mock": "handauthored"},
+	}
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+		Data:       map[string]string{"mock": "would-have-been-ome"},
+	}
+	tr := &stubTranslator{name: "envoy-gateway", respObj: desired}
+	r, c := newReconcilerWithStub(t, tr, existing)
+
+	isvc := newISVC("isvc")
+	isvc.UID = "isvc-uid"
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{
+		Algorithm: ptrAlg(v1beta1.LoadBalancingTypeRoundRobin),
+	}
+
+	got, err := r.Reconcile(context.Background(), isvc, []string{"isvc"})
+	if err == nil {
+		t.Fatalf("Reconcile must return the wrapped ErrConflictingPolicy")
+	}
+	if !errors.Is(err, ErrConflictingPolicy) {
+		t.Fatalf("err must wrap ErrConflictingPolicy, got: %v", err)
+	}
+
+	if got == nil || len(got.Conditions) == 0 {
+		t.Fatalf("status must include the BackendPolicyReady condition; got = %+v", got)
+	}
+	if got.Conditions[0].Reason != v1beta1.TrafficReasonConflictingPolicy {
+		t.Fatalf("Reason = %q, want %q", got.Conditions[0].Reason, v1beta1.TrafficReasonConflictingPolicy)
+	}
+
+	// Existing object MUST NOT have been overwritten.
+	preserved := &corev1.ConfigMap{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "isvc-btp"}, preserved); err != nil {
+		t.Fatalf("existing policy missing: %v", err)
+	}
+	if preserved.Data["mock"] != "handauthored" {
+		t.Fatalf("ConflictingPolicy guard overwrote a hand-authored policy: %+v", preserved.Data)
+	}
+}
+
+func TestReconcile_TranslatorError_NoApplySurfacedInStatus(t *testing.T) {
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+	}
+	tr := &stubTranslator{
+		name:    "envoy-gateway",
+		respObj: desired, // non-nil but should be ignored due to err
+		respErr: errors.New("invalid hash type"),
+	}
+	r, c := newReconcilerWithStub(t, tr)
+
+	isvc := newISVC("isvc")
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{Algorithm: ptrAlg(v1beta1.LoadBalancingTypeRoundRobin)}
+
+	got, err := r.Reconcile(context.Background(), isvc, []string{"isvc"})
+	if err == nil {
+		t.Fatalf("Reconcile must propagate translator error")
+	}
+	if got.Conditions[0].Reason != v1beta1.TrafficReasonTranslationFailed {
+		t.Fatalf("Reason = %q, want TranslationFailed", got.Conditions[0].Reason)
+	}
+
+	// Apply must NOT have been attempted on translator error.
+	cm := &corev1.ConfigMap{}
+	getErr := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "isvc-btp"}, cm)
+	if getErr == nil {
+		t.Fatalf("policy must not be created when translator errors")
+	}
+}
+
+func TestReconcile_PassesTargetRoutesIntoTranslator(t *testing.T) {
+	tr := &stubTranslator{name: "envoy-gateway"}
+	r, _ := newReconcilerWithStub(t, tr)
+
+	isvc := newISVC("isvc")
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{Algorithm: ptrAlg(v1beta1.LoadBalancingTypeRoundRobin)}
+	routes := []string{"isvc", "isvc-engine", "isvc-decoder"}
+
+	if _, err := r.Reconcile(context.Background(), isvc, routes); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(tr.gotRoutes) != len(routes) {
+		t.Fatalf("translator received %v, want %v", tr.gotRoutes, routes)
+	}
+	for i := range routes {
+		if tr.gotRoutes[i] != routes[i] {
+			t.Fatalf("route %d mismatch: got %q want %q", i, tr.gotRoutes[i], routes[i])
+		}
+	}
+}
+
+func TestComputeTargetHTTPRoutes(t *testing.T) {
+	cases := []struct {
+		name       string
+		isvcName   string
+		hasDecoder bool
+		hasRouter  bool
+		wantRoutes []string
+	}{
+		{
+			name:       "engine only",
+			isvcName:   "foo",
+			wantRoutes: []string{"foo", "foo-engine"},
+		},
+		{
+			name:       "engine + decoder",
+			isvcName:   "foo",
+			hasDecoder: true,
+			wantRoutes: []string{"foo", "foo-engine", "foo-decoder"},
+		},
+		{
+			name:       "engine + router",
+			isvcName:   "foo",
+			hasRouter:  true,
+			wantRoutes: []string{"foo", "foo-engine", "foo-router"},
+		},
+		{
+			name:       "engine + decoder + router (PD-disaggregated)",
+			isvcName:   "foo",
+			hasDecoder: true,
+			hasRouter:  true,
+			wantRoutes: []string{"foo", "foo-engine", "foo-decoder", "foo-router"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ComputeTargetHTTPRoutes(
+				&v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: tc.isvcName}},
+				tc.hasDecoder,
+				tc.hasRouter,
+			)
+			if len(got) != len(tc.wantRoutes) {
+				t.Fatalf("len = %d, want %d (got %v)", len(got), len(tc.wantRoutes), got)
+			}
+			for i := range tc.wantRoutes {
+				if got[i] != tc.wantRoutes[i] {
+					t.Fatalf("route %d: got %q want %q", i, got[i], tc.wantRoutes[i])
+				}
+			}
+		})
+	}
+}
+
+func TestReconciler_TranslatorNameAndWatchesPassThrough(t *testing.T) {
+	wantWatch := &corev1.ConfigMap{}
+	tr := &stubTranslator{name: "envoy-gateway", watches: wantWatch}
+	r, _ := newReconcilerWithStub(t, tr)
+	if r.TranslatorName() != "envoy-gateway" {
+		t.Fatalf("TranslatorName = %q", r.TranslatorName())
+	}
+	if r.Watches() != wantWatch {
+		t.Fatalf("Watches = %v, want %v", r.Watches(), wantWatch)
+	}
+}
+
+func TestReconcile_GatewayAccepted_SurfacesAcceptedByGateway(t *testing.T) {
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+	}
+	tr := &stubTranslator{
+		name:    "envoy-gateway",
+		respObj: desired,
+		observeFunc: func(_ client.Object) AcceptanceObservation {
+			return AcceptanceObservation{
+				State:   AcceptanceAccepted,
+				Reason:  "Accepted",
+				Message: "Policy is valid and accepted",
+			}
+		},
+	}
+	r, _ := newReconcilerWithStub(t, tr)
+	isvc := newISVC("isvc")
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{Algorithm: ptrAlg(v1beta1.LoadBalancingTypeRoundRobin)}
+
+	got, err := r.Reconcile(context.Background(), isvc, []string{"isvc"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	c := got.Conditions[0]
+	if c.Status != metav1.ConditionTrue {
+		t.Fatalf("Status = %q, want True", c.Status)
+	}
+	if c.Reason != v1beta1.TrafficReasonAcceptedByGateway {
+		t.Fatalf("Reason = %q, want AcceptedByGateway", c.Reason)
+	}
+	if c.Message != "Policy is valid and accepted" {
+		t.Fatalf("Message = %q, want pass-through from observation", c.Message)
+	}
+	if tr.observedWith == nil {
+		t.Fatalf("ObserveAcceptance was not called")
+	}
+}
+
+func TestReconcile_GatewayRejected_SurfacesGatewayRejected(t *testing.T) {
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+	}
+	tr := &stubTranslator{
+		name:    "envoy-gateway",
+		respObj: desired,
+		observeFunc: func(_ client.Object) AcceptanceObservation {
+			return AcceptanceObservation{
+				State:   AcceptanceRejected,
+				Reason:  "Invalid",
+				Message: "unsupported field foo.bar",
+			}
+		},
+	}
+	r, _ := newReconcilerWithStub(t, tr)
+	isvc := newISVC("isvc")
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{Algorithm: ptrAlg(v1beta1.LoadBalancingTypeRoundRobin)}
+
+	got, err := r.Reconcile(context.Background(), isvc, []string{"isvc"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	c := got.Conditions[0]
+	if c.Status != metav1.ConditionFalse {
+		t.Fatalf("Status = %q, want False", c.Status)
+	}
+	if c.Reason != v1beta1.TrafficReasonGatewayRejected {
+		t.Fatalf("Reason = %q, want GatewayRejected", c.Reason)
+	}
+	if c.Message != "unsupported field foo.bar" {
+		t.Fatalf("Message = %q, want gateway controller message", c.Message)
+	}
+}
+
+func TestReconcile_GatewayPending_DefaultsCondition(t *testing.T) {
+	// observeFunc nil -> stub returns Pending. The reconciler must
+	// then keep the BackendPolicyReady condition at Unknown/Pending.
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+	}
+	tr := &stubTranslator{name: "envoy-gateway", respObj: desired}
+	r, _ := newReconcilerWithStub(t, tr)
+	isvc := newISVC("isvc")
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{Algorithm: ptrAlg(v1beta1.LoadBalancingTypeRoundRobin)}
+
+	got, err := r.Reconcile(context.Background(), isvc, []string{"isvc"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	c := got.Conditions[0]
+	if c.Status != metav1.ConditionUnknown {
+		t.Fatalf("Status = %q, want Unknown", c.Status)
+	}
+	if c.Reason != v1beta1.TrafficReasonPending {
+		t.Fatalf("Reason = %q, want Pending", c.Reason)
+	}
+}
+
+func TestReconcile_NoIntent_NoPriorStatus_NoDeleteAttempted(t *testing.T) {
+	// Fresh ISVC, no intent, no prior status: cleanup must skip the
+	// Delete API call entirely so the common "ISVC never had traffic
+	// intent" case is free.
+	tr := &stubTranslator{name: "envoy-gateway", watches: &corev1.ConfigMap{}}
+	r, c := newReconcilerWithStub(t, tr)
+	// Seed a phantom policy with the ISVC's name to prove no Delete
+	// touches it. If the reconciler called Delete, this ConfigMap
+	// would disappear.
+	phantom := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc", Namespace: "default"},
+	}
+	if err := c.Create(context.Background(), phantom); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	isvc := newISVC("isvc")
+	// isvc.Status.Traffic stays nil.
+
+	got, err := r.Reconcile(context.Background(), isvc, []string{"isvc"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("status must be nil when no intent, got %+v", got)
+	}
+	// Phantom must still exist — proves no Delete was attempted.
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "isvc"}, cm); err != nil {
+		t.Fatalf("phantom was unexpectedly deleted: %v", err)
+	}
+}
+
+func TestReconcile_NoIntent_PriorPolicyExists_DeletesIt(t *testing.T) {
+	tr := &stubTranslator{name: "envoy-gateway", watches: &corev1.ConfigMap{}}
+	// Seed a BTP-stand-in that a prior reconcile would have emitted.
+	prior := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+	}
+	r, c := newReconcilerWithStub(t, tr, prior)
+
+	isvc := newISVC("isvc")
+	// Status reflects a previous successful emit.
+	isvc.Status.Traffic = &v1beta1.TrafficStatus{
+		BackendPolicyResource: &v1beta1.BackendPolicyRef{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "isvc-btp",
+		},
+	}
+
+	got, err := r.Reconcile(context.Background(), isvc, []string{"isvc"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("status must be nil when no intent, got %+v", got)
+	}
+	// Prior policy must be gone.
+	cm := &corev1.ConfigMap{}
+	getErr := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "isvc-btp"}, cm)
+	if getErr == nil {
+		t.Fatalf("prior policy still exists after cleanup")
+	}
+}
+
+func TestReconcile_NoIntent_PriorPolicyAlreadyGone_NotFoundIsOK(t *testing.T) {
+	// Status says we emitted a policy but it's already gone (manual
+	// delete, GC race). Cleanup must treat NotFound as a no-op.
+	tr := &stubTranslator{name: "envoy-gateway", watches: &corev1.ConfigMap{}}
+	r, _ := newReconcilerWithStub(t, tr) // no seed
+
+	isvc := newISVC("isvc")
+	isvc.Status.Traffic = &v1beta1.TrafficStatus{
+		BackendPolicyResource: &v1beta1.BackendPolicyRef{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "isvc-btp",
+		},
+	}
+
+	if _, err := r.Reconcile(context.Background(), isvc, []string{"isvc"}); err != nil {
+		t.Fatalf("NotFound must not propagate, got: %v", err)
+	}
+}
+
+func TestReconcile_NoIntent_NoopTranslator_NeverDeletes(t *testing.T) {
+	// Noop's Watches() returns nil; cleanup must skip even if status
+	// somehow has a BackendPolicyResource (it shouldn't, but defense
+	// in depth).
+	tr := &stubTranslator{name: status.NoopTranslatorName, watches: nil}
+	phantom := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+	}
+	r, c := newReconcilerWithStub(t, tr, phantom)
+
+	isvc := newISVC("isvc")
+	isvc.Status.Traffic = &v1beta1.TrafficStatus{
+		BackendPolicyResource: &v1beta1.BackendPolicyRef{Name: "isvc-btp"},
+	}
+
+	if _, err := r.Reconcile(context.Background(), isvc, []string{"isvc"}); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "isvc-btp"}, cm); err != nil {
+		t.Fatalf("noop translator must not delete: %v", err)
+	}
+}
+
+func TestReconcile_TranslateError_SkipsAcceptanceObservation(t *testing.T) {
+	// Apply path is skipped on translator error, and so must
+	// ObserveAcceptance — otherwise we'd report a stale acceptance
+	// from a previous reconcile that does not reflect the current
+	// (failed) attempt.
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+	}
+	observed := false
+	tr := &stubTranslator{
+		name:    "envoy-gateway",
+		respObj: desired,
+		respErr: errors.New("boom"),
+		observeFunc: func(_ client.Object) AcceptanceObservation {
+			observed = true
+			return AcceptanceObservation{State: AcceptanceAccepted}
+		},
+	}
+	r, _ := newReconcilerWithStub(t, tr)
+	isvc := newISVC("isvc")
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{Algorithm: ptrAlg(v1beta1.LoadBalancingTypeRoundRobin)}
+
+	_, err := r.Reconcile(context.Background(), isvc, []string{"isvc"})
+	if err == nil {
+		t.Fatalf("expected translator error to propagate")
+	}
+	if observed {
+		t.Fatalf("ObserveAcceptance must NOT be called when translator errors")
+	}
+}
+
+func TestReconcile_SurfacesUnsupportedAnnotationsFromIsvc(t *testing.T) {
+	// EG-style translator: supports only retry-attempts and the EG
+	// pass-through prefix. The ISVC declares an Istio pass-through and
+	// an unsupported per-key annotation — both should appear in the
+	// UnsupportedFields condition's message.
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "isvc-btp", Namespace: "default"},
+	}
+	tr := &stubTranslator{
+		name:             "envoy-gateway",
+		respObj:          desired,
+		watches:          &corev1.ConfigMap{},
+		supports:         sets.New("ome.io/retry-attempts"),
+		supportedPrefixs: []string{"ome.io/btp."},
+	}
+	r, _ := newReconcilerWithStub(t, tr)
+
+	isvc := newISVC("isvc")
+	isvc.Spec.Traffic = &v1beta1.TrafficSpec{Algorithm: ptrAlg(v1beta1.LoadBalancingTypeRoundRobin)}
+	isvc.Annotations = map[string]string{
+		"ome.io/retry-attempts":                  "3",
+		"ome.io/circuit-breaker-max-connections": "1024", // unsupported per-key
+		"ome.io/dr.trafficPolicy.connectionPool": "30s",  // unsupported prefix
+	}
+
+	got, err := r.Reconcile(context.Background(), isvc, []string{"isvc"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(got.Conditions) != 2 {
+		t.Fatalf("expected 2 conditions, got %d: %+v", len(got.Conditions), got.Conditions)
+	}
+	var uc *metav1.Condition
+	for i := range got.Conditions {
+		if got.Conditions[i].Type == v1beta1.TrafficConditionBackendPolicyUnsupportedFields {
+			uc = &got.Conditions[i]
+		}
+	}
+	if uc == nil {
+		t.Fatalf("UnsupportedFields condition missing: %+v", got.Conditions)
+	}
+	for _, want := range []string{
+		"ome.io/circuit-breaker-max-connections",
+		"ome.io/dr.trafficPolicy.connectionPool",
+	} {
+		if !strings.Contains(uc.Message, want) {
+			t.Errorf("Message should list %q, got: %q", want, uc.Message)
+		}
+	}
+}
+
+func ptrAlg(a v1beta1.LoadBalancingType) *v1beta1.LoadBalancingType { return &a }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/status/status.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/status/status.go
@@ -1,0 +1,306 @@
+// Package status builds the TrafficStatus the InferenceService
+// controller writes back to the API server after invoking the traffic
+// translator.
+//
+// Build is a pure function so the writer can be unit-tested without a
+// live API server or controller-runtime client. The reconciler is
+// responsible for the actual Update / Patch call; this package just
+// produces the value to assign.
+//
+// This package intentionally consumes only primitive inputs (no
+// dependency on the parent traffic package) so the reconciler can
+// compose intent resolution -> translator invocation -> status build
+// without an import cycle.
+package status
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// NoopTranslatorName is the well-known translator name the Build
+// function short-circuits on to surface NoTranslatorAvailable. The
+// noop translator package defines the canonical constant; this
+// duplicate exists here so the status package stays dependency-free.
+// Any drift between the two surfaces as a unit-test failure in
+// translators/noop_test.go (which asserts the canonical value).
+const NoopTranslatorName = "noop"
+
+// GatewayAcceptance is the post-apply observation the reconciler
+// extracts from the gateway controller's status writeback. The status
+// package consumes only primitive values so it stays dependency-free
+// from the parent traffic package (which owns the matching
+// AcceptanceState enum).
+type GatewayAcceptance int
+
+const (
+	// GatewayAcceptancePending means no acceptance signal — first
+	// reconcile after create, or the gateway controller has not run yet.
+	// The condition surfaces as Unknown/Pending.
+	GatewayAcceptancePending GatewayAcceptance = iota
+	// GatewayAcceptanceAccepted means the gateway controller has
+	// accepted the policy. Condition becomes True/AcceptedByGateway.
+	GatewayAcceptanceAccepted
+	// GatewayAcceptanceRejected means the gateway controller has
+	// rejected the policy. Condition becomes False/GatewayRejected;
+	// the reason/message from the observation are passed through.
+	GatewayAcceptanceRejected
+)
+
+// algorithmDefault is the value Build stamps into
+// TrafficStatus.Algorithm when the operator did not pick an
+// algorithm. Surfaced verbatim so operators reading the status can
+// distinguish "OME defaulted" from any concrete algorithm name.
+const algorithmDefault = "Default"
+
+// BuildArgs is the input to Build. The reconciler fills this in from
+// the translator's outputs and the InferenceService it is reconciling.
+type BuildArgs struct {
+	// TranslatorName is the active translator's Name(). The noop
+	// translator name short-circuits to NoTranslatorAvailable;
+	// every other name proceeds to the success / error branch.
+	TranslatorName string
+
+	// HasIntent reports whether the operator declared any
+	// traffic-management intent on this InferenceService. When false
+	// Build returns nil so older clients keep seeing no traffic
+	// status.
+	HasIntent bool
+
+	// Algorithm is the operator-declared load-balancing algorithm
+	// (e.g. "RoundRobin"), or "" when unset. Build stamps "Default"
+	// into TrafficStatus.Algorithm in the empty case so operators
+	// can distinguish "OME defaulted" from any concrete algorithm.
+	// Caller resolves this from the intent's typed core so Build does
+	// not need to import the intent types.
+	Algorithm string
+
+	// EmittedPolicy is the resource the translator produced for this
+	// reconcile, or nil when the translator returned no resource
+	// (noop, or a real translator that deferred).
+	EmittedPolicy client.Object
+
+	// TargetedRoutes lists the OME-managed HTTPRoute names the
+	// emitted policy targets. Empty when no policy was emitted.
+	TargetedRoutes []string
+
+	// Passthroughs lists ome.io/btp.* or ome.io/dr.* paths the
+	// translator stitched into the emitted resource. Surfaced in the
+	// condition message so operators can audit what was used without
+	// reading the policy resource directly. Empty when none.
+	Passthroughs []string
+
+	// TranslateErr is the error from Translator.Translate. When
+	// non-nil it supersedes every other branch and produces a
+	// BackendPolicyReady=False condition with reason
+	// TranslationFailed (or ConflictingPolicy if ConflictDetected).
+	TranslateErr error
+
+	// ConflictDetected is set when applyPolicy refused to overwrite
+	// a pre-existing backend policy that isn't owned by this ISVC
+	// (hand-authored, or owned by a different controller). When true,
+	// the BackendPolicyReady condition is False with reason
+	// ConflictingPolicy and message ConflictMessage. Supersedes
+	// TranslateErr's TranslationFailed branch.
+	ConflictDetected bool
+	ConflictMessage  string
+
+	// GatewayAcceptance is the post-apply observation extracted from
+	// the gateway controller's status writeback on the emitted policy
+	// resource. Defaults to Pending (zero value), keeping the
+	// condition at Unknown/Pending.
+	GatewayAcceptance GatewayAcceptance
+
+	// GatewayAcceptanceReason / GatewayAcceptanceMessage are passed
+	// through from the gateway controller's condition so operators
+	// can see why the policy was rejected (or what triggered the
+	// acceptance). Both empty when GatewayAcceptance=Pending.
+	GatewayAcceptanceReason  string
+	GatewayAcceptanceMessage string
+
+	// UnsupportedAnnotations lists ome.io/* traffic annotations the
+	// operator declared that the active translator does not honor
+	// (wrong pass-through prefix, or a per-key annotation outside
+	// SupportedAnnotations). Sorted for deterministic messages.
+	//
+	// When non-empty, Build adds a second condition of type
+	// BackendPolicyUnsupportedFields=True with the list in the
+	// message. The condition is omitted when this slice is empty
+	// (positive-polarity: absence = nothing dropped) and on noop /
+	// TranslationFailed branches where the primary condition already
+	// explains the situation.
+	UnsupportedAnnotations []string
+
+	// ObservedGeneration is the InferenceService.metadata.generation
+	// observed when this reconcile started. Stamped into the
+	// condition so operators can correlate status with spec.
+	ObservedGeneration int64
+
+	// Now is the timestamp used for the condition's
+	// LastTransitionTime. Injected explicitly so Build stays
+	// deterministic for tests.
+	Now metav1.Time
+}
+
+// Build produces the TrafficStatus for the InferenceService, or nil
+// when there is no traffic intent to surface. The returned struct is
+// safe for direct assignment to InferenceServiceStatus.Traffic.
+//
+// Build is deterministic: same args -> identical output. The
+// reconciler relies on that property to avoid spurious status
+// patches when nothing has changed.
+func Build(args BuildArgs) *v1beta1.TrafficStatus {
+	if !args.HasIntent {
+		return nil
+	}
+
+	out := &v1beta1.TrafficStatus{
+		Algorithm: algorithmFor(args.Algorithm),
+	}
+
+	if args.EmittedPolicy != nil {
+		gvk := args.EmittedPolicy.GetObjectKind().GroupVersionKind()
+		out.BackendPolicyResource = &v1beta1.BackendPolicyRef{
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
+			Name:       args.EmittedPolicy.GetName(),
+		}
+		// Defensive copy so a caller mutating TargetedRoutes after
+		// the call doesn't smuggle changes into the written status.
+		if len(args.TargetedRoutes) > 0 {
+			out.TargetedHTTPRoutes = append(make([]string, 0, len(args.TargetedRoutes)), args.TargetedRoutes...)
+		}
+	}
+
+	out.Conditions = []metav1.Condition{buildReadyCondition(args)}
+	if cond, ok := buildUnsupportedFieldsCondition(args); ok {
+		out.Conditions = append(out.Conditions, cond)
+	}
+	return out
+}
+
+// buildUnsupportedFieldsCondition returns the
+// BackendPolicyUnsupportedFields condition and true when the active
+// translator dropped operator-declared annotations. Returns ok=false
+// when there is nothing to report, or when another condition already
+// explains the situation (noop / TranslationFailed) and listing the
+// dropped keys would be redundant noise.
+func buildUnsupportedFieldsCondition(args BuildArgs) (metav1.Condition, bool) {
+	if len(args.UnsupportedAnnotations) == 0 {
+		return metav1.Condition{}, false
+	}
+	if args.TranslateErr != nil {
+		return metav1.Condition{}, false
+	}
+	if args.TranslatorName == NoopTranslatorName {
+		return metav1.Condition{}, false
+	}
+	return metav1.Condition{
+		Type:               v1beta1.TrafficConditionBackendPolicyUnsupportedFields,
+		Status:             metav1.ConditionTrue,
+		Reason:             v1beta1.TrafficReasonUnsupportedField,
+		LastTransitionTime: args.Now,
+		ObservedGeneration: args.ObservedGeneration,
+		Message: fmt.Sprintf(
+			"translator %q dropped %d operator-declared annotation(s): %v",
+			args.TranslatorName, len(args.UnsupportedAnnotations), args.UnsupportedAnnotations,
+		),
+	}, true
+}
+
+func buildReadyCondition(args BuildArgs) metav1.Condition {
+	cond := metav1.Condition{
+		Type:               v1beta1.TrafficConditionBackendPolicyReady,
+		LastTransitionTime: args.Now,
+		ObservedGeneration: args.ObservedGeneration,
+	}
+
+	switch {
+	case args.ConflictDetected:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = v1beta1.TrafficReasonConflictingPolicy
+		cond.Message = args.ConflictMessage
+
+	case args.TranslateErr != nil:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = v1beta1.TrafficReasonTranslationFailed
+		cond.Message = args.TranslateErr.Error()
+
+	case args.TranslatorName == NoopTranslatorName:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = v1beta1.TrafficReasonNoTranslatorAvailable
+		cond.Message = "no Gateway-implementation backend policy CRD installed; traffic intent ignored"
+
+	case args.EmittedPolicy == nil:
+		// Translator ran without error but produced no resource. Pending
+		// is the honest answer; a translator that wants to refuse on
+		// principle returns an error instead.
+		cond.Status = metav1.ConditionUnknown
+		cond.Reason = v1beta1.TrafficReasonPending
+		cond.Message = "translator did not emit a backend policy resource"
+
+	default:
+		// Policy was applied. The gateway controller's acceptance
+		// signal (if any) drives the final condition.
+		switch args.GatewayAcceptance {
+		case GatewayAcceptanceAccepted:
+			cond.Status = metav1.ConditionTrue
+			cond.Reason = v1beta1.TrafficReasonAcceptedByGateway
+			cond.Message = acceptedMessage(args)
+		case GatewayAcceptanceRejected:
+			cond.Status = metav1.ConditionFalse
+			cond.Reason = v1beta1.TrafficReasonGatewayRejected
+			cond.Message = rejectedMessage(args)
+		default: // GatewayAcceptancePending
+			cond.Status = metav1.ConditionUnknown
+			cond.Reason = v1beta1.TrafficReasonPending
+			cond.Message = passthroughMessage(args.Passthroughs)
+		}
+	}
+
+	return cond
+}
+
+func acceptedMessage(args BuildArgs) string {
+	if args.GatewayAcceptanceMessage != "" {
+		return args.GatewayAcceptanceMessage
+	}
+	if len(args.Passthroughs) == 0 {
+		return "backend policy accepted by gateway controller"
+	}
+	return fmt.Sprintf(
+		"backend policy accepted by gateway controller with %d pass-through field(s) (%v)",
+		len(args.Passthroughs), args.Passthroughs,
+	)
+}
+
+func rejectedMessage(args BuildArgs) string {
+	if args.GatewayAcceptanceMessage != "" {
+		return args.GatewayAcceptanceMessage
+	}
+	if args.GatewayAcceptanceReason != "" {
+		return fmt.Sprintf("backend policy rejected by gateway controller: %s", args.GatewayAcceptanceReason)
+	}
+	return "backend policy rejected by gateway controller"
+}
+
+func passthroughMessage(paths []string) string {
+	if len(paths) == 0 {
+		return "backend policy emitted; awaiting gateway acceptance"
+	}
+	return fmt.Sprintf(
+		"backend policy emitted with %d pass-through field(s) (%v); awaiting gateway acceptance",
+		len(paths), paths,
+	)
+}
+
+func algorithmFor(s string) string {
+	if s == "" {
+		return algorithmDefault
+	}
+	return s
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/status/status_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/status/status_test.go
@@ -1,0 +1,467 @@
+package status
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// fixedNow is a stable transition time used everywhere so test
+// failures don't depend on wall clock.
+var fixedNow = metav1.NewTime(time.Date(2026, time.May, 17, 12, 0, 0, 0, time.UTC))
+
+// fakeEmittedPolicy is a minimal client.Object stand-in. The real
+// Envoy Gateway BackendTrafficPolicy lives behind a go.mod dep that
+// is not yet vendored; using a fake decouples the writer test from
+// that dep.
+type fakeEmittedPolicy struct {
+	client.Object
+	name string
+	gvk  schema.GroupVersionKind
+}
+
+func (f *fakeEmittedPolicy) GetName() string { return f.name }
+func (f *fakeEmittedPolicy) GetObjectKind() schema.ObjectKind {
+	return &fakeObjectKind{gvk: f.gvk}
+}
+
+type fakeObjectKind struct {
+	gvk schema.GroupVersionKind
+}
+
+func (f *fakeObjectKind) GroupVersionKind() schema.GroupVersionKind {
+	return f.gvk
+}
+func (f *fakeObjectKind) SetGroupVersionKind(_ schema.GroupVersionKind) {}
+
+// Statically verify fake satisfies client.Object via embedding (the
+// fakeclient package is imported solely to surface compile errors if
+// the embedded interface shape ever drifts).
+var _ = fakeclient.NewClientBuilder
+
+func newEmittedPolicy(name string) client.Object {
+	return &fakeEmittedPolicy{
+		name: name,
+		gvk: schema.GroupVersionKind{
+			Group:   "gateway.envoyproxy.io",
+			Version: "v1alpha1",
+			Kind:    "BackendTrafficPolicy",
+		},
+	}
+}
+
+func TestBuild_HasIntentFalse_ReturnsNil(t *testing.T) {
+	// When the operator declares nothing, the writer must NOT emit a
+	// TrafficStatus so older clients keep seeing the field as nil.
+	got := Build(BuildArgs{HasIntent: false, Now: fixedNow})
+	if got != nil {
+		t.Fatalf("Build with HasIntent=false must return nil, got %+v", got)
+	}
+}
+
+func TestBuild_NoopTranslator_NoTranslatorAvailable(t *testing.T) {
+	got := Build(BuildArgs{
+		TranslatorName:     NoopTranslatorName,
+		HasIntent:          true,
+		Algorithm:          string(v1beta1.LoadBalancingTypeRoundRobin),
+		ObservedGeneration: 7,
+		Now:                fixedNow,
+	})
+	if got == nil {
+		t.Fatalf("Build must emit a TrafficStatus when intent is set, even for noop")
+	}
+	if got.Algorithm != string(v1beta1.LoadBalancingTypeRoundRobin) {
+		t.Fatalf("LoadBalancingType = %q, want RoundRobin", got.Algorithm)
+	}
+	if got.BackendPolicyResource != nil {
+		t.Fatalf("noop emits no policy resource; got %+v", got.BackendPolicyResource)
+	}
+	if len(got.TargetedHTTPRoutes) != 0 {
+		t.Fatalf("noop targets no routes; got %v", got.TargetedHTTPRoutes)
+	}
+	if len(got.Conditions) != 1 {
+		t.Fatalf("expected 1 condition, got %d: %+v", len(got.Conditions), got.Conditions)
+	}
+	c := got.Conditions[0]
+	if c.Type != v1beta1.TrafficConditionBackendPolicyReady {
+		t.Fatalf("condition Type = %q", c.Type)
+	}
+	if c.Status != metav1.ConditionFalse {
+		t.Fatalf("condition Status = %q, want False", c.Status)
+	}
+	if c.Reason != v1beta1.TrafficReasonNoTranslatorAvailable {
+		t.Fatalf("condition Reason = %q", c.Reason)
+	}
+	if c.ObservedGeneration != 7 {
+		t.Fatalf("ObservedGeneration = %d, want 7", c.ObservedGeneration)
+	}
+	if !c.LastTransitionTime.Equal(&fixedNow) {
+		t.Fatalf("LastTransitionTime = %v, want %v", c.LastTransitionTime, fixedNow)
+	}
+}
+
+func TestBuild_TranslateError_TranslationFailed(t *testing.T) {
+	wantMsg := "unsupported algorithm"
+	got := Build(BuildArgs{
+		TranslatorName: "envoy-gateway",
+		HasIntent:      true,
+		TranslateErr:   errors.New(wantMsg),
+		Now:            fixedNow,
+	})
+	if got == nil {
+		t.Fatalf("expected status, got nil")
+	}
+	c := got.Conditions[0]
+	if c.Status != metav1.ConditionFalse {
+		t.Fatalf("Status = %q, want False", c.Status)
+	}
+	if c.Reason != v1beta1.TrafficReasonTranslationFailed {
+		t.Fatalf("Reason = %q, want TranslationFailed", c.Reason)
+	}
+	if c.Message != wantMsg {
+		t.Fatalf("Message = %q, want %q", c.Message, wantMsg)
+	}
+	if got.Algorithm != algorithmDefault {
+		t.Fatalf("LoadBalancingType = %q, want %q (empty input)", got.Algorithm, algorithmDefault)
+	}
+}
+
+func TestBuild_TranslateError_BeatsNoop(t *testing.T) {
+	// The error branch must beat the noop short-circuit so operators
+	// see the actionable reason.
+	got := Build(BuildArgs{
+		TranslatorName: NoopTranslatorName,
+		HasIntent:      true,
+		TranslateErr:   errors.New("synthetic"),
+		Now:            fixedNow,
+	})
+	if got.Conditions[0].Reason != v1beta1.TrafficReasonTranslationFailed {
+		t.Fatalf("error must beat noop; got Reason %q", got.Conditions[0].Reason)
+	}
+}
+
+func TestBuild_EmittedPolicy_Pending(t *testing.T) {
+	policy := newEmittedPolicy("foo-btp")
+	routes := []string{"foo", "foo-engine", "foo-decoder"}
+
+	got := Build(BuildArgs{
+		TranslatorName: "envoy-gateway",
+		HasIntent:      true,
+		Algorithm:      string(v1beta1.LoadBalancingTypeLeastRequest),
+		EmittedPolicy:  policy,
+		TargetedRoutes: routes,
+		Now:            fixedNow,
+	})
+
+	if got.Algorithm != string(v1beta1.LoadBalancingTypeLeastRequest) {
+		t.Fatalf("LoadBalancingType = %q", got.Algorithm)
+	}
+	if got.BackendPolicyResource == nil {
+		t.Fatalf("BackendPolicyResource missing")
+	}
+	if got.BackendPolicyResource.APIVersion != "gateway.envoyproxy.io/v1alpha1" {
+		t.Fatalf("APIVersion = %q", got.BackendPolicyResource.APIVersion)
+	}
+	if got.BackendPolicyResource.Kind != "BackendTrafficPolicy" {
+		t.Fatalf("Kind = %q", got.BackendPolicyResource.Kind)
+	}
+	if got.BackendPolicyResource.Name != "foo-btp" {
+		t.Fatalf("Name = %q", got.BackendPolicyResource.Name)
+	}
+
+	// TargetedHTTPRoutes must be a defensive copy: mutating the
+	// caller's slice afterwards must not change the status.
+	if len(got.TargetedHTTPRoutes) != 3 {
+		t.Fatalf("expected 3 routes, got %v", got.TargetedHTTPRoutes)
+	}
+	routes[0] = "tampered"
+	if got.TargetedHTTPRoutes[0] == "tampered" {
+		t.Fatalf("TargetedHTTPRoutes must be a defensive copy")
+	}
+
+	c := got.Conditions[0]
+	if c.Status != metav1.ConditionUnknown {
+		t.Fatalf("Status = %q, want Unknown", c.Status)
+	}
+	if c.Reason != v1beta1.TrafficReasonPending {
+		t.Fatalf("Reason = %q, want Pending", c.Reason)
+	}
+}
+
+func TestBuild_Passthroughs_AppearInMessage(t *testing.T) {
+	policy := newEmittedPolicy("foo-btp")
+	got := Build(BuildArgs{
+		TranslatorName: "envoy-gateway",
+		HasIntent:      true,
+		EmittedPolicy:  policy,
+		Passthroughs:   []string{"loadBalancer.slowStart.window"},
+		Now:            fixedNow,
+	})
+	msg := got.Conditions[0].Message
+	if !strings.Contains(msg, "1 pass-through") {
+		t.Fatalf("expected pass-through count in message, got %q", msg)
+	}
+	if !strings.Contains(msg, "loadBalancer.slowStart.window") {
+		t.Fatalf("expected pass-through path in message, got %q", msg)
+	}
+}
+
+func TestBuild_NoEmittedPolicyNoError_Pending(t *testing.T) {
+	got := Build(BuildArgs{
+		TranslatorName: "envoy-gateway",
+		HasIntent:      true,
+		Now:            fixedNow,
+	})
+	c := got.Conditions[0]
+	if c.Status != metav1.ConditionUnknown {
+		t.Fatalf("Status = %q, want Unknown", c.Status)
+	}
+	if c.Reason != v1beta1.TrafficReasonPending {
+		t.Fatalf("Reason = %q, want Pending", c.Reason)
+	}
+}
+
+func TestBuild_Determinism(t *testing.T) {
+	// Same args must produce equivalent output across calls — the
+	// reconciler relies on this to avoid noisy status patches.
+	args := BuildArgs{
+		TranslatorName: "envoy-gateway",
+		HasIntent:      true,
+		Algorithm:      string(v1beta1.LoadBalancingTypeConsistentHash),
+		EmittedPolicy:  newEmittedPolicy("foo-btp"),
+		TargetedRoutes: []string{"foo"},
+		Passthroughs:   []string{"a.b.c"},
+		Now:            fixedNow,
+	}
+	a := Build(args)
+	b := Build(args)
+	if a.Algorithm != b.Algorithm ||
+		a.BackendPolicyResource.Name != b.BackendPolicyResource.Name ||
+		a.Conditions[0].Message != b.Conditions[0].Message {
+		t.Fatalf("Build is not deterministic:\n a=%+v\n b=%+v", a, b)
+	}
+}
+
+func TestBuild_GatewayAccepted_TruePassThroughMessage(t *testing.T) {
+	policy := newEmittedPolicy("foo-btp")
+	got := Build(BuildArgs{
+		TranslatorName:           "envoy-gateway",
+		HasIntent:                true,
+		EmittedPolicy:            policy,
+		GatewayAcceptance:        GatewayAcceptanceAccepted,
+		GatewayAcceptanceReason:  "Accepted",
+		GatewayAcceptanceMessage: "Policy is valid and accepted",
+		Now:                      fixedNow,
+	})
+	c := got.Conditions[0]
+	if c.Status != metav1.ConditionTrue {
+		t.Fatalf("Status = %q, want True", c.Status)
+	}
+	if c.Reason != v1beta1.TrafficReasonAcceptedByGateway {
+		t.Fatalf("Reason = %q, want AcceptedByGateway", c.Reason)
+	}
+	if c.Message != "Policy is valid and accepted" {
+		t.Fatalf("Message = %q, want pass-through", c.Message)
+	}
+}
+
+func TestBuild_GatewayAccepted_FallbackMessage(t *testing.T) {
+	// When the gateway controller writes no message, Build composes
+	// a default that still tells the operator the policy was accepted.
+	policy := newEmittedPolicy("foo-btp")
+	got := Build(BuildArgs{
+		TranslatorName:    "envoy-gateway",
+		HasIntent:         true,
+		EmittedPolicy:     policy,
+		GatewayAcceptance: GatewayAcceptanceAccepted,
+		Passthroughs:      []string{"loadBalancer.slowStart.window"},
+		Now:               fixedNow,
+	})
+	if !strings.Contains(got.Conditions[0].Message, "accepted by gateway") {
+		t.Fatalf("default accepted message missing: %q", got.Conditions[0].Message)
+	}
+	if !strings.Contains(got.Conditions[0].Message, "loadBalancer.slowStart.window") {
+		t.Fatalf("pass-through paths should appear in default message: %q", got.Conditions[0].Message)
+	}
+}
+
+func TestBuild_GatewayRejected_FalsePassThroughMessage(t *testing.T) {
+	policy := newEmittedPolicy("foo-btp")
+	got := Build(BuildArgs{
+		TranslatorName:           "envoy-gateway",
+		HasIntent:                true,
+		EmittedPolicy:            policy,
+		GatewayAcceptance:        GatewayAcceptanceRejected,
+		GatewayAcceptanceReason:  "Invalid",
+		GatewayAcceptanceMessage: "unsupported field foo.bar",
+		Now:                      fixedNow,
+	})
+	c := got.Conditions[0]
+	if c.Status != metav1.ConditionFalse {
+		t.Fatalf("Status = %q, want False", c.Status)
+	}
+	if c.Reason != v1beta1.TrafficReasonGatewayRejected {
+		t.Fatalf("Reason = %q, want GatewayRejected", c.Reason)
+	}
+	if c.Message != "unsupported field foo.bar" {
+		t.Fatalf("Message = %q", c.Message)
+	}
+}
+
+func TestBuild_GatewayRejected_ReasonOnlyFallback(t *testing.T) {
+	// Reason but no message — Build composes a useful fallback.
+	policy := newEmittedPolicy("foo-btp")
+	got := Build(BuildArgs{
+		TranslatorName:          "envoy-gateway",
+		HasIntent:               true,
+		EmittedPolicy:           policy,
+		GatewayAcceptance:       GatewayAcceptanceRejected,
+		GatewayAcceptanceReason: "Invalid",
+		Now:                     fixedNow,
+	})
+	if !strings.Contains(got.Conditions[0].Message, "Invalid") {
+		t.Fatalf("Message should mention reason: %q", got.Conditions[0].Message)
+	}
+}
+
+func TestBuild_GatewayPending_KeepsPendingCondition(t *testing.T) {
+	// Default (Pending) acceptance must produce the same condition as
+	// before adding acceptance signals — no regression for the
+	// first-reconcile case.
+	policy := newEmittedPolicy("foo-btp")
+	got := Build(BuildArgs{
+		TranslatorName:    "envoy-gateway",
+		HasIntent:         true,
+		EmittedPolicy:     policy,
+		GatewayAcceptance: GatewayAcceptancePending,
+		Now:               fixedNow,
+	})
+	c := got.Conditions[0]
+	if c.Status != metav1.ConditionUnknown {
+		t.Fatalf("Status = %q, want Unknown", c.Status)
+	}
+	if c.Reason != v1beta1.TrafficReasonPending {
+		t.Fatalf("Reason = %q, want Pending", c.Reason)
+	}
+}
+
+func TestBuild_TranslateError_BeatsGatewayAcceptance(t *testing.T) {
+	// The error branch trumps even an "Accepted" observation — if
+	// translation failed this cycle, the policy on the API server
+	// is from a prior successful cycle and its acceptance state is
+	// no longer authoritative.
+	got := Build(BuildArgs{
+		TranslatorName:    "envoy-gateway",
+		HasIntent:         true,
+		TranslateErr:      errors.New("boom"),
+		GatewayAcceptance: GatewayAcceptanceAccepted,
+		Now:               fixedNow,
+	})
+	if got.Conditions[0].Reason != v1beta1.TrafficReasonTranslationFailed {
+		t.Fatalf("Reason = %q, want TranslationFailed", got.Conditions[0].Reason)
+	}
+}
+
+func TestBuild_UnsupportedFields_AddsSecondCondition(t *testing.T) {
+	policy := newEmittedPolicy("foo-btp")
+	got := Build(BuildArgs{
+		TranslatorName:         "envoy-gateway",
+		HasIntent:              true,
+		EmittedPolicy:          policy,
+		UnsupportedAnnotations: []string{"ome.io/dr.foo", "ome.io/dr.bar"},
+		Now:                    fixedNow,
+	})
+	if len(got.Conditions) != 2 {
+		t.Fatalf("expected 2 conditions, got %d: %+v", len(got.Conditions), got.Conditions)
+	}
+	// Find the UnsupportedFields condition.
+	var uc *metav1.Condition
+	for i := range got.Conditions {
+		if got.Conditions[i].Type == v1beta1.TrafficConditionBackendPolicyUnsupportedFields {
+			uc = &got.Conditions[i]
+			break
+		}
+	}
+	if uc == nil {
+		t.Fatalf("BackendPolicyUnsupportedFields condition missing: %+v", got.Conditions)
+	}
+	if uc.Status != metav1.ConditionTrue {
+		t.Fatalf("Status = %q, want True", uc.Status)
+	}
+	if uc.Reason != v1beta1.TrafficReasonUnsupportedField {
+		t.Fatalf("Reason = %q, want UnsupportedField", uc.Reason)
+	}
+	if !strings.Contains(uc.Message, "envoy-gateway") {
+		t.Fatalf("Message should mention translator: %q", uc.Message)
+	}
+	if !strings.Contains(uc.Message, "ome.io/dr.foo") || !strings.Contains(uc.Message, "ome.io/dr.bar") {
+		t.Fatalf("Message should list dropped keys: %q", uc.Message)
+	}
+}
+
+func TestBuild_UnsupportedFields_EmptyList_OmitsCondition(t *testing.T) {
+	policy := newEmittedPolicy("foo-btp")
+	got := Build(BuildArgs{
+		TranslatorName:    "envoy-gateway",
+		HasIntent:         true,
+		EmittedPolicy:     policy,
+		GatewayAcceptance: GatewayAcceptanceAccepted,
+		Now:               fixedNow,
+	})
+	if len(got.Conditions) != 1 {
+		t.Fatalf("clean ISVC should have only the Ready condition, got %d: %+v",
+			len(got.Conditions), got.Conditions)
+	}
+}
+
+func TestBuild_UnsupportedFields_NoopTranslator_OmitsCondition(t *testing.T) {
+	// NoTranslatorAvailable already explains why nothing is honored;
+	// listing every dropped key would be noise.
+	got := Build(BuildArgs{
+		TranslatorName:         NoopTranslatorName,
+		HasIntent:              true,
+		UnsupportedAnnotations: []string{"ome.io/circuit-breaker-max-connections"},
+		Now:                    fixedNow,
+	})
+	if len(got.Conditions) != 1 {
+		t.Fatalf("noop must not surface UnsupportedFields, got %d: %+v",
+			len(got.Conditions), got.Conditions)
+	}
+	if got.Conditions[0].Reason != v1beta1.TrafficReasonNoTranslatorAvailable {
+		t.Fatalf("primary condition reason = %q", got.Conditions[0].Reason)
+	}
+}
+
+func TestBuild_UnsupportedFields_TranslateError_OmitsCondition(t *testing.T) {
+	// TranslationFailed already explains the situation.
+	got := Build(BuildArgs{
+		TranslatorName:         "envoy-gateway",
+		HasIntent:              true,
+		TranslateErr:           errors.New("boom"),
+		UnsupportedAnnotations: []string{"ome.io/dr.foo"},
+		Now:                    fixedNow,
+	})
+	if len(got.Conditions) != 1 {
+		t.Fatalf("translate error must suppress UnsupportedFields, got %d: %+v",
+			len(got.Conditions), got.Conditions)
+	}
+}
+
+func TestBuild_LoadBalancingType_DefaultsWhenEmpty(t *testing.T) {
+	got := Build(BuildArgs{
+		TranslatorName: "envoy-gateway",
+		HasIntent:      true,
+		Now:            fixedNow,
+	})
+	if got.Algorithm != algorithmDefault {
+		t.Fatalf("LoadBalancingType = %q, want %q", got.Algorithm, algorithmDefault)
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translator.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translator.go
@@ -1,0 +1,132 @@
+// Translator is the per-Gateway-implementation abstraction that turns a
+// resolved traffic-management intent into the right backend policy
+// resource for whichever Gateway implementation is installed in the
+// cluster (Envoy Gateway BackendTrafficPolicy, Istio DestinationRule,
+// kgateway TrafficPolicy, etc.). Translator implementations live under
+// pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/.
+//
+// The interface lives alongside ResolvedIntent — both are consumed by
+// the Reconciler and translator implementations, and the interface
+// names ResolvedIntent so splitting them would create an import cycle.
+package traffic
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// AcceptanceState reports whether the Gateway implementation has
+// accepted the emitted backend policy resource. The reconciler reads
+// status.conditions on the post-apply object via Translator.
+// ObserveAcceptance to decide which TrafficStatus condition to surface.
+type AcceptanceState int
+
+const (
+	// AcceptancePending means the gateway controller has not (yet)
+	// written an acceptance signal. Typical on first reconcile after
+	// the policy was created, or for translators whose target
+	// implementation does not surface acceptance state.
+	AcceptancePending AcceptanceState = iota
+	// AcceptanceAccepted means the gateway controller has accepted
+	// the policy.
+	AcceptanceAccepted
+	// AcceptanceRejected means the gateway controller has rejected
+	// the policy. The reason / message live on AcceptanceObservation.
+	AcceptanceRejected
+)
+
+// AcceptanceObservation is the result of Translator.ObserveAcceptance.
+// State drives the TrafficStatus condition; Reason / Message are
+// passed through to the operator-visible condition so they can debug
+// without inspecting the policy resource directly.
+type AcceptanceObservation struct {
+	State   AcceptanceState
+	Reason  string
+	Message string
+}
+
+// Translator emits the backend policy resource for a single
+// InferenceService. Exactly one translator is active per controller
+// process (chosen by the factory at startup); the active translator's
+// Translate method is invoked per ISVC during reconciliation when
+// the ISVC declares any traffic-management intent.
+type Translator interface {
+	// Name returns a stable identifier for log / metric labels
+	// (e.g. "envoy-gateway", "istio", "noop"). Must be unique
+	// across all translators registered with the factory.
+	Name() string
+
+	// SupportedAnnotations returns the set of ome.io/* annotation
+	// keys the translator can honor. The reconciler uses this set to
+	// surface UnsupportedField conditions for annotations declared
+	// on the ISVC that this translator does not implement (e.g. an
+	// Envoy-only field set on an Istio cluster). Returning an empty
+	// set is valid — it means the translator implements no
+	// annotation extensions (legitimate for a stub).
+	//
+	// The result is the support matrix of which policy fields each
+	// gateway backend honors, expressed as runtime data.
+	SupportedAnnotations() sets.Set[string]
+
+	// SupportedPassthroughPrefixes returns the ome.io/* annotation
+	// prefixes whose contents this translator stitches verbatim into
+	// the emitted resource. Annotations under any other pass-through
+	// prefix are surfaced as UnsupportedField (e.g. ome.io/dr.* on a
+	// cluster where the Envoy Gateway translator is active).
+	//
+	// Returning nil / an empty slice is valid (e.g. noop). Each
+	// prefix MUST end with a "." to match the constants in
+	// pkg/constants/traffic_annotations.go.
+	SupportedPassthroughPrefixes() []string
+
+	// Translate produces the backend policy resource for the
+	// InferenceService given the resolved intent and the list of
+	// OME-managed HTTPRoute names the policy must target (top-level,
+	// router, decoder, engine; per-revision HTTPRoutes for canaries
+	// are not separate routes — the HTTPRoute builder represents
+	// canaries as weighted backendRefs on the existing per-Component
+	// routes).
+	//
+	// Returns:
+	//   - the emitted resource (typed as client.Object so the
+	//     translator package can be implementation-agnostic). The
+	//     resource MUST have its OwnerReferences set to the ISVC so
+	//     deletion of the ISVC garbage-collects the policy. The
+	//     resource's name MUST be deterministic — typically the ISVC
+	//     name — so subsequent reconciles update rather than create
+	//     duplicates.
+	//   - the list of pass-through field paths that were stitched
+	//     into the resource (for status condition message + metrics).
+	//     Empty when the translator stitched nothing.
+	//   - an error when translation fails. Returning (nil, nil, nil)
+	//     means "no resource needed for this intent" (e.g. the noop
+	//     translator returns this so the reconciler skips emission).
+	//
+	// Translate must be deterministic: same inputs -> byte-identical
+	// output. The reconciler uses this property to avoid noisy
+	// API server updates when nothing has changed.
+	Translate(
+		isvc *v1beta1.InferenceService,
+		targetHTTPRoutes []string,
+		intent *ResolvedIntent,
+	) (client.Object, []string, error)
+
+	// Watches returns a zero-value instance of the resource type the
+	// translator emits, used by the reconciler's SetupWithManager
+	// to register an Owns() watch. Returns nil when the translator
+	// does not emit any resource (e.g. the noop translator).
+	Watches() client.Object
+
+	// ObserveAcceptance inspects the post-apply policy resource (as
+	// fetched from the API server) and reports whether the Gateway
+	// implementation has accepted it. Returning AcceptancePending
+	// means "no acceptance signal yet" — the reconciler keeps the
+	// BackendPolicyReady condition at Pending.
+	//
+	// obj is the resource the translator previously emitted, fetched
+	// fresh from the cluster so its status subresource reflects any
+	// updates the gateway controller has written since.
+	ObserveAcceptance(obj client.Object) AcceptanceObservation
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/envoygateway/translator.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/envoygateway/translator.go
@@ -1,0 +1,521 @@
+// Package envoygateway translates traffic intent into an Envoy Gateway
+// BackendTrafficPolicy (gateway.envoyproxy.io/v1alpha1).
+//
+// The translator emits an unstructured.Unstructured object so OME does
+// not vendor the Envoy Gateway Go module — a dep that would force
+// large transitive upgrades (notably KEDA). The string paths the
+// translator writes into map to the BackendTrafficPolicy CRD schema;
+// gateway-controller schema errors surface as GatewayRejected on the
+// InferenceService status.
+//
+// Pass-through (`ome.io/btp.<path>=<value>`) is applied last so an
+// operator can override any structured field — this is the documented
+// escape hatch.
+package envoygateway
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic"
+)
+
+// Name is the stable identifier the factory uses for log / metric
+// labels and that the status writer matches on.
+const Name = "envoy-gateway"
+
+// Envoy Gateway BackendTrafficPolicy coordinates. These are pinned by
+// the Envoy Gateway public API; any change (e.g. a v1beta1 graduation)
+// is a deliberate upgrade.
+const (
+	groupEnvoyGateway = "gateway.envoyproxy.io"
+	versionV1Alpha1   = "v1alpha1"
+	kindBTP           = "BackendTrafficPolicy"
+
+	groupGatewayAPI = "gateway.networking.k8s.io"
+	kindHTTPRoute   = "HTTPRoute"
+)
+
+var btpGVK = schema.GroupVersionKind{
+	Group:   groupEnvoyGateway,
+	Version: versionV1Alpha1,
+	Kind:    kindBTP,
+}
+
+// Translator emits a BackendTrafficPolicy per InferenceService.
+type Translator struct{}
+
+// New returns a ready-to-use Translator. There is no per-cluster
+// configuration to bind so this exists solely to match the constructor
+// shape of other translators (consistency for the factory).
+func New() *Translator {
+	return &Translator{}
+}
+
+// Name returns the stable identifier "envoy-gateway".
+func (t *Translator) Name() string {
+	return Name
+}
+
+// Watches returns a zero-value unstructured BackendTrafficPolicy with
+// the GVK set so controller-runtime's Owns() can register the watch
+// without us importing the Envoy Gateway types.
+func (t *Translator) Watches() client.Object {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(btpGVK)
+	return u
+}
+
+// gatewayAcceptedConditionType is the well-known Gateway API
+// condition type the Envoy Gateway control plane writes to the BTP's
+// status.conditions list when it accepts (or rejects) a policy.
+// Pinned by Gateway API GEP-713; same value used across BackendTLSPolicy,
+// BackendTrafficPolicy, ClientTrafficPolicy, etc.
+const gatewayAcceptedConditionType = "Accepted"
+
+// ObserveAcceptance inspects the post-apply BackendTrafficPolicy and
+// reports whether Envoy Gateway has accepted it. The control plane
+// writes a Gateway-API-shaped condition (type=Accepted) to
+// status.conditions; we map True->Accepted, False->Rejected, anything
+// else (or absent) -> Pending.
+func (t *Translator) ObserveAcceptance(obj client.Object) traffic.AcceptanceObservation {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok || u == nil {
+		return traffic.AcceptanceObservation{State: traffic.AcceptancePending}
+	}
+	conds, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if err != nil || !found {
+		return traffic.AcceptanceObservation{State: traffic.AcceptancePending}
+	}
+	for _, raw := range conds {
+		c, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if cType, _ := c["type"].(string); cType != gatewayAcceptedConditionType {
+			continue
+		}
+		statusStr, _ := c["status"].(string)
+		reason, _ := c["reason"].(string)
+		message, _ := c["message"].(string)
+		switch statusStr {
+		case "True":
+			return traffic.AcceptanceObservation{
+				State:   traffic.AcceptanceAccepted,
+				Reason:  reason,
+				Message: message,
+			}
+		case "False":
+			return traffic.AcceptanceObservation{
+				State:   traffic.AcceptanceRejected,
+				Reason:  reason,
+				Message: message,
+			}
+		}
+		// status=Unknown or anything else falls through to Pending.
+	}
+	return traffic.AcceptanceObservation{State: traffic.AcceptancePending}
+}
+
+// SupportedPassthroughPrefixes declares that the Envoy Gateway
+// translator owns the ome.io/btp.* pass-through namespace. The
+// reconciler uses this to surface UnsupportedField when an operator
+// sets an ome.io/dr.* (Istio) pass-through on an EG cluster.
+func (t *Translator) SupportedPassthroughPrefixes() []string {
+	return []string{constants.PassthroughEnvoyGatewayPrefix}
+}
+
+// SupportedAnnotations returns the set of ome.io/* annotation keys
+// the Envoy Gateway BTP can honor. Pass-through (ome.io/btp.*) is not
+// listed because pass-through is per-prefix, not per-key.
+func (t *Translator) SupportedAnnotations() sets.Set[string] {
+	return sets.New(
+		constants.CircuitBreakerMaxConnectionsAnnotation,
+		constants.CircuitBreakerMaxParallelRequestsAnnotation,
+		constants.CircuitBreakerMaxPendingRequestsAnnotation,
+		constants.CircuitBreakerMaxParallelRetriesAnnotation,
+		constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation,
+		constants.RetryAttemptsAnnotation,
+		constants.RetryOnAnnotation,
+		constants.RetryPerTryTimeoutAnnotation,
+		constants.TimeoutIdleAnnotation,
+		constants.TimeoutMaxConnectionDurationAnnotation,
+		constants.TimeoutTCPConnectAnnotation,
+	)
+}
+
+// Translate produces the BackendTrafficPolicy resource for the
+// InferenceService. Deterministic — same inputs produce byte-identical
+// output, so the reconciler's coarse Update doesn't churn the API
+// server when nothing has changed.
+func (t *Translator) Translate(
+	isvc *v1beta1.InferenceService,
+	targetHTTPRoutes []string,
+	intent *traffic.ResolvedIntent,
+) (client.Object, []string, error) {
+	btp := &unstructured.Unstructured{}
+	btp.SetGroupVersionKind(btpGVK)
+	btp.SetName(isvc.Name)
+	btp.SetNamespace(isvc.Namespace)
+
+	if err := setTargetRefs(btp, targetHTTPRoutes); err != nil {
+		return nil, nil, err
+	}
+
+	if intent.Traffic != nil {
+		if err := applyLoadBalancer(btp, intent.Traffic); err != nil {
+			return nil, nil, err
+		}
+	}
+	if intent.CircuitBreaker != nil {
+		if err := applyCircuitBreaker(btp, intent.CircuitBreaker); err != nil {
+			return nil, nil, err
+		}
+	}
+	if intent.Retry != nil {
+		if err := applyRetry(btp, intent.Retry); err != nil {
+			return nil, nil, err
+		}
+	}
+	if intent.Timeout != nil {
+		if err := applyTimeout(btp, intent.Timeout); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Pass-through stitches are applied LAST so operators can override
+	// any structured field via ome.io/btp.<path>=<value>. The returned
+	// slice is sorted so the status condition message and metrics are
+	// deterministic.
+	passthroughs, err := applyPassthroughs(btp, intent.PassthroughEnvoyGateway)
+	if err != nil {
+		return nil, nil, err
+	}
+	return btp, passthroughs, nil
+}
+
+// setTargetRefs writes spec.targetRefs as a list of HTTPRoute
+// references. One entry per OME-managed HTTPRoute.
+func setTargetRefs(btp *unstructured.Unstructured, routes []string) error {
+	refs := make([]interface{}, 0, len(routes))
+	for _, name := range routes {
+		refs = append(refs, map[string]interface{}{
+			"group": groupGatewayAPI,
+			"kind":  kindHTTPRoute,
+			"name":  name,
+		})
+	}
+	return unstructured.SetNestedSlice(btp.Object, refs, "spec", "targetRefs")
+}
+
+func applyLoadBalancer(btp *unstructured.Unstructured, spec *v1beta1.TrafficSpec) error {
+	if spec.Algorithm != nil {
+		// EG BackendTrafficPolicy CRD has CEL validation
+		//   self.type == 'ConsistentHash' ? has(self.consistentHash) : !has(self.consistentHash)
+		// Admission catches the missing consistentHash block (the
+		// MissingConsistentHashSpec rule), but if admission is
+		// bypassed the translator must still fail safe rather than
+		// emit a malformed BTP that the gateway controller will
+		// reject silently. Same for the inverse — a consistentHash
+		// block without algorithm=ConsistentHash would violate the
+		// CEL rule from the other side.
+		if *spec.Algorithm == v1beta1.LoadBalancingTypeConsistentHash && spec.ConsistentHash == nil {
+			return fmt.Errorf("spec.traffic.algorithm=ConsistentHash requires spec.traffic.consistentHash to be set")
+		}
+		if *spec.Algorithm != v1beta1.LoadBalancingTypeConsistentHash && spec.ConsistentHash != nil {
+			return fmt.Errorf("spec.traffic.consistentHash must not be set when algorithm=%q", *spec.Algorithm)
+		}
+		if err := unstructured.SetNestedField(
+			btp.Object, string(*spec.Algorithm),
+			"spec", "loadBalancer", "type",
+		); err != nil {
+			return fmt.Errorf("set loadBalancer.type: %w", err)
+		}
+	}
+	if spec.ConsistentHash != nil {
+		if err := applyConsistentHash(btp, spec.ConsistentHash); err != nil {
+			return err
+		}
+	}
+	if spec.EndpointOverride != nil {
+		if err := applyEndpointOverride(btp, spec.EndpointOverride); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyConsistentHash(btp *unstructured.Unstructured, ch *v1beta1.ConsistentHashSpec) error {
+	// Map the OME enum to the EG-side type field. EG v1.7+ added the
+	// plural "Headers" type + headers[] list for multi-header hashing
+	// (the singular "Header"/header is marked Deprecated in EG v1.7).
+	// The OME API exposes a single "Header" enum value; the translator
+	// picks the EG-side type based on header count so that older EG
+	// clusters keep working with one header.
+	egType := string(ch.Type)
+	if ch.Type == v1beta1.HashTypeHeader && len(ch.Headers) > 1 {
+		egType = "Headers"
+	}
+	if err := unstructured.SetNestedField(
+		btp.Object, egType,
+		"spec", "loadBalancer", "consistentHash", "type",
+	); err != nil {
+		return fmt.Errorf("set consistentHash.type: %w", err)
+	}
+	switch ch.Type {
+	case v1beta1.HashTypeHeader:
+		if len(ch.Headers) == 0 {
+			return errors.New("consistentHash.type=Header requires at least one header")
+		}
+		if len(ch.Headers) == 1 {
+			// Singular form — works on EG <v1.7 too.
+			if err := unstructured.SetNestedField(
+				btp.Object, ch.Headers[0].Name,
+				"spec", "loadBalancer", "consistentHash", "header", "name",
+			); err != nil {
+				return fmt.Errorf("set consistentHash.header.name: %w", err)
+			}
+		} else {
+			// Plural form — requires EG v1.7+ which exposes
+			// spec.loadBalancer.consistentHash.headers[] alongside the
+			// new "Headers" type enum value. CEL validation in the EG
+			// CRD enforces type/field correspondence; the type
+			// override above keeps us aligned with that.
+			items := make([]interface{}, 0, len(ch.Headers))
+			for _, h := range ch.Headers {
+				items = append(items, map[string]interface{}{"name": h.Name})
+			}
+			if err := unstructured.SetNestedSlice(
+				btp.Object, items,
+				"spec", "loadBalancer", "consistentHash", "headers",
+			); err != nil {
+				return fmt.Errorf("set consistentHash.headers: %w", err)
+			}
+		}
+	case v1beta1.HashTypeCookie:
+		if ch.Cookie == nil {
+			return errors.New("consistentHash.type=Cookie requires cookie")
+		}
+		if err := unstructured.SetNestedField(
+			btp.Object, ch.Cookie.Name,
+			"spec", "loadBalancer", "consistentHash", "cookie", "name",
+		); err != nil {
+			return fmt.Errorf("set consistentHash.cookie.name: %w", err)
+		}
+		if ch.Cookie.TTLSeconds != nil && *ch.Cookie.TTLSeconds > 0 {
+			if err := unstructured.SetNestedField(
+				btp.Object, fmt.Sprintf("%ds", *ch.Cookie.TTLSeconds),
+				"spec", "loadBalancer", "consistentHash", "cookie", "ttl",
+			); err != nil {
+				return fmt.Errorf("set consistentHash.cookie.ttl: %w", err)
+			}
+		}
+	case v1beta1.HashTypeSourceIP:
+		// EG infers source-IP hashing from type=SourceIP alone; no
+		// additional fields required.
+	}
+	return nil
+}
+
+func applyEndpointOverride(btp *unstructured.Unstructured, eo *v1beta1.EndpointOverrideSpec) error {
+	switch eo.Type {
+	case v1beta1.EndpointOverrideTypeHeader:
+		if len(eo.Headers) == 0 {
+			return errors.New("endpointOverride.type=Header requires at least one header")
+		}
+		extract := make([]interface{}, 0, len(eo.Headers))
+		for _, h := range eo.Headers {
+			extract = append(extract, map[string]interface{}{
+				"header": h.Name,
+			})
+		}
+		if err := unstructured.SetNestedSlice(
+			btp.Object, extract,
+			"spec", "loadBalancer", "endpointOverride", "extractFrom",
+		); err != nil {
+			return fmt.Errorf("set endpointOverride.extractFrom: %w", err)
+		}
+	case v1beta1.EndpointOverrideTypeMetadata:
+		// Reserved for future use per the API doc; webhook gates it.
+	}
+	return nil
+}
+
+func applyCircuitBreaker(btp *unstructured.Unstructured, cb *traffic.CircuitBreakerIntent) error {
+	setInt := func(value *int32, path ...string) error {
+		if value == nil {
+			return nil
+		}
+		full := append([]string{"spec", "circuitBreaker"}, path...)
+		if err := unstructured.SetNestedField(btp.Object, int64(*value), full...); err != nil {
+			return fmt.Errorf("set %s: %w", strings.Join(path, "."), err)
+		}
+		return nil
+	}
+	if err := setInt(cb.MaxConnections, "maxConnections"); err != nil {
+		return err
+	}
+	if err := setInt(cb.MaxParallelRequests, "maxParallelRequests"); err != nil {
+		return err
+	}
+	if err := setInt(cb.MaxPendingRequests, "maxPendingRequests"); err != nil {
+		return err
+	}
+	if err := setInt(cb.MaxParallelRetries, "maxParallelRetries"); err != nil {
+		return err
+	}
+	if err := setInt(cb.PerEndpointMaxConnections, "perEndpoint", "maxConnections"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyRetry(btp *unstructured.Unstructured, r *traffic.RetryIntent) error {
+	if r.Attempts != nil {
+		if err := unstructured.SetNestedField(
+			btp.Object, int64(*r.Attempts),
+			"spec", "retry", "numRetries",
+		); err != nil {
+			return fmt.Errorf("set retry.numRetries: %w", err)
+		}
+	}
+	if r.PerTryTimeout != nil {
+		if err := unstructured.SetNestedField(
+			btp.Object, r.PerTryTimeout.String(),
+			"spec", "retry", "perRetry", "timeout",
+		); err != nil {
+			return fmt.Errorf("set retry.perRetry.timeout: %w", err)
+		}
+	}
+	if len(r.RetryOn) > 0 {
+		triggers, codes := splitRetryOnTokens(r.RetryOn)
+		if len(triggers) > 0 {
+			items := make([]interface{}, 0, len(triggers))
+			for _, t := range triggers {
+				items = append(items, t)
+			}
+			if err := unstructured.SetNestedSlice(
+				btp.Object, items,
+				"spec", "retry", "retryOn", "triggers",
+			); err != nil {
+				return fmt.Errorf("set retry.retryOn.triggers: %w", err)
+			}
+		}
+		if len(codes) > 0 {
+			items := make([]interface{}, 0, len(codes))
+			for _, c := range codes {
+				items = append(items, int64(c))
+			}
+			if err := unstructured.SetNestedSlice(
+				btp.Object, items,
+				"spec", "retry", "retryOn", "httpStatusCodes",
+			); err != nil {
+				return fmt.Errorf("set retry.retryOn.httpStatusCodes: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func applyTimeout(btp *unstructured.Unstructured, to *traffic.TimeoutIntent) error {
+	if to.Idle != nil {
+		if err := unstructured.SetNestedField(
+			btp.Object, to.Idle.String(),
+			"spec", "timeout", "http", "connectionIdleTimeout",
+		); err != nil {
+			return fmt.Errorf("set timeout.http.connectionIdleTimeout: %w", err)
+		}
+	}
+	if to.MaxConnectionDuration != nil {
+		if err := unstructured.SetNestedField(
+			btp.Object, to.MaxConnectionDuration.String(),
+			"spec", "timeout", "http", "maxConnectionDuration",
+		); err != nil {
+			return fmt.Errorf("set timeout.http.maxConnectionDuration: %w", err)
+		}
+	}
+	if to.TCPConnect != nil {
+		if err := unstructured.SetNestedField(
+			btp.Object, to.TCPConnect.String(),
+			"spec", "timeout", "tcp", "connectTimeout",
+		); err != nil {
+			return fmt.Errorf("set timeout.tcp.connectTimeout: %w", err)
+		}
+	}
+	return nil
+}
+
+// applyPassthroughs writes each ome.io/btp.<path>=<value> annotation
+// verbatim into spec.<path>. Pass-throughs win over structured fields
+// at the same path. Returns the sorted list of paths applied so the
+// status writer can surface them deterministically.
+func applyPassthroughs(btp *unstructured.Unstructured, paths map[string]string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	sortedKeys := make([]string, 0, len(paths))
+	for k := range paths {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	applied := make([]string, 0, len(sortedKeys))
+	for _, k := range sortedKeys {
+		segments := append([]string{"spec"}, strings.Split(k, ".")...)
+		if err := unstructured.SetNestedField(btp.Object, parseScalar(paths[k]), segments...); err != nil {
+			return nil, fmt.Errorf("set passthrough %q: %w", k, err)
+		}
+		applied = append(applied, k)
+	}
+	return applied, nil
+}
+
+// parseScalar best-effort-coerces a string annotation value into a
+// type unstructured.SetNestedField accepts. Falls back to the original
+// string when nothing parses. The gateway controller catches type
+// mismatches at admission and we surface GatewayRejected — OME does
+// not pre-validate pass-through types since the schema is owned by
+// the gateway implementation.
+func parseScalar(v string) interface{} {
+	if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return i
+	}
+	if b, err := strconv.ParseBool(v); err == nil {
+		return b
+	}
+	if f, err := strconv.ParseFloat(v, 64); err == nil {
+		return f
+	}
+	return v
+}
+
+// splitRetryOnTokens splits the operator-supplied retry-on list into
+// EG's two buckets: numeric tokens become httpStatusCodes; everything
+// else stays a string trigger. Empty tokens are skipped (Resolve
+// already drops them, this is defense-in-depth).
+func splitRetryOnTokens(tokens []string) (triggers []string, codes []int32) {
+	for _, t := range tokens {
+		if t == "" {
+			continue
+		}
+		if n, err := strconv.ParseInt(t, 10, 32); err == nil {
+			codes = append(codes, int32(n))
+			continue
+		}
+		triggers = append(triggers, t)
+	}
+	return triggers, codes
+}
+
+// Compile-time check that Translator satisfies the Translator interface.
+var _ traffic.Translator = (*Translator)(nil)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/envoygateway/translator_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/envoygateway/translator_test.go
@@ -1,0 +1,661 @@
+package envoygateway
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic"
+)
+
+func newISVC(name, ns string) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+}
+
+func translate(t *testing.T, isvc *v1beta1.InferenceService, routes []string, intent *traffic.ResolvedIntent) (*unstructured.Unstructured, []string) {
+	t.Helper()
+	obj, passes, err := New().Translate(isvc, routes, intent)
+	if err != nil {
+		t.Fatalf("Translate err = %v", err)
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("Translate returned %T, want *unstructured.Unstructured", obj)
+	}
+	return u, passes
+}
+
+func nestedString(t *testing.T, u *unstructured.Unstructured, path ...string) string {
+	t.Helper()
+	v, found, err := unstructured.NestedString(u.Object, path...)
+	if err != nil {
+		t.Fatalf("NestedString %v: %v", path, err)
+	}
+	if !found {
+		t.Fatalf("path %v not found in %s", path, mustJSON(t, u))
+	}
+	return v
+}
+
+func nestedInt64(t *testing.T, u *unstructured.Unstructured, path ...string) int64 {
+	t.Helper()
+	v, found, err := unstructured.NestedInt64(u.Object, path...)
+	if err != nil {
+		t.Fatalf("NestedInt64 %v: %v", path, err)
+	}
+	if !found {
+		t.Fatalf("path %v not found in %s", path, mustJSON(t, u))
+	}
+	return v
+}
+
+func mustJSON(t *testing.T, u *unstructured.Unstructured) string {
+	t.Helper()
+	b, err := json.MarshalIndent(u.Object, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func TestName_AndWatches(t *testing.T) {
+	tr := New()
+	if tr.Name() != Name {
+		t.Fatalf("Name = %q, want %q", tr.Name(), Name)
+	}
+	w := tr.Watches()
+	if w == nil {
+		t.Fatalf("Watches must return a non-nil object")
+	}
+	u, ok := w.(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("Watches returned %T, want *unstructured.Unstructured", w)
+	}
+	if got := u.GroupVersionKind(); got != btpGVK {
+		t.Fatalf("Watches GVK = %v, want %v", got, btpGVK)
+	}
+}
+
+func TestSupportedAnnotations(t *testing.T) {
+	got := New().SupportedAnnotations()
+	// Spot-check a few known keys; full coverage would just mirror the
+	// constants list back to itself.
+	for _, k := range []string{
+		constants.CircuitBreakerMaxConnectionsAnnotation,
+		constants.RetryAttemptsAnnotation,
+		constants.TimeoutIdleAnnotation,
+	} {
+		if !got.Has(k) {
+			t.Errorf("SupportedAnnotations missing %q", k)
+		}
+	}
+	// Pass-through is per-prefix and must NOT be in the per-key set.
+	if got.Has(constants.PassthroughEnvoyGatewayPrefix) {
+		t.Errorf("SupportedAnnotations must not include pass-through prefix")
+	}
+}
+
+func TestTranslate_TargetRefsAndMetadata(t *testing.T) {
+	isvc := newISVC("isvc", "ns")
+	alg := v1beta1.LoadBalancingTypeRoundRobin
+	intent := &traffic.ResolvedIntent{Traffic: &v1beta1.TrafficSpec{Algorithm: &alg}}
+	routes := []string{"isvc", "isvc-engine", "isvc-decoder"}
+
+	u, _ := translate(t, isvc, routes, intent)
+
+	if u.GetName() != "isvc" || u.GetNamespace() != "ns" {
+		t.Fatalf("name/ns = %q/%q", u.GetName(), u.GetNamespace())
+	}
+	if u.GroupVersionKind() != btpGVK {
+		t.Fatalf("GVK = %v, want %v", u.GroupVersionKind(), btpGVK)
+	}
+	refs, found, err := unstructured.NestedSlice(u.Object, "spec", "targetRefs")
+	if err != nil || !found {
+		t.Fatalf("targetRefs missing: %v", err)
+	}
+	if len(refs) != len(routes) {
+		t.Fatalf("targetRefs len = %d, want %d", len(refs), len(routes))
+	}
+	for i, r := range refs {
+		m, ok := r.(map[string]interface{})
+		if !ok {
+			t.Fatalf("ref %d not a map: %T", i, r)
+		}
+		if m["group"] != groupGatewayAPI || m["kind"] != kindHTTPRoute || m["name"] != routes[i] {
+			t.Fatalf("ref %d = %+v, want HTTPRoute %q", i, m, routes[i])
+		}
+	}
+}
+
+func TestTranslate_LoadBalancer_AlgorithmOnly(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeLeastRequest
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"},
+		&traffic.ResolvedIntent{Traffic: &v1beta1.TrafficSpec{Algorithm: &alg}})
+
+	if got := nestedString(t, u, "spec", "loadBalancer", "type"); got != "LeastRequest" {
+		t.Fatalf("loadBalancer.type = %q", got)
+	}
+}
+
+func TestTranslate_ConsistentHash_Header(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	intent := &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			Algorithm: &alg,
+			ConsistentHash: &v1beta1.ConsistentHashSpec{
+				Type:    v1beta1.HashTypeHeader,
+				Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+			},
+		},
+	}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"}, intent)
+
+	if got := nestedString(t, u, "spec", "loadBalancer", "consistentHash", "type"); got != "Header" {
+		t.Fatalf("consistentHash.type = %q", got)
+	}
+	if got := nestedString(t, u, "spec", "loadBalancer", "consistentHash", "header", "name"); got != "X-Session-ID" {
+		t.Fatalf("consistentHash.header.name = %q", got)
+	}
+}
+
+func TestTranslate_ConsistentHash_MultiHeader_PluralForm(t *testing.T) {
+	// EG v1.7+ adds the "Headers" (plural) consistent-hash type and a
+	// headers[] list — the singular "Header"/header is marked Deprecated
+	// in v1.7 but kept for back-compat. The OME API exposes only the
+	// singular "Header" enum value; the translator promotes the EG-side
+	// type to "Headers" when more than one header is declared.
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	intent := &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			Algorithm: &alg,
+			ConsistentHash: &v1beta1.ConsistentHashSpec{
+				Type:    v1beta1.HashTypeHeader,
+				Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}, {Name: "X-User-ID"}},
+			},
+		},
+	}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"}, intent)
+
+	if got := nestedString(t, u, "spec", "loadBalancer", "consistentHash", "type"); got != "Headers" {
+		t.Fatalf("multi-header must promote type to Headers (plural), got %q", got)
+	}
+	// Singular header field must NOT be set (CEL validation in EG
+	// requires header XOR headers per type).
+	if _, found, _ := unstructured.NestedMap(u.Object, "spec", "loadBalancer", "consistentHash", "header"); found {
+		t.Fatalf("type=Headers must not set the singular header field; got header present")
+	}
+	headers, found, err := unstructured.NestedSlice(u.Object, "spec", "loadBalancer", "consistentHash", "headers")
+	if err != nil || !found {
+		t.Fatalf("consistentHash.headers missing: err=%v", err)
+	}
+	if len(headers) != 2 {
+		t.Fatalf("len(headers)=%d, want 2", len(headers))
+	}
+	for i, want := range []string{"X-Session-ID", "X-User-ID"} {
+		got := headers[i].(map[string]interface{})["name"]
+		if got != want {
+			t.Fatalf("headers[%d].name = %v, want %q", i, got, want)
+		}
+	}
+}
+
+func TestTranslate_ConsistentHash_Cookie_WithTTL(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	ttl := int64(60)
+	intent := &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			Algorithm: &alg,
+			ConsistentHash: &v1beta1.ConsistentHashSpec{
+				Type:   v1beta1.HashTypeCookie,
+				Cookie: &v1beta1.HashCookie{Name: "sticky", TTLSeconds: &ttl},
+			},
+		},
+	}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"}, intent)
+	if got := nestedString(t, u, "spec", "loadBalancer", "consistentHash", "cookie", "name"); got != "sticky" {
+		t.Fatalf("cookie.name = %q", got)
+	}
+	if got := nestedString(t, u, "spec", "loadBalancer", "consistentHash", "cookie", "ttl"); got != "60s" {
+		t.Fatalf("cookie.ttl = %q, want 60s", got)
+	}
+}
+
+func TestTranslate_ConsistentHash_Cookie_WithoutTTL_OmitsField(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	intent := &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			Algorithm: &alg,
+			ConsistentHash: &v1beta1.ConsistentHashSpec{
+				Type:   v1beta1.HashTypeCookie,
+				Cookie: &v1beta1.HashCookie{Name: "sticky"},
+			},
+		},
+	}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"}, intent)
+	_, found, _ := unstructured.NestedString(u.Object, "spec", "loadBalancer", "consistentHash", "cookie", "ttl")
+	if found {
+		t.Fatalf("ttl must be omitted when TTLSeconds nil")
+	}
+}
+
+func TestTranslate_ConsistentHash_SourceIP_TypeOnly(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	intent := &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			Algorithm:      &alg,
+			ConsistentHash: &v1beta1.ConsistentHashSpec{Type: v1beta1.HashTypeSourceIP},
+		},
+	}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"}, intent)
+	if got := nestedString(t, u, "spec", "loadBalancer", "consistentHash", "type"); got != "SourceIP" {
+		t.Fatalf("type = %q", got)
+	}
+	// No header or cookie subfields.
+	if _, found, _ := unstructured.NestedMap(u.Object, "spec", "loadBalancer", "consistentHash", "header"); found {
+		t.Fatalf("source-IP hash must not set header")
+	}
+	if _, found, _ := unstructured.NestedMap(u.Object, "spec", "loadBalancer", "consistentHash", "cookie"); found {
+		t.Fatalf("source-IP hash must not set cookie")
+	}
+}
+
+func TestTranslate_EndpointOverride_Header(t *testing.T) {
+	intent := &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			EndpointOverride: &v1beta1.EndpointOverrideSpec{
+				Type:    v1beta1.EndpointOverrideTypeHeader,
+				Headers: []v1beta1.HashHeader{{Name: "X-Endpoint-HostPort"}, {Name: "X-Endpoint-IP"}},
+			},
+		},
+	}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"}, intent)
+	extract, found, err := unstructured.NestedSlice(u.Object, "spec", "loadBalancer", "endpointOverride", "extractFrom")
+	if err != nil || !found {
+		t.Fatalf("extractFrom missing: %v", err)
+	}
+	if len(extract) != 2 {
+		t.Fatalf("len(extractFrom) = %d, want 2", len(extract))
+	}
+	for i, want := range []string{"X-Endpoint-HostPort", "X-Endpoint-IP"} {
+		got := extract[i].(map[string]interface{})["header"]
+		if got != want {
+			t.Fatalf("extract[%d].header = %v, want %q", i, got, want)
+		}
+	}
+}
+
+func TestTranslate_CircuitBreaker_AllFields(t *testing.T) {
+	cb := &traffic.CircuitBreakerIntent{
+		MaxConnections:            i32p(1024),
+		MaxParallelRequests:       i32p(2048),
+		MaxPendingRequests:        i32p(512),
+		MaxParallelRetries:        i32p(8),
+		PerEndpointMaxConnections: i32p(1),
+	}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"},
+		&traffic.ResolvedIntent{CircuitBreaker: cb})
+
+	if got := nestedInt64(t, u, "spec", "circuitBreaker", "maxConnections"); got != 1024 {
+		t.Fatalf("maxConnections = %d", got)
+	}
+	if got := nestedInt64(t, u, "spec", "circuitBreaker", "maxParallelRequests"); got != 2048 {
+		t.Fatalf("maxParallelRequests = %d", got)
+	}
+	if got := nestedInt64(t, u, "spec", "circuitBreaker", "maxPendingRequests"); got != 512 {
+		t.Fatalf("maxPendingRequests = %d", got)
+	}
+	if got := nestedInt64(t, u, "spec", "circuitBreaker", "maxParallelRetries"); got != 8 {
+		t.Fatalf("maxParallelRetries = %d", got)
+	}
+	if got := nestedInt64(t, u, "spec", "circuitBreaker", "perEndpoint", "maxConnections"); got != 1 {
+		t.Fatalf("perEndpoint.maxConnections = %d", got)
+	}
+}
+
+func TestTranslate_CircuitBreaker_PartialSet_OmitsRest(t *testing.T) {
+	cb := &traffic.CircuitBreakerIntent{MaxConnections: i32p(100)}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"},
+		&traffic.ResolvedIntent{CircuitBreaker: cb})
+
+	if got := nestedInt64(t, u, "spec", "circuitBreaker", "maxConnections"); got != 100 {
+		t.Fatalf("maxConnections = %d", got)
+	}
+	for _, p := range [][]string{
+		{"spec", "circuitBreaker", "maxParallelRequests"},
+		{"spec", "circuitBreaker", "maxPendingRequests"},
+		{"spec", "circuitBreaker", "maxParallelRetries"},
+		{"spec", "circuitBreaker", "perEndpoint"},
+	} {
+		if _, found, _ := unstructured.NestedFieldNoCopy(u.Object, p...); found {
+			t.Errorf("path %v must be omitted when intent is nil", p)
+		}
+	}
+}
+
+func TestTranslate_Retry_SplitsNumericIntoHttpStatusCodes(t *testing.T) {
+	per := 5 * time.Second
+	r := &traffic.RetryIntent{
+		Attempts:      i32p(3),
+		RetryOn:       []string{"5xx", "reset", "503", "gateway-error", "504"},
+		PerTryTimeout: &per,
+	}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"},
+		&traffic.ResolvedIntent{Retry: r})
+
+	if got := nestedInt64(t, u, "spec", "retry", "numRetries"); got != 3 {
+		t.Fatalf("numRetries = %d", got)
+	}
+	if got := nestedString(t, u, "spec", "retry", "perRetry", "timeout"); got != "5s" {
+		t.Fatalf("perRetry.timeout = %q", got)
+	}
+	triggers, found, err := unstructured.NestedSlice(u.Object, "spec", "retry", "retryOn", "triggers")
+	if err != nil || !found {
+		t.Fatalf("triggers missing: %v", err)
+	}
+	wantTriggers := []string{"5xx", "reset", "gateway-error"}
+	if len(triggers) != len(wantTriggers) {
+		t.Fatalf("triggers = %v, want %v", triggers, wantTriggers)
+	}
+	for i, w := range wantTriggers {
+		if triggers[i] != w {
+			t.Fatalf("trigger[%d] = %v, want %q", i, triggers[i], w)
+		}
+	}
+	codes, found, _ := unstructured.NestedSlice(u.Object, "spec", "retry", "retryOn", "httpStatusCodes")
+	if !found {
+		t.Fatalf("httpStatusCodes missing")
+	}
+	wantCodes := []int64{503, 504}
+	if len(codes) != len(wantCodes) {
+		t.Fatalf("codes = %v, want %v", codes, wantCodes)
+	}
+	for i, w := range wantCodes {
+		if codes[i] != w {
+			t.Fatalf("code[%d] = %v, want %d", i, codes[i], w)
+		}
+	}
+}
+
+func TestTranslate_Retry_OnlyTriggers_OmitsCodesField(t *testing.T) {
+	r := &traffic.RetryIntent{Attempts: i32p(1), RetryOn: []string{"reset"}}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"},
+		&traffic.ResolvedIntent{Retry: r})
+
+	if _, found, _ := unstructured.NestedSlice(u.Object, "spec", "retry", "retryOn", "httpStatusCodes"); found {
+		t.Fatalf("httpStatusCodes must be omitted when no numeric tokens")
+	}
+}
+
+func TestTranslate_Timeout_AllFields(t *testing.T) {
+	idle := 30 * time.Second
+	mcd := 5 * time.Minute
+	tcp := 2 * time.Second
+	to := &traffic.TimeoutIntent{Idle: &idle, MaxConnectionDuration: &mcd, TCPConnect: &tcp}
+	u, _ := translate(t, newISVC("isvc", "ns"), []string{"isvc"},
+		&traffic.ResolvedIntent{Timeout: to})
+
+	if got := nestedString(t, u, "spec", "timeout", "http", "connectionIdleTimeout"); got != "30s" {
+		t.Fatalf("idle = %q", got)
+	}
+	if got := nestedString(t, u, "spec", "timeout", "http", "maxConnectionDuration"); got != "5m0s" {
+		t.Fatalf("maxConnectionDuration = %q", got)
+	}
+	if got := nestedString(t, u, "spec", "timeout", "tcp", "connectTimeout"); got != "2s" {
+		t.Fatalf("tcpConnect = %q", got)
+	}
+}
+
+func TestTranslate_Passthrough_StitchesAndOverrides(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeRoundRobin
+	intent := &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{Algorithm: &alg},
+		// Pass-through wins: this should overwrite loadBalancer.type set above.
+		PassthroughEnvoyGateway: map[string]string{
+			"loadBalancer.type":             "LeastRequest",
+			"loadBalancer.slowStart.window": "30s",
+			"loadBalancer.slowStart.aggro":  "1.5",
+			"retry.numRetries":              "7",
+			"someToggle":                    "true",
+		},
+	}
+	u, passes := translate(t, newISVC("isvc", "ns"), []string{"isvc"}, intent)
+
+	// Pass-through must win.
+	if got := nestedString(t, u, "spec", "loadBalancer", "type"); got != "LeastRequest" {
+		t.Fatalf("pass-through did not override loadBalancer.type: got %q", got)
+	}
+	// Nested string survives.
+	if got := nestedString(t, u, "spec", "loadBalancer", "slowStart", "window"); got != "30s" {
+		t.Fatalf("slowStart.window = %q", got)
+	}
+	// Numeric parses as int64.
+	if got := nestedInt64(t, u, "spec", "retry", "numRetries"); got != 7 {
+		t.Fatalf("retry.numRetries = %d", got)
+	}
+	// Float parses as float (verify via raw access).
+	v, _, _ := unstructured.NestedFieldNoCopy(u.Object, "spec", "loadBalancer", "slowStart", "aggro")
+	if _, ok := v.(float64); !ok {
+		t.Fatalf("aggro = %v (%T), want float64", v, v)
+	}
+	// Bool parses as bool.
+	v, _, _ = unstructured.NestedFieldNoCopy(u.Object, "spec", "someToggle")
+	if got, ok := v.(bool); !ok || !got {
+		t.Fatalf("someToggle = %v (%T), want true", v, v)
+	}
+	// Returned passthrough list is sorted for deterministic status output.
+	wantPasses := []string{
+		"loadBalancer.slowStart.aggro",
+		"loadBalancer.slowStart.window",
+		"loadBalancer.type",
+		"retry.numRetries",
+		"someToggle",
+	}
+	if !reflect.DeepEqual(passes, wantPasses) {
+		t.Fatalf("passes = %v, want sorted %v", passes, wantPasses)
+	}
+}
+
+func TestTranslate_Determinism_ByteIdenticalOutput(t *testing.T) {
+	// Same input twice must produce byte-identical JSON. The reconciler's
+	// coarse Update relies on this to avoid noisy API server writes.
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	intent := &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			Algorithm: &alg,
+			ConsistentHash: &v1beta1.ConsistentHashSpec{
+				Type:    v1beta1.HashTypeHeader,
+				Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}},
+			},
+		},
+		CircuitBreaker: &traffic.CircuitBreakerIntent{MaxConnections: i32p(100)},
+		Retry: &traffic.RetryIntent{
+			Attempts: i32p(2),
+			RetryOn:  []string{"5xx", "503"},
+		},
+		PassthroughEnvoyGateway: map[string]string{
+			"a.b": "1",
+			"x.y": "2",
+		},
+	}
+	isvc := newISVC("isvc", "ns")
+	routes := []string{"isvc", "isvc-engine"}
+
+	u1, p1 := translate(t, isvc, routes, intent)
+	u2, p2 := translate(t, isvc, routes, intent)
+
+	b1, _ := json.Marshal(u1.Object)
+	b2, _ := json.Marshal(u2.Object)
+	if string(b1) != string(b2) {
+		t.Fatalf("Translate is not deterministic:\n a=%s\n b=%s", b1, b2)
+	}
+	if !reflect.DeepEqual(p1, p2) {
+		t.Fatalf("passthroughs not deterministic: %v vs %v", p1, p2)
+	}
+	// Sanity check the sorted property explicitly.
+	sortedPasses := append([]string{}, p1...)
+	sort.Strings(sortedPasses)
+	if !reflect.DeepEqual(p1, sortedPasses) {
+		t.Fatalf("passthroughs not sorted: %v", p1)
+	}
+}
+
+func TestTranslate_EmptyIntent_ProducesShellOnly(t *testing.T) {
+	// Defensive: even with an "empty" intent (no fields set besides
+	// empty maps), Translate produces a valid BTP shell with just
+	// targetRefs. This is technically a wasted reconcile (HasIntent
+	// short-circuits at the reconciler) but we don't want a panic if
+	// it ever happens.
+	u, passes := translate(t, newISVC("isvc", "ns"), []string{"isvc"},
+		&traffic.ResolvedIntent{PassthroughEnvoyGateway: map[string]string{}})
+
+	if u.GetName() != "isvc" {
+		t.Fatalf("name = %q", u.GetName())
+	}
+	if _, found, _ := unstructured.NestedSlice(u.Object, "spec", "targetRefs"); !found {
+		t.Fatalf("targetRefs missing")
+	}
+	if _, found, _ := unstructured.NestedMap(u.Object, "spec", "loadBalancer"); found {
+		t.Fatalf("loadBalancer must be absent when no traffic spec")
+	}
+	if len(passes) != 0 {
+		t.Fatalf("passes = %v, want empty", passes)
+	}
+}
+
+func TestSplitRetryOnTokens_HandlesEmptyAndWhitespace(t *testing.T) {
+	triggers, codes := splitRetryOnTokens([]string{"5xx", "", "503"})
+	if len(triggers) != 1 || triggers[0] != "5xx" {
+		t.Fatalf("triggers = %v", triggers)
+	}
+	if len(codes) != 1 || codes[0] != 503 {
+		t.Fatalf("codes = %v", codes)
+	}
+}
+
+func TestParseScalar(t *testing.T) {
+	cases := []struct {
+		in   string
+		want interface{}
+	}{
+		{"42", int64(42)},
+		{"-7", int64(-7)},
+		{"true", true},
+		{"false", false},
+		{"3.14", 3.14},
+		{"hello", "hello"},
+		{"", ""},
+		{"30s", "30s"}, // duration strings stay string
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := parseScalar(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseScalar(%q) = %v (%T), want %v (%T)", tc.in, got, got, tc.want, tc.want)
+			}
+		})
+	}
+}
+
+func i32p(v int32) *int32 { return &v }
+
+// btpWithStatusConditions builds an unstructured BTP carrying the
+// given Gateway-API-shaped status.conditions. Used to drive
+// ObserveAcceptance tests without spinning up an Envoy Gateway control
+// plane.
+func btpWithStatusConditions(conds []map[string]interface{}) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(btpGVK)
+	raw := make([]interface{}, 0, len(conds))
+	for _, c := range conds {
+		raw = append(raw, c)
+	}
+	_ = unstructured.SetNestedSlice(u.Object, raw, "status", "conditions")
+	return u
+}
+
+func TestObserveAcceptance_AcceptedTrue(t *testing.T) {
+	u := btpWithStatusConditions([]map[string]interface{}{
+		{
+			"type":    "Accepted",
+			"status":  "True",
+			"reason":  "Accepted",
+			"message": "Policy has been accepted",
+		},
+	})
+	got := New().ObserveAcceptance(u)
+	if got.State != traffic.AcceptanceAccepted {
+		t.Fatalf("state = %d, want Accepted", got.State)
+	}
+	if got.Reason != "Accepted" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+	if got.Message != "Policy has been accepted" {
+		t.Fatalf("message = %q", got.Message)
+	}
+}
+
+func TestObserveAcceptance_AcceptedFalse(t *testing.T) {
+	u := btpWithStatusConditions([]map[string]interface{}{
+		{
+			"type":    "Accepted",
+			"status":  "False",
+			"reason":  "Invalid",
+			"message": "loadBalancer.type: unsupported value foo",
+		},
+	})
+	got := New().ObserveAcceptance(u)
+	if got.State != traffic.AcceptanceRejected {
+		t.Fatalf("state = %d, want Rejected", got.State)
+	}
+	if got.Reason != "Invalid" || got.Message != "loadBalancer.type: unsupported value foo" {
+		t.Fatalf("reason/message = %q / %q", got.Reason, got.Message)
+	}
+}
+
+func TestObserveAcceptance_AcceptedUnknown_IsPending(t *testing.T) {
+	u := btpWithStatusConditions([]map[string]interface{}{
+		{"type": "Accepted", "status": "Unknown"},
+	})
+	got := New().ObserveAcceptance(u)
+	if got.State != traffic.AcceptancePending {
+		t.Fatalf("status=Unknown must map to Pending, got %d", got.State)
+	}
+}
+
+func TestObserveAcceptance_NoConditions_IsPending(t *testing.T) {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(btpGVK)
+	got := New().ObserveAcceptance(u)
+	if got.State != traffic.AcceptancePending {
+		t.Fatalf("no status -> Pending, got %d", got.State)
+	}
+}
+
+func TestObserveAcceptance_OtherConditionTypes_Skipped(t *testing.T) {
+	// EG writes both "Accepted" and "Programmed" (and more). We only
+	// look at "Accepted"; other types must be ignored.
+	u := btpWithStatusConditions([]map[string]interface{}{
+		{"type": "Programmed", "status": "True"},
+		{"type": "ResolvedRefs", "status": "True"},
+	})
+	got := New().ObserveAcceptance(u)
+	if got.State != traffic.AcceptancePending {
+		t.Fatalf("non-Accepted conditions must be ignored, got %d", got.State)
+	}
+}
+
+func TestObserveAcceptance_NonUnstructuredInput_IsPending(t *testing.T) {
+	// Defensive: a translator misuse (passing a typed object) must
+	// not panic.
+	got := New().ObserveAcceptance(nil)
+	if got.State != traffic.AcceptancePending {
+		t.Fatalf("nil input -> Pending, got %d", got.State)
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/istio/translator.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/istio/translator.go
@@ -1,0 +1,352 @@
+// Package istio translates traffic intent into an Istio DestinationRule
+// (networking.istio.io/v1).
+//
+// The translator emits an unstructured.Unstructured object so OME does
+// not vendor the Istio API. Field paths are pinned by the Istio
+// DestinationRule API; control-plane schema errors surface as
+// GatewayRejected via the post-apply observation.
+//
+// Hosting model: one DR per InferenceService targeting the top-level
+// Service hostname (isvc.Name in the ISVC namespace). Per-Component
+// Services (engine, decoder, router) are not covered — operators needing
+// per-component behavior can hand-author additional DRs.
+//
+// Pass-through (ome.io/dr.<path>=<value>) is applied last so an operator
+// can override any structured field.
+package istio
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic"
+)
+
+// Name is the stable identifier the factory uses for log/metric labels
+// and that the status writer matches on.
+const Name = "istio"
+
+const (
+	groupIstio     = "networking.istio.io"
+	versionV1      = "v1"
+	kindDR         = "DestinationRule"
+	istioReadyType = "Reconciled" // Istio control plane uses Reconciled / NotReconciled on .status
+)
+
+var drGVK = schema.GroupVersionKind{
+	Group:   groupIstio,
+	Version: versionV1,
+	Kind:    kindDR,
+}
+
+// algorithmToIstioSimple maps LoadBalancingType values to Istio's
+// loadBalancer.simple enum (Istio uses UPPER_SNAKE_CASE).
+// ConsistentHash is handled separately (it sets consistentHash, not
+// simple).
+var algorithmToIstioSimple = map[v1beta1.LoadBalancingType]string{
+	v1beta1.LoadBalancingTypeRoundRobin:   "ROUND_ROBIN",
+	v1beta1.LoadBalancingTypeLeastRequest: "LEAST_REQUEST",
+	v1beta1.LoadBalancingTypeRandom:       "RANDOM",
+}
+
+// Translator emits a DestinationRule per InferenceService.
+type Translator struct{}
+
+// New returns a ready-to-use Translator.
+func New() *Translator { return &Translator{} }
+
+// Name returns the stable identifier "istio".
+func (t *Translator) Name() string { return Name }
+
+// Watches returns a zero-value unstructured DestinationRule with the
+// GVK set so controller-runtime's Owns() can register the watch
+// without importing the Istio types.
+func (t *Translator) Watches() client.Object {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(drGVK)
+	return u
+}
+
+// SupportedAnnotations returns the ome.io/* annotation keys the Istio
+// DR can honor. This is a STRICT SUBSET of the Envoy Gateway translator's
+// matrix because the DestinationRule API doesn't cover retries (those
+// live on VirtualService), per-endpoint circuit-breaker limits, or
+// max-connection-duration. Unsupported keys surface as UnsupportedField
+// on the InferenceService when this translator is active.
+func (t *Translator) SupportedAnnotations() sets.Set[string] {
+	return sets.New(
+		constants.CircuitBreakerMaxConnectionsAnnotation,
+		constants.CircuitBreakerMaxParallelRequestsAnnotation,
+		constants.CircuitBreakerMaxPendingRequestsAnnotation,
+		constants.TimeoutIdleAnnotation,
+		constants.TimeoutTCPConnectAnnotation,
+	)
+}
+
+// SupportedPassthroughPrefixes declares that this translator owns the
+// ome.io/dr.* pass-through namespace.
+func (t *Translator) SupportedPassthroughPrefixes() []string {
+	return []string{constants.PassthroughIstioPrefix}
+}
+
+// Translate produces the DestinationRule for the InferenceService.
+// Deterministic — same inputs produce byte-identical output.
+func (t *Translator) Translate(
+	isvc *v1beta1.InferenceService,
+	_ []string,
+	intent *traffic.ResolvedIntent,
+) (client.Object, []string, error) {
+	dr := &unstructured.Unstructured{}
+	dr.SetGroupVersionKind(drGVK)
+	dr.SetName(isvc.Name)
+	dr.SetNamespace(isvc.Namespace)
+
+	// Istio DR targets a Service hostname, not HTTPRoutes. We target
+	// the top-level Service; per-Component coverage would require
+	// multiple DRs (deferred).
+	host := fmt.Sprintf("%s.%s.svc.cluster.local", isvc.Name, isvc.Namespace)
+	if err := unstructured.SetNestedField(dr.Object, host, "spec", "host"); err != nil {
+		return nil, nil, fmt.Errorf("set host: %w", err)
+	}
+
+	if intent.Traffic != nil {
+		if err := applyLoadBalancer(dr, intent.Traffic); err != nil {
+			return nil, nil, err
+		}
+	}
+	if intent.CircuitBreaker != nil {
+		if err := applyCircuitBreaker(dr, intent.CircuitBreaker); err != nil {
+			return nil, nil, err
+		}
+	}
+	if intent.Timeout != nil {
+		if err := applyTimeout(dr, intent.Timeout); err != nil {
+			return nil, nil, err
+		}
+	}
+	// retry intent is intentionally ignored — Istio's DR doesn't model
+	// retries (those live on VirtualService). The reconciler surfaces
+	// the dropped retry-* annotations as UnsupportedField.
+
+	passthroughs, err := applyPassthroughs(dr, intent.PassthroughIstio)
+	if err != nil {
+		return nil, nil, err
+	}
+	return dr, passthroughs, nil
+}
+
+// ObserveAcceptance inspects the DestinationRule status. Istio writes
+// a `Reconciled` condition on status.conditions when the resource is
+// accepted; absent/False maps to Pending/Rejected.
+func (t *Translator) ObserveAcceptance(obj client.Object) traffic.AcceptanceObservation {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok || u == nil {
+		return traffic.AcceptanceObservation{State: traffic.AcceptancePending}
+	}
+	conds, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if err != nil || !found {
+		return traffic.AcceptanceObservation{State: traffic.AcceptancePending}
+	}
+	for _, raw := range conds {
+		c, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if cType, _ := c["type"].(string); cType != istioReadyType {
+			continue
+		}
+		statusStr, _ := c["status"].(string)
+		reason, _ := c["reason"].(string)
+		message, _ := c["message"].(string)
+		switch statusStr {
+		case "True":
+			return traffic.AcceptanceObservation{
+				State:   traffic.AcceptanceAccepted,
+				Reason:  reason,
+				Message: message,
+			}
+		case "False":
+			return traffic.AcceptanceObservation{
+				State:   traffic.AcceptanceRejected,
+				Reason:  reason,
+				Message: message,
+			}
+		}
+	}
+	return traffic.AcceptanceObservation{State: traffic.AcceptancePending}
+}
+
+func applyLoadBalancer(dr *unstructured.Unstructured, spec *v1beta1.TrafficSpec) error {
+	if spec.Algorithm != nil && *spec.Algorithm != v1beta1.LoadBalancingTypeConsistentHash {
+		simple, ok := algorithmToIstioSimple[*spec.Algorithm]
+		if !ok {
+			return fmt.Errorf("unsupported algorithm %q for Istio DR", *spec.Algorithm)
+		}
+		if err := unstructured.SetNestedField(
+			dr.Object, simple,
+			"spec", "trafficPolicy", "loadBalancer", "simple",
+		); err != nil {
+			return fmt.Errorf("set loadBalancer.simple: %w", err)
+		}
+	}
+	if spec.ConsistentHash != nil {
+		if err := applyConsistentHash(dr, spec.ConsistentHash); err != nil {
+			return err
+		}
+	}
+	// EndpointOverride is Envoy-only; webhook should already block it
+	// here, but defensive: silently drop and let the reconciler
+	// surface UnsupportedField via the per-key matrix.
+	return nil
+}
+
+func applyConsistentHash(dr *unstructured.Unstructured, ch *v1beta1.ConsistentHashSpec) error {
+	switch ch.Type {
+	case v1beta1.HashTypeHeader:
+		if len(ch.Headers) == 0 {
+			return errors.New("consistentHash.type=Header requires at least one header")
+		}
+		// Istio's httpHeaderName is a single string; we pin to the first
+		// header. The webhook enforces this constraint at admission.
+		if err := unstructured.SetNestedField(
+			dr.Object, ch.Headers[0].Name,
+			"spec", "trafficPolicy", "loadBalancer", "consistentHash", "httpHeaderName",
+		); err != nil {
+			return fmt.Errorf("set consistentHash.httpHeaderName: %w", err)
+		}
+	case v1beta1.HashTypeCookie:
+		if ch.Cookie == nil {
+			return errors.New("consistentHash.type=Cookie requires cookie")
+		}
+		if err := unstructured.SetNestedField(
+			dr.Object, ch.Cookie.Name,
+			"spec", "trafficPolicy", "loadBalancer", "consistentHash", "httpCookie", "name",
+		); err != nil {
+			return fmt.Errorf("set consistentHash.httpCookie.name: %w", err)
+		}
+		if ch.Cookie.TTLSeconds != nil && *ch.Cookie.TTLSeconds > 0 {
+			if err := unstructured.SetNestedField(
+				dr.Object, fmt.Sprintf("%ds", *ch.Cookie.TTLSeconds),
+				"spec", "trafficPolicy", "loadBalancer", "consistentHash", "httpCookie", "ttl",
+			); err != nil {
+				return fmt.Errorf("set consistentHash.httpCookie.ttl: %w", err)
+			}
+		}
+	case v1beta1.HashTypeSourceIP:
+		if err := unstructured.SetNestedField(
+			dr.Object, true,
+			"spec", "trafficPolicy", "loadBalancer", "consistentHash", "useSourceIp",
+		); err != nil {
+			return fmt.Errorf("set consistentHash.useSourceIp: %w", err)
+		}
+	}
+	return nil
+}
+
+func applyCircuitBreaker(dr *unstructured.Unstructured, cb *traffic.CircuitBreakerIntent) error {
+	if cb.MaxConnections != nil {
+		if err := unstructured.SetNestedField(
+			dr.Object, int64(*cb.MaxConnections),
+			"spec", "trafficPolicy", "connectionPool", "tcp", "maxConnections",
+		); err != nil {
+			return fmt.Errorf("set connectionPool.tcp.maxConnections: %w", err)
+		}
+	}
+	if cb.MaxParallelRequests != nil {
+		// Istio's closest analogue is http2MaxRequests (TCP-level
+		// concurrent request cap). Operators want a "max in-flight
+		// requests" cap; this is it.
+		if err := unstructured.SetNestedField(
+			dr.Object, int64(*cb.MaxParallelRequests),
+			"spec", "trafficPolicy", "connectionPool", "http", "http2MaxRequests",
+		); err != nil {
+			return fmt.Errorf("set connectionPool.http.http2MaxRequests: %w", err)
+		}
+	}
+	if cb.MaxPendingRequests != nil {
+		if err := unstructured.SetNestedField(
+			dr.Object, int64(*cb.MaxPendingRequests),
+			"spec", "trafficPolicy", "connectionPool", "http", "http1MaxPendingRequests",
+		); err != nil {
+			return fmt.Errorf("set connectionPool.http.http1MaxPendingRequests: %w", err)
+		}
+	}
+	// MaxParallelRetries and PerEndpointMaxConnections have no direct
+	// Istio DR analogue; the reconciler surfaces them as
+	// UnsupportedField.
+	return nil
+}
+
+func applyTimeout(dr *unstructured.Unstructured, to *traffic.TimeoutIntent) error {
+	if to.Idle != nil {
+		if err := unstructured.SetNestedField(
+			dr.Object, to.Idle.String(),
+			"spec", "trafficPolicy", "connectionPool", "http", "idleTimeout",
+		); err != nil {
+			return fmt.Errorf("set connectionPool.http.idleTimeout: %w", err)
+		}
+	}
+	if to.TCPConnect != nil {
+		if err := unstructured.SetNestedField(
+			dr.Object, to.TCPConnect.String(),
+			"spec", "trafficPolicy", "connectionPool", "tcp", "connectTimeout",
+		); err != nil {
+			return fmt.Errorf("set connectionPool.tcp.connectTimeout: %w", err)
+		}
+	}
+	// MaxConnectionDuration has no Istio DR analogue.
+	return nil
+}
+
+// applyPassthroughs writes each ome.io/dr.<path>=<value> annotation
+// verbatim into spec.trafficPolicy.<path>. Pass-throughs win over
+// structured fields at the same path. Returns sorted list of paths
+// applied so status output is deterministic.
+func applyPassthroughs(dr *unstructured.Unstructured, paths map[string]string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	sortedKeys := make([]string, 0, len(paths))
+	for k := range paths {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	applied := make([]string, 0, len(sortedKeys))
+	for _, k := range sortedKeys {
+		segments := append([]string{"spec", "trafficPolicy"}, strings.Split(k, ".")...)
+		if err := unstructured.SetNestedField(dr.Object, parseScalar(paths[k]), segments...); err != nil {
+			return nil, fmt.Errorf("set passthrough %q: %w", k, err)
+		}
+		applied = append(applied, k)
+	}
+	return applied, nil
+}
+
+// parseScalar best-effort-coerces a string annotation value into a
+// type unstructured.SetNestedField accepts.
+func parseScalar(v string) interface{} {
+	if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return i
+	}
+	if b, err := strconv.ParseBool(v); err == nil {
+		return b
+	}
+	if f, err := strconv.ParseFloat(v, 64); err == nil {
+		return f
+	}
+	return v
+}
+
+// Compile-time check that Translator satisfies the Translator interface.
+var _ traffic.Translator = (*Translator)(nil)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/istio/translator_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/istio/translator_test.go
@@ -1,0 +1,371 @@
+package istio
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic"
+)
+
+func newISVC(name, ns string) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+}
+
+func translate(t *testing.T, isvc *v1beta1.InferenceService, intent *traffic.ResolvedIntent) (*unstructured.Unstructured, []string) {
+	t.Helper()
+	obj, passes, err := New().Translate(isvc, nil, intent)
+	if err != nil {
+		t.Fatalf("Translate err = %v", err)
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("Translate returned %T, want *unstructured.Unstructured", obj)
+	}
+	return u, passes
+}
+
+func nestedString(t *testing.T, u *unstructured.Unstructured, path ...string) string {
+	t.Helper()
+	v, found, err := unstructured.NestedString(u.Object, path...)
+	if err != nil || !found {
+		t.Fatalf("NestedString %v: found=%v err=%v", path, found, err)
+	}
+	return v
+}
+
+func nestedInt64(t *testing.T, u *unstructured.Unstructured, path ...string) int64 {
+	t.Helper()
+	v, found, err := unstructured.NestedInt64(u.Object, path...)
+	if err != nil || !found {
+		t.Fatalf("NestedInt64 %v: found=%v err=%v", path, found, err)
+	}
+	return v
+}
+
+func TestName_AndWatches(t *testing.T) {
+	tr := New()
+	if tr.Name() != Name {
+		t.Fatalf("Name = %q, want %q", tr.Name(), Name)
+	}
+	w := tr.Watches()
+	u, ok := w.(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("Watches returned %T", w)
+	}
+	if got := u.GroupVersionKind(); got != drGVK {
+		t.Fatalf("Watches GVK = %v, want %v", got, drGVK)
+	}
+}
+
+func TestSupportedAnnotations_SubsetOfEG(t *testing.T) {
+	// The Istio DR API doesn't model retries (those live on
+	// VirtualService) or per-endpoint cb limits or max-connection
+	// duration. SupportedAnnotations must therefore be a STRICT subset
+	// of the EG translator's matrix.
+	got := New().SupportedAnnotations()
+	for _, k := range []string{
+		constants.CircuitBreakerMaxConnectionsAnnotation,
+		constants.CircuitBreakerMaxParallelRequestsAnnotation,
+		constants.CircuitBreakerMaxPendingRequestsAnnotation,
+		constants.TimeoutIdleAnnotation,
+		constants.TimeoutTCPConnectAnnotation,
+	} {
+		if !got.Has(k) {
+			t.Errorf("Istio translator must support %q", k)
+		}
+	}
+	// Explicitly unsupported (these surface as UnsupportedField when
+	// Istio is active).
+	for _, k := range []string{
+		constants.RetryAttemptsAnnotation,
+		constants.RetryOnAnnotation,
+		constants.RetryPerTryTimeoutAnnotation,
+		constants.CircuitBreakerMaxParallelRetriesAnnotation,
+		constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation,
+		constants.TimeoutMaxConnectionDurationAnnotation,
+	} {
+		if got.Has(k) {
+			t.Errorf("Istio translator must NOT advertise support for %q", k)
+		}
+	}
+}
+
+func TestSupportedPassthroughPrefixes(t *testing.T) {
+	got := New().SupportedPassthroughPrefixes()
+	if len(got) != 1 || got[0] != constants.PassthroughIstioPrefix {
+		t.Fatalf("got %v, want [%q]", got, constants.PassthroughIstioPrefix)
+	}
+}
+
+func TestTranslate_HostAndMetadata(t *testing.T) {
+	u, _ := translate(t, newISVC("isvc", "ns"), &traffic.ResolvedIntent{})
+	if u.GetName() != "isvc" || u.GetNamespace() != "ns" {
+		t.Fatalf("name/ns = %q/%q", u.GetName(), u.GetNamespace())
+	}
+	if u.GroupVersionKind() != drGVK {
+		t.Fatalf("GVK = %v", u.GroupVersionKind())
+	}
+	if got := nestedString(t, u, "spec", "host"); got != "isvc.ns.svc.cluster.local" {
+		t.Fatalf("host = %q", got)
+	}
+}
+
+func TestTranslate_LoadBalancer_AlgorithmMapping(t *testing.T) {
+	cases := []struct {
+		in   v1beta1.LoadBalancingType
+		want string
+	}{
+		{v1beta1.LoadBalancingTypeRoundRobin, "ROUND_ROBIN"},
+		{v1beta1.LoadBalancingTypeLeastRequest, "LEAST_REQUEST"},
+		{v1beta1.LoadBalancingTypeRandom, "RANDOM"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.in), func(t *testing.T) {
+			alg := tc.in
+			u, _ := translate(t, newISVC("isvc", "ns"),
+				&traffic.ResolvedIntent{Traffic: &v1beta1.TrafficSpec{Algorithm: &alg}})
+			if got := nestedString(t, u, "spec", "trafficPolicy", "loadBalancer", "simple"); got != tc.want {
+				t.Fatalf("simple = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslate_LoadBalancer_ConsistentHash_Header(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	u, _ := translate(t, newISVC("isvc", "ns"), &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			Algorithm: &alg,
+			ConsistentHash: &v1beta1.ConsistentHashSpec{
+				Type:    v1beta1.HashTypeHeader,
+				Headers: []v1beta1.HashHeader{{Name: "X-Session-ID"}, {Name: "X-User-ID"}},
+			},
+		},
+	})
+	// Istio uses httpHeaderName (single string) — translator pins to first.
+	if got := nestedString(t, u, "spec", "trafficPolicy", "loadBalancer", "consistentHash", "httpHeaderName"); got != "X-Session-ID" {
+		t.Fatalf("httpHeaderName = %q", got)
+	}
+	// simple must NOT be set when ConsistentHash is in play.
+	if _, found, _ := unstructured.NestedString(u.Object, "spec", "trafficPolicy", "loadBalancer", "simple"); found {
+		t.Fatalf("simple must not be set alongside consistentHash")
+	}
+}
+
+func TestTranslate_LoadBalancer_ConsistentHash_Cookie(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	ttl := int64(60)
+	u, _ := translate(t, newISVC("isvc", "ns"), &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			Algorithm: &alg,
+			ConsistentHash: &v1beta1.ConsistentHashSpec{
+				Type:   v1beta1.HashTypeCookie,
+				Cookie: &v1beta1.HashCookie{Name: "sticky", TTLSeconds: &ttl},
+			},
+		},
+	})
+	if got := nestedString(t, u, "spec", "trafficPolicy", "loadBalancer", "consistentHash", "httpCookie", "name"); got != "sticky" {
+		t.Fatalf("cookie.name = %q", got)
+	}
+	if got := nestedString(t, u, "spec", "trafficPolicy", "loadBalancer", "consistentHash", "httpCookie", "ttl"); got != "60s" {
+		t.Fatalf("cookie.ttl = %q", got)
+	}
+}
+
+func TestTranslate_LoadBalancer_ConsistentHash_SourceIP(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	u, _ := translate(t, newISVC("isvc", "ns"), &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			Algorithm:      &alg,
+			ConsistentHash: &v1beta1.ConsistentHashSpec{Type: v1beta1.HashTypeSourceIP},
+		},
+	})
+	v, found, err := unstructured.NestedBool(u.Object, "spec", "trafficPolicy", "loadBalancer", "consistentHash", "useSourceIp")
+	if err != nil || !found || !v {
+		t.Fatalf("useSourceIp = %v, found=%v err=%v; want true", v, found, err)
+	}
+}
+
+func TestTranslate_CircuitBreaker_SupportedFields(t *testing.T) {
+	cb := &traffic.CircuitBreakerIntent{
+		MaxConnections:      i32p(1024),
+		MaxParallelRequests: i32p(2048),
+		MaxPendingRequests:  i32p(512),
+		// MaxParallelRetries + PerEndpointMaxConnections intentionally
+		// set — they MUST NOT appear on the emitted DR (no Istio analogue).
+		MaxParallelRetries:        i32p(8),
+		PerEndpointMaxConnections: i32p(1),
+	}
+	u, _ := translate(t, newISVC("isvc", "ns"), &traffic.ResolvedIntent{CircuitBreaker: cb})
+
+	if got := nestedInt64(t, u, "spec", "trafficPolicy", "connectionPool", "tcp", "maxConnections"); got != 1024 {
+		t.Fatalf("maxConnections = %d", got)
+	}
+	if got := nestedInt64(t, u, "spec", "trafficPolicy", "connectionPool", "http", "http2MaxRequests"); got != 2048 {
+		t.Fatalf("http2MaxRequests = %d", got)
+	}
+	if got := nestedInt64(t, u, "spec", "trafficPolicy", "connectionPool", "http", "http1MaxPendingRequests"); got != 512 {
+		t.Fatalf("http1MaxPendingRequests = %d", got)
+	}
+	// Unsupported fields must NOT appear anywhere on the DR.
+	tp, found, _ := unstructured.NestedMap(u.Object, "spec", "trafficPolicy")
+	if !found {
+		t.Fatalf("trafficPolicy missing")
+	}
+	if _, hasMPR := tp["maxParallelRetries"]; hasMPR {
+		t.Errorf("maxParallelRetries must not appear (no Istio analogue)")
+	}
+	// perEndpoint is an Envoy concept; ensure it's absent.
+	cp, _, _ := unstructured.NestedMap(u.Object, "spec", "trafficPolicy", "connectionPool")
+	if _, hasPE := cp["perEndpoint"]; hasPE {
+		t.Errorf("perEndpoint must not appear")
+	}
+}
+
+func TestTranslate_Timeout_SupportedFields(t *testing.T) {
+	idle := 30 * time.Second
+	mcd := 5 * time.Minute
+	tcp := 2 * time.Second
+	to := &traffic.TimeoutIntent{
+		Idle:                  &idle,
+		MaxConnectionDuration: &mcd, // unsupported — must NOT appear
+		TCPConnect:            &tcp,
+	}
+	u, _ := translate(t, newISVC("isvc", "ns"), &traffic.ResolvedIntent{Timeout: to})
+
+	if got := nestedString(t, u, "spec", "trafficPolicy", "connectionPool", "http", "idleTimeout"); got != "30s" {
+		t.Fatalf("idleTimeout = %q", got)
+	}
+	if got := nestedString(t, u, "spec", "trafficPolicy", "connectionPool", "tcp", "connectTimeout"); got != "2s" {
+		t.Fatalf("tcpConnect = %q", got)
+	}
+	// MaxConnectionDuration must NOT appear (no Istio DR analogue).
+	cp, _, _ := unstructured.NestedMap(u.Object, "spec", "trafficPolicy", "connectionPool")
+	for _, m := range []string{"maxConnectionDuration", "maxStreamDuration"} {
+		if _, has := cp[m]; has {
+			t.Errorf("%s must not appear on Istio DR", m)
+		}
+	}
+}
+
+func TestTranslate_Retry_IsSilentlyIgnored(t *testing.T) {
+	// Retry intent must not appear on the DR — Istio retries live on
+	// VirtualService. The reconciler surfaces dropped retry-* annotations
+	// as UnsupportedField; the translator just doesn't emit them.
+	r := &traffic.RetryIntent{Attempts: i32p(3), RetryOn: []string{"5xx"}}
+	u, _ := translate(t, newISVC("isvc", "ns"), &traffic.ResolvedIntent{Retry: r})
+	if _, found, _ := unstructured.NestedMap(u.Object, "spec", "trafficPolicy", "retry"); found {
+		t.Fatalf("retry must not appear on Istio DR")
+	}
+}
+
+func TestTranslate_Passthrough_StitchedUnderTrafficPolicy(t *testing.T) {
+	intent := &traffic.ResolvedIntent{
+		PassthroughIstio: map[string]string{
+			"connectionPool.tcp.tcpKeepalive.time":  "30s",
+			"outlierDetection.consecutive5xxErrors": "5",
+		},
+	}
+	u, passes := translate(t, newISVC("isvc", "ns"), intent)
+	if got := nestedString(t, u, "spec", "trafficPolicy", "connectionPool", "tcp", "tcpKeepalive", "time"); got != "30s" {
+		t.Fatalf("tcpKeepalive.time = %q", got)
+	}
+	if got := nestedInt64(t, u, "spec", "trafficPolicy", "outlierDetection", "consecutive5xxErrors"); got != 5 {
+		t.Fatalf("consecutive5xxErrors = %d", got)
+	}
+	wantPasses := []string{
+		"connectionPool.tcp.tcpKeepalive.time",
+		"outlierDetection.consecutive5xxErrors",
+	}
+	if !reflect.DeepEqual(passes, wantPasses) {
+		t.Fatalf("passes = %v, want sorted %v", passes, wantPasses)
+	}
+}
+
+func TestTranslate_Determinism(t *testing.T) {
+	alg := v1beta1.LoadBalancingTypeConsistentHash
+	intent := &traffic.ResolvedIntent{
+		Traffic: &v1beta1.TrafficSpec{
+			Algorithm: &alg,
+			ConsistentHash: &v1beta1.ConsistentHashSpec{
+				Type:    v1beta1.HashTypeHeader,
+				Headers: []v1beta1.HashHeader{{Name: "X-User"}},
+			},
+		},
+		CircuitBreaker: &traffic.CircuitBreakerIntent{MaxConnections: i32p(100)},
+		PassthroughIstio: map[string]string{
+			"a.b": "1", "x.y": "2",
+		},
+	}
+	a, p1 := translate(t, newISVC("isvc", "ns"), intent)
+	b, p2 := translate(t, newISVC("isvc", "ns"), intent)
+	if !reflect.DeepEqual(a.Object, b.Object) {
+		t.Fatalf("non-deterministic output")
+	}
+	if !reflect.DeepEqual(p1, p2) {
+		t.Fatalf("non-deterministic passes")
+	}
+}
+
+// --- ObserveAcceptance tests ---
+
+func drWithConditions(conds []map[string]interface{}) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(drGVK)
+	raw := make([]interface{}, 0, len(conds))
+	for _, c := range conds {
+		raw = append(raw, c)
+	}
+	_ = unstructured.SetNestedSlice(u.Object, raw, "status", "conditions")
+	return u
+}
+
+func TestObserveAcceptance_Reconciled_True(t *testing.T) {
+	u := drWithConditions([]map[string]interface{}{
+		{"type": "Reconciled", "status": "True", "reason": "Reconciled", "message": "policy accepted"},
+	})
+	got := New().ObserveAcceptance(u)
+	if got.State != traffic.AcceptanceAccepted {
+		t.Fatalf("state = %d", got.State)
+	}
+	if got.Message != "policy accepted" {
+		t.Fatalf("message = %q", got.Message)
+	}
+}
+
+func TestObserveAcceptance_Reconciled_False(t *testing.T) {
+	u := drWithConditions([]map[string]interface{}{
+		{"type": "Reconciled", "status": "False", "reason": "Invalid", "message": "bad host"},
+	})
+	got := New().ObserveAcceptance(u)
+	if got.State != traffic.AcceptanceRejected {
+		t.Fatalf("state = %d", got.State)
+	}
+}
+
+func TestObserveAcceptance_NoStatus_IsPending(t *testing.T) {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(drGVK)
+	got := New().ObserveAcceptance(u)
+	if got.State != traffic.AcceptancePending {
+		t.Fatalf("state = %d", got.State)
+	}
+}
+
+func TestObserveAcceptance_OtherConditionTypes_Ignored(t *testing.T) {
+	u := drWithConditions([]map[string]interface{}{
+		{"type": "SomethingElse", "status": "True"},
+	})
+	got := New().ObserveAcceptance(u)
+	if got.State != traffic.AcceptancePending {
+		t.Fatalf("state = %d", got.State)
+	}
+}
+
+func i32p(v int32) *int32 { return &v }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/noop.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/noop.go
@@ -1,0 +1,96 @@
+// Package translators holds Translator implementations that turn
+// resolved traffic-management intent into backend policy resources for
+// specific Gateway implementations.
+//
+// Each translator turns a resolved traffic-management intent into the
+// backend policy resource its target Gateway implementation expects.
+// Exactly one translator is selected per controller process by the
+// factory at startup based on installed CRDs.
+//
+// Translators in this package:
+//
+//   - noop: returned when no supported Gateway-implementation policy CRD
+//     is installed. Emits nothing and surfaces NoTranslatorAvailable so
+//     the reconciler can record the condition without blocking the ISVC
+//     lifecycle.
+//   - envoygateway: emits gateway.envoyproxy.io/v1alpha1 BackendTrafficPolicy.
+package translators
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic"
+)
+
+// NoopName is the stable identifier the factory uses for log / metric
+// labels and that the reconciler matches on to surface the
+// NoTranslatorAvailable condition.
+const NoopName = "noop"
+
+// Noop is the translator the factory falls back to when no supported
+// Gateway-implementation backend policy CRD is installed.
+//
+// Translate returns (nil, nil, nil) on every call — the reconciler
+// interprets that as "no resource to emit" and skips the apply. The
+// reconciler is also expected to surface a NoTranslatorAvailable
+// condition on the ISVC so operators can see why their traffic-
+// management intent did not take effect; surfacing that condition is
+// the reconciler's job, not the translator's, so this implementation
+// stays a pure no-op.
+type Noop struct{}
+
+// NewNoop returns a ready-to-use Noop translator. There is no
+// per-cluster configuration to bind, so this exists only to match the
+// constructor shape of real translators.
+func NewNoop() *Noop {
+	return &Noop{}
+}
+
+// Name returns the stable identifier "noop".
+func (n *Noop) Name() string {
+	return NoopName
+}
+
+// SupportedAnnotations returns the empty set. The Noop translator
+// honors no annotations. The reconciler does NOT surface
+// UnsupportedField for noop — the NoTranslatorAvailable condition on
+// BackendPolicyReady already explains the situation; listing every
+// dropped key would be noise.
+func (n *Noop) SupportedAnnotations() sets.Set[string] {
+	return sets.New[string]()
+}
+
+// SupportedPassthroughPrefixes returns nil. The Noop translator emits
+// nothing so nothing can be stitched through.
+func (n *Noop) SupportedPassthroughPrefixes() []string {
+	return nil
+}
+
+// Translate is a no-op. Returning (nil, nil, nil) signals "no resource
+// needed for this intent" per the Translator contract.
+func (n *Noop) Translate(
+	_ *v1beta1.InferenceService,
+	_ []string,
+	_ *traffic.ResolvedIntent,
+) (client.Object, []string, error) {
+	return nil, nil, nil
+}
+
+// Watches returns nil because the Noop translator does not emit any
+// resource the reconciler would need to watch.
+func (n *Noop) Watches() client.Object {
+	return nil
+}
+
+// ObserveAcceptance always returns AcceptancePending because the Noop
+// translator emits no resource and the reconciler never calls this
+// method when no policy was emitted. Defined to satisfy the
+// Translator interface.
+func (n *Noop) ObserveAcceptance(_ client.Object) traffic.AcceptanceObservation {
+	return traffic.AcceptanceObservation{State: traffic.AcceptancePending}
+}
+
+// Compile-time check that Noop satisfies the Translator interface.
+var _ traffic.Translator = (*Noop)(nil)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/noop_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/translators/noop_test.go
@@ -1,0 +1,52 @@
+package translators
+
+import (
+	"testing"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic"
+)
+
+func TestNoop_Name(t *testing.T) {
+	if got := NewNoop().Name(); got != NoopName {
+		t.Fatalf("Name() = %q, want %q", got, NoopName)
+	}
+}
+
+func TestNoop_SupportedAnnotations_IsEmpty(t *testing.T) {
+	// The Noop translator advertises no annotation support so the
+	// reconciler reports every ome.io/* annotation as UnsupportedField.
+	got := NewNoop().SupportedAnnotations()
+	if got == nil {
+		t.Fatalf("SupportedAnnotations() must return non-nil set")
+	}
+	if got.Len() != 0 {
+		t.Fatalf("SupportedAnnotations() must be empty, got: %v", got.UnsortedList())
+	}
+}
+
+func TestNoop_Translate_ReturnsNil(t *testing.T) {
+	// (nil, nil, nil) is the documented "no resource needed" signal.
+	// The reconciler treats this as "skip apply" and surfaces
+	// NoTranslatorAvailable separately based on the translator name.
+	obj, passthroughs, err := NewNoop().Translate(
+		&v1beta1.InferenceService{},
+		[]string{"isvc", "isvc-engine"},
+		&traffic.ResolvedIntent{},
+	)
+	if err != nil {
+		t.Fatalf("Translate() err = %v, want nil", err)
+	}
+	if obj != nil {
+		t.Fatalf("Translate() obj = %v, want nil", obj)
+	}
+	if passthroughs != nil {
+		t.Fatalf("Translate() passthroughs = %v, want nil", passthroughs)
+	}
+}
+
+func TestNoop_Watches_ReturnsNil(t *testing.T) {
+	if got := NewNoop().Watches(); got != nil {
+		t.Fatalf("Watches() = %v, want nil", got)
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/unsupported.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/unsupported.go
@@ -1,0 +1,104 @@
+package traffic
+
+import (
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// allBackendAnnotationKeys is the canonical set of ome.io/* keys that
+// flow through a translator. A translator MAY support a subset of
+// these (e.g. an implementation that doesn't model per-endpoint
+// circuit-breaker limits). Operator-declared keys in this set that
+// the active translator does NOT support are surfaced as
+// UnsupportedField on the InferenceService.
+func allBackendAnnotationKeys() sets.Set[string] {
+	return sets.New(
+		constants.CircuitBreakerMaxConnectionsAnnotation,
+		constants.CircuitBreakerMaxParallelRequestsAnnotation,
+		constants.CircuitBreakerMaxPendingRequestsAnnotation,
+		constants.CircuitBreakerMaxParallelRetriesAnnotation,
+		constants.CircuitBreakerPerEndpointMaxConnectionsAnnotation,
+		constants.RetryAttemptsAnnotation,
+		constants.RetryOnAnnotation,
+		constants.RetryPerTryTimeoutAnnotation,
+		constants.TimeoutIdleAnnotation,
+		constants.TimeoutMaxConnectionDurationAnnotation,
+		constants.TimeoutTCPConnectAnnotation,
+	)
+}
+
+// allPassthroughPrefixes is the canonical set of ome.io/* pass-through
+// prefixes. A pass-through annotation under a prefix NOT in the active
+// translator's SupportedPassthroughPrefixes is surfaced as
+// UnsupportedField.
+func allPassthroughPrefixes() []string {
+	return []string{
+		constants.PassthroughEnvoyGatewayPrefix,
+		constants.PassthroughIstioPrefix,
+	}
+}
+
+// ComputeUnsupportedAnnotations returns the sorted list of ome.io/*
+// traffic annotations declared on the InferenceService that the
+// active translator does not honor. Two sources:
+//
+//  1. A per-key annotation in allBackendAnnotationKeys() that the
+//     translator's SupportedAnnotations does not include.
+//  2. A pass-through annotation under a prefix the translator does
+//     not own (e.g. ome.io/dr.* on an Envoy-Gateway cluster).
+//
+// Operational annotations (rollout-promote, rollout-rollback,
+// managed-by-conflict-acked, etc.) are NOT translator-handled and
+// are excluded from the check.
+//
+// Returned slice is sorted for deterministic status messages.
+func ComputeUnsupportedAnnotations(annotations map[string]string, translator Translator) []string {
+	if len(annotations) == 0 {
+		return nil
+	}
+	supported := translator.SupportedAnnotations()
+	if supported == nil {
+		supported = sets.New[string]()
+	}
+	ownedPrefixes := translator.SupportedPassthroughPrefixes()
+	allKnownBackend := allBackendAnnotationKeys()
+
+	var unsupported []string
+	for key := range annotations {
+		// Bucket 1: per-key annotation flowing through the translator.
+		if allKnownBackend.Has(key) {
+			if !supported.Has(key) {
+				unsupported = append(unsupported, key)
+			}
+			continue
+		}
+		// Bucket 2: pass-through annotation under a known prefix.
+		if isPassthroughKey(key) && !hasMatchingPrefix(key, ownedPrefixes) {
+			unsupported = append(unsupported, key)
+		}
+	}
+	sort.Strings(unsupported)
+	return unsupported
+}
+
+func isPassthroughKey(key string) bool {
+	for _, p := range allPassthroughPrefixes() {
+		if strings.HasPrefix(key, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMatchingPrefix(key string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(key, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/unsupported_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/traffic/unsupported_test.go
@@ -1,0 +1,174 @@
+package traffic
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// classifyStub is a lightweight Translator that implements only the
+// classification surface ComputeUnsupportedAnnotations cares about.
+// Translate / ObserveAcceptance / Watches panic if called — they MUST
+// NOT be invoked by the classifier.
+type classifyStub struct {
+	name     string
+	supports sets.Set[string]
+	prefixes []string
+}
+
+func (c *classifyStub) Name() string                           { return c.name }
+func (c *classifyStub) SupportedAnnotations() sets.Set[string] { return c.supports }
+func (c *classifyStub) SupportedPassthroughPrefixes() []string { return c.prefixes }
+func (c *classifyStub) Watches() client.Object                 { panic("Watches not relevant") }
+func (c *classifyStub) Translate(
+	_ *v1beta1.InferenceService, _ []string, _ *ResolvedIntent,
+) (client.Object, []string, error) {
+	panic("Translate not relevant")
+}
+func (c *classifyStub) ObserveAcceptance(_ client.Object) AcceptanceObservation {
+	panic("ObserveAcceptance not relevant")
+}
+
+func TestComputeUnsupportedAnnotations_AllSupported_ReturnsNil(t *testing.T) {
+	tr := &classifyStub{
+		name: "envoy-gateway",
+		supports: sets.New(
+			constants.CircuitBreakerMaxConnectionsAnnotation,
+			constants.RetryAttemptsAnnotation,
+		),
+		prefixes: []string{constants.PassthroughEnvoyGatewayPrefix},
+	}
+	in := map[string]string{
+		constants.CircuitBreakerMaxConnectionsAnnotation:                   "100",
+		constants.RetryAttemptsAnnotation:                                  "3",
+		constants.PassthroughEnvoyGatewayPrefix + "loadBalancer.slowStart": "30s",
+		// Foreign-namespace annotations are ignored entirely.
+		"foo.example.com/anything": "ignored",
+	}
+	if got := ComputeUnsupportedAnnotations(in, tr); got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+}
+
+func TestComputeUnsupportedAnnotations_WrongPassthroughPrefix(t *testing.T) {
+	// EG-active cluster, operator set an Istio pass-through.
+	tr := &classifyStub{
+		name:     "envoy-gateway",
+		supports: sets.New(constants.RetryAttemptsAnnotation),
+		prefixes: []string{constants.PassthroughEnvoyGatewayPrefix},
+	}
+	in := map[string]string{
+		constants.PassthroughIstioPrefix + "trafficPolicy.connectionPool.tcp.tcpKeepalive.time": "30s",
+		constants.RetryAttemptsAnnotation: "1",
+	}
+	got := ComputeUnsupportedAnnotations(in, tr)
+	want := []string{constants.PassthroughIstioPrefix + "trafficPolicy.connectionPool.tcp.tcpKeepalive.time"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestComputeUnsupportedAnnotations_UnsupportedPerKey(t *testing.T) {
+	// EG translator that doesn't yet support per-endpoint cap (subset
+	// translator). Operator set it -> unsupported.
+	tr := &classifyStub{
+		name: "alpha-eg",
+		supports: sets.New(
+			constants.CircuitBreakerMaxConnectionsAnnotation,
+			// MaxParallelRequests intentionally NOT supported.
+		),
+		prefixes: []string{constants.PassthroughEnvoyGatewayPrefix},
+	}
+	in := map[string]string{
+		constants.CircuitBreakerMaxConnectionsAnnotation:      "100",
+		constants.CircuitBreakerMaxParallelRequestsAnnotation: "200",
+	}
+	got := ComputeUnsupportedAnnotations(in, tr)
+	want := []string{constants.CircuitBreakerMaxParallelRequestsAnnotation}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestComputeUnsupportedAnnotations_NoopTranslator_AllBackendUnsupported(t *testing.T) {
+	// Noop supports nothing — every backend key on the ISVC ends up in
+	// the list. Pass-throughs of both kinds also unsupported.
+	tr := &classifyStub{name: "noop", supports: sets.New[string](), prefixes: nil}
+	in := map[string]string{
+		constants.CircuitBreakerMaxConnectionsAnnotation:                                "1",
+		constants.RetryAttemptsAnnotation:                                               "1",
+		constants.PassthroughEnvoyGatewayPrefix + "loadBalancer.slowStart.window":       "30s",
+		constants.PassthroughIstioPrefix + "trafficPolicy.connectionPool.tcp.connectTo": "30s",
+	}
+	got := ComputeUnsupportedAnnotations(in, tr)
+	want := []string{
+		constants.CircuitBreakerMaxConnectionsAnnotation,
+		constants.RetryAttemptsAnnotation,
+		constants.PassthroughEnvoyGatewayPrefix + "loadBalancer.slowStart.window",
+		constants.PassthroughIstioPrefix + "trafficPolicy.connectionPool.tcp.connectTo",
+	}
+	// Ordering: sorted lexicographically by ComputeUnsupportedAnnotations.
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for _, w := range want {
+		found := false
+		for _, g := range got {
+			if g == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("want %q to be in unsupported list, got: %v", w, got)
+		}
+	}
+	// Verify sorted.
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Errorf("output not sorted: %v", got)
+		}
+	}
+}
+
+func TestComputeUnsupportedAnnotations_OperationalAnnotationsExcluded(t *testing.T) {
+	// rollout-promote / managed-by-conflict-acked etc are NOT
+	// translator-handled; they MUST NOT appear in the unsupported
+	// list even when the translator is noop.
+	tr := &classifyStub{name: "noop", supports: sets.New[string](), prefixes: nil}
+	in := map[string]string{
+		constants.RolloutPromoteAnnotation:         "1",
+		constants.RolloutRollbackAnnotation:        "true",
+		constants.RolloutReadyTimeoutAnnotation:    "10m",
+		constants.RevisionHistoryLimitAnnotation:   "5",
+		constants.ManagedByConflictAckedAnnotation: "true",
+	}
+	if got := ComputeUnsupportedAnnotations(in, tr); got != nil {
+		t.Fatalf("operational annotations must be excluded, got: %v", got)
+	}
+}
+
+func TestComputeUnsupportedAnnotations_NilAnnotations_ReturnsNil(t *testing.T) {
+	tr := &classifyStub{name: "noop", supports: sets.New[string]()}
+	if got := ComputeUnsupportedAnnotations(nil, tr); got != nil {
+		t.Fatalf("nil annotations -> nil, got %v", got)
+	}
+}
+
+func TestComputeUnsupportedAnnotations_ForeignNamespaceIgnored(t *testing.T) {
+	tr := &classifyStub{name: "envoy-gateway", supports: sets.New[string]()}
+	in := map[string]string{
+		"foo.example.com/whatever":          "ignored",
+		"app.kubernetes.io/name":            "ignored",
+		"prometheus.io/scrape":              "ignored",
+		"random.invalid/cb.max-connections": "looks suspicious but not ours",
+	}
+	if got := ComputeUnsupportedAnnotations(in, tr); got != nil {
+		t.Fatalf("foreign annotations must be ignored, got: %v", got)
+	}
+}


### PR DESCRIPTION
## What

`spec.traffic` and `status.traffic` exist in the API, but nothing consumed them — setting a traffic policy was a silent no-op. This adds the engine:

- **`reconcilers/traffic`** — resolves the ISVC's traffic intent (typed `spec.traffic` core + `ome.io/*` annotation extension) into a `ResolvedIntent`, hands it to the active translator, applies the emitted backend-policy resource targeting every OME-managed HTTPRoute for the ISVC, and returns the `TrafficStatus` written to `status.traffic`.
- **Translators** are per-Gateway-implementation:
  | Translator | Emits | Selected when |
  |---|---|---|
  | `envoygateway` | `BackendTrafficPolicy` | Envoy Gateway CRD installed (preferred) |
  | `istio` | `DestinationRule` | Istio CRD installed |
  | `noop` | nothing (advisory status) | neither present |
- Selection happens **once at startup** via CRD probing (`factory.New`); policy objects are written through `unstructured`, so this adds **zero new module dependencies**.
- Controller wiring: `TrafficReconciler` field (nil = traffic management off, controller fully functional), invoked after component/ingress reconciliation; on translation failure the status still lands so operators see the `TranslationFailed` reason immediately.

## Testing

- Full tree ports with its suites: intent resolution, reconciler behavior, per-translator emission (envoygateway, istio, noop), factory CRD-probe selection, status writing — all pass.
- `go test ./pkg/controller/v1beta1/inferenceservice/...`: pass.

## Notes

The ingress reconciler's Gateway API strategy will hand BackendTrafficPolicy ownership to this engine when traffic intent is present — that lands in the follow-up ingress-sync PR stacked on this one.