### PR TITLE
[Core] Multi-cluster: IR projection + helpers

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/irstatus_read.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/irstatus_read.go
@@ -1,0 +1,41 @@
+package irprojector
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// ComponentIRStatus returns the authoritative InferenceReplica status for one
+// Component of an ISVC, read via the supplied reader (cached client is fine —
+// these are non-destructive coordination reads). Returns (nil, nil) when the IR
+// does not exist yet, so callers treat "no authoritative status" the same as the
+// pre-migration empty projection. Any other read failure is returned as a
+// wrapped error — callers MUST distinguish it from the missing-IR case: a
+// transient read error is not "no observation yet", and safety gates that treat
+// it that way fail open. A nil reader is likewise an error, not a missing IR —
+// it signals a wiring bug the caller must not silently absorb. This is the
+// single source of truth every in-cluster decision reads instead of the ISVC's
+// copied LifecycleStatus.
+func ComponentIRStatus(ctx context.Context, reads client.Reader, namespace, isvcName string, c v1beta1.ComponentType) (*v1beta1.InferenceReplicaStatus, error) {
+	// A nil reader is a wiring bug, not an absent IR. Surface it as an
+	// error so safety gates fail closed instead of mistaking it for the
+	// missing-IR case, while still not panicking the reconcile.
+	if reads == nil {
+		return nil, fmt.Errorf("nil reader for InferenceReplica %s/%s (component %s)",
+			namespace, InferenceReplicaName(isvcName, c), c)
+	}
+	ir := &v1beta1.InferenceReplica{}
+	key := types.NamespacedName{Namespace: namespace, Name: InferenceReplicaName(isvcName, c)}
+	if err := reads.Get(ctx, key, ir); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get InferenceReplica %s/%s: %w", key.Namespace, key.Name, err)
+	}
+	return &ir.Status, nil
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/irstatus_read_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/irstatus_read_test.go
@@ -1,0 +1,81 @@
+package irprojector
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestComponentIRStatus_ReturnsAuthoritativeStatus(t *testing.T) {
+	ir := &v1beta1.InferenceReplica{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: InferenceReplicaName("svc", v1beta1.EngineComponent)},
+		Status: v1beta1.InferenceReplicaStatus{
+			Replicas: 3, ReadyReplicas: 2,
+			InstanceStatuses: []v1beta1.OMENativeInstanceStatus{{Index: 0, Phase: v1beta1.OMENativeInstanceReady}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(ir).Build()
+
+	got, err := ComponentIRStatus(context.Background(), c, "ns", "svc", v1beta1.EngineComponent)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got == nil || got.Replicas != 3 || len(got.InstanceStatuses) != 1 {
+		t.Fatalf("want authoritative IR status (3 replicas, 1 instance); got %+v", got)
+	}
+}
+
+func TestComponentIRStatus_MissingIRReturnsNil(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	got, err := ComponentIRStatus(context.Background(), c, "ns", "svc", v1beta1.EngineComponent)
+	if err != nil {
+		t.Fatalf("missing IR must not error; got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("missing IR must return nil status; got %+v", got)
+	}
+}
+
+func TestComponentIRStatus_NilReaderErrors(t *testing.T) {
+	// A nil reader is a wiring bug: it must surface as an error (so gate
+	// callers fail closed) rather than being mistaken for a missing IR —
+	// and must not panic the reconcile.
+	got, err := ComponentIRStatus(context.Background(), nil, "ns", "svc", v1beta1.EngineComponent)
+	if err == nil {
+		t.Fatalf("nil reader must return an error; got (%+v, nil)", got)
+	}
+	if got != nil {
+		t.Fatalf("nil reader must return nil status; got %+v", got)
+	}
+	if !strings.Contains(err.Error(), "nil reader") {
+		t.Errorf("error should name the nil-reader cause: %v", err)
+	}
+}
+
+// erroringReader fails every Get with a non-NotFound error.
+type erroringReader struct {
+	client.Reader
+}
+
+func (erroringReader) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return errors.New("simulated apiserver failure")
+}
+
+func TestComponentIRStatus_ReadErrorPropagatesWrapped(t *testing.T) {
+	// Only NotFound maps to (nil, nil). Any other read failure must
+	// surface as a wrapped error so gate callers can fail closed instead
+	// of mistaking a flaky read for "no observation yet".
+	got, err := ComponentIRStatus(context.Background(), erroringReader{}, "ns", "svc", v1beta1.EngineComponent)
+	if err == nil || got != nil {
+		t.Fatalf("read error must propagate with nil status; got (%+v, %v)", got, err)
+	}
+	if !strings.Contains(err.Error(), "get InferenceReplica ns/") || !strings.Contains(err.Error(), "simulated apiserver failure") {
+		t.Errorf("error should wrap the IR key and cause: %v", err)
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/projector.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/projector.go
@@ -1,0 +1,584 @@
+// Package irprojector projects an InferenceService Component (engine /
+// decoder / router) into the per-(ISVC, Component) InferenceReplica
+// resource the IR controller reconciles.
+//
+// The projector is the bridge into the IR-driven world: when a
+// Component's effective deployment mode is OMENative, the ISVC
+// controller hands the desired per-Component spec to
+// ensureInferenceReplica. The IR controller then takes over the
+// per-Instance lifecycle — Create / Update / Restart / Migrate /
+// Delete — owning its own pods, ControllerRevisions, and per-Component
+// headless Service.
+//
+// The package is intentionally narrow:
+//
+//   - IsIRManagedComponent reads the resolved deployment mode and
+//     returns the predicate the dispatch sites in
+//     components/{engine,decoder,router}.go branch on. OMENative-mode
+//     Components ALWAYS route through the IR-managed path.
+//
+//   - EnsureInferenceReplica is the CreateOrUpdate driver: build the
+//     desired IR Spec from the rendered per-Component inputs, owner-ref
+//     the IR back to the parent ISVC, stamp the controller-write
+//     annotation the IR webhook gates on, and persist.
+//
+// The package does NOT:
+//   - reach into the IR controller's internals (writes Spec, reads
+//     Status only — see ReadInferenceReplica in status.go);
+//   - duplicate pod-spec rendering (the dispatch site already computed
+//     the PodSpec; ensure passes it through verbatim);
+//   - manage IR deletion beyond the owner-ref cascade (GC handles it
+//     on ISVC delete; explicit operator IR deletes are out of scope).
+package irprojector
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// IsIRManagedComponent returns true when the given Component should be
+// driven through the InferenceReplica path. Only constants.OMENative
+// routes through the IR-managed path; every other mode (RawDeployment,
+// …) falls through to its own dispatch branch in
+// components/{engine,decoder,router}.go.
+//
+// OMENative-mode Components ALWAYS route through the IR-managed path —
+// there is no per-Component opt-in and no cluster-wide opt-out. The IR
+// path is the sole OMENative implementation.
+func IsIRManagedComponent(deploymentMode constants.DeploymentModeType) bool {
+	return deploymentMode == constants.OMENative
+}
+
+// isvcGVK identifies the parent ISVC for owner-ref stamping on
+// emitted InferenceReplicas. Declared here so the package is
+// self-contained and doesn't need a cross-package import.
+var isvcGVK = v1beta1.SchemeGroupVersion.WithKind("InferenceService")
+
+// Params is the input bag EnsureInferenceReplica reads to build the
+// desired IR Spec. The dispatch site in
+// components/{engine,decoder,router}.go fills it from the rendered
+// per-Component values.
+//
+// Critical contract: PodSpec / WorkerPodSpec / ObjectMeta are the
+// rendered per-pod template values. The projector does not re-render —
+// it hands the IR controller the exact same per-pod template the
+// dispatch site computed.
+type Params struct {
+	// ISVC is the parent InferenceService. The projector reads
+	// ISVC.Name / Namespace / UID for IR naming + owner-ref, and
+	// passes Spec.<component>.Lifecycle into the IR Spec.
+	ISVC *v1beta1.InferenceService
+
+	// Component identifies which of engine / decoder / router is
+	// being projected. The IR name is <isvc>-<component>; the IR
+	// Spec.Component field stamps this verbatim.
+	Component v1beta1.ComponentType
+
+	// ComponentExt is the merged ComponentExtensionSpec for this
+	// Component. The projector reads MinReplicas (defaults to 1) and
+	// Lifecycle. Other fields (autoscaler, KEDA, deployment strategy)
+	// are owned by the ISVC controller's other reconcilers — they
+	// don't influence the IR Spec.
+	ComponentExt *v1beta1.ComponentExtensionSpec
+
+	// ObjectMeta is the rendered per-Component pod metadata. Threaded
+	// into the IR via the PodTemplateSpec.ObjectMeta on each Runner so
+	// the IR-rendered pods inherit the canonical OMENative labels /
+	// annotations.
+	ObjectMeta metav1.ObjectMeta
+
+	// PodSpec is the rendered leader / single-pod template. Required.
+	PodSpec *corev1.PodSpec
+
+	// WorkerPodSpec is the rendered worker template for multi-pod
+	// Components. nil for single-pod Components (router; engine /
+	// decoder without Worker block).
+	WorkerPodSpec *corev1.PodSpec
+
+	// WorkerSize is Worker.Size for multi-pod Components. Zero for
+	// single-pod Components.
+	WorkerSize int
+
+	// MultiPod indicates the Component declares Leader + Worker
+	// (each Instance materializes more than one pod). Set at the
+	// dispatch site since EngineSpec / DecoderSpec aren't carried
+	// through this bag.
+	MultiPod bool
+
+	// TopologyKey is the resolved gang co-location node-label key for
+	// this Component (effective ISVC↔runtime value). Projected verbatim
+	// onto ir.Spec.TopologyKey so the IR controller can auto-generate the
+	// per-Instance worker→leader podAffinity. Set at the dispatch site
+	// since EngineSpec / DecoderSpec aren't carried through this bag. nil
+	// for single-pod Components or when unset on both ISVC and runtime.
+	TopologyKey *string
+
+	// ResolvedAutoscaler is the authoritative per-Component
+	// ComponentAutoscaler the autoscaler.ResolveComponentAutoscaler
+	// helper picked from the ISVC → runtime → default chain. The
+	// projector deep-copies this onto ir.Spec.Autoscaler with
+	// whole-block replace semantics (operator-side ISVC / runtime
+	// edits always win over any drifted IR.spec.autoscaler). nil is
+	// accepted and projects to nil ir.Spec.Autoscaler (no spurious
+	// empty block); callers should normally pass the resolver's
+	// non-nil return value.
+	ResolvedAutoscaler *v1beta1.ComponentAutoscaler
+
+	// Client is the controller-runtime client used to CreateOrUpdate
+	// the IR. The ISVC controller already holds this.
+	Client client.Client
+}
+
+// EnsureInferenceReplica computes the desired IR Spec from Params,
+// stamps the owner-ref back to the parent ISVC, attaches the
+// controller-write annotation the IR webhook gates on, and
+// CreateOrUpdates the object. Returns the post-write IR so the
+// caller can read IR.Status downstream (status.go uses this).
+//
+// Idempotent: the second invocation with the same Params produces the
+// same Spec and no-ops (projectionUnchanged skips the write). On a real
+// change it issues a merge patch of only the diffed fields — with no
+// ResourceVersion precondition, so a concurrent IR status write from the
+// IR controller can't turn it into an optimistic-lock conflict. The
+// retry.RetryOnConflict wrapper remains for the racing-create path, which
+// synthesizes a Conflict.
+//
+// Errors are wrapped with the offending IR namespace/name for grep-
+// ability in operator logs — except apierrors.IsConflict, which callers
+// treat as a benign requeue rather than a hard error.
+func EnsureInferenceReplica(ctx context.Context, p Params) (*v1beta1.InferenceReplica, error) {
+	if err := validateParams(p); err != nil {
+		return nil, err
+	}
+
+	name := InferenceReplicaName(p.ISVC.Name, p.Component)
+	key := types.NamespacedName{Namespace: p.ISVC.Namespace, Name: name}
+
+	logger := log.FromContext(ctx).WithValues(
+		"isvc", client.ObjectKey{Namespace: p.ISVC.Namespace, Name: p.ISVC.Name},
+		"component", p.Component,
+		"inferencereplica", key)
+
+	var committed *v1beta1.InferenceReplica
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ir := &v1beta1.InferenceReplica{}
+		getErr := p.Client.Get(ctx, key, ir)
+		switch {
+		case apierrors.IsNotFound(getErr):
+			ir = newInferenceReplica(p, name)
+			if err := p.Client.Create(ctx, ir); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					// Cache lag: the Get said NotFound but the
+					// apiserver already has the IR (the projector's
+					// own previous Create just landed, or a racing
+					// peer wrote it). Log so repeated firings of this
+					// branch — a real symptom of cache desync — surface
+					// in operator logs at V(1).
+					logger.V(1).Info("InferenceReplica racing-create resolved as Conflict; retrying",
+						"parentUID", p.ISVC.UID)
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: v1beta1.SchemeGroupVersion.Group, Resource: "inferencereplicas"},
+						name,
+						fmt.Errorf("racing create"),
+					)
+				}
+				return fmt.Errorf("create IR %s/%s: %w", p.ISVC.Namespace, name, err)
+			}
+			committed = ir
+			return nil
+		case getErr != nil:
+			return fmt.Errorf("get IR %s/%s: %w", p.ISVC.Namespace, name, getErr)
+		}
+
+		// IR exists - apply the desired spec on top of the live object. Pacing is
+		// owned by coordination and preserved here. Paused is projected from the
+		// parent ISVC's operator-facing rollout-paused annotation below.
+		original := ir.DeepCopy()
+		applyDesiredSpec(ir, p, name)
+
+		// No-op guard: skip the write entirely when nothing the projector
+		// owns changed. In steady state — including a workload stuck in
+		// CrashLoopBackOff — the desired spec is constant, so an
+		// unconditional write would churn the IR's ResourceVersion every
+		// reconcile and fight the IR controller's rapid status writes,
+		// producing a conflict hot-loop.
+		if projectionUnchanged(original, ir) {
+			committed = ir
+			return nil
+		}
+
+		// Merge patch (no ResourceVersion precondition) so a concurrent
+		// IR status write from the IR controller doesn't turn this into an
+		// optimistic-lock conflict — the projector only owns spec/metadata
+		// fields, never status. RetryOnConflict still wraps the Get→patch
+		// for the racing-create path below, which synthesizes a Conflict.
+		if err := p.Client.Patch(ctx, ir, client.MergeFrom(original)); err != nil {
+			return fmt.Errorf("patch IR %s/%s: %w", p.ISVC.Namespace, name, err)
+		}
+		committed = ir
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return committed, nil
+}
+
+// InferenceReplicaName returns the canonical IR name for an
+// (ISVC, Component) pair: <isvc>-<component>. The IR controller's
+// revision/service helpers all key off ParentRef.Name so the IR's
+// name itself is mostly a routing identifier; we keep the legacy
+// per-Component naming so kubectl debugging is intuitive.
+func InferenceReplicaName(isvcName string, component v1beta1.ComponentType) string {
+	return isvcName + "-" + string(component)
+}
+
+// validateParams enforces the contract the projector relies on. The
+// dispatch site in components/{engine,decoder,router}.go always
+// passes a non-nil ISVC / ComponentExt / PodSpec; the explicit guard
+// surfaces wiring bugs as a clear error instead of a nil deref.
+func validateParams(p Params) error {
+	if p.Client == nil {
+		return fmt.Errorf("EnsureInferenceReplica: nil client")
+	}
+	if p.ISVC == nil {
+		return fmt.Errorf("EnsureInferenceReplica: nil ISVC (component=%s)", p.Component)
+	}
+	if p.ComponentExt == nil {
+		return fmt.Errorf("EnsureInferenceReplica: nil ComponentExtensionSpec (isvc=%s/%s, component=%s)",
+			p.ISVC.Namespace, p.ISVC.Name, p.Component)
+	}
+	if p.PodSpec == nil {
+		return fmt.Errorf("EnsureInferenceReplica: nil PodSpec (isvc=%s/%s, component=%s)",
+			p.ISVC.Namespace, p.ISVC.Name, p.Component)
+	}
+	if p.MultiPod && p.WorkerPodSpec == nil {
+		return fmt.Errorf("EnsureInferenceReplica: MultiPod=true but nil WorkerPodSpec (isvc=%s/%s, component=%s)",
+			p.ISVC.Namespace, p.ISVC.Name, p.Component)
+	}
+	return nil
+}
+
+// newInferenceReplica builds a fresh IR from Params for the Create
+// branch. The owner-ref stamps the ISVC as the controller (so
+// GC cascades on ISVC delete) and stamps the
+// controller-write annotation the IR validating webhook gates on.
+//
+// Labels are inherited from the rendered per-Component ObjectMeta so
+// the IR object itself carries the same legacy OMENative trio every
+// downstream consumer expects.
+func newInferenceReplica(p Params, name string) *v1beta1.InferenceReplica {
+	ir := &v1beta1.InferenceReplica{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: p.ISVC.Namespace,
+			Labels:    copyMap(p.ObjectMeta.Labels),
+			Annotations: map[string]string{
+				constants.InferenceReplicaControllerWriteAnnotationKey: constants.InferenceReplicaControllerWriteAnnotationVal,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(p.ISVC, isvcGVK),
+			},
+		},
+	}
+	applyDesiredSpec(ir, p, name)
+	return ir
+}
+
+// applyDesiredSpec stamps the projected fields onto the IR. Split out
+// so the Create + Update branches in EnsureInferenceReplica produce
+// the same Spec (the only difference between Create and Update is
+// whether the apiserver assigns a UID — and Spec.Replicas, which is
+// autoscaler-owned on Update; see desiredReplicas).
+//
+// Preserves Spec.Pacing on Update. Spec.Paused is projected from the existing
+// operator-facing ISVC annotation because InferenceReplica is controller-only;
+// removing the annotation explicitly clears the circuit breaker on every IR.
+//
+// Preserves Spec.Replicas on Update when the Component is autoscaler-
+// managed — the IR's /scale subresource is the HPA / KEDA / external
+// scale target, so the autoscaler is the authoritative writer of
+// spec.replicas. Re-stamping MinReplicas every reconcile would clobber
+// the autoscaler's value and make the ISVC controller and the autoscaler
+// fight over the count. See desiredReplicas for the full decision.
+func applyDesiredSpec(ir *v1beta1.InferenceReplica, p Params, name string) {
+	// Force the metadata fields the projector owns. Annotations get
+	// the controller-write stamp; user-set annotations on the IR are
+	// not preserved across reconciles (the IR is a controller-only
+	// resource — users edit the parent ISVC).
+	if ir.Annotations == nil {
+		ir.Annotations = map[string]string{}
+	}
+	ir.Annotations[constants.InferenceReplicaControllerWriteAnnotationKey] = constants.InferenceReplicaControllerWriteAnnotationVal
+
+	// Labels track the per-Component ObjectMeta the omenative path
+	// would have stamped on pods — copying them onto the IR itself
+	// gives kubectl-side filterability without changing the pod
+	// label-set the IR controller emits.
+	ir.Labels = copyMap(p.ObjectMeta.Labels)
+
+	// Owner-ref must stamp the live ISVC so GC cascades
+	// the IR on ISVC delete. Update overwrites any drifted owner ref
+	// (operators who edit the IR's owner refs by hand will see them
+	// re-stamped next reconcile — intentional).
+	ir.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(p.ISVC, isvcGVK),
+	}
+
+	// ParentRef + Component are immutable post-create per the IR
+	// webhook. On Update we re-stamp the same values — no-op for a
+	// well-formed IR, defense-in-depth if someone manually edited
+	// the live object.
+	ir.Spec.ParentRef = v1beta1.ParentReference{
+		Name: p.ISVC.Name,
+	}
+	ir.Spec.Component = p.Component
+	ir.Spec.Replicas = desiredReplicas(ir, p)
+	ir.Spec.Runners = runnersFromParams(p)
+	ir.Spec.Lifecycle = lifecycleFromComponentExt(p.ComponentExt)
+	ir.Spec.Paused = p.ISVC.Annotations[constants.PausedRolloutAnnotation] == "true"
+	// Project the resolved gang co-location key verbatim. The IR
+	// controller reads it to auto-generate the worker→leader podAffinity
+	// for multi-node Components; nil is a no-op there.
+	ir.Spec.TopologyKey = p.TopologyKey
+	// Project the resolved Autoscaler onto the IR. Whole-block replace
+	// semantics — operator-side changes to isvc.spec.<comp>.autoscaler
+	// always win over any drifted IR.spec.autoscaler. DeepCopy keeps the
+	// IR's pointer disjoint from the resolver's return value so a downstream
+	// caller mutating the IR cannot corrupt the next reconcile's resolution.
+	// nil ResolvedAutoscaler clears ir.Spec.Autoscaler — defensive against a
+	// dispatch site that doesn't run the resolver (no spurious empty block
+	// lands on the IR).
+	ir.Spec.Autoscaler = p.ResolvedAutoscaler.DeepCopy()
+}
+
+// projectionUnchanged reports whether applyDesiredSpec left the fields the
+// projector owns (Spec + the stamped metadata) byte-equal to the live
+// object — i.e. there is nothing to write. Status is never compared: the
+// projector doesn't own it, and the IR controller writes it on a separate
+// cadence.
+func projectionUnchanged(old, updated *v1beta1.InferenceReplica) bool {
+	return equality.Semantic.DeepEqual(old.Spec, updated.Spec) &&
+		equality.Semantic.DeepEqual(old.Labels, updated.Labels) &&
+		equality.Semantic.DeepEqual(old.Annotations, updated.Annotations) &&
+		equality.Semantic.DeepEqual(old.OwnerReferences, updated.OwnerReferences)
+}
+
+// desiredReplicas decides the value to stamp on ir.Spec.Replicas,
+// mirroring the Raw path's "preserve existing replicas" approach
+// (reconcilers/deployment/deployment_reconciler.go: checkDeploymentExist
+// copies existingDeployment.Spec.Replicas onto the target so HPA's writes
+// survive the reconcile).
+//
+// The IR exposes a /scale subresource at .spec.replicas
+// (inferencereplica_types.go), so for an autoscaler-managed Component the
+// HPA / KEDA / external scaler is the authoritative writer of
+// spec.replicas. The decision:
+//
+//   - CREATE (no live IR yet — ir.ResourceVersion == ""): stamp
+//     MinReplicas. There is nothing for the autoscaler to have written
+//     yet; MinReplicas is the correct initial desired count regardless of
+//     autoscaler class.
+//
+//   - UPDATE + autoscaler-managed (resolved Class != None): PRESERVE the
+//     live ir.Spec.Replicas. Re-stamping MinReplicas would clobber the
+//     value HPA / KEDA / an external scaler wrote via /scale, making the
+//     ISVC controller and the autoscaler fight over the count every
+//     reconcile. Defensive fall-back to MinReplicas if the live value is
+//     somehow nil/<=0 (a well-formed IR always has it set from create, so
+//     this only guards against a hand-edited or partially-migrated IR —
+//     we never write a nil into a live scale target).
+//
+//   - UPDATE + autoscaling OFF (resolved Class == None / nil): the ISVC
+//     controller owns the count, so stamp MinReplicas. (Class None is the
+//     proportional-policy follower case where OME drives replicas directly;
+//     until that coordinator wires in, MinReplicas is the floor.)
+//
+// ir is the object applyDesiredSpec is mutating — on the Update path it is
+// the live IR fetched via Get (so ResourceVersion + the autoscaler-written
+// Spec.Replicas are populated); on the Create path it is a freshly built
+// object with an empty ResourceVersion.
+func desiredReplicas(ir *v1beta1.InferenceReplica, p Params) *int32 {
+	creating := ir.ResourceVersion == ""
+	if creating || !isAutoscalerManaged(p.ResolvedAutoscaler) {
+		return replicasFromComponentExt(p.ComponentExt)
+	}
+	// Update + autoscaler-managed: preserve the live (autoscaler-written)
+	// value. Guard against a malformed live IR carrying nil/<=0 — never
+	// write a nil into a live scale target.
+	if ir.Spec.Replicas != nil && *ir.Spec.Replicas > 0 {
+		return ir.Spec.Replicas
+	}
+	return replicasFromComponentExt(p.ComponentExt)
+}
+
+// isAutoscalerManaged reports whether the resolved Component autoscaler
+// drives the IR's /scale subresource — i.e. whether an autoscaler (not the
+// ISVC controller) is the authoritative writer of spec.replicas.
+//
+// Every class except None has an external writer of spec.replicas: HPA and
+// KEDA are OME-managed scalers that target the /scale subresource, and
+// External is an operator-owned scaler that writes /scale directly
+// (documented on InferenceReplicaSpec.Replicas / .Autoscaler). Only None
+// means "no autoscaler at all" — the ISVC controller (or the proportional
+// coordinator, also OME) owns the count. A nil resolved block is treated as
+// None (matches autoscaler.autoscalerClass / resolvedClass).
+func isAutoscalerManaged(a *v1beta1.ComponentAutoscaler) bool {
+	if a == nil {
+		return false
+	}
+	return a.Class != v1beta1.AutoscalerNone
+}
+
+// replicasFromComponentExt projects ComponentExtensionSpec.MinReplicas
+// into the IR Spec.Replicas pointer. Defaults to 1 when MinReplicas
+// is nil OR <= 0 — matches the workload-side projection
+// (core/params.go: replicasFromComponentExt) so the rendered Instance
+// count is consistent regardless of which adapter built the IR.
+func replicasFromComponentExt(c *v1beta1.ComponentExtensionSpec) *int32 {
+	if c == nil || c.MinReplicas == nil || *c.MinReplicas <= 0 {
+		one := int32(1)
+		return &one
+	}
+	r := int32(*c.MinReplicas)
+	return &r
+}
+
+// runnersFromParams produces the IR.Spec.Runners projection. Single-
+// pod Components emit one Runner of {Name: default, Size: 1};
+// multi-pod Components emit {leader, Size=1} + {worker, Size=N}.
+// Mirrors the workload.BuildPlan projection (core/params.go:
+// runnersForDesired) so the workload dispatcher sees the same Runner
+// shape regardless of which adapter built the IR.
+//
+// The Runner.Template carries the rendered PodSpec PLUS the
+// per-Component ObjectMeta (labels + annotations). The IR controller's
+// desiredFromIR projection reads back PodSpec + ObjectMeta from
+// these templates into WorkloadDesiredSpec.PodSpec /
+// PodTemplateObjectMeta — that's how the rendered template flows
+// into the workload renderer without re-rendering.
+func runnersFromParams(p Params) []v1beta1.Runner {
+	tmplMeta := templateObjectMeta(p)
+	if !p.MultiPod {
+		return []v1beta1.Runner{{
+			Name: v1beta1.RunnerNameDefault,
+			Size: 1,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: tmplMeta,
+				Spec:       *p.PodSpec,
+			},
+		}}
+	}
+	out := []v1beta1.Runner{
+		{
+			Name: v1beta1.RunnerNameLeader,
+			Size: 1,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: tmplMeta,
+				Spec:       *p.PodSpec,
+			},
+		},
+	}
+	if p.WorkerPodSpec != nil {
+		out = append(out, v1beta1.Runner{
+			Name: v1beta1.RunnerNameWorker,
+			Size: int32(p.WorkerSize),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: tmplMeta,
+				Spec:       *p.WorkerPodSpec,
+			},
+		})
+	}
+	return out
+}
+
+// templateObjectMeta builds the PodTemplateSpec.ObjectMeta stamped on
+// every Runner. It merges TWO sources:
+//
+//  1. p.ObjectMeta.{Labels,Annotations} — the rendered per-Component
+//     metadata the dispatch site computed via reconcileObjectMeta
+//     (which already folds in BaseModel / ServingRuntime / ISVC-level
+//     labels + annotations).
+//
+//  2. p.ComponentExt.{Labels,Annotations} — the user-declared
+//     per-Component overrides from spec.<component>.{labels,annotations}.
+//     These take precedence (last-write-wins) so an operator bumping
+//     spec.engine.annotations to force a rollout sees that key land on
+//     the pod template, which in turn flips the revision hash and
+//     triggers the ControllerRevision / rollout machinery the IR
+//     controller drives. Mirrors the components/{engine,decoder,router}.go
+//     processAnnotations / processLabels merge order.
+//
+// Name / Namespace / GenerateName / CreationTimestamp / ResourceVersion
+// / UID are intentionally dropped — those are owner-object fields and
+// stamping them on the template would leak the per-Component ObjectMeta
+// identity onto every emitted pod.
+//
+// Defensive against caller bugs: even when the dispatch site forgets
+// to merge p.ComponentExt.{Labels,Annotations} into p.ObjectMeta, the
+// projector still emits them on the template. Annotation-only ISVC
+// edits (the canonical no-image-bump rollout trigger) only work if
+// the projector treats ComponentExt as authoritative for these keys.
+func templateObjectMeta(p Params) metav1.ObjectMeta {
+	labels := copyMap(p.ObjectMeta.Labels)
+	annotations := copyMap(p.ObjectMeta.Annotations)
+	if p.ComponentExt != nil {
+		if len(p.ComponentExt.Labels) > 0 {
+			if labels == nil {
+				labels = make(map[string]string, len(p.ComponentExt.Labels))
+			}
+			for k, v := range p.ComponentExt.Labels {
+				labels[k] = v
+			}
+		}
+		if len(p.ComponentExt.Annotations) > 0 {
+			if annotations == nil {
+				annotations = make(map[string]string, len(p.ComponentExt.Annotations))
+			}
+			for k, v := range p.ComponentExt.Annotations {
+				annotations[k] = v
+			}
+		}
+	}
+	return metav1.ObjectMeta{
+		Labels:      labels,
+		Annotations: annotations,
+	}
+}
+
+// lifecycleFromComponentExt deep-copies the LifecycleSpec when set
+// (defensive — the ISVC and IR controllers should not share a
+// pointer). nil when ComponentExt has no Lifecycle block.
+func lifecycleFromComponentExt(c *v1beta1.ComponentExtensionSpec) *v1beta1.LifecycleSpec {
+	if c == nil || c.Lifecycle == nil {
+		return nil
+	}
+	return c.Lifecycle.DeepCopy()
+}
+
+// copyMap returns a shallow copy of m. nil input returns nil so the
+// caller can distinguish "no labels" from "empty labels" (some
+// downstream serializers care about the distinction).
+func copyMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/projector_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/projector_test.go
@@ -1,0 +1,1068 @@
+package irprojector
+
+import (
+	"context"
+	"testing"
+
+	kedav1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/onsi/gomega"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// testScheme returns a runtime.Scheme with v1beta1 registered. Bare
+// scheme (no status subresource wiring) is enough: the projector only
+// writes Spec — the IR controller writes Status.
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme corev1: %v", err)
+	}
+	return s
+}
+
+// baselineISVC returns a controller-write-ready ISVC carrying an
+// EngineSpec with MinReplicas=2 and a Lifecycle block. The default
+// per-Component shape is single-pod; tests that need multi-pod
+// override Leader / Worker before calling the projector.
+func baselineISVC(name, namespace string) *v1beta1.InferenceService {
+	min := 2
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  namespace,
+			UID:        types.UID(name + "-uid"),
+			Generation: 1,
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Engine: &v1beta1.EngineSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					MinReplicas: &min,
+					Lifecycle: &v1beta1.LifecycleSpec{
+						RestartPolicy: ptr.To(v1beta1.InstanceRestartPolicyNone),
+					},
+				},
+			},
+		},
+	}
+}
+
+// minimalParams returns a Params bag matching the ISVC shape above.
+// PodSpec carries a single container named "ome-container"; the
+// per-Component ObjectMeta carries the legacy OMENative pod label trio
+// so the IR's Spec.Runners[0].Template.ObjectMeta inherits it.
+func minimalParams(t *testing.T, isvc *v1beta1.InferenceService, c client.Client) Params {
+	t.Helper()
+	objMeta := metav1.ObjectMeta{
+		Name:      isvc.Name + "-engine",
+		Namespace: isvc.Namespace,
+		Labels: map[string]string{
+			constants.InferenceServicePodLabelKey: isvc.Name,
+			constants.OMEComponentLabel:           string(v1beta1.EngineComponent),
+			"managed-by":                          "OMENative",
+		},
+		Annotations: map[string]string{
+			"ome.io/some-annotation": "value",
+		},
+	}
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  "ome-container",
+			Image: "sgl:1.0",
+		}},
+	}
+	return Params{
+		ISVC:         isvc,
+		Component:    v1beta1.EngineComponent,
+		ComponentExt: &isvc.Spec.Engine.ComponentExtensionSpec,
+		ObjectMeta:   objMeta,
+		PodSpec:      podSpec,
+		MultiPod:     false,
+		Client:       c,
+	}
+}
+
+// TestIsIRManagedComponent_OMENativeMode_True pins the default state
+// post-cutover: an OMENative-mode Component routes through the
+// IR-managed path automatically (no per-Component opt-in required).
+func TestIsIRManagedComponent_OMENativeMode_True(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(IsIRManagedComponent(constants.OMENative)).To(gomega.BeTrue(),
+		"OMENative-mode Component must route through the IR-managed path by default")
+}
+
+// TestIsIRManagedComponent_NonOMENativeMode_False pins the routing
+// boundary: only OMENative-mode Components flow through the
+// IR-managed path. RawDeployment, PDDisaggregated, VirtualDeployment
+// all fall through to their own dispatch branches.
+func TestIsIRManagedComponent_NonOMENativeMode_False(t *testing.T) {
+	g := gomega.NewWithT(t)
+	for _, mode := range []constants.DeploymentModeType{
+		constants.RawDeployment,
+		constants.PDDisaggregated,
+		constants.VirtualDeployment,
+		constants.DeploymentModeType(""), // unresolved / unknown
+	} {
+		g.Expect(IsIRManagedComponent(mode)).To(gomega.BeFalse(),
+			"non-OMENative mode %q must NOT route through the IR-managed path", mode)
+	}
+}
+
+// TestEnsureInferenceReplica_Create_NewIR pins the create-from-scratch
+// path. The projected IR must carry:
+//   - Name == <isvc>-<component>
+//   - Annotations carry the controller-write annotation so the IR
+//     webhook accepts the create
+//   - OwnerReferences point at the parent ISVC as controller (cascade
+//     GC on ISVC delete)
+//   - ParentRef.Name matches the parent ISVC
+//   - Component matches the dispatched ComponentType
+//   - Replicas defaults from ComponentExt.MinReplicas (=2 in baseline)
+//   - Runners is single-pod {default, size 1} with the projected
+//     PodSpec + ObjectMeta on the template
+//   - Lifecycle carries the projected RestartPolicy
+func TestEnsureInferenceReplica_Create_NewIR(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	ir, err := EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(ir).NotTo(gomega.BeNil())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+
+	g.Expect(got.Name).To(gomega.Equal("llama-engine"),
+		"IR name must be <isvc>-<component>")
+	g.Expect(got.Namespace).To(gomega.Equal("prod"))
+	g.Expect(got.Annotations).To(gomega.HaveKeyWithValue(
+		constants.InferenceReplicaControllerWriteAnnotationKey,
+		constants.InferenceReplicaControllerWriteAnnotationVal),
+		"controller-write annotation must be stamped so the IR webhook accepts the create")
+
+	g.Expect(got.OwnerReferences).To(gomega.HaveLen(1))
+	ref := got.OwnerReferences[0]
+	g.Expect(ref.Kind).To(gomega.Equal("InferenceService"),
+		"IR owner ref must point at the parent ISVC for cascade GC")
+	g.Expect(ref.Name).To(gomega.Equal(isvc.Name))
+	g.Expect(ref.UID).To(gomega.Equal(isvc.UID))
+	g.Expect(ref.Controller).NotTo(gomega.BeNil())
+	g.Expect(*ref.Controller).To(gomega.BeTrue())
+
+	g.Expect(got.Spec.ParentRef.Name).To(gomega.Equal(isvc.Name))
+	g.Expect(got.Spec.Component).To(gomega.Equal(v1beta1.EngineComponent))
+
+	g.Expect(got.Spec.Replicas).NotTo(gomega.BeNil())
+	g.Expect(*got.Spec.Replicas).To(gomega.Equal(int32(2)),
+		"Replicas must default from MinReplicas")
+
+	g.Expect(got.Spec.Runners).To(gomega.HaveLen(1),
+		"single-pod Component must emit one Runner")
+	r0 := got.Spec.Runners[0]
+	g.Expect(r0.Name).To(gomega.Equal(v1beta1.RunnerNameDefault))
+	g.Expect(r0.Size).To(gomega.Equal(int32(1)))
+	g.Expect(r0.Template.Spec.Containers).To(gomega.HaveLen(1))
+	g.Expect(r0.Template.Spec.Containers[0].Image).To(gomega.Equal("sgl:1.0"),
+		"PodSpec must be threaded through verbatim — no re-rendering")
+	g.Expect(r0.Template.ObjectMeta.Labels).To(gomega.HaveKeyWithValue(
+		constants.InferenceServicePodLabelKey, isvc.Name),
+		"PodTemplate ObjectMeta labels must inherit from the projected ObjectMeta")
+
+	g.Expect(got.Spec.Lifecycle).NotTo(gomega.BeNil())
+	g.Expect(got.Spec.Lifecycle.RestartPolicy).NotTo(gomega.BeNil())
+	g.Expect(*got.Spec.Lifecycle.RestartPolicy).To(gomega.Equal(
+		v1beta1.InstanceRestartPolicyNone),
+		"Lifecycle must be threaded through")
+}
+
+func TestEnsureInferenceReplica_ProjectsPauseAnnotationAndClearsOnRemoval(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	isvc.Annotations = map[string]string{constants.PausedRolloutAnnotation: "true"}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	_, err := EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	key := types.NamespacedName{Name: "llama-engine", Namespace: "prod"}
+	paused := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(), key, paused)).To(gomega.Succeed())
+	g.Expect(paused.Spec.Paused).To(gomega.BeTrue(),
+		"the controller-only IR must receive pause intent from its parent ISVC")
+
+	delete(isvc.Annotations, constants.PausedRolloutAnnotation)
+	_, err = EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	unpaused := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(), key, unpaused)).To(gomega.Succeed())
+	g.Expect(unpaused.Spec.Paused).To(gomega.BeFalse(),
+		"removing the parent annotation must clear the projected circuit breaker")
+}
+
+// TestEnsureInferenceReplica_Update_PreservesGeneration pins the
+// update path: the projector emits the same IR Spec on a second
+// invocation, so the apiserver-side Generation should NOT bump (no
+// real change to write). The pre-existing IR must be respected.
+func TestEnsureInferenceReplica_Update_PreservesGeneration(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	_, err := EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	first := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, first)).To(gomega.Succeed())
+	firstRV := first.ResourceVersion
+
+	// Second invocation with identical params is a no-op: the projector's
+	// no-op guard skips the write when nothing it owns changed, so the
+	// ResourceVersion must be stable (no spurious churn that would fight
+	// the IR controller's status writes).
+	_, err = EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	second := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, second)).To(gomega.Succeed())
+
+	g.Expect(second.Spec.Replicas).To(gomega.Equal(first.Spec.Replicas))
+	g.Expect(second.Spec.Component).To(gomega.Equal(first.Spec.Component))
+	g.Expect(second.Spec.ParentRef).To(gomega.Equal(first.Spec.ParentRef))
+	g.Expect(second.ResourceVersion).To(gomega.Equal(firstRV),
+		"identical re-projection must not bump ResourceVersion (no-op guard)")
+}
+
+// TestEnsureInferenceReplica_NoChange_IssuesNoWrite pins the no-op guard at
+// the API layer: a second projection with identical params must issue ZERO
+// Create/Update/Patch calls. This is the fix for the conflict hot-loop —
+// an unconditional write every reconcile churned the IR's ResourceVersion
+// and fought the IR controller's status writes.
+func TestEnsureInferenceReplica_NoChange_IssuesNoWrite(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+
+	var writes int
+	count := interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			writes++
+			return c.Create(ctx, obj, opts...)
+		},
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			writes++
+			return c.Update(ctx, obj, opts...)
+		},
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			writes++
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).WithInterceptorFuncs(count).Build()
+
+	// First call creates the IR (one write).
+	_, err := EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(writes).To(gomega.Equal(1), "first projection should Create once")
+
+	// Second call with identical params must not write at all.
+	writes = 0
+	_, err = EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(writes).To(gomega.Equal(0), "identical re-projection must issue no writes")
+}
+
+// TestEnsureInferenceReplica_SpecChange_IssuesMergePatch pins the change
+// path: when the desired spec differs from the live IR, the projector
+// issues exactly one merge Patch (not an Update), so a concurrent status
+// write can't turn it into an optimistic-lock conflict.
+func TestEnsureInferenceReplica_SpecChange_IssuesMergePatch(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+
+	var patches, updates int
+	count := interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			updates++
+			return c.Update(ctx, obj, opts...)
+		},
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			patches++
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).WithInterceptorFuncs(count).Build()
+
+	_, err := EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Change the desired replica count, re-project.
+	patches, updates = 0, 0
+	changed := minimalParams(t, isvc, c)
+	changed.ComponentExt = &v1beta1.ComponentExtensionSpec{MinReplicas: ptr.To(7)}
+	_, err = EnsureInferenceReplica(context.Background(), changed)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(updates).To(gomega.Equal(0), "projector must not use Update")
+	g.Expect(patches).To(gomega.Equal(1), "a real spec change must issue exactly one merge Patch")
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+	g.Expect(got.Spec.Replicas).NotTo(gomega.BeNil())
+	g.Expect(*got.Spec.Replicas).To(gomega.Equal(int32(7)))
+}
+
+// TestEnsureInferenceReplica_MultiPod_LeaderAndWorker pins the
+// multi-pod projection: MultiPod=true with WorkerPodSpec set emits
+// {leader, size=1} + {worker, size=WorkerSize} Runners with the
+// respective pod templates.
+func TestEnsureInferenceReplica_MultiPod_LeaderAndWorker(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	p.MultiPod = true
+	p.WorkerSize = 3
+	p.WorkerPodSpec = &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "worker", Image: "worker:1.0"}},
+	}
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+
+	g.Expect(got.Spec.Runners).To(gomega.HaveLen(2),
+		"multi-pod Component must emit leader + worker Runners")
+	g.Expect(got.Spec.Runners[0].Name).To(gomega.Equal(v1beta1.RunnerNameLeader))
+	g.Expect(got.Spec.Runners[0].Size).To(gomega.Equal(int32(1)))
+	g.Expect(got.Spec.Runners[0].Template.Spec.Containers[0].Image).To(gomega.Equal("sgl:1.0"),
+		"leader Template must use the primary PodSpec")
+	g.Expect(got.Spec.Runners[1].Name).To(gomega.Equal(v1beta1.RunnerNameWorker))
+	g.Expect(got.Spec.Runners[1].Size).To(gomega.Equal(int32(3)),
+		"worker Size must equal WorkerSize")
+	g.Expect(got.Spec.Runners[1].Template.Spec.Containers[0].Image).To(gomega.Equal("worker:1.0"),
+		"worker Template must use the WorkerPodSpec")
+}
+
+// TestEnsureInferenceReplica_MultiPod_RejectsNilWorkerSpec pins the
+// validation guard: MultiPod=true with WorkerPodSpec=nil is a
+// dispatch-site wiring bug. The projector surfaces it as a clear
+// error instead of producing a malformed IR.
+func TestEnsureInferenceReplica_MultiPod_RejectsNilWorkerSpec(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	p.MultiPod = true
+	p.WorkerSize = 3
+	// p.WorkerPodSpec intentionally nil
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("WorkerPodSpec"))
+}
+
+// TestEnsureInferenceReplica_NilPodSpec_Rejected pins the validation
+// guard: nil PodSpec is a dispatch-site wiring bug — the omenative
+// path requires it too.
+func TestEnsureInferenceReplica_NilPodSpec_Rejected(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	p.PodSpec = nil
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("nil PodSpec"))
+}
+
+// TestEnsureInferenceReplica_NilComponentExt_Rejected pins the
+// validation guard: a nil ComponentExt would mean Lifecycle / Replicas
+// projection fall back to defaults silently. The projector rejects
+// it so the dispatch site surfaces a clear error.
+func TestEnsureInferenceReplica_NilComponentExt_Rejected(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	p.ComponentExt = nil
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("ComponentExtensionSpec"))
+}
+
+// TestEnsureInferenceReplica_NilClient_Rejected pins the validation
+// guard: a nil client at the projector means the dispatch site
+// dropped the BaseComponentFields.Client.
+func TestEnsureInferenceReplica_NilClient_Rejected(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	p := minimalParams(t, isvc, nil)
+	p.Client = nil
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("nil client"))
+}
+
+// TestEnsureInferenceReplica_DefaultsReplicasToOne pins the default:
+// MinReplicas=nil produces Replicas=1.
+func TestEnsureInferenceReplica_DefaultsReplicasToOne(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	isvc.Spec.Engine.MinReplicas = nil
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	p.ComponentExt = &isvc.Spec.Engine.ComponentExtensionSpec
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+	g.Expect(got.Spec.Replicas).NotTo(gomega.BeNil())
+	g.Expect(*got.Spec.Replicas).To(gomega.Equal(int32(1)),
+		"nil MinReplicas must default to 1")
+}
+
+// TestInferenceReplicaName_FormatPins pins the canonical IR name
+// shape used by the projector + the IR controller for revision /
+// service / pod naming.
+func TestInferenceReplicaName_FormatPins(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(InferenceReplicaName("llama", v1beta1.EngineComponent)).To(gomega.Equal("llama-engine"))
+	g.Expect(InferenceReplicaName("llama", v1beta1.DecoderComponent)).To(gomega.Equal("llama-decoder"))
+	g.Expect(InferenceReplicaName("llama", v1beta1.RouterComponent)).To(gomega.Equal("llama-router"))
+}
+
+// TestEnsureInferenceReplica_AlreadyExists_PropagatedAsUpdate pins
+// the race between two concurrent reconciles: the second one's Get
+// returns the live IR (which the first just created) and the Update
+// path lands.
+func TestEnsureInferenceReplica_AlreadyExists_PropagatedAsUpdate(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	// Pre-seed an IR with the same name to simulate a parallel reconcile
+	// that created the IR between our Get and Create.
+	preExisting := &v1beta1.InferenceReplica{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llama-engine",
+			Namespace: "prod",
+			Annotations: map[string]string{
+				constants.InferenceReplicaControllerWriteAnnotationKey: constants.InferenceReplicaControllerWriteAnnotationVal,
+			},
+		},
+		Spec: v1beta1.InferenceReplicaSpec{
+			ParentRef: v1beta1.ParentReference{Name: "llama"},
+			Component: v1beta1.EngineComponent,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(preExisting).Build()
+
+	_, err := EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		"a pre-existing IR must be patched, not error out")
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+	g.Expect(got.Spec.Replicas).NotTo(gomega.BeNil())
+	g.Expect(*got.Spec.Replicas).To(gomega.Equal(int32(2)),
+		"Update must propagate the projector's desired Replicas onto the live IR")
+
+	// Sanity: not an apierror NotFound on the post-write Get.
+	_, getErr := c.RESTMapper().RESTMapping(got.GroupVersionKind().GroupKind())
+	g.Expect(apierrors.IsNotFound(getErr)).To(gomega.BeFalse(),
+		"sanity: post-create Get must succeed")
+}
+
+// TestEnsureInferenceReplica_PropagatesComponentAnnotations pins the
+// annotation-propagation contract: spec.<component>.annotations bumps MUST
+// land on every Runner.Template.ObjectMeta.Annotations so the workload
+// renderer stamps the new annotation on every emitted pod AND so the
+// revision hash flips and triggers the ControllerRevision / rollout
+// machinery.
+//
+// Real-cluster failure shape (pre-fix): operator bumps
+// spec.engine.annotations.test.ome.io/rollout-trigger to a fresh
+// timestamp; ISVC generation bumps; IR.spec.runners[].template
+// .metadata.annotations stays EMPTY; no new ControllerRevision; the
+// rollout never fires. The fix is for the projector to treat
+// p.ComponentExt.Annotations as authoritative — even when the dispatch
+// site forgets to merge them into p.ObjectMeta, the projector still
+// emits them.
+//
+// Same bug class as the legacy direct-omenative path; this is the
+// IR-managed analog.
+func TestEnsureInferenceReplica_PropagatesComponentAnnotations(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	isvc.Spec.Engine.Annotations = map[string]string{
+		"test.ome.io/rollout-trigger": "2026-05-29T01:02:03.456789Z",
+		"linkerd.io/inject":           "enabled",
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	// Deliberately leave p.ObjectMeta.Annotations as the minimal fixture
+	// value to prove the projector pulls from p.ComponentExt directly —
+	// not just from a caller-side merge. The real dispatch site DOES
+	// merge them upstream (engine.go::processAnnotations), but the
+	// projector must remain self-contained for this scenario.
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+
+	g.Expect(got.Spec.Runners).To(gomega.HaveLen(1))
+	tmplAnns := got.Spec.Runners[0].Template.ObjectMeta.Annotations
+	g.Expect(tmplAnns).To(gomega.HaveKeyWithValue(
+		"test.ome.io/rollout-trigger", "2026-05-29T01:02:03.456789Z"),
+		"rollout-trigger annotation must reach the Runner template — "+
+			"the revision hash flips off this key, no propagation means no rollout")
+	g.Expect(tmplAnns).To(gomega.HaveKeyWithValue(
+		"linkerd.io/inject", "enabled"),
+		"all per-Component annotations must propagate, not just the rollout-trigger")
+	// Baseline ObjectMeta annotation also propagates (no regression).
+	g.Expect(tmplAnns).To(gomega.HaveKeyWithValue(
+		"ome.io/some-annotation", "value"),
+		"existing ObjectMeta annotations must still propagate alongside ComponentExt")
+}
+
+// TestEnsureInferenceReplica_PropagatesComponentLabels pins the label
+// half of the fix: spec.<component>.labels MUST land on every
+// Runner.Template.ObjectMeta.Labels for pod affinity / NetworkPolicy
+// selectors / kubectl filtering. Same defensive-merge contract as
+// annotations.
+func TestEnsureInferenceReplica_PropagatesComponentLabels(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	isvc.Spec.Engine.Labels = map[string]string{
+		"team":        "ml-platform",
+		"cost-center": "1234",
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+
+	g.Expect(got.Spec.Runners).To(gomega.HaveLen(1))
+	tmplLabels := got.Spec.Runners[0].Template.ObjectMeta.Labels
+	g.Expect(tmplLabels).To(gomega.HaveKeyWithValue("team", "ml-platform"),
+		"per-Component labels must reach the Runner template for selector matching")
+	g.Expect(tmplLabels).To(gomega.HaveKeyWithValue("cost-center", "1234"))
+	// Baseline ObjectMeta labels also propagate.
+	g.Expect(tmplLabels).To(gomega.HaveKeyWithValue(
+		constants.InferenceServicePodLabelKey, isvc.Name),
+		"existing ObjectMeta labels must still propagate alongside ComponentExt")
+}
+
+// TestEnsureInferenceReplica_NilComponentAnnotationsAndLabels_NoRegression
+// pins the negative case: ISVCs with no per-Component annotations /
+// labels see the same Runner.Template.ObjectMeta they always saw —
+// only the existing p.ObjectMeta content, no spurious empty maps,
+// no nil-deref panics in the merge path.
+func TestEnsureInferenceReplica_NilComponentAnnotationsAndLabels_NoRegression(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	// ComponentExt has nil Annotations + nil Labels (the baseline).
+	g.Expect(isvc.Spec.Engine.Annotations).To(gomega.BeNil(),
+		"sanity: baseline fixture has no per-Component annotations")
+	g.Expect(isvc.Spec.Engine.Labels).To(gomega.BeNil(),
+		"sanity: baseline fixture has no per-Component labels")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	_, err := EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+
+	g.Expect(got.Spec.Runners).To(gomega.HaveLen(1))
+	// Only the minimalParams ObjectMeta content lands on the template.
+	g.Expect(got.Spec.Runners[0].Template.ObjectMeta.Labels).To(gomega.HaveKeyWithValue(
+		constants.InferenceServicePodLabelKey, isvc.Name),
+		"baseline ObjectMeta labels must still propagate when ComponentExt is empty")
+	g.Expect(got.Spec.Runners[0].Template.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(
+		"ome.io/some-annotation", "value"),
+		"baseline ObjectMeta annotations must still propagate when ComponentExt is empty")
+}
+
+// TestEnsureInferenceReplica_ComponentExt_PropagatesToBothRunners pins
+// that on a multi-pod Component, the per-Component annotations + labels
+// land on BOTH the leader and worker Runner templates — not just the
+// leader. The renderer reads them off both templates for its respective
+// pods, so missing the worker template would silently break per-Component
+// rollout for the worker pod set.
+func TestEnsureInferenceReplica_ComponentExt_PropagatesToBothRunners(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	isvc.Spec.Engine.Annotations = map[string]string{
+		"test.ome.io/rollout-trigger": "2026-05-29T04:05:06Z",
+	}
+	isvc.Spec.Engine.Labels = map[string]string{
+		"team": "ml-platform",
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	p.MultiPod = true
+	p.WorkerSize = 3
+	p.WorkerPodSpec = &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "worker", Image: "worker:1.0"}},
+	}
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+
+	g.Expect(got.Spec.Runners).To(gomega.HaveLen(2))
+	for _, r := range got.Spec.Runners {
+		g.Expect(r.Template.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(
+			"test.ome.io/rollout-trigger", "2026-05-29T04:05:06Z"),
+			"runner %q template must carry per-Component rollout-trigger annotation", r.Name)
+		g.Expect(r.Template.ObjectMeta.Labels).To(gomega.HaveKeyWithValue(
+			"team", "ml-platform"),
+			"runner %q template must carry per-Component team label", r.Name)
+	}
+}
+
+// TestEnsureInferenceReplica_ComponentExt_OverridesObjectMetaOnCollision
+// pins the merge precedence: when p.ObjectMeta AND p.ComponentExt both
+// declare the same key, p.ComponentExt wins. Mirrors the dispatch site's
+// merge order (engine.go::processAnnotations does
+// utils.Union(annotations, engineAnnotations) — last-write-wins for
+// engineAnnotations). The projector must produce the same result if a
+// future caller diverges from the canonical merge.
+func TestEnsureInferenceReplica_ComponentExt_OverridesObjectMetaOnCollision(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	isvc.Spec.Engine.Annotations = map[string]string{
+		"ome.io/some-annotation": "from-component-ext",
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	// p.ObjectMeta.Annotations["ome.io/some-annotation"] == "value" (from minimalParams).
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+
+	g.Expect(got.Spec.Runners).To(gomega.HaveLen(1))
+	g.Expect(got.Spec.Runners[0].Template.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(
+		"ome.io/some-annotation", "from-component-ext"),
+		"ComponentExt annotation MUST win over ObjectMeta on key collision (matches engine.go merge order)")
+}
+
+// TestEnsureInferenceReplica_ComponentAnnotationUpdate_RepatchesTemplate
+// pins the update path: a re-projection with a different
+// p.ComponentExt.Annotations value MUST land on the live IR's runner
+// template. Without this the second reconcile after an annotation bump
+// would leave the IR carrying the stale value — the exact failure
+// shape.
+func TestEnsureInferenceReplica_ComponentAnnotationUpdate_RepatchesTemplate(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	isvc.Spec.Engine.Annotations = map[string]string{
+		"test.ome.io/rollout-trigger": "initial",
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	_, err := EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	first := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, first)).To(gomega.Succeed())
+	g.Expect(first.Spec.Runners[0].Template.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(
+		"test.ome.io/rollout-trigger", "initial"),
+		"sanity: first projection lands the initial value")
+
+	// Operator bumps the annotation; the dispatch site re-runs with the
+	// updated ComponentExt. The projector must patch the IR.
+	isvc.Spec.Engine.Annotations["test.ome.io/rollout-trigger"] = "bumped"
+	_, err = EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	second := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, second)).To(gomega.Succeed())
+	g.Expect(second.Spec.Runners[0].Template.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(
+		"test.ome.io/rollout-trigger", "bumped"),
+		"annotation bump must repatch the IR runner template — "+
+			"this is the canonical no-image-bump rollout trigger")
+}
+
+// autoscalerBlockA returns a distinctive KEDA-class ComponentAutoscaler
+// for the projector autoscaler-propagation tests. The block carries a
+// non-empty Triggers list + a non-default PollingInterval so a buggy
+// shallow projection trips the deep-equality assertions.
+func autoscalerBlockA() *v1beta1.ComponentAutoscaler {
+	return &v1beta1.ComponentAutoscaler{
+		Class: v1beta1.AutoscalerKEDA,
+		Keda: &v1beta1.KedaAutoscaler{
+			Triggers: []kedav1.ScaleTriggers{
+				{Type: "prometheus", Metadata: map[string]string{"v": "A"}},
+			},
+			PollingInterval: ptr.To(int32(15)),
+		},
+	}
+}
+
+// autoscalerBlockB returns a second, distinct ComponentAutoscaler so
+// the update-replaces-whole-block test can distinguish "no projection"
+// from "projection took". Differs from autoscalerBlockA in Class, Keda
+// shape (nil), and HPA shape (non-nil) — the swap exercises every
+// pointer in ComponentAutoscaler.
+func autoscalerBlockB() *v1beta1.ComponentAutoscaler {
+	return &v1beta1.ComponentAutoscaler{
+		Class: v1beta1.AutoscalerHPA,
+		HPA: &v1beta1.HPAAutoscaler{
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: "cpu",
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: ptr.To(int32(60)),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestEnsureInferenceReplica_PropagatesResolvedAutoscaler pins the
+// resolver→projector contract: a non-nil p.ResolvedAutoscaler lands on
+// the IR at Create time. The autoscaler dispatch reads ir.Spec
+// .Autoscaler — if the projector drops it, the entire autoscaler chain
+// is dead on arrival.
+//
+// The block is deep-equal-asserted so a half-applied projection (e.g.,
+// Class only, Keda dropped) trips the test instead of slipping through.
+func TestEnsureInferenceReplica_PropagatesResolvedAutoscaler(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	p.ResolvedAutoscaler = autoscalerBlockA()
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+
+	g.Expect(got.Spec.Autoscaler).NotTo(gomega.BeNil(),
+		"non-nil p.ResolvedAutoscaler must land on ir.Spec.Autoscaler at Create — "+
+			"the autoscaler dispatch reads this field")
+	g.Expect(got.Spec.Autoscaler).To(gomega.Equal(autoscalerBlockA()),
+		"projection must be deep-equal — Class + Keda + HPA all preserved verbatim")
+}
+
+// TestEnsureInferenceReplica_UpdateAutoscalerRepatchesIR pins the
+// whole-block replace semantics: a second projection with a different
+// ResolvedAutoscaler swaps the IR's autoscaler wholesale, not merges.
+// Operator-side changes to isvc.spec.<comp>.autoscaler always win over
+// any drifted ir.spec.autoscaler.
+//
+// Failure shape this catches: a projector that only merges sub-fields
+// (e.g., keeps Class from A while overwriting Keda with B's HPA) would
+// leave the IR in a corrupted half-A/half-B state where the dispatch
+// can't decide which scaler to emit.
+func TestEnsureInferenceReplica_UpdateAutoscalerRepatchesIR(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	// First projection: block A (KEDA, Triggers set, HPA nil).
+	p := minimalParams(t, isvc, c)
+	p.ResolvedAutoscaler = autoscalerBlockA()
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	first := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, first)).To(gomega.Succeed())
+	g.Expect(first.Spec.Autoscaler).To(gomega.Equal(autoscalerBlockA()),
+		"sanity: first projection lands block A")
+
+	// Second projection: block B (HPA, Keda nil, Metrics set). The
+	// dispatch site re-resolves the autoscaler every reconcile, so a
+	// different ResolvedAutoscaler is the normal case (operator bumped
+	// isvc.spec.engine.autoscaler.class from keda to hpa).
+	p2 := minimalParams(t, isvc, c)
+	p2.ResolvedAutoscaler = autoscalerBlockB()
+	_, err = EnsureInferenceReplica(context.Background(), p2)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	second := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, second)).To(gomega.Succeed())
+
+	g.Expect(second.Spec.Autoscaler).To(gomega.Equal(autoscalerBlockB()),
+		"second projection must REPLACE the whole block — not merge — so block B fully wins")
+	g.Expect(second.Spec.Autoscaler.Class).To(gomega.Equal(v1beta1.AutoscalerHPA),
+		"Class must flip from KEDA to HPA")
+	g.Expect(second.Spec.Autoscaler.Keda).To(gomega.BeNil(),
+		"Keda block must be cleared — block B doesn't have one")
+	g.Expect(second.Spec.Autoscaler.HPA).NotTo(gomega.BeNil(),
+		"HPA block must be set — block B has one")
+}
+
+// TestEnsureInferenceReplica_NilResolvedAutoscaler_NoRegression pins
+// the defensive path: a nil ResolvedAutoscaler (e.g., a dispatch site
+// that doesn't run the resolver) projects to nil ir.Spec.Autoscaler.
+// No spurious empty {Class: ""} block lands.
+//
+// Without this guard, the projector would either (a) panic on a nil
+// deref of p.ResolvedAutoscaler.DeepCopy() or (b) leave the IR with
+// a partially-defaulted block the dispatch can't interpret.
+func TestEnsureInferenceReplica_NilResolvedAutoscaler_NoRegression(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	// p.ResolvedAutoscaler intentionally nil.
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		"nil ResolvedAutoscaler must not panic — defensive against unwired dispatch sites")
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+
+	g.Expect(got.Spec.Autoscaler).To(gomega.BeNil(),
+		"nil ResolvedAutoscaler must project to nil ir.Spec.Autoscaler — "+
+			"no spurious empty block")
+}
+
+// hpaAutoscalerBlock returns a minimal HPA-class ComponentAutoscaler for
+// the replica-preservation tests. The exact metric shape is irrelevant —
+// only Class drives the projector's "is this Component autoscaler-managed"
+// decision — so a bare {Class: HPA} is enough.
+func hpaAutoscalerBlock() *v1beta1.ComponentAutoscaler {
+	return &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerHPA}
+}
+
+// TestEnsureInferenceReplica_AutoscalerManaged_PreservesLiveReplicas pins
+// the core bugfix: when the Component is autoscaler-managed (HPA / KEDA /
+// External), a re-projection MUST NOT clobber the live ir.Spec.Replicas.
+//
+// The IR's /scale subresource (.spec.replicas) is the HPA / KEDA / external
+// scale target — the autoscaler is the authoritative writer of
+// spec.replicas. Before this fix the projector unconditionally re-stamped
+// MinReplicas on every reconcile, so the ISVC controller and the autoscaler
+// fought over the count: HPA scales engine from 2 -> 8, the next ISVC
+// reconcile slams it back to MinReplicas=2, HPA scales back up, ... forever.
+//
+// Failure shape (pre-fix): scaledReplicas (8) is overwritten with
+// MinReplicas (2) on the second EnsureInferenceReplica call.
+func TestEnsureInferenceReplica_AutoscalerManaged_PreservesLiveReplicas(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod") // MinReplicas = 2
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	// First projection (create) -- HPA-managed, so MinReplicas=2 lands as
+	// the initial desired count.
+	p := minimalParams(t, isvc, c)
+	p.ResolvedAutoscaler = hpaAutoscalerBlock()
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	created := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, created)).To(gomega.Succeed())
+	g.Expect(created.Spec.Replicas).NotTo(gomega.BeNil())
+	g.Expect(*created.Spec.Replicas).To(gomega.Equal(int32(2)),
+		"create must stamp MinReplicas as the initial desired count")
+
+	// Simulate the autoscaler scaling the IR up via the /scale subresource:
+	// HPA writes spec.replicas = 8 directly on the live object.
+	const scaledReplicas int32 = 8
+	created.Spec.Replicas = ptr.To(scaledReplicas)
+	g.Expect(c.Update(context.Background(), created)).To(gomega.Succeed())
+
+	// Second projection (update) with the SAME autoscaler-managed params.
+	// This is the every-reconcile path -- it must NOT clobber the
+	// autoscaler-written value.
+	p2 := minimalParams(t, isvc, c)
+	p2.ResolvedAutoscaler = hpaAutoscalerBlock()
+	_, err = EnsureInferenceReplica(context.Background(), p2)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	after := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, after)).To(gomega.Succeed())
+	g.Expect(after.Spec.Replicas).NotTo(gomega.BeNil())
+	g.Expect(*after.Spec.Replicas).To(gomega.Equal(scaledReplicas),
+		"autoscaler-managed Component must PRESERVE the live (autoscaler-written) "+
+			"spec.replicas across reconciles -- re-stamping MinReplicas clobbers HPA/KEDA")
+}
+
+// TestEnsureInferenceReplica_AutoscalingOff_AppliesMinReplicas pins the
+// other half of the bugfix: when autoscaling is OFF (resolved Class None),
+// the ISVC controller owns the count, so a re-projection re-applies
+// MinReplicas even if the live IR drifted to a different value. A drifted
+// spec.replicas with no autoscaler running must converge back to the spec.
+func TestEnsureInferenceReplica_AutoscalingOff_AppliesMinReplicas(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod") // MinReplicas = 2
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	// First projection (create) -- autoscaling OFF.
+	p := minimalParams(t, isvc, c)
+	p.ResolvedAutoscaler = &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerNone}
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	created := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, created)).To(gomega.Succeed())
+	g.Expect(*created.Spec.Replicas).To(gomega.Equal(int32(2)),
+		"create must stamp MinReplicas")
+
+	// Drift the live spec.replicas (no autoscaler running -- e.g. a stale
+	// manual edit). The next reconcile must pull it back to MinReplicas.
+	created.Spec.Replicas = ptr.To(int32(9))
+	g.Expect(c.Update(context.Background(), created)).To(gomega.Succeed())
+
+	p2 := minimalParams(t, isvc, c)
+	p2.ResolvedAutoscaler = &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerNone}
+	_, err = EnsureInferenceReplica(context.Background(), p2)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	after := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, after)).To(gomega.Succeed())
+	g.Expect(*after.Spec.Replicas).To(gomega.Equal(int32(2)),
+		"autoscaling-off Component must re-apply MinReplicas -- the ISVC controller "+
+			"owns the count when no autoscaler drives /scale")
+}
+
+// TestEnsureInferenceReplica_NilResolvedAutoscaler_AppliesMinReplicasOnUpdate
+// pins that a nil resolved block is treated as autoscaling-off: the ISVC
+// controller owns the count, so an update re-applies MinReplicas. (A nil
+// block also means no autoscaler is running to have written /scale, so
+// there is nothing to preserve.)
+func TestEnsureInferenceReplica_NilResolvedAutoscaler_AppliesMinReplicasOnUpdate(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod") // MinReplicas = 2
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	// Create with nil ResolvedAutoscaler.
+	_, err := EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	created := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, created)).To(gomega.Succeed())
+	created.Spec.Replicas = ptr.To(int32(5))
+	g.Expect(c.Update(context.Background(), created)).To(gomega.Succeed())
+
+	// Update with nil ResolvedAutoscaler -- must re-apply MinReplicas.
+	_, err = EnsureInferenceReplica(context.Background(), minimalParams(t, isvc, c))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	after := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, after)).To(gomega.Succeed())
+	g.Expect(*after.Spec.Replicas).To(gomega.Equal(int32(2)),
+		"nil ResolvedAutoscaler is autoscaling-off -- update must re-apply MinReplicas")
+}
+
+// TestEnsureInferenceReplica_AutoscalerManaged_CreateStampsMinReplicas pins
+// the create-path carve-out: even when the Component is autoscaler-managed,
+// the FIRST projection (no live IR yet) stamps MinReplicas as the initial
+// desired count. There is nothing for the autoscaler to have written before
+// the IR exists, so MinReplicas is correct on create regardless of class.
+func TestEnsureInferenceReplica_AutoscalerManaged_CreateStampsMinReplicas(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod") // MinReplicas = 2
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	p.ResolvedAutoscaler = hpaAutoscalerBlock()
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+	g.Expect(got.Spec.Replicas).NotTo(gomega.BeNil())
+	g.Expect(*got.Spec.Replicas).To(gomega.Equal(int32(2)),
+		"autoscaler-managed create must still stamp MinReplicas as the initial count")
+}
+
+// TestEnsureInferenceReplica_AutoscalerProjection_DeepCopies pins the
+// memory-isolation guard: the IR's ir.Spec.Autoscaler MUST NOT alias
+// p.ResolvedAutoscaler. A downstream mutator (e.g., the IR controller
+// reading the field, the autoscaler dispatch building an HPA spec)
+// must not be able to corrupt the resolver's source-of-truth.
+func TestEnsureInferenceReplica_AutoscalerProjection_DeepCopies(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	p := minimalParams(t, isvc, c)
+	original := autoscalerBlockA()
+	p.ResolvedAutoscaler = autoscalerBlockA() // separate instance, deep-equal to `original`
+
+	_, err := EnsureInferenceReplica(context.Background(), p)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	got := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got)).To(gomega.Succeed())
+
+	// Mutate the input AFTER projection. If the projector aliased the
+	// pointer, the live IR would show the mutation through the Get
+	// fake-client round-trip (fake client stores by reference for in-memory).
+	p.ResolvedAutoscaler.Class = v1beta1.AutoscalerNone
+	p.ResolvedAutoscaler.Keda.Triggers[0].Type = "mutated"
+
+	got2 := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: "llama-engine", Namespace: "prod"}, got2)).To(gomega.Succeed())
+	g.Expect(got2.Spec.Autoscaler).To(gomega.Equal(original),
+		"post-projection input mutation must NOT leak into the stored IR — "+
+			"ir.Spec.Autoscaler must be a deep copy of p.ResolvedAutoscaler")
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/status.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/status.go
@@ -1,0 +1,287 @@
+package irprojector
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/status"
+)
+
+// AggregateIRStatus reads the live InferenceReplica for each
+// IR-managed Component on the given ISVC and writes IR.Status into
+// ISVC.Status.Components[<component>].Lifecycle via Status().Update.
+//
+// The IR controller computes the per-Component aggregate counters and
+// the projector just relays them onto the parent ISVC, so the downstream
+// status contract (kubectl, dashboards, status field shapes) is stable.
+//
+// Called from the ISVC controller's reconcile loop AFTER the
+// per-Component dispatcher (irprojector.EnsureInferenceReplica for the
+// IR-managed OMENative Components) finishes. The dispatch path writes
+// IR.Spec; the IR controller reconciles + writes IR.Status; THIS function
+// reads IR.Status back onto the parent ISVC.
+//
+// componentModes carries the resolved DeploymentModeType for each
+// declared Component on the ISVC (engine/decoder/router). The
+// caller already computes this via isvcutils.DetermineDeploymentModes
+// for its dispatch decisions — passing the map through avoids
+// recomputing per-Component modes here and keeps the IR-managed
+// predicate (IsIRManagedComponent) reading the same resolved mode the
+// dispatch site read. Components missing from the map are treated as
+// non-OMENative and skipped.
+//
+// Writes directly via Status().Update rather than mutating the
+// passed-in ISVC for the outer updateStatus to flush, because the
+// outer flush's retry.RetryOnConflict path re-Gets latest + merges
+// preserved.Lifecycle from latest — clobbering what we just wrote
+// would defeat the purpose.
+//
+// Mutates the in-memory ISVC after the write so subsequent code in
+// the same reconcile pass observes the post-write state.
+//
+// Sequence per Component:
+//
+//  1. Skip Components whose resolved deployment mode is not
+//     OMENative — the RawDeployment path already wrote
+//     ISVC.Status.Components[c].Lifecycle in its own pass.
+//
+//  2. Fetch the IR by name. NotFound is non-fatal — the IR may not
+//     yet exist on the first reconcile, OR the IR was deleted between
+//     the projector's CreateOrUpdate and our read. In either case,
+//     leaving the ISVC status entry empty is the right behavior (the
+//     next reconcile re-creates / re-reads).
+//
+//  3. Status().Update under retry.RetryOnConflict to merge the
+//     IR-derived OMENative subtree onto the live ISVC. Re-read on
+//     conflict so concurrent writers (a different Component's
+//     reconcile) don't lose to us.
+//
+// Errors are wrapped with the offending IR namespace/name for grep-
+// ability in operator logs. A real read/write error (apiserver
+// outage, permission denied) is returned to the caller so the
+// reconcile retries; transient NotFound on the IR Get is swallowed.
+func AggregateIRStatus(ctx context.Context, c client.Client, isvc *v1beta1.InferenceService, componentModes map[v1beta1.ComponentType]constants.DeploymentModeType) error {
+	if c == nil {
+		return fmt.Errorf("AggregateIRStatus: nil client")
+	}
+	if isvc == nil {
+		return fmt.Errorf("AggregateIRStatus: nil ISVC")
+	}
+
+	for _, comp := range allDeclaredComponents(isvc) {
+		mode := componentModes[comp]
+		// Non-OMENative Components are reconciled by their own dispatch
+		// path (RawDeployment), which already wrote their status subtree;
+		// skip them here.
+		if !IsIRManagedComponent(mode) {
+			continue
+		}
+		if err := aggregateOneComponent(ctx, c, isvc, comp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// componentExtFor returns the ComponentExtensionSpec for one Component of the
+// ISVC (Engine / Decoder / Router), or nil when that Component isn't declared.
+// Its MinAvailable / MaxUnavailable (and rolling-update MaxUnavailable) set the
+// availability floor for the Component-ready condition.
+func componentExtFor(isvc *v1beta1.InferenceService, component v1beta1.ComponentType) *v1beta1.ComponentExtensionSpec {
+	switch component {
+	case v1beta1.EngineComponent:
+		if isvc.Spec.Engine != nil {
+			return &isvc.Spec.Engine.ComponentExtensionSpec
+		}
+	case v1beta1.DecoderComponent:
+		if isvc.Spec.Decoder != nil {
+			return &isvc.Spec.Decoder.ComponentExtensionSpec
+		}
+	case v1beta1.RouterComponent:
+		if isvc.Spec.Router != nil {
+			return &isvc.Spec.Router.ComponentExtensionSpec
+		}
+	}
+	return nil
+}
+
+// aggregateOneComponent fetches one IR, computes the desired
+// LifecycleStatus, and writes it to the live ISVC via
+// Status().Update under retry.RetryOnConflict.
+//
+// On apierrors.IsNotFound for the IR Get: returns nil so the outer
+// loop keeps going. The next reconcile picks up the IR's fresh
+// status once the cache observes it.
+//
+// On apierrors.IsNotFound for the ISVC Update: returns nil so a
+// race with ISVC deletion drops cleanly.
+func aggregateOneComponent(ctx context.Context, c client.Client, isvc *v1beta1.InferenceService, component v1beta1.ComponentType) error {
+	name := InferenceReplicaName(isvc.Name, component)
+	key := types.NamespacedName{Namespace: isvc.Namespace, Name: name}
+	ir := &v1beta1.InferenceReplica{}
+	if err := c.Get(ctx, key, ir); err != nil {
+		if apierrors.IsNotFound(err) {
+			// First-reconcile race: the projector's CreateOrUpdate
+			// landed but the cache hasn't observed it yet, OR the
+			// IR was deleted between writes. Leave the status entry
+			// empty and let the next reconcile pick it up. Log at
+			// V(1) so a *persistent* NotFound (projector failing to
+			// create) is visible in operator logs — otherwise this
+			// state is invisible from the ISVC status surface.
+			log.FromContext(ctx).V(1).Info("InferenceReplica not found; leaving ISVC status entry empty until next reconcile",
+				"isvc", client.ObjectKeyFromObject(isvc),
+				"inferencereplica", key,
+				"component", component)
+			return nil
+		}
+		return fmt.Errorf("AggregateIRStatus: get IR %s/%s for component=%s: %w",
+			isvc.Namespace, name, component, err)
+	}
+
+	desired := IRStatusToComponentStatus(ir)
+	// topCond is the standard top-level Component-ready condition
+	// (EngineReady / DecoderReady / RouterReady) derived from the
+	// OMENative counters. Computed once
+	// outside the retry closure: the derivation is a pure function of
+	// `desired`, which is recomputed only when the IR changes (a
+	// separate reconcile would re-enter AggregateIRStatus). On a peer
+	// status-write conflict we re-Get the ISVC and re-stamp, but the
+	// condition itself is stable for this pass.
+	topCond := status.TopLevelComponentReadyFromLifecycle(component, desired, componentExtFor(isvc, component))
+	isvcKey := client.ObjectKeyFromObject(isvc)
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh := &v1beta1.InferenceService{}
+		if err := c.Get(ctx, isvcKey, fresh); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("re-read ISVC: %w", err)
+		}
+		if fresh.Status.Components == nil {
+			fresh.Status.Components = map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{}
+		}
+		// Snapshot the live status before mutation so a no-op rollup
+		// (IR.Status unchanged since the last pass) skips the
+		// Status().Update below. Each ISVC status write re-triggers the
+		// ISVC reconciler, so at steady state the unconditional write
+		// amplified idle reconciles. SetCondition (knative conditionSet)
+		// preserves LastTransitionTime when the condition value is
+		// unchanged, so an unchanged status DeepEquals its prior snapshot.
+		before := fresh.Status.DeepCopy()
+		cs := fresh.Status.Components[component]
+		cs.Lifecycle = desired.DeepCopy()
+		fresh.Status.Components[component] = cs
+		// Emit the top-level component-ready condition in the same
+		// Status().Update round-trip as the subtree write. Without this,
+		// the OMENative counters land but no EngineReady / DecoderReady /
+		// RouterReady ever flips True, so the aggregate Ready rollup and
+		// `kubectl wait --for=condition=Ready` see Status=Unknown
+		// indefinitely.
+		if topCond != nil {
+			fresh.Status.SetCondition(topCond.Type, topCond)
+		}
+		// Skip the write when the recomputed status matches what's already
+		// live: a no-op rollup must perform ZERO writes so it triggers
+		// nothing downstream. The in-memory mirror after the retry loop
+		// still runs so callers in this pass observe the fresh subtree.
+		if equality.Semantic.DeepEqual(*before, fresh.Status) {
+			return nil
+		}
+		if err := c.Status().Update(ctx, fresh); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("update ISVC status: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("AggregateIRStatus: persist component=%s status: %w", component, err)
+	}
+
+	// Mirror onto the caller's in-memory ISVC so downstream code in
+	// the same reconcile pass observes the post-write state. Without
+	// the mirror, the outer reconciler's status-equality short-circuit
+	// (inferenceServiceStatusEqual) may incorrectly skip the next
+	// updateStatus call because its baseline doesn't reflect what we
+	// just committed.
+	if isvc.Status.Components == nil {
+		isvc.Status.Components = map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{}
+	}
+	cs := isvc.Status.Components[component]
+	cs.Lifecycle = desired.DeepCopy()
+	isvc.Status.Components[component] = cs
+	// Mirror the just-committed top-level condition onto the cached
+	// ISVC so the outer reconciler's updateStatus flush — which copies
+	// p.ISVC.Status onto a fresh re-read of the cluster — doesn't clobber
+	// it on the next pass.
+	if topCond != nil {
+		isvc.Status.SetCondition(topCond.Type, topCond)
+	}
+	return nil
+}
+
+// IRStatusToComponentStatus projects the IR.Status fields onto a
+// fresh LifecycleStatus. 1:1 field mapping — IR.Status and the
+// per-Component LifecycleStatus were intentionally shaped identically.
+//
+// Returns a non-nil pointer even when every field is zero; the
+// presence of the pointer is itself a signal that the IR-managed
+// path is driving the Component, and downstream consumers (the
+// controller's preserveLifecycleStatus helper) treat the nil/non-nil
+// boundary as load-bearing.
+func IRStatusToComponentStatus(ir *v1beta1.InferenceReplica) *v1beta1.LifecycleStatus {
+	out := &v1beta1.LifecycleStatus{
+		ObservedGeneration:   ir.Status.ObservedGeneration,
+		Replicas:             ir.Status.Replicas,
+		ReadyReplicas:        ir.Status.ReadyReplicas,
+		ServingReplicas:      ir.Status.ServingReplicas,
+		AvailableReplicas:    ir.Status.AvailableReplicas,
+		UpdatedReplicas:      ir.Status.UpdatedReplicas,
+		UpdatedReadyReplicas: ir.Status.UpdatedReadyReplicas,
+		CurrentRevision:      ir.Status.CurrentRevision,
+		UpdateRevision:       ir.Status.UpdateRevision,
+		LabelSelector:        ir.Status.LabelSelector,
+	}
+	if ir.Status.CollisionCount != nil {
+		cc := *ir.Status.CollisionCount
+		out.CollisionCount = &cc
+	}
+	// Per-Instance detail is intentionally NOT projected onto the ISVC
+	// summary — the authoritative source is the IR's own status, read
+	// directly by in-cluster consumers via ComponentIRStatus.
+	// Conditions follow the same deep-copy contract.
+	if len(ir.Status.Conditions) > 0 {
+		out.Conditions = make([]metav1.Condition, len(ir.Status.Conditions))
+		copy(out.Conditions, ir.Status.Conditions)
+	}
+	return out
+}
+
+// allDeclaredComponents returns the ComponentTypes that have a
+// non-nil spec on the ISVC. Used by AggregateIRStatus to decide
+// which IRs to look up. Components whose specs are nil are not
+// reconciled by anything — including IR-managed paths — so we skip
+// them.
+func allDeclaredComponents(isvc *v1beta1.InferenceService) []v1beta1.ComponentType {
+	var out []v1beta1.ComponentType
+	if isvc.Spec.Engine != nil {
+		out = append(out, v1beta1.EngineComponent)
+	}
+	if isvc.Spec.Decoder != nil {
+		out = append(out, v1beta1.DecoderComponent)
+	}
+	if isvc.Spec.Router != nil {
+		out = append(out, v1beta1.RouterComponent)
+	}
+	return out
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/status_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector/status_test.go
@@ -1,0 +1,510 @@
+package irprojector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// engineOMENativeModes is the per-Component mode map for tests whose
+// engine flows through the IR-managed path. Mirrors what
+// controller.go builds from isvcutils.DetermineDeploymentModes after
+// the OMENative cutover.
+var engineOMENativeModes = map[v1beta1.ComponentType]constants.DeploymentModeType{
+	v1beta1.EngineComponent: constants.OMENative,
+}
+
+// engineDirectModes is the per-Component mode map for tests whose
+// engine flows through the legacy direct path (RawDeployment /
+// missing). Drives the "skip aggregation" branch.
+var engineDirectModes = map[v1beta1.ComponentType]constants.DeploymentModeType{
+	v1beta1.EngineComponent: constants.RawDeployment,
+}
+
+// liveIR returns an IR fixture with realistic Status fields the
+// aggregator should mirror onto the ISVC.
+func liveIR(parentName, namespace string, replicas int32) *v1beta1.InferenceReplica {
+	cc := int32(0)
+	return &v1beta1.InferenceReplica{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      parentName + "-engine",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				constants.InferenceReplicaControllerWriteAnnotationKey: constants.InferenceReplicaControllerWriteAnnotationVal,
+			},
+		},
+		Spec: v1beta1.InferenceReplicaSpec{
+			ParentRef: v1beta1.ParentReference{Name: parentName},
+			Component: v1beta1.EngineComponent,
+		},
+		Status: v1beta1.InferenceReplicaStatus{
+			ObservedGeneration:   1,
+			Replicas:             replicas,
+			ReadyReplicas:        replicas,
+			ServingReplicas:      replicas,
+			AvailableReplicas:    replicas,
+			UpdatedReplicas:      replicas,
+			UpdatedReadyReplicas: replicas,
+			CurrentRevision:      "llama-engine-abc123",
+			UpdateRevision:       "llama-engine-abc123",
+			CollisionCount:       &cc,
+			LabelSelector:        "ome.io/inferenceservice=llama,component=engine,ome.io/managed-by=OMENative",
+			InstanceStatuses: []v1beta1.OMENativeInstanceStatus{
+				{Index: 0, Incarnation: 1, Phase: v1beta1.OMENativeInstanceReady, PodCount: 1, ReadyPodCount: 1, ServingPodCount: 1, AvailablePodCount: 1, ActiveOrdinal: 0},
+			},
+			Conditions: []metav1.Condition{
+				{Type: "Available", Status: metav1.ConditionTrue, Reason: "AllComponentsReady"},
+			},
+		},
+	}
+}
+
+// TestAggregateIRStatus_NonOMENativeMode_NoOp pins the gate: when a
+// Component's resolved deployment mode is NOT OMENative, the
+// aggregator skips it entirely. The status subtree must NOT be
+// populated from any IR (which may not even exist).
+func TestAggregateIRStatus_NonOMENativeMode_NoOp(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	// Pre-populate the ISVC status with a sentinel so we can detect
+	// any accidental overwrite.
+	isvc.Status.Components = map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+		v1beta1.EngineComponent: {
+			Lifecycle: &v1beta1.LifecycleStatus{Replicas: 99},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&v1beta1.InferenceService{}).
+		WithObjects(isvc).
+		Build()
+
+	g.Expect(AggregateIRStatus(context.Background(), c, isvc, engineDirectModes)).To(gomega.Succeed())
+
+	// The pre-populated sentinel must survive — we didn't touch the status.
+	g.Expect(isvc.Status.Components[v1beta1.EngineComponent].Lifecycle).NotTo(gomega.BeNil())
+	g.Expect(isvc.Status.Components[v1beta1.EngineComponent].Lifecycle.Replicas).To(gomega.Equal(int32(99)),
+		"direct-path status sentinel must NOT be overwritten when the resolved mode is not OMENative")
+}
+
+// TestAggregateIRStatus_OMENative_NoIR_NoErr pins the first-reconcile
+// race: engine resolves to OMENative but the IR hasn't been created
+// yet (the projector's CreateOrUpdate landed but the cache hasn't
+// observed it yet). AggregateIRStatus must NOT error — the next
+// reconcile will pick up the IR.
+func TestAggregateIRStatus_OMENative_NoIR_NoErr(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&v1beta1.InferenceService{}).
+		WithObjects(isvc).
+		Build()
+
+	err := AggregateIRStatus(context.Background(), c, isvc, engineOMENativeModes)
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		"missing IR on first reconcile after OMENative dispatch must be a clean no-op")
+}
+
+// TestAggregateIRStatus_OMENative_CopiesStatusFromIR pins the happy
+// path: engine resolves to OMENative, IR exists with realistic
+// Status. The aggregator must write a 1:1 copy of IR.Status into
+// ISVC.Status.Components[engine].Lifecycle.
+func TestAggregateIRStatus_OMENative_CopiesStatusFromIR(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	ir := liveIR("llama", "prod", 3)
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&v1beta1.InferenceService{}, &v1beta1.InferenceReplica{}).
+		WithObjects(isvc, ir).
+		Build()
+
+	g.Expect(AggregateIRStatus(context.Background(), c, isvc, engineOMENativeModes)).To(gomega.Succeed())
+
+	// Read the post-write ISVC from the apiserver — the aggregator
+	// writes via Status().Update so we can't rely on the in-memory
+	// snapshot alone.
+	got := &v1beta1.InferenceService{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, got)).To(gomega.Succeed())
+
+	om := got.Status.Components[v1beta1.EngineComponent].Lifecycle
+	g.Expect(om).NotTo(gomega.BeNil(),
+		"OMENative subtree must be populated for IR-managed Component")
+	g.Expect(om.Replicas).To(gomega.Equal(int32(3)),
+		"Replicas counter must mirror IR.Status.Replicas")
+	g.Expect(om.ReadyReplicas).To(gomega.Equal(int32(3)))
+	g.Expect(om.ServingReplicas).To(gomega.Equal(int32(3)))
+	g.Expect(om.AvailableReplicas).To(gomega.Equal(int32(3)))
+	g.Expect(om.UpdatedReplicas).To(gomega.Equal(int32(3)))
+	g.Expect(om.UpdatedReadyReplicas).To(gomega.Equal(int32(3)))
+	g.Expect(om.CurrentRevision).To(gomega.Equal("llama-engine-abc123"))
+	g.Expect(om.UpdateRevision).To(gomega.Equal("llama-engine-abc123"))
+	g.Expect(om.LabelSelector).To(gomega.ContainSubstring("component=engine"))
+	g.Expect(om.CollisionCount).NotTo(gomega.BeNil())
+	g.Expect(*om.CollisionCount).To(gomega.Equal(int32(0)))
+	// Per-Instance detail is deliberately NOT projected onto the ISVC summary;
+	// the authoritative source is the IR, read via ComponentIRStatus.
+	g.Expect(om.Conditions).To(gomega.HaveLen(1))
+	g.Expect(om.Conditions[0].Type).To(gomega.Equal("Available"))
+
+	// Aggregator must also mirror onto the in-memory ISVC so
+	// downstream code (e.g. the outer updateStatus equality
+	// short-circuit) observes the post-write state.
+	g.Expect(isvc.Status.Components[v1beta1.EngineComponent].Lifecycle).NotTo(gomega.BeNil())
+	g.Expect(isvc.Status.Components[v1beta1.EngineComponent].Lifecycle.Replicas).To(gomega.Equal(int32(3)))
+}
+
+// TestAggregateIRStatus_OMENative_OnlyTouchesOMENativeComponents pins
+// the per-Component isolation: when engine resolves to OMENative but
+// decoder resolves to RawDeployment, the aggregator must NOT touch
+// the decoder OMENative subtree (the omenative direct path is the
+// sole writer for non-OMENative-mode Components — defensive
+// preservation in case downstream code reuses the OMENative subtree
+// shape).
+func TestAggregateIRStatus_OMENative_OnlyTouchesOMENativeComponents(t *testing.T) {
+	g := gomega.NewWithT(t)
+	min := 1
+	isvc := baselineISVC("llama", "prod")
+	isvc.Spec.Decoder = &v1beta1.DecoderSpec{
+		ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: &min},
+	}
+	// Decoder's resolved mode is intentionally NOT OMENative.
+	isvc.Status.Components = map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+		v1beta1.DecoderComponent: {
+			Lifecycle: &v1beta1.LifecycleStatus{Replicas: 42}, // pre-existing sentinel value
+		},
+	}
+	ir := liveIR("llama", "prod", 2)
+
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&v1beta1.InferenceService{}, &v1beta1.InferenceReplica{}).
+		WithObjects(isvc, ir).
+		Build()
+
+	componentModes := map[v1beta1.ComponentType]constants.DeploymentModeType{
+		v1beta1.EngineComponent:  constants.OMENative,
+		v1beta1.DecoderComponent: constants.RawDeployment,
+	}
+	g.Expect(AggregateIRStatus(context.Background(), c, isvc, componentModes)).To(gomega.Succeed())
+
+	got := &v1beta1.InferenceService{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, got)).To(gomega.Succeed())
+
+	// Engine: mirrored from IR.
+	g.Expect(got.Status.Components[v1beta1.EngineComponent].Lifecycle).NotTo(gomega.BeNil())
+	g.Expect(got.Status.Components[v1beta1.EngineComponent].Lifecycle.Replicas).To(gomega.Equal(int32(2)))
+
+	// Decoder: untouched — sentinel survives.
+	g.Expect(got.Status.Components[v1beta1.DecoderComponent].Lifecycle).NotTo(gomega.BeNil(),
+		"decoder OMENative subtree must NOT be cleared by the IR-managed engine path")
+	g.Expect(got.Status.Components[v1beta1.DecoderComponent].Lifecycle.Replicas).To(gomega.Equal(int32(42)),
+		"decoder direct-path sentinel must survive the IR-managed engine aggregation")
+}
+
+// TestAggregateIRStatus_NilClient_Rejected pins the validation
+// guard: nil client at the aggregator means the dispatch site
+// dropped r.Client.
+func TestAggregateIRStatus_NilClient_Rejected(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	err := AggregateIRStatus(context.Background(), nil, isvc, engineOMENativeModes)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("nil client"))
+}
+
+// TestAggregateIRStatus_NilISVC_Rejected pins the validation
+// guard: nil ISVC at the aggregator means the dispatch site
+// dropped the reconcile target.
+func TestAggregateIRStatus_NilISVC_Rejected(t *testing.T) {
+	g := gomega.NewWithT(t)
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	err := AggregateIRStatus(context.Background(), c, nil, engineOMENativeModes)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("nil ISVC"))
+}
+
+// TestAggregateIRStatus_OMENative_PreservesNonOMENativeFields pins
+// the field-isolation contract: the aggregator only touches
+// ISVC.Status.Components[<comp>].Lifecycle — other fields on the
+// ComponentStatusSpec (URL, RestURL, Address, RolloutPhase) must
+// survive.
+func TestAggregateIRStatus_OMENative_PreservesNonOMENativeFields(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	isvc.Status.Components = map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+		v1beta1.EngineComponent: {
+			// Pre-existing non-OMENative fields the outer reconciler
+			// owns. The aggregator must not clear them.
+			LatestReadyRevision: "rev-1",
+		},
+	}
+	ir := liveIR("llama", "prod", 1)
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&v1beta1.InferenceService{}, &v1beta1.InferenceReplica{}).
+		WithObjects(isvc, ir).
+		Build()
+
+	g.Expect(AggregateIRStatus(context.Background(), c, isvc, engineOMENativeModes)).To(gomega.Succeed())
+
+	got := &v1beta1.InferenceService{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, got)).To(gomega.Succeed())
+
+	cs := got.Status.Components[v1beta1.EngineComponent]
+	g.Expect(cs.LatestReadyRevision).To(gomega.Equal("rev-1"),
+		"non-OMENative ComponentStatusSpec fields must survive aggregation")
+	g.Expect(cs.Lifecycle).NotTo(gomega.BeNil())
+	g.Expect(cs.Lifecycle.Replicas).To(gomega.Equal(int32(1)))
+}
+
+// TestAggregateIRStatus_EmitsEngineReadyCondition pins the bug fix: the
+// IR-managed path must emit the top-level EngineReady condition derived
+// from the OMENative counters, mirroring what the legacy direct path
+// does (omenative/status_aggregate.go:140-143). Without it, the aggregate
+// Ready rollup stays Unknown forever even though the subtree counters
+// are correct.
+//
+// Real-cluster symptom: a PD-disagg-shaped single-engine
+// ISVC in OMENative mode had all subtree fields populated (replicas=1,
+// updatedReplicas=1, InstanceStatuses[0].Phase=Ready) and IngressReady=True
+// — but ISVC.Status.Conditions carried only IngressReady + Ready=Unknown.
+// No EngineReady was emitted, so the top-level Ready aggregator never
+// flipped.
+func TestAggregateIRStatus_EmitsEngineReadyCondition(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	// liveIR with replicas=1, all-ready counters — the same shape the
+	// real-cluster ISVC was in when the bug was observed.
+	ir := liveIR("llama", "prod", 1)
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&v1beta1.InferenceService{}, &v1beta1.InferenceReplica{}).
+		WithObjects(isvc, ir).
+		Build()
+
+	g.Expect(AggregateIRStatus(context.Background(), c, isvc, engineOMENativeModes)).To(gomega.Succeed())
+
+	got := &v1beta1.InferenceService{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, got)).To(gomega.Succeed())
+
+	// Existing subtree assertion: the OMENative subtree must still be
+	// populated (regression guard against accidentally moving the
+	// subtree write out of the closure).
+	om := got.Status.Components[v1beta1.EngineComponent].Lifecycle
+	g.Expect(om).NotTo(gomega.BeNil(), "OMENative subtree must be populated")
+	g.Expect(om.Replicas).To(gomega.Equal(int32(1)))
+	g.Expect(om.ReadyReplicas).To(gomega.Equal(int32(1)))
+
+	// NEW: the EngineReady top-level condition must be emitted with
+	// Status=True. This is the bug fix.
+	cond := got.Status.GetCondition(v1beta1.EngineReady)
+	g.Expect(cond).NotTo(gomega.BeNil(),
+		"EngineReady condition must be emitted alongside the OMENative subtree")
+	g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionTrue),
+		"EngineReady must be True when ReadyReplicas == Replicas > 0")
+	g.Expect(cond.Reason).To(gomega.Equal("Ready"))
+
+	// Mirror onto the in-memory ISVC: the outer reconciler's updateStatus
+	// flush re-copies p.ISVC.Status onto a fresh re-read of the cluster,
+	// so without the mirror the value we just committed gets clobbered
+	// on the next pass.
+	inMemCond := isvc.Status.GetCondition(v1beta1.EngineReady)
+	g.Expect(inMemCond).NotTo(gomega.BeNil(),
+		"EngineReady must be mirrored onto the in-memory ISVC for the outer reconciler to observe")
+	g.Expect(inMemCond.Status).To(gomega.Equal(corev1.ConditionTrue))
+}
+
+// TestAggregateIRStatus_EmitsEngineReadyConditionFalse pins the
+// not-serving branch: when the IR reports Replicas=1 with 0 serving (pod not
+// yet Ready) and no disruption budget, EngineReady must be emitted with
+// Status=False / Reason=InsufficientAvailable (serving below the strict floor).
+func TestAggregateIRStatus_EmitsEngineReadyConditionFalse(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	ir := liveIR("llama", "prod", 1)
+	// Pull the IR down to 0 serving — pod not yet Ready.
+	ir.Status.ReadyReplicas = 0
+	ir.Status.ServingReplicas = 0
+	ir.Status.AvailableReplicas = 0
+	// Also down the per-Instance Phase so callers reading
+	// InstanceStatuses see the partial-ready state.
+	ir.Status.InstanceStatuses[0].Phase = v1beta1.OMENativeInstanceCreating
+	ir.Status.InstanceStatuses[0].ReadyPodCount = 0
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&v1beta1.InferenceService{}, &v1beta1.InferenceReplica{}).
+		WithObjects(isvc, ir).
+		Build()
+
+	g.Expect(AggregateIRStatus(context.Background(), c, isvc, engineOMENativeModes)).To(gomega.Succeed())
+
+	got := &v1beta1.InferenceService{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, got)).To(gomega.Succeed())
+
+	cond := got.Status.GetCondition(v1beta1.EngineReady)
+	g.Expect(cond).NotTo(gomega.BeNil(),
+		"EngineReady must be emitted even when not all replicas are Ready")
+	g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionFalse),
+		"EngineReady must be False when serving is below the availability floor")
+	g.Expect(cond.Reason).To(gomega.Equal("InsufficientAvailable"))
+}
+
+// TestAggregateIRStatus_MultiComponent_EmitsBothConditions pins the
+// per-Component independence: with engine + decoder both in OMENative
+// mode and both IRs reporting all-ready, both EngineReady and
+// DecoderReady conditions must flip True. The aggregator runs once per
+// Component; each one independently emits its own condition.
+func TestAggregateIRStatus_MultiComponent_EmitsBothConditions(t *testing.T) {
+	g := gomega.NewWithT(t)
+	min := 1
+	isvc := baselineISVC("llama", "prod")
+	isvc.Spec.Decoder = &v1beta1.DecoderSpec{
+		ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: &min},
+	}
+
+	engineIR := liveIR("llama", "prod", 1)
+	// Build the decoder IR by hand — liveIR hard-codes the engine name
+	// + EngineComponent label; for decoder we need <isvc>-decoder.
+	cc := int32(0)
+	decoderIR := &v1beta1.InferenceReplica{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llama-decoder",
+			Namespace: "prod",
+			Annotations: map[string]string{
+				constants.InferenceReplicaControllerWriteAnnotationKey: constants.InferenceReplicaControllerWriteAnnotationVal,
+			},
+		},
+		Spec: v1beta1.InferenceReplicaSpec{
+			ParentRef: v1beta1.ParentReference{Name: "llama"},
+			Component: v1beta1.DecoderComponent,
+		},
+		Status: v1beta1.InferenceReplicaStatus{
+			ObservedGeneration:   1,
+			Replicas:             2,
+			ReadyReplicas:        2,
+			ServingReplicas:      2,
+			AvailableReplicas:    2,
+			UpdatedReplicas:      2,
+			UpdatedReadyReplicas: 2,
+			CurrentRevision:      "llama-decoder-def456",
+			UpdateRevision:       "llama-decoder-def456",
+			CollisionCount:       &cc,
+			LabelSelector:        "ome.io/inferenceservice=llama,component=decoder,ome.io/managed-by=OMENative",
+			InstanceStatuses: []v1beta1.OMENativeInstanceStatus{
+				{Index: 0, Incarnation: 1, Phase: v1beta1.OMENativeInstanceReady, PodCount: 1, ReadyPodCount: 1},
+				{Index: 1, Incarnation: 1, Phase: v1beta1.OMENativeInstanceReady, PodCount: 1, ReadyPodCount: 1},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&v1beta1.InferenceService{}, &v1beta1.InferenceReplica{}).
+		WithObjects(isvc, engineIR, decoderIR).
+		Build()
+
+	componentModes := map[v1beta1.ComponentType]constants.DeploymentModeType{
+		v1beta1.EngineComponent:  constants.OMENative,
+		v1beta1.DecoderComponent: constants.OMENative,
+	}
+	g.Expect(AggregateIRStatus(context.Background(), c, isvc, componentModes)).To(gomega.Succeed())
+
+	got := &v1beta1.InferenceService{}
+	g.Expect(c.Get(context.Background(),
+		types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, got)).To(gomega.Succeed())
+
+	// Engine subtree + condition.
+	g.Expect(got.Status.Components[v1beta1.EngineComponent].Lifecycle).NotTo(gomega.BeNil())
+	g.Expect(got.Status.Components[v1beta1.EngineComponent].Lifecycle.Replicas).To(gomega.Equal(int32(1)))
+	engineCond := got.Status.GetCondition(v1beta1.EngineReady)
+	g.Expect(engineCond).NotTo(gomega.BeNil(), "EngineReady must be emitted")
+	g.Expect(engineCond.Status).To(gomega.Equal(corev1.ConditionTrue))
+
+	// Decoder subtree + condition.
+	g.Expect(got.Status.Components[v1beta1.DecoderComponent].Lifecycle).NotTo(gomega.BeNil())
+	g.Expect(got.Status.Components[v1beta1.DecoderComponent].Lifecycle.Replicas).To(gomega.Equal(int32(2)))
+	decoderCond := got.Status.GetCondition(v1beta1.DecoderReady)
+	g.Expect(decoderCond).NotTo(gomega.BeNil(), "DecoderReady must be emitted")
+	g.Expect(decoderCond.Status).To(gomega.Equal(corev1.ConditionTrue))
+}
+
+// TestAggregateIRStatus_NoWriteWhenUnchanged pins the no-op
+// short-circuit: a second AggregateIRStatus pass over an unchanged IR
+// must perform ZERO ISVC Status().Update writes. Each ISVC status write
+// re-triggers the ISVC reconciler, so the prior unconditional write
+// amplified idle reconciles into a write storm at scale.
+//
+// Verified via ResourceVersion: the fake client bumps RV on every
+// Status().Update. The first pass mutates the ISVC subtree + EngineReady
+// condition (RV bumps); the second pass over the same IR must recompute
+// an identical status and skip the write (RV unchanged). The knative
+// SetCondition LastTransitionTime-preserving semantics are what make the
+// second-pass status DeepEqual the first.
+func TestAggregateIRStatus_NoWriteWhenUnchanged(t *testing.T) {
+	g := gomega.NewWithT(t)
+	isvc := baselineISVC("llama", "prod")
+	ir := liveIR("llama", "prod", 1)
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&v1beta1.InferenceService{}, &v1beta1.InferenceReplica{}).
+		WithObjects(isvc, ir).
+		Build()
+	key := types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}
+
+	// First pass: status changes (subtree + EngineReady condition) → write.
+	g.Expect(AggregateIRStatus(context.Background(), c, isvc, engineOMENativeModes)).To(gomega.Succeed())
+	afterFirst := &v1beta1.InferenceService{}
+	g.Expect(c.Get(context.Background(), key, afterFirst)).To(gomega.Succeed())
+	rvAfterFirst := afterFirst.ResourceVersion
+
+	// Second pass over the same IR: recomputed status equals live status →
+	// the DeepEqual guard must skip Status().Update (ResourceVersion stable).
+	// Use a fresh in-memory ISVC snapshot so the in-memory mirror from the
+	// first pass doesn't shortcut the recompute.
+	g.Expect(AggregateIRStatus(context.Background(), c, afterFirst.DeepCopy(), engineOMENativeModes)).To(gomega.Succeed())
+	afterSecond := &v1beta1.InferenceService{}
+	g.Expect(c.Get(context.Background(), key, afterSecond)).To(gomega.Succeed())
+	g.Expect(afterSecond.ResourceVersion).To(gomega.Equal(rvAfterFirst),
+		"a no-op AggregateIRStatus pass must perform ZERO writes (ResourceVersion unchanged)")
+}
+
+// TestIrStatusToComponentStatus_DeepCopiesCollisionCount pins the
+// aliasing guard for the fields the projector still copies. The
+// CollisionCount pointer must be a fresh allocation so downstream
+// mutations of the ISVC summary don't clobber the IR's source-of-truth.
+// (Per-Instance detail is intentionally no longer projected onto the
+// summary — the IR is read directly via ComponentIRStatus.)
+func TestIrStatusToComponentStatus_DeepCopiesCollisionCount(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ir := &v1beta1.InferenceReplica{
+		Status: v1beta1.InferenceReplicaStatus{
+			InstanceStatuses: []v1beta1.OMENativeInstanceStatus{
+				{Index: 0, Phase: v1beta1.OMENativeInstanceReady},
+			},
+			CollisionCount: ptr.To(int32(5)),
+		},
+	}
+	out := IRStatusToComponentStatus(ir)
+	g.Expect(out).NotTo(gomega.BeNil())
+
+	// CollisionCount pointer must NOT be aliased.
+	*out.CollisionCount = 99
+	g.Expect(*ir.Status.CollisionCount).To(gomega.Equal(int32(5)),
+		"mutating the output CollisionCount must NOT alias back to the IR")
+}

--- a/pkg/controller/v1beta1/inferenceservice/status/top_level_condition.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/top_level_condition.go
@@ -1,0 +1,107 @@
+package status
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/apis"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/utils"
+)
+
+// TopLevelComponentReadyFromLifecycle derives the standard top-level
+// component-ready condition (EngineReady / DecoderReady / RouterReady) from
+// OMENative counters, honoring the Component's disruption budget. Returns nil for
+// unknown Component types so callers leave the condition surface untouched.
+//
+// Ready is availability-based, not strict: True when the number of serving
+// Instances is at or above the Component's availability floor (see
+// utils.AvailabilityFloor) — the same MinAvailable/MaxUnavailable that drive the
+// Component's PodDisruptionBudget, falling back to its rolling-update
+// MaxUnavailable (defaulted 25% for OMENative). This mirrors how RawDeployment
+// derives readiness from a Deployment's maxUnavailable-thresholded Available
+// condition, so a Component serving 9/10 Instances (within budget) reports Ready
+// instead of flapping to NotReady on every single-Instance disruption or
+// in-budget rollout. A genuine outage below the floor still reports NotReady.
+// The floor is never below 1 for a Component with desired Instances, so a budget
+// that permits every Instance to be down cannot report a zero-serving Component
+// as Ready.
+//
+// The reason distinguishes fully-converged ("Ready") from serving-at-or-above-
+// floor but not fully rolled out ("MinimumAvailable"), so rollout progress stays
+// visible. `ext` may be nil (e.g. a hand-crafted object bypassing the defaulter),
+// in which case the floor is strict (all Instances must serve).
+//
+// Lives in the neutral inferenceservice/status package — the single source of
+// truth for the Ready predicate that the IR-managed projector (irprojector
+// status.go) calls. The IR's own Ready condition derives the same way via
+// utils.AvailabilityFloor.
+func TopLevelComponentReadyFromLifecycle(component v1beta1.ComponentType, cs *v1beta1.LifecycleStatus, ext *v1beta1.ComponentExtensionSpec) *apis.Condition {
+	var readyType apis.ConditionType
+	switch component {
+	case v1beta1.EngineComponent:
+		readyType = v1beta1.EngineReady
+	case v1beta1.DecoderComponent:
+		readyType = v1beta1.DecoderReady
+	case v1beta1.RouterComponent:
+		readyType = v1beta1.RouterReady
+	default:
+		return nil
+	}
+	cond := &apis.Condition{Type: readyType}
+	if cs == nil || cs.Replicas == 0 {
+		cond.Status = corev1.ConditionFalse
+		cond.Reason = "NoReplicas"
+		cond.Message = "Component has no desired Instances"
+		return cond
+	}
+	floor := utils.AvailabilityFloor(cs.Replicas, extMinAvailable(ext), extMaxUnavailable(ext), rolloutMaxUnavailable(ext))
+	// A budget permitting every Instance to be down (MaxUnavailable "100%", or
+	// an integer at or above Replicas) yields a zero floor, which would report
+	// Ready for a Component serving no traffic. Replicas > 0 here, so require
+	// at least one serving Instance.
+	if floor < 1 {
+		floor = 1
+	}
+	switch {
+	case cs.ReadyReplicas >= cs.Replicas:
+		cond.Status = corev1.ConditionTrue
+		cond.Reason = "Ready"
+		cond.Message = "All Instances are Ready"
+	case cs.ServingReplicas >= floor:
+		cond.Status = corev1.ConditionTrue
+		cond.Reason = "MinimumAvailable"
+		cond.Message = fmt.Sprintf("%d/%d Instances serving (min %d)", cs.ServingReplicas, cs.Replicas, floor)
+	default:
+		cond.Status = corev1.ConditionFalse
+		cond.Reason = "InsufficientAvailable"
+		cond.Message = fmt.Sprintf("%d/%d Instances serving, need %d", cs.ServingReplicas, cs.Replicas, floor)
+	}
+	return cond
+}
+
+// extMinAvailable / extMaxUnavailable / rolloutMaxUnavailable pull the disruption
+// budget off a (possibly nil) ComponentExtensionSpec: the PDB MinAvailable /
+// MaxUnavailable, and the rolling-update MaxUnavailable fallback.
+func extMinAvailable(ext *v1beta1.ComponentExtensionSpec) *intstr.IntOrString {
+	if ext == nil {
+		return nil
+	}
+	return ext.MinAvailable
+}
+
+func extMaxUnavailable(ext *v1beta1.ComponentExtensionSpec) *intstr.IntOrString {
+	if ext == nil {
+		return nil
+	}
+	return ext.MaxUnavailable
+}
+
+func rolloutMaxUnavailable(ext *v1beta1.ComponentExtensionSpec) *intstr.IntOrString {
+	if ext == nil || ext.Lifecycle == nil || ext.Lifecycle.UpdateStrategy == nil || ext.Lifecycle.UpdateStrategy.RollingUpdate == nil {
+		return nil
+	}
+	return ext.Lifecycle.UpdateStrategy.RollingUpdate.MaxUnavailable
+}

--- a/pkg/controller/v1beta1/inferenceservice/status/top_level_condition_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/status/top_level_condition_test.go
@@ -1,0 +1,150 @@
+package status
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/apis"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/utils"
+)
+
+func maxUnavailableExt(v *intstr.IntOrString) *v1beta1.ComponentExtensionSpec {
+	return &v1beta1.ComponentExtensionSpec{MaxUnavailable: v}
+}
+
+func TestTopLevelComponentReadyFromLifecycle(t *testing.T) {
+	cases := []struct {
+		name       string
+		component  v1beta1.ComponentType
+		cs         *v1beta1.LifecycleStatus
+		ext        *v1beta1.ComponentExtensionSpec
+		wantNil    bool
+		wantType   apis.ConditionType
+		wantStatus corev1.ConditionStatus
+		wantReason string
+	}{
+		{
+			name:      "unknown component leaves the surface untouched",
+			component: v1beta1.ComponentType("bogus"),
+			cs:        &v1beta1.LifecycleStatus{Replicas: 1},
+			wantNil:   true,
+		},
+		{
+			name:       "nil status reports NoReplicas",
+			component:  v1beta1.EngineComponent,
+			cs:         nil,
+			wantType:   v1beta1.EngineReady,
+			wantStatus: corev1.ConditionFalse,
+			wantReason: "NoReplicas",
+		},
+		{
+			name:       "zero desired reports NoReplicas",
+			component:  v1beta1.DecoderComponent,
+			cs:         &v1beta1.LifecycleStatus{Replicas: 0},
+			wantType:   v1beta1.DecoderReady,
+			wantStatus: corev1.ConditionFalse,
+			wantReason: "NoReplicas",
+		},
+		{
+			name:       "fully converged reports Ready",
+			component:  v1beta1.EngineComponent,
+			cs:         &v1beta1.LifecycleStatus{Replicas: 3, ReadyReplicas: 3, ServingReplicas: 3},
+			wantType:   v1beta1.EngineReady,
+			wantStatus: corev1.ConditionTrue,
+			wantReason: "Ready",
+		},
+		{
+			name:       "serving at or above floor reports MinimumAvailable",
+			component:  v1beta1.RouterComponent,
+			cs:         &v1beta1.LifecycleStatus{Replicas: 10, ReadyReplicas: 9, ServingReplicas: 9},
+			ext:        maxUnavailableExt(utils.PtrIntOrStringFromString("25%")),
+			wantType:   v1beta1.RouterReady,
+			wantStatus: corev1.ConditionTrue,
+			wantReason: "MinimumAvailable",
+		},
+		{
+			name:       "serving below floor reports InsufficientAvailable",
+			component:  v1beta1.EngineComponent,
+			cs:         &v1beta1.LifecycleStatus{Replicas: 10, ReadyReplicas: 2, ServingReplicas: 2},
+			ext:        maxUnavailableExt(utils.PtrIntOrStringFromString("25%")),
+			wantType:   v1beta1.EngineReady,
+			wantStatus: corev1.ConditionFalse,
+			wantReason: "InsufficientAvailable",
+		},
+		{
+			name:       "nil ext is strict",
+			component:  v1beta1.EngineComponent,
+			cs:         &v1beta1.LifecycleStatus{Replicas: 3, ReadyReplicas: 2, ServingReplicas: 2},
+			ext:        nil,
+			wantType:   v1beta1.EngineReady,
+			wantStatus: corev1.ConditionFalse,
+			wantReason: "InsufficientAvailable",
+		},
+		{
+			// Regression: a budget permitting every Instance to be down
+			// yields a zero floor. Without a minimum of 1, "0 >= 0" would
+			// report Ready for a component serving no traffic.
+			name:       "percent budget allowing full outage does not report Ready at zero serving",
+			component:  v1beta1.EngineComponent,
+			cs:         &v1beta1.LifecycleStatus{Replicas: 5, ReadyReplicas: 0, ServingReplicas: 0},
+			ext:        maxUnavailableExt(utils.PtrIntOrStringFromString("100%")),
+			wantType:   v1beta1.EngineReady,
+			wantStatus: corev1.ConditionFalse,
+			wantReason: "InsufficientAvailable",
+		},
+		{
+			// Same zero-floor hazard via an integer MaxUnavailable at or
+			// above the replica count.
+			name:       "integer budget at replica count does not report Ready at zero serving",
+			component:  v1beta1.DecoderComponent,
+			cs:         &v1beta1.LifecycleStatus{Replicas: 4, ReadyReplicas: 0, ServingReplicas: 0},
+			ext:        maxUnavailableExt(ptrIntOrString32(4)),
+			wantType:   v1beta1.DecoderReady,
+			wantStatus: corev1.ConditionFalse,
+			wantReason: "InsufficientAvailable",
+		},
+		{
+			// The floor-of-1 must not mask real progress: one serving
+			// Instance under a fully-permissive budget is still Ready.
+			name:       "one serving Instance under a permissive budget reports MinimumAvailable",
+			component:  v1beta1.EngineComponent,
+			cs:         &v1beta1.LifecycleStatus{Replicas: 5, ReadyReplicas: 1, ServingReplicas: 1},
+			ext:        maxUnavailableExt(utils.PtrIntOrStringFromString("100%")),
+			wantType:   v1beta1.EngineReady,
+			wantStatus: corev1.ConditionTrue,
+			wantReason: "MinimumAvailable",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TopLevelComponentReadyFromLifecycle(tc.component, tc.cs, tc.ext)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("want nil condition for unknown component; got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("want a condition; got nil")
+			}
+			if string(got.Type) != string(tc.wantType) {
+				t.Errorf("condition type = %q; want %q", got.Type, tc.wantType)
+			}
+			if got.Status != tc.wantStatus {
+				t.Errorf("condition status = %q; want %q (message: %s)", got.Status, tc.wantStatus, got.Message)
+			}
+			if got.Reason != tc.wantReason {
+				t.Errorf("condition reason = %q; want %q (message: %s)", got.Reason, tc.wantReason, got.Message)
+			}
+		})
+	}
+}
+
+func ptrIntOrString32(i int32) *intstr.IntOrString {
+	out := intstr.FromInt32(i)
+	return &out
+}

--- a/pkg/utils/intstr.go
+++ b/pkg/utils/intstr.go
@@ -1,0 +1,96 @@
+package utils
+
+import "k8s.io/apimachinery/pkg/util/intstr"
+
+// PtrIntOrStringFromString returns a pointer to an IntOrString carrying
+// the supplied percentage string (e.g. "25%"). Convenience for pacing
+// defaulters that need an addressable percent literal.
+func PtrIntOrStringFromString(s string) *intstr.IntOrString {
+	out := intstr.FromString(s)
+	return &out
+}
+
+// ScaledCountFromIntOrString resolves an IntOrString budget (a pod
+// count or a percentage of total) into an absolute, non-negative count.
+// It is the single int/percent → count helper shared across the
+// coordination, workload-budget, and canary-capacity callers.
+//
+// Semantics:
+//
+//   - nil v → 0.
+//   - Integer form: the literal value, floored at 0. NOT clamped to
+//     total — an integer MaxSurge larger than the replica count is a
+//     deliberate over-allocation the former coordination/workload copies
+//     returned as-is. Callers that need an upper bound (e.g. canary's
+//     new-pod count) compose with ClampInt32.
+//   - Percent form: round(total * pct / 100) via
+//     intstr.GetScaledValueFromIntOrPercent (ceil when roundUp, floor
+//     otherwise), then floored at 0 and CLAMPED to total. The clamp
+//     reproduces the former copies' "a 100%+ expression never exceeds
+//     total" rule: for pct in [0,100] the ceil already sits at or below
+//     total so the clamp is a no-op; for pct > 100 it caps at total,
+//     exactly as the old percent→count helpers did by clamping the
+//     percent to 100 first.
+//   - Malformed string (no '%' suffix, non-numeric): the stdlib parser
+//     errors and we return 0 — matching the conservative
+//     parse-failure → 0 contract of the former strPercent /
+//     parsePercentString helpers. Validated webhook payloads never reach
+//     this branch.
+func ScaledCountFromIntOrString(v *intstr.IntOrString, total int32, roundUp bool) int32 {
+	if v == nil {
+		return 0
+	}
+	if v.Type == intstr.Int {
+		n := int32(v.IntValue())
+		if n < 0 {
+			return 0
+		}
+		return n
+	}
+	n, err := intstr.GetScaledValueFromIntOrPercent(v, int(total), roundUp)
+	if err != nil || n < 0 {
+		return 0
+	}
+	// Compare in the wider type: n is an int, so narrowing first would let a
+	// value above math.MaxInt32 wrap negative and slip past the clamp.
+	if total >= 0 && n > int(total) {
+		return total
+	}
+	return int32(n)
+}
+
+// AvailabilityFloor returns the minimum number of pods (out of total) that must
+// remain available to satisfy a disruption budget, in precedence order:
+//
+//   - minAvailable set → that many must be available (a percent resolves via
+//     ceil, then clamped to total);
+//   - else maxUnavailable set → total minus that many may be down (floored at 0);
+//   - else fallbackMaxUnavailable set → total minus that many (floored at 0);
+//   - else total (strict — all must be available).
+//
+// Percent budgets resolve with ScaledCountFromIntOrString (ceil), the same
+// resolver the rollout drain-budget math uses, so an availability check and the
+// pacing gate agree byte-for-byte. total <= 0 yields 0.
+func AvailabilityFloor(total int32, minAvailable, maxUnavailable, fallbackMaxUnavailable *intstr.IntOrString) int32 {
+	if total <= 0 {
+		return 0
+	}
+	if minAvailable != nil {
+		f := ScaledCountFromIntOrString(minAvailable, total, true)
+		if f > total {
+			return total
+		}
+		return f
+	}
+	mu := maxUnavailable
+	if mu == nil {
+		mu = fallbackMaxUnavailable
+	}
+	if mu != nil {
+		if f := total - ScaledCountFromIntOrString(mu, total, true); f > 0 {
+			return f
+		}
+		return 0
+	}
+	return total
+}

--- a/pkg/utils/intstr_test.go
+++ b/pkg/utils/intstr_test.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"math"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func ptrInt(i int32) *intstr.IntOrString {
+	out := intstr.FromInt32(i)
+	return &out
+}
+
+func TestScaledCountFromIntOrString(t *testing.T) {
+	cases := []struct {
+		name    string
+		v       *intstr.IntOrString
+		total   int32
+		roundUp bool
+		want    int32
+	}{
+		{name: "nil yields zero", v: nil, total: 10, want: 0},
+		{name: "integer literal is returned as-is", v: ptrInt(3), total: 10, want: 3},
+		{name: "integer above total is not clamped", v: ptrInt(25), total: 10, want: 25},
+		{name: "negative integer floors at zero", v: ptrInt(-1), total: 10, want: 0},
+		{name: "percent rounds up when roundUp", v: PtrIntOrStringFromString("25%"), total: 10, roundUp: true, want: 3},
+		{name: "percent rounds down when not roundUp", v: PtrIntOrStringFromString("25%"), total: 10, want: 2},
+		{name: "percent over 100 clamps to total", v: PtrIntOrStringFromString("150%"), total: 10, roundUp: true, want: 10},
+		{name: "malformed string yields zero", v: PtrIntOrStringFromString("bogus"), total: 10, want: 0},
+		{
+			// Regression: the clamp compares in int. Narrowing to int32
+			// first would wrap this to a negative value, bypass the clamp,
+			// and return a negative count.
+			name:    "percent overflowing int32 clamps to total",
+			v:       PtrIntOrStringFromString("99999999999%"),
+			total:   math.MaxInt32,
+			roundUp: true,
+			want:    math.MaxInt32,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ScaledCountFromIntOrString(tc.v, tc.total, tc.roundUp)
+			if got != tc.want {
+				t.Errorf("ScaledCountFromIntOrString(%v, %d, %t) = %d; want %d", tc.v, tc.total, tc.roundUp, got, tc.want)
+			}
+			if got < 0 {
+				t.Errorf("count must never be negative; got %d", got)
+			}
+		})
+	}
+}
+
+func TestAvailabilityFloor(t *testing.T) {
+	cases := []struct {
+		name                   string
+		total                  int32
+		minAvailable           *intstr.IntOrString
+		maxUnavailable         *intstr.IntOrString
+		fallbackMaxUnavailable *intstr.IntOrString
+		want                   int32
+	}{
+		{name: "non-positive total yields zero", total: 0, want: 0},
+		{name: "no budget is strict", total: 10, want: 10},
+		{name: "minAvailable takes precedence", total: 10, minAvailable: ptrInt(4), maxUnavailable: ptrInt(9), want: 4},
+		{name: "minAvailable above total clamps to total", total: 10, minAvailable: ptrInt(25), want: 10},
+		{name: "minAvailable percent resolves via ceil", total: 10, minAvailable: PtrIntOrStringFromString("25%"), want: 3},
+		{name: "maxUnavailable subtracts from total", total: 10, maxUnavailable: ptrInt(3), want: 7},
+		{name: "maxUnavailable at total floors at zero", total: 10, maxUnavailable: ptrInt(10), want: 0},
+		{name: "maxUnavailable 100 percent floors at zero", total: 10, maxUnavailable: PtrIntOrStringFromString("100%"), want: 0},
+		{name: "fallback used only when maxUnavailable is nil", total: 10, fallbackMaxUnavailable: ptrInt(2), want: 8},
+		{name: "maxUnavailable wins over fallback", total: 10, maxUnavailable: ptrInt(3), fallbackMaxUnavailable: ptrInt(9), want: 7},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AvailabilityFloor(tc.total, tc.minAvailable, tc.maxUnavailable, tc.fallbackMaxUnavailable)
+			if got != tc.want {
+				t.Errorf("AvailabilityFloor(%d, %v, %v, %v) = %d; want %d",
+					tc.total, tc.minAvailable, tc.maxUnavailable, tc.fallbackMaxUnavailable, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Part 1 of 5** — multi-cluster placement control plane, split for reviewability. Merge in order 1→5.

**Series:**
1. #726 — IR projection + helpers *(this PR, foundation)*
2. #727 — WorkloadCluster transport
3. #728 — placement + endpoint publisher
4. #729 — controller config
5. #730 — manager wiring + RBAC

Adds the InferenceReplica projector (projects an ISVC Component into a per-(ISVC, Component) InferenceReplica and reads its authoritative status back) plus the shared helpers it needs:
- `pkg/utils/intstr.go`: `AvailabilityFloor`, the min-available floor helper.
- `inferenceservice/status/top_level_condition.go`: derive a Component's top-level readiness Condition from its `LifecycleStatus`.
- `inferenceservice/reconcilers/irprojector`: the projection + status-read package consumed by the placement admission path (#728).

This is the foundation of the series; it builds standalone.

> Note: the repo is squash-only, so this series is 5 cumulative PRs against `main` (fork branches can't be PR bases). After each merges, the remaining PRs rebase onto the new `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated management of inference replica resources for supported deployment components.
  - Component settings, labels, annotations, pod configuration, lifecycle, topology, pause state, and autoscaling are now reflected in replica resources.
  - Inference replica status is aggregated into component and top-level service status.
  - Readiness conditions now account for replica availability and disruption-budget settings.

- **Bug Fixes**
  - Avoids unnecessary updates and preserves autoscaler-managed replica counts.
  - Handles missing resources, concurrent creation, deletion, and transient update conflicts more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->