### PR TITLE
[Core] Multi-cluster: WorkloadCluster transport

### DIFF
--- a/charts/ome-resources/templates/ome-controller/rbac/role.yaml
+++ b/charts/ome-resources/templates/ome-controller/rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   - persistentvolumeclaims
   - persistentvolumes
   - pods
+  - secrets
   - serviceaccounts
   - services
   verbs:
@@ -31,16 +32,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - patch
-  - update
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -191,6 +182,7 @@ rules:
   - inferenceservices/finalizers
   - servingruntimes
   - servingruntimes/finalizers
+  - workloadclusters
   verbs:
   - create
   - delete
@@ -218,6 +210,7 @@ rules:
   - finetunedweights/status
   - inferenceservices/status
   - servingruntimes/status
+  - workloadclusters/status
   verbs:
   - get
   - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   - persistentvolumeclaims
   - persistentvolumes
   - pods
+  - secrets
   - serviceaccounts
   - services
   verbs:
@@ -31,16 +32,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - patch
-  - update
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -191,6 +182,7 @@ rules:
   - inferenceservices/finalizers
   - servingruntimes
   - servingruntimes/finalizers
+  - workloadclusters
   verbs:
   - create
   - delete
@@ -218,6 +210,7 @@ rules:
   - finetunedweights/status
   - inferenceservices/status
   - servingruntimes/status
+  - workloadclusters/status
   verbs:
   - get
   - patch

--- a/pkg/controller/v1beta1/workloadcluster/backoff.go
+++ b/pkg/controller/v1beta1/workloadcluster/backoff.go
@@ -1,0 +1,134 @@
+// The establish/retry backoff schedule below is adapted from kubernetes-sigs/
+// kueue (pkg/controller/admissionchecks/multikueue), Apache-2.0.
+
+package workloadcluster
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Default* are the graceful-degradation fallbacks for the connection-layer
+// timing knobs. They are NOT the operative values: those are config-driven
+// (manager flags / chart) and injected via functional Options. Absent config,
+// these keep the controller working with sane behavior rather than a magic
+// literal buried mid-function.
+const (
+	// DefaultEventsBatchPeriod debounces Secret-change re-enqueues. A rotated
+	// kubeconfig Secret typically updates several keys back-to-back; folding the
+	// burst into one reconcile avoids a thundering rebuild of the remote client.
+	DefaultEventsBatchPeriod = 100 * time.Millisecond
+
+	// DefaultEstablishInitialTimeout bounds the first attempt to establish a
+	// remote watch before it is abandoned and retried.
+	DefaultEstablishInitialTimeout = 1 * time.Minute
+	// DefaultEstablishMaxTimeout caps the (growing) establish-watch timeout.
+	DefaultEstablishMaxTimeout = 10 * time.Minute
+	// defaultEstablishFactor is the per-attempt growth factor for the establish
+	// timeout (1m, 2m, 4m, 8m, 10m, ...).
+	defaultEstablishFactor = 2.0
+
+	// DefaultReconnectRetryMax caps the inter-attempt retry delay. With a 5s
+	// increment doubling from 0, the schedule is 0, 5s, 10s, 20s, 40s, 80s,
+	// 160s, 320s (~5m20s) — matching the Kueue reference cap.
+	DefaultReconnectRetryMax = 320 * time.Second
+	// reconnectRetryIncrement is the base step the retry delay doubles from.
+	reconnectRetryIncrement = 5 * time.Second
+)
+
+// errWatchEstablishTimeout is returned when establishWatch's bounded attempt to
+// open a remote watch does not complete before the establish timeout, so the
+// caller falls back to the retry backoff.
+var errWatchEstablishTimeout = errors.New("watch establishment timed out")
+
+// establishWaitTime returns the establish-watch timeout for the given attempt
+// (1-based), growing from establishInitial by establishFactor up to
+// establishMax. attempt<=1 returns establishInitial.
+func (b reconnectBackoff) establishWaitTime(attempt int) time.Duration {
+	if attempt <= 1 {
+		return b.establishInitial
+	}
+	bo := wait.Backoff{
+		Duration: b.establishInitial,
+		Factor:   b.establishFactor,
+		Cap:      b.establishMax,
+		Steps:    attempt,
+	}
+	var d time.Duration
+	for i := 0; i < attempt; i++ {
+		d = bo.Step()
+		if d >= b.establishMax {
+			return b.establishMax
+		}
+	}
+	return d
+}
+
+// retryAfter returns the inter-attempt delay after failedAttempts consecutive
+// failures: 0 for the first, then retryInitial doubling up to retryMax. With
+// retryInitial==0 the increment falls back to reconnectRetryIncrement so the
+// schedule still grows (0, 5s, 10s, ... up to retryMax).
+func (b reconnectBackoff) retryAfter(failedAttempts uint) time.Duration {
+	if failedAttempts == 0 {
+		return 0
+	}
+	step := b.retryInitial
+	if step <= 0 {
+		step = reconnectRetryIncrement
+	}
+	d := step << (failedAttempts - 1)
+	if d > b.retryMax || d <= 0 { // d<=0 guards shift overflow
+		return b.retryMax
+	}
+	return d
+}
+
+// cancelOnStopWatcher carries the establishment context's cancel func so it runs
+// when Stop is called, satisfying govet's lostcancel check without shortening
+// the watch's stream lifetime on the success path.
+type cancelOnStopWatcher struct {
+	watch.Interface
+	cancel context.CancelFunc
+}
+
+func (cw *cancelOnStopWatcher) Stop() {
+	cw.Interface.Stop()
+	cw.cancel()
+}
+
+// establishWatch opens a remote watch bounded by timeout. On timeout the
+// in-flight Watch is canceled and errWatchEstablishTimeout is returned so the
+// caller falls back to the retry backoff.
+func establishWatch(ctx context.Context, c client.WithWatch, list client.ObjectList, timeout time.Duration, opts ...client.ListOption) (watch.Interface, error) {
+	type result struct {
+		w   watch.Interface
+		err error
+	}
+	resultCh := make(chan result, 1)
+	establishCtx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		w, err := c.Watch(establishCtx, list, opts...)
+		resultCh <- result{w: w, err: err}
+	}()
+
+	select {
+	case r := <-resultCh:
+		if r.err != nil {
+			cancel()
+			return nil, r.err
+		}
+		return &cancelOnStopWatcher{Interface: r.w, cancel: cancel}, nil
+	case <-time.After(timeout):
+		cancel()
+		if r := <-resultCh; r.w != nil {
+			r.w.Stop()
+		}
+		return nil, errWatchEstablishTimeout
+	}
+}

--- a/pkg/controller/v1beta1/workloadcluster/backoff.go
+++ b/pkg/controller/v1beta1/workloadcluster/backoff.go
@@ -126,9 +126,14 @@ func establishWatch(ctx context.Context, c client.WithWatch, list client.ObjectL
 		return &cancelOnStopWatcher{Interface: r.w, cancel: cancel}, nil
 	case <-time.After(timeout):
 		cancel()
-		if r := <-resultCh; r.w != nil {
-			r.w.Stop()
-		}
+		// Do not wait for a broken client implementation to honor cancellation.
+		// The buffered result channel lets the producer finish independently; a
+		// late watcher is still stopped so it cannot leak.
+		go func() {
+			if r := <-resultCh; r.w != nil {
+				r.w.Stop()
+			}
+		}()
 		return nil, errWatchEstablishTimeout
 	}
 }

--- a/pkg/controller/v1beta1/workloadcluster/connection.go
+++ b/pkg/controller/v1beta1/workloadcluster/connection.go
@@ -1,0 +1,167 @@
+// Package workloadcluster implements the WorkloadCluster registry
+// controller: it resolves each cluster's kubeconfig, connects, and reports a
+// Ready (reachable) condition. Capacity is never read here.
+package workloadcluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// ExecCredentialPolicy controls whether a kubeconfig may use an exec credential
+// plugin to authenticate to a workload cluster, and which commands are allowed.
+// The zero value denies exec (the safe default).
+type ExecCredentialPolicy struct {
+	// Allowed turns exec credential plugins on. Default false.
+	Allowed bool
+	// AllowedCommands is the set of permitted plugin command basenames
+	// (e.g. "aws", "gke-gcloud-auth-plugin", "kubelogin"). Empty => none allowed.
+	AllowedCommands []string
+}
+
+func (p ExecCredentialPolicy) commandAllowed(cmd string) bool {
+	base := filepath.Base(cmd)
+	for _, a := range p.AllowedCommands {
+		if a == base || a == cmd {
+			return true
+		}
+	}
+	return false
+}
+
+// RESTConfigFromKubeConfig parses raw kubeconfig bytes into a *rest.Config and
+// rejects credential shapes that are unsafe to run from the control plane — a
+// stored kubeconfig is a cross-cluster blast radius.
+// It validates twice, mirroring Kueue's validateKubeconfig: once over the raw
+// kubeconfig (every cluster/user, before flattening) and once over the
+// flattened rest.Config.
+func RESTConfigFromKubeConfig(raw []byte, exec ExecCredentialPolicy) (*rest.Config, error) {
+	if err := validateKubeConfigBytes(raw, exec); err != nil {
+		return nil, err
+	}
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse kubeconfig: %w", err)
+	}
+	if err := validateRESTConfig(cfg, exec); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// validateKubeConfigBytes inspects the raw kubeconfig at the API-config level
+// (across ALL clusters and users, not just the current context) and rejects:
+// per-user on-disk token files, per-cluster insecure TLS, CA file paths
+// (require inline certificate-authority-data), and a missing server URL.
+func validateKubeConfigBytes(raw []byte, exec ExecCredentialPolicy) error {
+	cfg, err := clientcmd.Load(raw)
+	if err != nil {
+		return fmt.Errorf("parse kubeconfig: %w", err)
+	}
+	for name, authInfo := range cfg.AuthInfos {
+		if authInfo.Exec != nil && !exec.Allowed {
+			return fmt.Errorf("kubeconfig user %q uses an exec credential plugin, which is not allowed (enable --allow-exec-credentials)", name)
+		}
+		if authInfo.TokenFile != "" {
+			return fmt.Errorf("kubeconfig user %q references an on-disk token file, which is not allowed", name)
+		}
+	}
+	for name, cluster := range cfg.Clusters {
+		if cluster.InsecureSkipTLSVerify {
+			return fmt.Errorf("kubeconfig disables TLS verification for cluster %q, which is not allowed", name)
+		}
+		if cluster.CertificateAuthority != "" {
+			return fmt.Errorf("kubeconfig cluster %q uses a certificate-authority file path; use certificate-authority-data instead", name)
+		}
+		if cluster.Server == "" {
+			return fmt.Errorf("kubeconfig cluster %q has no server URL", name)
+		}
+	}
+	return nil
+}
+
+// validateRESTConfig rejects unsafe settings on the flattened rest.Config:
+// exec/auth-provider plugins, on-disk token files, basic auth, disabled TLS, a
+// CA file path, or an untrusted server endpoint. BearerToken (service-account
+// token) and inline CA data are allowed.
+func validateRESTConfig(cfg *rest.Config, exec ExecCredentialPolicy) error {
+	switch {
+	case cfg.ExecProvider != nil:
+		if !exec.Allowed {
+			return errors.New("kubeconfig uses an exec credential plugin, which is not allowed (enable --allow-exec-credentials)")
+		}
+		if !exec.commandAllowed(cfg.ExecProvider.Command) {
+			return fmt.Errorf("exec credential plugin command %q is not in the allowed list", cfg.ExecProvider.Command)
+		}
+	case cfg.AuthProvider != nil:
+		return errors.New("kubeconfig uses an auth-provider plugin, which is not allowed")
+	case cfg.BearerTokenFile != "":
+		return errors.New("kubeconfig references an on-disk token file, which is not allowed")
+	case cfg.Username != "" || cfg.Password != "":
+		return errors.New("kubeconfig uses basic auth, which is not allowed")
+	case cfg.TLSClientConfig.Insecure:
+		return errors.New("kubeconfig disables TLS verification, which is not allowed")
+	case cfg.TLSClientConfig.CAFile != "":
+		return errors.New("kubeconfig uses a CA file path; use inline CA data instead")
+	case !isValidHostname(cfg.Host):
+		return errors.New("kubeconfig server endpoint is not a trusted host")
+	}
+	return nil
+}
+
+// isValidHostname reports whether server is an https endpoint whose host is a
+// valid IP or DNS name — guards against malformed/untrusted endpoints. Mirrors
+// Kueue's isValidHostname (url.Parse -> SplitHostPort -> ParseIP / DNS1123).
+func isValidHostname(server string) bool {
+	u, err := url.Parse(strings.ToLower(server))
+	if err != nil {
+		return false
+	}
+	// A workload-cluster API endpoint carries a cross-cluster bearer credential;
+	// it MUST be reached over TLS. Reject plaintext (http) and scheme-less
+	// endpoints so a credential is never sent in the clear.
+	if u.Scheme != "https" {
+		return false
+	}
+	host := u.Host
+	if h, _, err := net.SplitHostPort(u.Host); err == nil {
+		host = h
+	}
+	if host == "" {
+		return false
+	}
+	if net.ParseIP(host) != nil {
+		return true
+	}
+	return len(validation.IsDNS1123Subdomain(host)) == 0
+}
+
+// probeViaServerVersion is the default reachability probe: build a discovery
+// client and fetch the remote /version. Cheap and needs no extra RBAC. It is
+// assigned to Reconciler.Probe by SetupWithManager and overridden in tests.
+func probeViaServerVersion(_ context.Context, raw []byte, exec ExecCredentialPolicy) error {
+	cfg, err := RESTConfigFromKubeConfig(raw, exec)
+	if err != nil {
+		return err
+	}
+	cfg.Timeout = 10 * time.Second
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("build discovery client: %w", err)
+	}
+	if _, err := dc.ServerVersion(); err != nil {
+		return fmt.Errorf("connect to cluster: %w", err)
+	}
+	return nil
+}

--- a/pkg/controller/v1beta1/workloadcluster/connection.go
+++ b/pkg/controller/v1beta1/workloadcluster/connection.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -31,9 +30,11 @@ type ExecCredentialPolicy struct {
 }
 
 func (p ExecCredentialPolicy) commandAllowed(cmd string) bool {
-	base := filepath.Base(cmd)
 	for _, a := range p.AllowedCommands {
-		if a == base || a == cmd {
+		// Exact matching permits either a bare command resolved through PATH or
+		// an explicitly allowlisted absolute path. It must never let an
+		// attacker-controlled path through merely because its basename matches.
+		if a == cmd {
 			return true
 		}
 	}
@@ -76,6 +77,9 @@ func validateKubeConfigBytes(raw []byte, exec ExecCredentialPolicy) error {
 		if authInfo.TokenFile != "" {
 			return fmt.Errorf("kubeconfig user %q references an on-disk token file, which is not allowed", name)
 		}
+		if authInfo.ClientCertificate != "" || authInfo.ClientKey != "" {
+			return fmt.Errorf("kubeconfig user %q references on-disk client certificate/key files; use inline certificate and key data instead", name)
+		}
 	}
 	for name, cluster := range cfg.Clusters {
 		if cluster.InsecureSkipTLSVerify {
@@ -96,14 +100,15 @@ func validateKubeConfigBytes(raw []byte, exec ExecCredentialPolicy) error {
 // CA file path, or an untrusted server endpoint. BearerToken (service-account
 // token) and inline CA data are allowed.
 func validateRESTConfig(cfg *rest.Config, exec ExecCredentialPolicy) error {
-	switch {
-	case cfg.ExecProvider != nil:
+	if cfg.ExecProvider != nil {
 		if !exec.Allowed {
 			return errors.New("kubeconfig uses an exec credential plugin, which is not allowed (enable --allow-exec-credentials)")
 		}
 		if !exec.commandAllowed(cfg.ExecProvider.Command) {
 			return fmt.Errorf("exec credential plugin command %q is not in the allowed list", cfg.ExecProvider.Command)
 		}
+	}
+	switch {
 	case cfg.AuthProvider != nil:
 		return errors.New("kubeconfig uses an auth-provider plugin, which is not allowed")
 	case cfg.BearerTokenFile != "":
@@ -114,6 +119,8 @@ func validateRESTConfig(cfg *rest.Config, exec ExecCredentialPolicy) error {
 		return errors.New("kubeconfig disables TLS verification, which is not allowed")
 	case cfg.TLSClientConfig.CAFile != "":
 		return errors.New("kubeconfig uses a CA file path; use inline CA data instead")
+	case cfg.TLSClientConfig.CertFile != "" || cfg.TLSClientConfig.KeyFile != "":
+		return errors.New("kubeconfig uses client certificate/key file paths; use inline data instead")
 	case !isValidHostname(cfg.Host):
 		return errors.New("kubeconfig server endpoint is not a trusted host")
 	}

--- a/pkg/controller/v1beta1/workloadcluster/connection.go
+++ b/pkg/controller/v1beta1/workloadcluster/connection.go
@@ -24,8 +24,11 @@ import (
 type ExecCredentialPolicy struct {
 	// Allowed turns exec credential plugins on. Default false.
 	Allowed bool
-	// AllowedCommands is the set of permitted plugin command basenames
-	// (e.g. "aws", "gke-gcloud-auth-plugin", "kubelogin"). Empty => none allowed.
+	// AllowedCommands is the set of permitted plugin commands, matched exactly
+	// against the command the kubeconfig names. List a bare command (e.g. "aws",
+	// "gke-gcloud-auth-plugin", "kubelogin") to permit PATH resolution, or an
+	// absolute path to pin one binary; a bare entry does NOT permit a path that
+	// merely ends in that name. Empty => none allowed.
 	AllowedCommands []string
 }
 
@@ -154,15 +157,24 @@ func isValidHostname(server string) bool {
 	return len(validation.IsDNS1123Subdomain(host)) == 0
 }
 
+// DefaultProbeTimeout bounds the reachability probe's single /version request
+// when no per-call timeout is configured. An unbounded probe would let one
+// black-holed endpoint hold a reconcile worker indefinitely.
+const DefaultProbeTimeout = 10 * time.Second
+
 // probeViaServerVersion is the default reachability probe: build a discovery
 // client and fetch the remote /version. Cheap and needs no extra RBAC. It is
 // assigned to Reconciler.Probe by SetupWithManager and overridden in tests.
-func probeViaServerVersion(_ context.Context, raw []byte, exec ExecCredentialPolicy) error {
+// A non-positive timeout falls back to DefaultProbeTimeout.
+func probeViaServerVersion(_ context.Context, raw []byte, exec ExecCredentialPolicy, timeout time.Duration) error {
 	cfg, err := RESTConfigFromKubeConfig(raw, exec)
 	if err != nil {
 		return err
 	}
-	cfg.Timeout = 10 * time.Second
+	if timeout <= 0 {
+		timeout = DefaultProbeTimeout
+	}
+	cfg.Timeout = timeout
 	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("build discovery client: %w", err)

--- a/pkg/controller/v1beta1/workloadcluster/connection_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/connection_test.go
@@ -21,6 +21,8 @@ func TestValidateRESTConfig(t *testing.T) {
 		{"insecure TLS", &rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}}, ExecCredentialPolicy{}, true},
 		{"basic auth", &rest.Config{Host: "https://h", Username: "u", Password: "p"}, ExecCredentialPolicy{}, true},
 		{"ca file path", &rest.Config{Host: "https://h", TLSClientConfig: rest.TLSClientConfig{CAFile: "/etc/ca.crt"}}, ExecCredentialPolicy{}, true},
+		{"client certificate file path", &rest.Config{Host: "https://h", TLSClientConfig: rest.TLSClientConfig{CertFile: "/etc/client.crt", KeyFile: "/etc/client.key"}}, ExecCredentialPolicy{}, true},
+		{"allowed exec still validates host", &rest.Config{Host: "http://h", ExecProvider: &clientcmdapi.ExecConfig{Command: "aws"}}, ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"aws"}}, true},
 		{"untrusted host", &rest.Config{Host: "https://bad_host"}, ExecCredentialPolicy{}, true},
 	}
 	for _, tc := range cases {
@@ -86,6 +88,17 @@ clusters:
   cluster:
     certificate-authority-data: ZHVtbXk=
 `
+	const clientCertificatePath = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster: {server: https://example.com, certificate-authority-data: ZHVtbXk=}
+users:
+- name: u
+  user:
+    client-certificate: /etc/client.crt
+    client-key: /etc/client.key
+`
 	cases := []struct {
 		name    string
 		raw     string
@@ -95,6 +108,7 @@ clusters:
 		{"per-user token file", tokenFile, true},
 		{"per-cluster insecure", insecure, true},
 		{"ca file path", caPath, true},
+		{"client certificate file path", clientCertificatePath, true},
 		{"missing server", noServer, true},
 		{"malformed", "this is not a kubeconfig", true},
 	}
@@ -105,6 +119,19 @@ clusters:
 				t.Errorf("validateKubeConfigBytes() err=%v wantErr=%v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestExecCredentialPolicy_CommandAllowed(t *testing.T) {
+	p := ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"aws", "/usr/local/bin/kubelogin"}}
+	if !p.commandAllowed("aws") {
+		t.Fatal("bare allowlisted command was rejected")
+	}
+	if !p.commandAllowed("/usr/local/bin/kubelogin") {
+		t.Fatal("exact allowlisted command path was rejected")
+	}
+	if p.commandAllowed("/tmp/attacker/aws") {
+		t.Fatal("path-qualified command matched a bare allowlist entry")
 	}
 }
 

--- a/pkg/controller/v1beta1/workloadcluster/connection_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/connection_test.go
@@ -1,0 +1,179 @@
+package workloadcluster
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestValidateRESTConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     *rest.Config
+		exec    ExecCredentialPolicy
+		wantErr bool
+	}{
+		{"clean", &rest.Config{Host: "https://h", BearerToken: "t", TLSClientConfig: rest.TLSClientConfig{CAData: []byte("ca")}}, ExecCredentialPolicy{}, false},
+		{"clean ip host", &rest.Config{Host: "https://10.0.0.1:6443", BearerToken: "t"}, ExecCredentialPolicy{}, false},
+		{"exec provider denied", &rest.Config{ExecProvider: &clientcmdapi.ExecConfig{Command: "aws"}}, ExecCredentialPolicy{}, true},
+		{"bearer token file", &rest.Config{BearerTokenFile: "/var/run/token"}, ExecCredentialPolicy{}, true},
+		{"insecure TLS", &rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}}, ExecCredentialPolicy{}, true},
+		{"basic auth", &rest.Config{Host: "https://h", Username: "u", Password: "p"}, ExecCredentialPolicy{}, true},
+		{"ca file path", &rest.Config{Host: "https://h", TLSClientConfig: rest.TLSClientConfig{CAFile: "/etc/ca.crt"}}, ExecCredentialPolicy{}, true},
+		{"untrusted host", &rest.Config{Host: "https://bad_host"}, ExecCredentialPolicy{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRESTConfig(tc.cfg, tc.exec)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateRESTConfig() err=%v wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateKubeConfigBytes pins the raw-kubeconfig-level checks (run across
+// ALL clusters/users, before flattening): per-user token files, per-cluster
+// insecure TLS, and CA file paths are rejected; a server URL is required.
+func TestValidateKubeConfigBytes(t *testing.T) {
+	const clean = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://example.com
+    certificate-authority-data: ZHVtbXk=
+contexts:
+- name: ctx
+  context: {cluster: c, user: u}
+current-context: ctx
+users:
+- name: u
+  user:
+    token: abc
+`
+	const tokenFile = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster: {server: https://example.com, certificate-authority-data: ZHVtbXk=}
+users:
+- name: u
+  user:
+    tokenFile: /var/run/secrets/token
+`
+	const insecure = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://example.com
+    insecure-skip-tls-verify: true
+`
+	const caPath = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://example.com
+    certificate-authority: /etc/ca.crt
+`
+	const noServer = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    certificate-authority-data: ZHVtbXk=
+`
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{"clean", clean, false},
+		{"per-user token file", tokenFile, true},
+		{"per-cluster insecure", insecure, true},
+		{"ca file path", caPath, true},
+		{"missing server", noServer, true},
+		{"malformed", "this is not a kubeconfig", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateKubeConfigBytes([]byte(tc.raw), ExecCredentialPolicy{})
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateKubeConfigBytes() err=%v wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestIsValidHostname_RequiresHTTPS pins that a workload-cluster endpoint must
+// be reached over TLS: a plaintext (http) or scheme-less server is rejected so
+// the cross-cluster bearer credential is never sent in the clear.
+func TestIsValidHostname_RequiresHTTPS(t *testing.T) {
+	cases := []struct {
+		name   string
+		server string
+		want   bool
+	}{
+		{"https dns", "https://api.example.com:6443", true},
+		{"https ip", "https://10.0.0.1:6443", true},
+		{"http rejected", "http://api.example.com:6443", false},
+		{"http ip rejected", "http://10.0.0.1:6443", false},
+		{"scheme-less rejected", "api.example.com:6443", false},
+		{"empty rejected", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidHostname(tc.server); got != tc.want {
+				t.Errorf("isValidHostname(%q) = %v, want %v", tc.server, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRESTConfigFromKubeConfig_BadBytes(t *testing.T) {
+	if _, err := RESTConfigFromKubeConfig([]byte("not-a-kubeconfig"), ExecCredentialPolicy{}); err == nil {
+		t.Errorf("expected error for malformed kubeconfig, got nil")
+	}
+}
+
+func TestRESTConfig_ExecPolicy(t *testing.T) {
+	const execKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://example.com
+    certificate-authority-data: ZHVtbXk=
+contexts:
+- name: ctx
+  context: {cluster: c, user: u}
+current-context: ctx
+users:
+- name: u
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: aws
+      args: ["eks","get-token","--cluster-name","c"]
+`
+	cases := []struct {
+		name    string
+		exec    ExecCredentialPolicy
+		wantErr bool
+	}{
+		{"deny exec (zero policy)", ExecCredentialPolicy{}, true},
+		{"allow aws command", ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"aws"}}, false},
+		{"command not in allowlist", ExecCredentialPolicy{Allowed: true, AllowedCommands: []string{"kubelogin"}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := RESTConfigFromKubeConfig([]byte(execKubeconfig), tc.exec)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("RESTConfigFromKubeConfig() err=%v wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/controller/v1beta1/workloadcluster/controller.go
+++ b/pkg/controller/v1beta1/workloadcluster/controller.go
@@ -39,6 +39,8 @@ const DefaultHealthInterval = time.Minute
 // default".
 const DefaultConnectionGracePeriod = 2 * time.Minute
 
+const kubeConfigSecretRefIndex = "spec.clusterSource.kubeConfig.secretRef"
+
 // +kubebuilder:rbac:groups=ome.io,resources=workloadclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ome.io,resources=workloadclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
@@ -365,10 +367,22 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts ...Option) error {
 	if r.Manager != nil {
 		r.Manager.SetReconnectBackoff(cfg.reconnect)
 	}
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &v1beta1.WorkloadCluster{}, kubeConfigSecretRefIndex, kubeConfigSecretRefValues); err != nil {
+		return fmt.Errorf("index WorkloadClusters by kubeconfig Secret: %w", err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.WorkloadCluster{}).
 		Watches(&corev1.Secret{}, r.secretEventHandler(cfg.eventsBatchPeriod)).
 		Complete(r)
+}
+
+func kubeConfigSecretRefValues(obj client.Object) []string {
+	wc := obj.(*v1beta1.WorkloadCluster)
+	kc := wc.Spec.ClusterSource.KubeConfig
+	if kc == nil || kc.SecretRef.Name == "" || kc.SecretRef.Namespace == "" {
+		return nil
+	}
+	return []string{types.NamespacedName{Namespace: kc.SecretRef.Namespace, Name: kc.SecretRef.Name}.String()}
 }
 
 // secretEventHandler re-enqueues the WorkloadClusters referencing a changed
@@ -402,15 +416,14 @@ func (r *Reconciler) secretEventHandler(batchPeriod time.Duration) handler.Event
 // kubeConfig.secretRef points at it.
 func (r *Reconciler) workloadClustersForSecret(ctx context.Context, obj client.Object) []ctrl.Request {
 	list := &v1beta1.WorkloadClusterList{}
-	if err := r.List(ctx, list); err != nil {
+	key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}.String()
+	if err := r.List(ctx, list, client.MatchingFields{kubeConfigSecretRefIndex: key}); err != nil {
+		r.Log.Error(err, "list WorkloadClusters for kubeconfig Secret", "secret", key)
 		return nil
 	}
-	var reqs []ctrl.Request
+	reqs := make([]ctrl.Request, 0, len(list.Items))
 	for i := range list.Items {
-		kc := list.Items[i].Spec.ClusterSource.KubeConfig
-		if kc != nil && kc.SecretRef.Name == obj.GetName() && kc.SecretRef.Namespace == obj.GetNamespace() {
-			reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: list.Items[i].Name}})
-		}
+		reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: list.Items[i].Name}})
 	}
 	return reqs
 }

--- a/pkg/controller/v1beta1/workloadcluster/controller.go
+++ b/pkg/controller/v1beta1/workloadcluster/controller.go
@@ -311,7 +311,11 @@ func (r *Reconciler) assess(ctx context.Context, wc *v1beta1.WorkloadCluster) (s
 			return metav1.ConditionFalse, "SecretNotFound",
 				fmt.Sprintf("kubeconfig Secret %s/%s not found", nn.Namespace, nn.Name), nil
 		}
-		return metav1.ConditionFalse, "SecretNotFound", err.Error(), nil
+		// Local-apiserver read failures are transient transport failures, not a
+		// missing configuration. Reuse the connection grace path so one timeout
+		// does not discard an otherwise healthy remote client.
+		return metav1.ConditionFalse, "ConnectionFailed",
+			fmt.Sprintf("reading kubeconfig Secret %s/%s: %v", nn.Namespace, nn.Name, err), nil
 	}
 	raw, ok := secret.Data[key]
 	if !ok || len(raw) == 0 {

--- a/pkg/controller/v1beta1/workloadcluster/controller.go
+++ b/pkg/controller/v1beta1/workloadcluster/controller.go
@@ -68,6 +68,11 @@ type Reconciler struct {
 	// disconnected; zero defaults to DefaultConnectionGracePeriod. A negative
 	// value disables grace.
 	ConnectionGracePeriod time.Duration
+	// ProbeTimeout bounds the default reachability probe's single request. It is
+	// the same budget as a remote per-call timeout, so the control-plane wiring
+	// feeds it the configured per-call value; zero defaults to
+	// DefaultProbeTimeout.
+	ProbeTimeout time.Duration
 
 	// mu guards firstFailure. The reconciler runs single-worker per key, but
 	// firstFailure is shared across keys.
@@ -347,6 +352,16 @@ func (r *Reconciler) healthInterval() time.Duration {
 	return DefaultHealthInterval
 }
 
+func (r *Reconciler) probeTimeout() time.Duration {
+	if r.cfg != nil {
+		return r.cfg.probeTimeout
+	}
+	if r.ProbeTimeout > 0 {
+		return r.ProbeTimeout
+	}
+	return DefaultProbeTimeout
+}
+
 // SetupWithManager wires the reconciler: watch WorkloadClusters, and re-enqueue
 // (debounced by the events-batch period) when a referenced kubeconfig Secret
 // changes. Functional Options shrink the timing knobs (health interval,
@@ -354,7 +369,7 @@ func (r *Reconciler) healthInterval() time.Duration {
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts ...Option) error {
 	if r.Probe == nil {
 		r.Probe = func(ctx context.Context, raw []byte) error {
-			return probeViaServerVersion(ctx, raw, r.ExecPolicy)
+			return probeViaServerVersion(ctx, raw, r.ExecPolicy, r.probeTimeout())
 		}
 	}
 	if r.firstFailure == nil {

--- a/pkg/controller/v1beta1/workloadcluster/controller.go
+++ b/pkg/controller/v1beta1/workloadcluster/controller.go
@@ -1,0 +1,412 @@
+package workloadcluster
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// DefaultHealthInterval is the fallback re-probe cadence used when
+// Reconciler.HealthInterval is unset — how often a WorkloadCluster is re-probed
+// for reachability when nothing else triggers a reconcile. The operative value
+// is supplied by the manager flag / chart; this is the graceful-degradation
+// default.
+const DefaultHealthInterval = time.Minute
+
+// DefaultConnectionGracePeriod is the fallback window during which a cluster
+// that was previously reachable tolerates transient probe failures before it is
+// flipped to Ready=False and disconnected. A single failed /version probe (a
+// momentary blip) must not tear down a live, working connection. The operative
+// value is supplied by the manager flag / chart; this is the
+// graceful-degradation default. A negative ConnectionGracePeriod disables
+// grace (flip to Ready=False on the first failure); zero means "use this
+// default".
+const DefaultConnectionGracePeriod = 2 * time.Minute
+
+// +kubebuilder:rbac:groups=ome.io,resources=workloadclusters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ome.io,resources=workloadclusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+
+// Reconciler reconciles a WorkloadCluster: it resolves the cluster's
+// kubeconfig, probes reachability, and stamps the Ready condition. It does NOT
+// read capacity — that is a placer concern.
+type Reconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	Log    logr.Logger
+	// Probe reports whether the cluster described by these kubeconfig bytes is
+	// reachable. Defaults to probeViaServerVersion; overridden in tests.
+	Probe func(ctx context.Context, kubeconfig []byte) error
+	// HealthInterval is the re-probe cadence; defaults to DefaultHealthInterval.
+	HealthInterval time.Duration
+	// Manager holds the live per-cluster clients; the reconciler connects a
+	// cluster when it becomes Reachable and disconnects it on removal. Optional
+	// (nil-safe) so the health-only path keeps working without transport.
+	Manager *Manager
+	// ExecPolicy is the exec credential policy applied during validation.
+	ExecPolicy ExecCredentialPolicy
+	// ConnectionGracePeriod is how long a previously reachable cluster tolerates
+	// transient probe failures before it is flipped to Ready=False and
+	// disconnected; zero defaults to DefaultConnectionGracePeriod. A negative
+	// value disables grace.
+	ConnectionGracePeriod time.Duration
+
+	// mu guards firstFailure. The reconciler runs single-worker per key, but
+	// firstFailure is shared across keys.
+	mu sync.Mutex
+	// firstFailure records, per cluster, when the current run of consecutive
+	// probe failures began. Cleared on a successful probe. Used to keep a live
+	// connection up across brief blips (within ConnectionGracePeriod).
+	firstFailure map[string]time.Time
+	// failCount records, per cluster, how many consecutive connection failures
+	// have occurred. It drives the reconnect retry backoff (retryAfter) so a
+	// persistently-down cluster is re-probed with exponentially-spaced requeues
+	// instead of every health interval. Cleared on a successful pass.
+	failCount map[string]uint
+
+	// cfg is the resolved timing configuration assembled at SetupWithManager
+	// from functional Options (seeded by the HealthInterval/ConnectionGracePeriod
+	// struct fields). Nil until Setup runs — the helper methods fall back to the
+	// struct fields + Default* consts so a Reconciler built directly (unit tests)
+	// keeps working without Setup.
+	cfg *controllerConfig
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	wc := &v1beta1.WorkloadCluster{}
+	if err := r.Get(ctx, req.NamespacedName, wc); err != nil {
+		if apierrors.IsNotFound(err) {
+			if r.Manager != nil {
+				r.Manager.Disconnect(req.Name)
+			}
+			r.clearFailure(req.Name)
+			r.clearRetry(req.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	status, reason, msg, raw := r.assess(ctx, wc)
+
+	// Reconnect/backoff: a transient probe failure must not immediately tear
+	// down a live, working connection. If the only thing that failed is the
+	// reachability probe (ConnectionFailed) and we still hold a connection that
+	// failed within the grace window, hold the previous Ready=True and keep the
+	// client connected. Only after the grace period elapses do we flip to
+	// Ready=False and disconnect. Non-probe failures (bad secret/kubeconfig/
+	// unsupported source) are config problems, not blips: act on them at once.
+	requeue := r.healthInterval()
+	if status == metav1.ConditionFalse && reason == "ConnectionFailed" && r.withinGrace(wc.Name) {
+		// Re-probe sooner than the steady-state cadence so a real outage is
+		// confirmed (and torn down) promptly once grace expires.
+		requeue = r.graceRequeue()
+		apimeta.SetStatusCondition(&wc.Status.Conditions, metav1.Condition{
+			Type:               v1beta1.WorkloadClusterReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             "ProbeFailedRetrying",
+			Message:            fmt.Sprintf("transient probe failure, holding connection within grace period: %s", msg),
+			ObservedGeneration: wc.Generation,
+		})
+		// Leave the existing connection in place; do not Connect/Disconnect.
+		return r.finish(ctx, wc, requeue)
+	}
+
+	if status == metav1.ConditionTrue {
+		r.clearFailure(wc.Name)
+	} else if reason == "ConnectionFailed" {
+		r.recordFailure(wc.Name)
+	} else {
+		// Non-probe failure: not a blip, so reset the failure clock.
+		r.clearFailure(wc.Name)
+	}
+
+	apimeta.SetStatusCondition(&wc.Status.Conditions, metav1.Condition{
+		Type:               v1beta1.WorkloadClusterReady,
+		Status:             status,
+		Reason:             reason,
+		Message:            msg,
+		ObservedGeneration: wc.Generation,
+	})
+	connFailed := status != metav1.ConditionTrue && reason == "ConnectionFailed"
+	if r.Manager != nil {
+		if status == metav1.ConditionTrue {
+			if err := r.Manager.Connect(r.connectCtx(), wc.Name, raw); err != nil {
+				r.recordFailure(wc.Name)
+				connFailed = true
+				apimeta.SetStatusCondition(&wc.Status.Conditions, metav1.Condition{
+					Type:               v1beta1.WorkloadClusterReady,
+					Status:             metav1.ConditionFalse,
+					Reason:             "ConnectionFailed",
+					Message:            err.Error(),
+					ObservedGeneration: wc.Generation,
+				})
+			}
+		} else {
+			r.Manager.Disconnect(wc.Name)
+		}
+	}
+	// Space reconnect attempts to a down cluster with the retry backoff
+	// (0 -> ~5m20s) instead of hammering at the health interval, and clear the
+	// counter once the cluster is healthy again.
+	if connFailed {
+		requeue = r.nextRetryRequeue(wc.Name)
+	} else {
+		r.clearRetry(wc.Name)
+	}
+	return r.finish(ctx, wc, requeue)
+}
+
+// finish writes the status and returns the steady requeue.
+func (r *Reconciler) finish(ctx context.Context, wc *v1beta1.WorkloadCluster, requeue time.Duration) (ctrl.Result, error) {
+	if err := r.Status().Update(ctx, wc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("workloadcluster %s: update status: %w", wc.Name, err)
+	}
+	return ctrl.Result{RequeueAfter: requeue}, nil
+}
+
+// connectCtx returns the long-lived context that remote clients (and their
+// future cache informers) must derive from, so they outlive the request-scoped
+// reconcile ctx and are torn down only by Manager.Disconnect / Stop. Falls back
+// to context.Background() when no base context was wired (e.g. unit tests that
+// build the Reconciler directly).
+func (r *Reconciler) connectCtx() context.Context {
+	if r.Manager != nil {
+		if base := r.Manager.BaseContext(); base != nil {
+			return base
+		}
+	}
+	return context.Background()
+}
+
+func (r *Reconciler) gracePeriod() time.Duration {
+	if r.cfg != nil {
+		return r.cfg.connectionGracePeriod
+	}
+	if r.ConnectionGracePeriod != 0 {
+		return r.ConnectionGracePeriod
+	}
+	return DefaultConnectionGracePeriod
+}
+
+// graceRequeue is the re-probe cadence used while holding a connection within
+// the grace window. It is the shorter of the health interval and the grace
+// period so the outage is confirmed promptly without busy-looping.
+func (r *Reconciler) graceRequeue() time.Duration {
+	g := r.gracePeriod()
+	h := r.healthInterval()
+	if g > 0 && g < h {
+		return g
+	}
+	return h
+}
+
+// withinGrace reports whether the named cluster is still inside its transient-
+// failure grace window AND currently holds a live connection. A cluster with no
+// connection (or no Manager) cannot be "held", so it is never within grace.
+func (r *Reconciler) withinGrace(name string) bool {
+	if r.Manager == nil {
+		return false
+	}
+	if _, connected := r.Manager.ClientFor(name); !connected {
+		return false
+	}
+	g := r.gracePeriod()
+	if g <= 0 {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.firstFailure == nil {
+		r.firstFailure = map[string]time.Time{}
+	}
+	first, ok := r.firstFailure[name]
+	if !ok {
+		// First failure of a previously-healthy connection: start the clock and
+		// hold the connection this pass.
+		r.firstFailure[name] = time.Now()
+		return true
+	}
+	return time.Since(first) < g
+}
+
+func (r *Reconciler) recordFailure(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.firstFailure == nil {
+		r.firstFailure = map[string]time.Time{}
+	}
+	if _, ok := r.firstFailure[name]; !ok {
+		r.firstFailure[name] = time.Now()
+	}
+}
+
+func (r *Reconciler) clearFailure(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.firstFailure, name)
+}
+
+// nextRetryRequeue increments the cluster's consecutive-failure count and
+// returns the retry-backoff delay for it (0 on the first failure, then growing
+// to the configured cap). Falls back to the default backoff when Setup has not
+// resolved one (e.g. unit tests building the Reconciler directly).
+func (r *Reconciler) nextRetryRequeue(name string) time.Duration {
+	r.mu.Lock()
+	if r.failCount == nil {
+		r.failCount = map[string]uint{}
+	}
+	r.failCount[name]++
+	n := r.failCount[name]
+	r.mu.Unlock()
+
+	b := defaultReconnectBackoff()
+	if r.cfg != nil {
+		b = r.cfg.reconnect
+	}
+	return b.retryAfter(n)
+}
+
+func (r *Reconciler) clearRetry(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.failCount, name)
+}
+
+// assess resolves the connection and probes it, returning the Ready condition
+// fields. The Probe is injected so this is unit-testable without a real cluster.
+func (r *Reconciler) assess(ctx context.Context, wc *v1beta1.WorkloadCluster) (status metav1.ConditionStatus, reason, msg string, kubeconfig []byte) {
+	src := wc.Spec.ClusterSource
+	if src.KubeConfig == nil {
+		return metav1.ConditionFalse, "ClusterProfileUnsupported",
+			"clusterProfileRef is not yet supported; use kubeConfig", nil
+	}
+
+	key := src.KubeConfig.Key
+	if key == "" {
+		key = "kubeconfig"
+	}
+	secret := &corev1.Secret{}
+	nn := types.NamespacedName{Name: src.KubeConfig.SecretRef.Name, Namespace: src.KubeConfig.SecretRef.Namespace}
+	if err := r.Get(ctx, nn, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return metav1.ConditionFalse, "SecretNotFound",
+				fmt.Sprintf("kubeconfig Secret %s/%s not found", nn.Namespace, nn.Name), nil
+		}
+		return metav1.ConditionFalse, "SecretNotFound", err.Error(), nil
+	}
+	raw, ok := secret.Data[key]
+	if !ok || len(raw) == 0 {
+		return metav1.ConditionFalse, "BadKubeConfig",
+			fmt.Sprintf("Secret %s/%s has no %q key", nn.Namespace, nn.Name, key), nil
+	}
+	// Validate the kubeconfig (parse + security: reject exec/token-file/insecure)
+	// BEFORE probing. This keeps "malformed/unsafe kubeconfig" (BadKubeConfig)
+	// distinct from "cluster unreachable" (ConnectionFailed), and ensures the
+	// security validation runs regardless of which probe is in use.
+	if _, err := RESTConfigFromKubeConfig(raw, r.ExecPolicy); err != nil {
+		return metav1.ConditionFalse, "BadKubeConfig", err.Error(), nil
+	}
+	if err := r.Probe(ctx, raw); err != nil {
+		return metav1.ConditionFalse, "ConnectionFailed", err.Error(), nil
+	}
+	return metav1.ConditionTrue, "Reachable", "", raw
+}
+
+func (r *Reconciler) healthInterval() time.Duration {
+	if r.cfg != nil {
+		return r.cfg.healthInterval
+	}
+	if r.HealthInterval > 0 {
+		return r.HealthInterval
+	}
+	return DefaultHealthInterval
+}
+
+// SetupWithManager wires the reconciler: watch WorkloadClusters, and re-enqueue
+// (debounced by the events-batch period) when a referenced kubeconfig Secret
+// changes. Functional Options shrink the timing knobs (health interval,
+// worker-lost timeout, reconnect backoff, events-batch period) for tests.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts ...Option) error {
+	if r.Probe == nil {
+		r.Probe = func(ctx context.Context, raw []byte) error {
+			return probeViaServerVersion(ctx, raw, r.ExecPolicy)
+		}
+	}
+	if r.firstFailure == nil {
+		r.firstFailure = map[string]time.Time{}
+	}
+	cfg := r.resolveConfig(opts...)
+	r.cfg = &cfg
+	// Propagate the resolved reconnect backoff to the transport so reconnect
+	// attempts use the configured establish/retry schedule.
+	if r.Manager != nil {
+		r.Manager.SetReconnectBackoff(cfg.reconnect)
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1beta1.WorkloadCluster{}).
+		Watches(&corev1.Secret{}, r.secretEventHandler(cfg.eventsBatchPeriod)).
+		Complete(r)
+}
+
+// secretEventHandler re-enqueues the WorkloadClusters referencing a changed
+// Secret, debounced by batchPeriod via AddAfter so a kubeconfig rotation that
+// touches several Secret keys back-to-back folds into one reconcile (and thus
+// one remote-client rebuild) instead of a burst.
+func (r *Reconciler) secretEventHandler(batchPeriod time.Duration) handler.EventHandler {
+	enqueue := func(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+		for _, req := range r.workloadClustersForSecret(ctx, obj) {
+			if batchPeriod > 0 {
+				q.AddAfter(req, batchPeriod)
+			} else {
+				q.Add(req)
+			}
+		}
+	}
+	return handler.Funcs{
+		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			enqueue(ctx, e.ObjectNew, q)
+		},
+		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+	}
+}
+
+// workloadClustersForSecret maps a Secret change to the WorkloadClusters whose
+// kubeConfig.secretRef points at it.
+func (r *Reconciler) workloadClustersForSecret(ctx context.Context, obj client.Object) []ctrl.Request {
+	list := &v1beta1.WorkloadClusterList{}
+	if err := r.List(ctx, list); err != nil {
+		return nil
+	}
+	var reqs []ctrl.Request
+	for i := range list.Items {
+		kc := list.Items[i].Spec.ClusterSource.KubeConfig
+		if kc != nil && kc.SecretRef.Name == obj.GetName() && kc.SecretRef.Namespace == obj.GetNamespace() {
+			reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Name: list.Items[i].Name}})
+		}
+	}
+	return reqs
+}

--- a/pkg/controller/v1beta1/workloadcluster/controller_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/controller_test.go
@@ -1,0 +1,336 @@
+package workloadcluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func scheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(s))
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	return s
+}
+
+func wcWithSecret(name string) *v1beta1.WorkloadCluster {
+	return &v1beta1.WorkloadCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1beta1.WorkloadClusterSpec{ClusterSource: v1beta1.ClusterConnectionSource{
+			KubeConfig: &v1beta1.KubeConfigSource{SecretRef: corev1.SecretReference{Name: "kc", Namespace: "ome-system"}, Key: "kubeconfig"},
+		}},
+	}
+}
+
+// validKubeconfig is a minimal, parseable kubeconfig that also passes
+// validateRESTConfig (no exec/token-file/insecure) so a reconcile gets past the
+// BadKubeConfig gate and reaches the injected Probe.
+const validKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://example.com
+    certificate-authority-data: ZHVtbXk=
+contexts:
+- name: ctx
+  context: {cluster: c, user: u}
+current-context: ctx
+users:
+- name: u
+  user:
+    token: abc123
+`
+
+func kcSecret(data string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kc", Namespace: "ome-system"},
+		Data:       map[string][]byte{"kubeconfig": []byte(data)},
+	}
+}
+
+func newReconciler(s *runtime.Scheme, probe func(context.Context, []byte) error, objs ...client.Object) (*Reconciler, client.Client) {
+	c := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(objs...).WithStatusSubresource(&v1beta1.WorkloadCluster{}).Build()
+	return &Reconciler{Client: c, Scheme: s, Log: log.Log, Probe: probe}, c
+}
+
+func readyCond(c client.Client, name string) *metav1.Condition {
+	wc := &v1beta1.WorkloadCluster{}
+	_ = c.Get(context.Background(), types.NamespacedName{Name: name}, wc)
+	return apimeta.FindStatusCondition(wc.Status.Conditions, v1beta1.WorkloadClusterReady)
+}
+
+func TestReconcile_Reachable(t *testing.T) {
+	s := scheme(t)
+	wc := wcWithSecret("c1")
+	secret := kcSecret(validKubeconfig)
+	probe := func(context.Context, []byte) error { return nil }
+	r, c := newReconciler(s, probe, wc, secret)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+
+	cond := readyCond(c, "c1")
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, "Reachable", cond.Reason)
+}
+
+func TestReconcile_SecretNotFound(t *testing.T) {
+	s := scheme(t)
+	r, c := newReconciler(s, func(context.Context, []byte) error { return nil }, wcWithSecret("c1"))
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+	cond := readyCond(c, "c1")
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "SecretNotFound", cond.Reason)
+}
+
+func TestReconcile_ConnectionFailed(t *testing.T) {
+	s := scheme(t)
+	wc := wcWithSecret("c1")
+	secret := kcSecret(validKubeconfig) // valid kubeconfig -> reaches the probe
+	probe := func(context.Context, []byte) error { return errors.New("dial tcp: timeout") }
+	r, c := newReconciler(s, probe, wc, secret)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+	cond := readyCond(c, "c1")
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "ConnectionFailed", cond.Reason)
+}
+
+// TestReconcile_BadKubeConfig: a malformed kubeconfig is rejected BEFORE the
+// probe runs (the probe here would say "Reachable" but must never be reached),
+// keeping BadKubeConfig distinct from ConnectionFailed.
+func TestReconcile_BadKubeConfig(t *testing.T) {
+	s := scheme(t)
+	wc := wcWithSecret("c1")
+	secret := kcSecret("this is not a kubeconfig")
+	probeReached := false
+	probe := func(context.Context, []byte) error { probeReached = true; return nil }
+	r, c := newReconciler(s, probe, wc, secret)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+	cond := readyCond(c, "c1")
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "BadKubeConfig", cond.Reason)
+	assert.False(t, probeReached, "probe must not run when the kubeconfig is malformed")
+}
+
+func TestReconcile_ClusterProfileUnsupported(t *testing.T) {
+	s := scheme(t)
+	wc := &v1beta1.WorkloadCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Spec: v1beta1.WorkloadClusterSpec{ClusterSource: v1beta1.ClusterConnectionSource{
+			ClusterProfileRef: &v1beta1.ClusterProfileRef{Name: "cp1"}}},
+	}
+	r, c := newReconciler(s, func(context.Context, []byte) error { return nil }, wc)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+	cond := readyCond(c, "c1")
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "ClusterProfileUnsupported", cond.Reason)
+}
+
+func TestReconcile_ConnectsManagerWhenReachable(t *testing.T) {
+	s := scheme(t)
+	wc := wcWithSecret("c1")
+	secret := kcSecret(validKubeconfig)
+	mgr := NewManager(s)
+	mgr.newClient = func(_ context.Context, raw []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		return &stubClient{id: "c1"}, func() {}, nil
+	}
+	r, _ := newReconciler(s, func(context.Context, []byte) error { return nil }, wc, secret)
+	r.Manager = mgr
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+
+	_, ok := mgr.ClientFor("c1")
+	assert.True(t, ok, "a Reachable cluster must be connected in the Manager")
+}
+
+// TestReconcile_BackoffHoldsConnectionOnTransientProbeFailure: a previously
+// reachable+connected cluster whose /version probe fails once must NOT be torn
+// down — within the grace window the live client stays connected and Ready is
+// held True (reason ProbeFailedRetrying).
+func TestReconcile_BackoffHoldsConnectionOnTransientProbeFailure(t *testing.T) {
+	s := scheme(t)
+	wc := wcWithSecret("c1")
+	secret := kcSecret(validKubeconfig)
+	mgr := NewManager(s)
+	mgr.newClient = func(_ context.Context, raw []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		return &stubClient{id: "c1"}, func() {}, nil
+	}
+	fail := false
+	r, c := newReconciler(s, func(context.Context, []byte) error {
+		if fail {
+			return errors.New("dial tcp: i/o timeout")
+		}
+		return nil
+	}, wc, secret)
+	r.Manager = mgr
+	r.ConnectionGracePeriod = time.Hour // generous grace so the blip is held
+
+	// Pass 1: reachable -> connected.
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+	_, ok := mgr.ClientFor("c1")
+	require.True(t, ok, "cluster must be connected after a reachable pass")
+
+	// Pass 2: transient probe failure within grace -> held.
+	fail = true
+	_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+	_, ok = mgr.ClientFor("c1")
+	assert.True(t, ok, "a transient probe failure within grace must NOT disconnect the live client")
+	cond := readyCond(c, "c1")
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status, "Ready must be held True within grace")
+	assert.Equal(t, "ProbeFailedRetrying", cond.Reason)
+}
+
+// TestReconcile_BackoffTearsDownAfterGrace: once the grace window elapses, a
+// persistent probe failure flips Ready=False and disconnects the client.
+func TestReconcile_BackoffTearsDownAfterGrace(t *testing.T) {
+	s := scheme(t)
+	wc := wcWithSecret("c1")
+	secret := kcSecret(validKubeconfig)
+	mgr := NewManager(s)
+	mgr.newClient = func(_ context.Context, raw []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		return &stubClient{id: "c1"}, func() {}, nil
+	}
+	fail := false
+	r, c := newReconciler(s, func(context.Context, []byte) error {
+		if fail {
+			return errors.New("dial tcp: i/o timeout")
+		}
+		return nil
+	}, wc, secret)
+	r.Manager = mgr
+	r.ConnectionGracePeriod = time.Hour
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+
+	// Simulate that the failure run started well outside the grace window.
+	fail = true
+	r.mu.Lock()
+	if r.firstFailure == nil {
+		r.firstFailure = map[string]time.Time{}
+	}
+	r.firstFailure["c1"] = time.Now().Add(-2 * time.Hour)
+	r.mu.Unlock()
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+	_, ok := mgr.ClientFor("c1")
+	assert.False(t, ok, "after grace elapses a persistent failure must disconnect the client")
+	cond := readyCond(c, "c1")
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "ConnectionFailed", cond.Reason)
+}
+
+// TestReconcile_NoGraceForNeverConnected: a cluster that was never connected
+// (probe fails on the very first pass) must flip to Ready=False immediately —
+// there is no live connection to protect.
+func TestReconcile_NoGraceForNeverConnected(t *testing.T) {
+	s := scheme(t)
+	wc := wcWithSecret("c1")
+	secret := kcSecret(validKubeconfig)
+	mgr := NewManager(s)
+	mgr.newClient = func(_ context.Context, raw []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		return &stubClient{id: "c1"}, func() {}, nil
+	}
+	r, c := newReconciler(s, func(context.Context, []byte) error { return errors.New("dial tcp: timeout") }, wc, secret)
+	r.Manager = mgr
+	r.ConnectionGracePeriod = time.Hour
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+	_, ok := mgr.ClientFor("c1")
+	assert.False(t, ok, "a never-connected cluster has nothing to hold")
+	cond := readyCond(c, "c1")
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "ConnectionFailed", cond.Reason)
+}
+
+// TestReconcile_RecoversAfterTransientFailure: a blip held within grace, then a
+// recovered probe, clears the failure clock and reports Reachable again.
+func TestReconcile_RecoversAfterTransientFailure(t *testing.T) {
+	s := scheme(t)
+	wc := wcWithSecret("c1")
+	secret := kcSecret(validKubeconfig)
+	mgr := NewManager(s)
+	mgr.newClient = func(_ context.Context, raw []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		return &stubClient{id: "c1"}, func() {}, nil
+	}
+	fail := false
+	r, c := newReconciler(s, func(context.Context, []byte) error {
+		if fail {
+			return errors.New("blip")
+		}
+		return nil
+	}, wc, secret)
+	r.Manager = mgr
+	r.ConnectionGracePeriod = time.Hour
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}}
+	_, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	fail = true
+	_, err = r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	fail = false
+	_, err = r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	r.mu.Lock()
+	_, stillFailing := r.firstFailure["c1"]
+	r.mu.Unlock()
+	assert.False(t, stillFailing, "a recovered probe must clear the failure clock")
+	cond := readyCond(c, "c1")
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, "Reachable", cond.Reason)
+}
+
+func TestReconcile_DisconnectsManagerWhenDeleted(t *testing.T) {
+	s := scheme(t)
+	mgr := NewManager(s)
+	mgr.newClient = func(_ context.Context, raw []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		return &stubClient{}, func() {}, nil
+	}
+	require.NoError(t, mgr.Connect(context.Background(), "gone", []byte("x")))
+	r, _ := newReconciler(s, func(context.Context, []byte) error { return nil }) // no objects -> NotFound
+	r.Manager = mgr
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "gone"}})
+	require.NoError(t, err)
+
+	_, ok := mgr.ClientFor("gone")
+	assert.False(t, ok, "a deleted WorkloadCluster must be disconnected")
+}

--- a/pkg/controller/v1beta1/workloadcluster/controller_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/controller_test.go
@@ -71,6 +71,20 @@ func newReconciler(s *runtime.Scheme, probe func(context.Context, []byte) error,
 	return &Reconciler{Client: c, Scheme: s, Log: log.Log, Probe: probe}, c
 }
 
+type secretReadErrorClient struct {
+	client.Client
+	fail bool
+}
+
+func (c *secretReadErrorClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if c.fail {
+		if _, ok := obj.(*corev1.Secret); ok {
+			return errors.New("local apiserver timeout")
+		}
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
 func readyCond(c client.Client, name string) *metav1.Condition {
 	wc := &v1beta1.WorkloadCluster{}
 	_ = c.Get(context.Background(), types.NamespacedName{Name: name}, wc)
@@ -208,6 +222,38 @@ func TestReconcile_BackoffHoldsConnectionOnTransientProbeFailure(t *testing.T) {
 	cond := readyCond(c, "c1")
 	require.NotNil(t, cond)
 	assert.Equal(t, metav1.ConditionTrue, cond.Status, "Ready must be held True within grace")
+	assert.Equal(t, "ProbeFailedRetrying", cond.Reason)
+}
+
+func TestReconcile_BackoffHoldsConnectionOnTransientSecretReadFailure(t *testing.T) {
+	s := scheme(t)
+	wc := wcWithSecret("c1")
+	secret := kcSecret(validKubeconfig)
+	base := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(wc, secret).WithStatusSubresource(&v1beta1.WorkloadCluster{}).Build()
+	c := &secretReadErrorClient{Client: base}
+	mgr := NewManager(s)
+	mgr.newClient = func(_ context.Context, _ []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		return &stubClient{id: "c1"}, func() {}, nil
+	}
+	r := &Reconciler{
+		Client: c, Scheme: s, Log: log.Log,
+		Probe:   func(context.Context, []byte) error { return nil },
+		Manager: mgr, ConnectionGracePeriod: time.Hour,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+	_, ok := mgr.ClientFor("c1")
+	require.True(t, ok)
+
+	c.fail = true
+	_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}})
+	require.NoError(t, err)
+	_, ok = mgr.ClientFor("c1")
+	assert.True(t, ok, "a transient Secret read failure within grace must not disconnect the live client")
+	cond := readyCond(base, "c1")
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
 	assert.Equal(t, "ProbeFailedRetrying", cond.Reason)
 }
 

--- a/pkg/controller/v1beta1/workloadcluster/controller_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/controller_test.go
@@ -118,6 +118,19 @@ func TestReconcile_SecretNotFound(t *testing.T) {
 	assert.Equal(t, "SecretNotFound", cond.Reason)
 }
 
+func TestWorkloadClustersForSecretUsesReferenceIndex(t *testing.T) {
+	s := scheme(t)
+	match := wcWithSecret("match")
+	other := wcWithSecret("other")
+	other.Spec.ClusterSource.KubeConfig.SecretRef.Name = "different"
+	c := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(match, other).
+		WithIndex(&v1beta1.WorkloadCluster{}, kubeConfigSecretRefIndex, kubeConfigSecretRefValues).Build()
+	r := &Reconciler{Client: c, Log: log.Log}
+	reqs := r.workloadClustersForSecret(context.Background(), kcSecret(validKubeconfig))
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "match", reqs[0].Name)
+}
+
 func TestReconcile_ConnectionFailed(t *testing.T) {
 	s := scheme(t)
 	wc := wcWithSecret("c1")

--- a/pkg/controller/v1beta1/workloadcluster/manager.go
+++ b/pkg/controller/v1beta1/workloadcluster/manager.go
@@ -40,8 +40,9 @@ type Manager struct {
 	// nil-safe — Connect falls back to its caller's ctx.
 	baseCtx context.Context
 
-	mu    sync.RWMutex
-	conns map[string]*remoteConn
+	mu             sync.RWMutex
+	conns          map[string]*remoteConn
+	nextGeneration uint64
 
 	// newClient builds a caching-capable client (+ a cancel for its background
 	// watch context) from raw kubeconfig bytes. Injected for tests; defaults to
@@ -80,6 +81,7 @@ type remoteConn struct {
 	client     SelectivelyCachingClient
 	cancel     context.CancelFunc
 	configHash string
+	generation uint64
 }
 
 // NewManager returns an empty Manager whose default builder constructs a
@@ -97,6 +99,8 @@ func NewManager(scheme *runtime.Scheme) *Manager {
 
 // SetExecCredentialPolicy configures the exec credential policy for this manager.
 func (m *Manager) SetExecCredentialPolicy(p ExecCredentialPolicy) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.execPolicy = p
 }
 
@@ -148,29 +152,37 @@ func (m *Manager) ReconnectBackoff() reconnectBackoff {
 // the caller falls back to the retry backoff (retryAfter). Returns (nil, false,
 // nil) when the cluster is not connected. This is the establish half of the
 // two-backoff reconnect scheme; the status-mirroring watch funnel consumes it.
-func (m *Manager) EstablishWatch(ctx context.Context, cluster string, list client.ObjectList, attempt int, opts ...client.ListOption) (watch.Interface, bool, error) {
-	cl, ok := m.ClientFor(cluster)
+func (m *Manager) EstablishWatch(ctx context.Context, cluster string, list client.ObjectList, attempt int, opts ...client.ListOption) (watch.Interface, uint64, bool, error) {
+	cl, generation, ok := m.clientForGeneration(cluster)
 	if !ok {
-		return nil, false, nil
+		return nil, 0, false, nil
 	}
 	timeout := m.ReconnectBackoff().establishWaitTime(attempt)
 	w, err := establishWatch(ctx, cl, list, timeout, opts...)
 	if err != nil {
-		return nil, true, err
+		return nil, generation, true, err
 	}
-	return w, true, nil
+	return w, generation, true, nil
 }
 
 // ClientFor returns the live client for a cluster, or (nil, false) if none is
 // connected.
 func (m *Manager) ClientFor(name string) (SelectivelyCachingClient, bool) {
+	cl, _, ok := m.clientForGeneration(name)
+	return cl, ok
+}
+
+// clientForGeneration returns the current client together with an identity
+// that changes whenever Connect replaces it. The funnel uses the generation to
+// attach one informer handler to each remote cache instance.
+func (m *Manager) clientForGeneration(name string) (SelectivelyCachingClient, uint64, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	c, ok := m.conns[name]
 	if !ok {
-		return nil, false
+		return nil, 0, false
 	}
-	return c.client, true
+	return c.client, c.generation, true
 }
 
 // Connect ensures a live client for the named cluster built from raw. It is a
@@ -200,7 +212,8 @@ func (m *Manager) Connect(ctx context.Context, name string, raw []byte) error {
 	if old, ok := m.conns[name]; ok && old.cancel != nil {
 		old.cancel()
 	}
-	m.conns[name] = &remoteConn{client: cl, cancel: cancel, configHash: hash}
+	m.nextGeneration++
+	m.conns[name] = &remoteConn{client: cl, cancel: cancel, configHash: hash, generation: m.nextGeneration}
 	m.mu.Unlock()
 	return nil
 }

--- a/pkg/controller/v1beta1/workloadcluster/manager.go
+++ b/pkg/controller/v1beta1/workloadcluster/manager.go
@@ -1,0 +1,293 @@
+package workloadcluster
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Manager holds one live remote client per registered WorkloadCluster, keyed by
+// cluster name. It is the cross-cluster transport: callers create
+// and watch remote objects via ClientFor(name).
+//
+// Safe for concurrent use across distinct cluster names; Connect/Disconnect for
+// the SAME name must be serialized by the caller (the WorkloadCluster reconciler
+// is single-worker per key, so this holds in practice).
+type Manager struct {
+	scheme     *runtime.Scheme
+	execPolicy ExecCredentialPolicy
+	// tuning sets QPS/Burst/per-call-timeout on every remote rest.Config. The
+	// zero value leaves client-go's own defaults in place (graceful degradation,
+	// no magic literal baked in).
+	tuning ClientTuning
+	// cacheOpts selects which kinds the remote client caches and how the cache is
+	// scoped. The zero value (empty CachedKinds) keeps the never-caching client.
+	cacheOpts CacheOptions
+	// reconnect is the establish/retry backoff schedule the transport uses when
+	// (re)establishing a remote connection. The zero value falls back to
+	// defaultReconnectBackoff via the ReconnectBackoff accessor.
+	reconnect reconnectBackoff
+
+	// baseCtx is the long-lived context remote clients derive from, so their
+	// cache informers are scoped to the controller-manager lifetime rather than a
+	// request-scoped reconcile ctx. Set by Start (the Runnable entrypoint);
+	// nil-safe — Connect falls back to its caller's ctx.
+	baseCtx context.Context
+
+	mu    sync.RWMutex
+	conns map[string]*remoteConn
+
+	// newClient builds a caching-capable client (+ a cancel for its background
+	// watch context) from raw kubeconfig bytes. Injected for tests; defaults to
+	// buildRemoteClient.
+	newClient func(ctx context.Context, raw []byte, scheme *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error)
+}
+
+// Start records the controller-manager's long-lived context as the base for all
+// remote-client and cache-informer contexts, then blocks until that context is
+// cancelled, at which point it disconnects every cluster so no background watch
+// leaks past manager shutdown. It implements
+// sigs.k8s.io/controller-runtime/pkg/manager.Runnable so the cmd wires it with
+// mgr.Add(clusterManager).
+func (m *Manager) Start(ctx context.Context) error {
+	m.mu.Lock()
+	m.baseCtx = ctx
+	m.mu.Unlock()
+	<-ctx.Done()
+	m.DisconnectAll()
+	return nil
+}
+
+// DisconnectAll disposes every connected client. Used on manager shutdown.
+func (m *Manager) DisconnectAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for name, c := range m.conns {
+		if c.cancel != nil {
+			c.cancel()
+		}
+		delete(m.conns, name)
+	}
+}
+
+type remoteConn struct {
+	client     SelectivelyCachingClient
+	cancel     context.CancelFunc
+	configHash string
+}
+
+// NewManager returns an empty Manager whose default builder constructs a
+// controller-runtime client from the validated kubeconfig. With no CacheOptions
+// configured (the default) the client is never-caching; SetCacheOptions with a
+// non-empty CachedKinds set switches it to a selectively-caching client.
+func NewManager(scheme *runtime.Scheme) *Manager {
+	m := &Manager{
+		scheme: scheme,
+		conns:  map[string]*remoteConn{},
+	}
+	m.newClient = m.buildRemoteClient
+	return m
+}
+
+// SetExecCredentialPolicy configures the exec credential policy for this manager.
+func (m *Manager) SetExecCredentialPolicy(p ExecCredentialPolicy) {
+	m.execPolicy = p
+}
+
+// SetClientTuning configures the QPS/Burst/per-call-timeout applied to every
+// remote rest.Config built after this call. Call before the WorkloadCluster
+// reconciler connects clusters (i.e. during wiring); already-connected clients
+// keep their tuning until their kubeconfig changes and they are rebuilt.
+func (m *Manager) SetClientTuning(t ClientTuning) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tuning = t
+}
+
+// SetCacheOptions configures the remote informer cache. A non-empty
+// CachedKinds switches buildRemoteClient to a selectively-caching client whose
+// cache is scoped by DefaultSelector and indexed by Indexes; an empty set keeps
+// the never-caching client. As with tuning, this applies to clients built after
+// the call, so set it during wiring.
+func (m *Manager) SetCacheOptions(o CacheOptions) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cacheOpts = o
+}
+
+// SetReconnectBackoff records the establish/retry backoff schedule the transport
+// uses when (re)establishing a remote connection. Wired from the reconciler's
+// resolved config at Setup so the schedule is config-driven.
+func (m *Manager) SetReconnectBackoff(b reconnectBackoff) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reconnect = b
+}
+
+// ReconnectBackoff returns the configured establish/retry backoff, falling back
+// to the package default when none was set. The watch-funnel reconnect path
+// consumes this via EstablishWatch / retryAfter.
+func (m *Manager) ReconnectBackoff() reconnectBackoff {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.reconnect.establishInitial <= 0 {
+		return defaultReconnectBackoff()
+	}
+	return m.reconnect
+}
+
+// EstablishWatch opens a remote watch on the named cluster's client, bounded by
+// the configured establish timeout for the given (1-based) attempt. On timeout
+// the in-flight Watch is abandoned and errWatchEstablishTimeout is returned so
+// the caller falls back to the retry backoff (retryAfter). Returns (nil, false,
+// nil) when the cluster is not connected. This is the establish half of the
+// two-backoff reconnect scheme; the status-mirroring watch funnel consumes it.
+func (m *Manager) EstablishWatch(ctx context.Context, cluster string, list client.ObjectList, attempt int, opts ...client.ListOption) (watch.Interface, bool, error) {
+	cl, ok := m.ClientFor(cluster)
+	if !ok {
+		return nil, false, nil
+	}
+	timeout := m.ReconnectBackoff().establishWaitTime(attempt)
+	w, err := establishWatch(ctx, cl, list, timeout, opts...)
+	if err != nil {
+		return nil, true, err
+	}
+	return w, true, nil
+}
+
+// ClientFor returns the live client for a cluster, or (nil, false) if none is
+// connected.
+func (m *Manager) ClientFor(name string) (SelectivelyCachingClient, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	c, ok := m.conns[name]
+	if !ok {
+		return nil, false
+	}
+	return c.client, true
+}
+
+// Connect ensures a live client for the named cluster built from raw. It is a
+// no-op when the kubeconfig is unchanged; on change it builds a fresh client
+// and disposes the old one (cancels its watch context).
+func (m *Manager) Connect(ctx context.Context, name string, raw []byte) error {
+	hash := hashBytes(raw)
+
+	m.mu.RLock()
+	if cur, ok := m.conns[name]; ok && cur.configHash == hash {
+		m.mu.RUnlock()
+		return nil
+	}
+	m.mu.RUnlock()
+
+	cl, cancel, err := m.newClient(ctx, raw, m.scheme)
+	if err != nil {
+		// Build failed for a CHANGED kubeconfig: the cached client (if any) is
+		// for the stale config and must not be left serving requests against
+		// credentials/endpoints the user has rotated away. Evict it so callers
+		// see (nil, false) rather than a silently-stale connection.
+		m.Disconnect(name)
+		return fmt.Errorf("workloadcluster %q: build remote client: %w", name, err)
+	}
+
+	m.mu.Lock()
+	if old, ok := m.conns[name]; ok && old.cancel != nil {
+		old.cancel()
+	}
+	m.conns[name] = &remoteConn{client: cl, cancel: cancel, configHash: hash}
+	m.mu.Unlock()
+	return nil
+}
+
+// BaseContext returns the long-lived context wired by Start, or nil if Start
+// has not run yet (e.g. in unit tests that drive Connect directly).
+func (m *Manager) BaseContext() context.Context {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.baseCtx
+}
+
+// Disconnect disposes the client for a cluster (cancels its watch context) and
+// drops it from the registry. No-op if absent.
+func (m *Manager) Disconnect(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if c, ok := m.conns[name]; ok {
+		if c.cancel != nil {
+			c.cancel()
+		}
+		delete(m.conns, name)
+	}
+}
+
+// Connected returns the names of all currently-connected clusters.
+func (m *Manager) Connected() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	names := make([]string, 0, len(m.conns))
+	for name := range m.conns {
+		names = append(names, name)
+	}
+	return names
+}
+
+func hashBytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// buildRemoteClient is the default Manager.newClient: validate+parse the
+// kubeconfig (RESTConfigFromKubeConfig), apply the configured client tuning,
+// build a watch-capable controller-runtime client, and — when CacheOptions
+// names cached kinds — wrap it in a selectively-caching client backed by a
+// background informer cache. The returned cancel tears that cache down on
+// Disconnect; the never-caching path returns a no-op cancel.
+func (m *Manager) buildRemoteClient(ctx context.Context, raw []byte, scheme *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+	// Snapshot config under the lock: distinct cluster names build concurrently
+	// and a setter may run during wiring.
+	m.mu.RLock()
+	tuning := m.tuning
+	cacheOpts := m.cacheOpts
+	execPolicy := m.execPolicy
+	m.mu.RUnlock()
+
+	restConfig, err := RESTConfigFromKubeConfig(raw, execPolicy)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Raise the per-cluster rate limits and per-call timeout from the client-go
+	// defaults (5 QPS / 10 burst) so fan-out across many remote apiservers is not
+	// throttled. Zero leaves client-go's default untouched (no magic literal).
+	tuning.apply(restConfig)
+
+	wc, err := client.NewWithWatch(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, nil, fmt.Errorf("new watch client: %w", err)
+	}
+
+	// No cached kinds configured: never-caching client has no background
+	// goroutines, so there is nothing to tear down — return a no-op cancel.
+	if !cacheOpts.enabled() {
+		return NewNeverCachingClient(wc), func() {}, nil
+	}
+
+	// Cached kinds configured: derive a cancellable context from the long-lived
+	// base ctx so the cache's informers are scoped to the manager lifetime, and
+	// return its cancel so Disconnect tears the cache down (no leaked watches).
+	cacheCtx, cancel := context.WithCancel(ctx)
+	cl, err := NewSelectivelyCachingClient(
+		cacheCtx, restConfig, wc, scheme,
+		cacheOpts.CachedKinds, cacheOpts.Indexes, cacheOpts.DefaultSelector,
+	)
+	if err != nil {
+		cancel()
+		return nil, nil, fmt.Errorf("new selectively-caching client: %w", err)
+	}
+	return cl, cancel, nil
+}

--- a/pkg/controller/v1beta1/workloadcluster/manager_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/manager_test.go
@@ -1,0 +1,129 @@
+package workloadcluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// stubClient is a minimal SelectivelyCachingClient sentinel for identity checks.
+type stubClient struct {
+	SelectivelyCachingClient
+	id string
+}
+
+func newTestManager() (*Manager, *[]string) {
+	var canceled []string
+	m := NewManager(runtime.NewScheme())
+	m.newClient = func(_ context.Context, raw []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		id := string(raw)
+		return &stubClient{id: id}, func() { canceled = append(canceled, id) }, nil
+	}
+	return m, &canceled
+}
+
+func TestManager_ConnectThenClientFor(t *testing.T) {
+	m, _ := newTestManager()
+	require.NoError(t, m.Connect(context.Background(), "c1", []byte("kubeconfA")))
+	got, ok := m.ClientFor("c1")
+	require.True(t, ok)
+	assert.Equal(t, "kubeconfA", got.(*stubClient).id)
+}
+
+func TestManager_ReconnectOnlyOnConfigChange(t *testing.T) {
+	m, canceled := newTestManager()
+	require.NoError(t, m.Connect(context.Background(), "c1", []byte("A")))
+	require.NoError(t, m.Connect(context.Background(), "c1", []byte("A")))
+	assert.Empty(t, *canceled, "unchanged kubeconfig must not rebuild")
+	require.NoError(t, m.Connect(context.Background(), "c1", []byte("B")))
+	assert.Equal(t, []string{"A"}, *canceled, "changed kubeconfig must dispose the old client")
+	got, _ := m.ClientFor("c1")
+	assert.Equal(t, "B", got.(*stubClient).id)
+}
+
+func TestManager_Disconnect(t *testing.T) {
+	m, canceled := newTestManager()
+	require.NoError(t, m.Connect(context.Background(), "c1", []byte("A")))
+	m.Disconnect("c1")
+	_, ok := m.ClientFor("c1")
+	assert.False(t, ok, "Disconnect must remove the client")
+	assert.Equal(t, []string{"A"}, *canceled, "Disconnect must cancel the watch context")
+}
+
+// TestManager_ConnectFailureEvictsStaleClient: when the kubeconfig CHANGES and
+// the rebuild fails, the previously-cached client (for the now-stale config)
+// must be evicted, not left serving against rotated-away credentials.
+func TestManager_ConnectFailureEvictsStaleClient(t *testing.T) {
+	var canceled []string
+	m := NewManager(runtime.NewScheme())
+	buildErr := false
+	m.newClient = func(_ context.Context, raw []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		if buildErr {
+			return nil, nil, errors.New("build failed")
+		}
+		id := string(raw)
+		return &stubClient{id: id}, func() { canceled = append(canceled, id) }, nil
+	}
+	require.NoError(t, m.Connect(context.Background(), "c1", []byte("good")))
+	_, ok := m.ClientFor("c1")
+	require.True(t, ok)
+
+	buildErr = true
+	err := m.Connect(context.Background(), "c1", []byte("rotated"))
+	require.Error(t, err)
+	_, ok = m.ClientFor("c1")
+	assert.False(t, ok, "a failed rebuild for a changed kubeconfig must evict the stale client")
+	assert.Equal(t, []string{"good"}, canceled, "the stale client's watch context must be cancelled")
+}
+
+// TestManager_StartSetsBaseContext: Start records the long-lived context —
+// remote clients must derive from a manager-scoped ctx, not a request ctx — and
+// disconnects everything when that context is cancelled.
+func TestManager_StartSetsBaseContext(t *testing.T) {
+	m, canceled := newTestManager()
+	require.NoError(t, m.Connect(context.Background(), "c1", []byte("A")))
+
+	assert.Nil(t, m.BaseContext(), "no base context before Start")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = m.Start(ctx); close(done) }()
+
+	require.Eventually(t, func() bool { return m.BaseContext() != nil }, time.Second, time.Millisecond,
+		"Start must record the base context")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+	_, ok := m.ClientFor("c1")
+	assert.False(t, ok, "Start must disconnect all clients on shutdown")
+	assert.Equal(t, []string{"A"}, *canceled, "shutdown must cancel each client's watch context")
+}
+
+func TestManager_ClientForUnknown(t *testing.T) {
+	m, _ := newTestManager()
+	_, ok := m.ClientFor("nope")
+	assert.False(t, ok)
+}
+
+func TestManager_Connected(t *testing.T) {
+	m, _ := newTestManager()
+	require.NoError(t, m.Connect(context.Background(), "a", []byte("kubeconfigA")))
+	require.NoError(t, m.Connect(context.Background(), "b", []byte("kubeconfigB")))
+
+	names := m.Connected()
+	require.Len(t, names, 2)
+	assert.ElementsMatch(t, []string{"a", "b"}, names)
+
+	m.Disconnect("a")
+	names = m.Connected()
+	assert.Equal(t, []string{"b"}, names)
+}

--- a/pkg/controller/v1beta1/workloadcluster/options.go
+++ b/pkg/controller/v1beta1/workloadcluster/options.go
@@ -94,6 +94,8 @@ type controllerConfig struct {
 	// previously-reachable cluster tolerates transient probe failures before it
 	// is flipped Ready=False and disconnected.
 	connectionGracePeriod time.Duration
+	// probeTimeout bounds the default reachability probe's single request.
+	probeTimeout time.Duration
 	// eventsBatchPeriod debounces Secret-change re-enqueues: a rotated kubeconfig
 	// Secret often updates several keys in quick succession, and batching folds
 	// that burst into one reconcile.
@@ -172,6 +174,7 @@ func (r *Reconciler) resolveConfig(opts ...Option) controllerConfig {
 	c := controllerConfig{
 		healthInterval:        r.HealthInterval,
 		connectionGracePeriod: r.ConnectionGracePeriod,
+		probeTimeout:          r.ProbeTimeout,
 		reconnect:             defaultReconnectBackoff(),
 	}
 	for _, o := range opts {
@@ -184,6 +187,9 @@ func (r *Reconciler) resolveConfig(opts ...Option) controllerConfig {
 	// explicit "disable grace" and is preserved.
 	if c.connectionGracePeriod == 0 {
 		c.connectionGracePeriod = DefaultConnectionGracePeriod
+	}
+	if c.probeTimeout <= 0 {
+		c.probeTimeout = DefaultProbeTimeout
 	}
 	if c.eventsBatchPeriod <= 0 {
 		c.eventsBatchPeriod = DefaultEventsBatchPeriod

--- a/pkg/controller/v1beta1/workloadcluster/options.go
+++ b/pkg/controller/v1beta1/workloadcluster/options.go
@@ -1,0 +1,204 @@
+package workloadcluster
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
+)
+
+// ClientTuning carries the rate-limit and per-call timeout applied to every
+// remote workload-cluster client. The control plane talks to N remote
+// apiservers concurrently, so the client-go default QPS/Burst (5/10) throttles
+// fan-out reconciles; the operative values are config-driven (manager flag /
+// chart) with NO in-code default — the zero value leaves client-go's own
+// defaults in place, degrading gracefully rather than baking a magic number in.
+type ClientTuning struct {
+	// QPS is the steady-state request rate to a remote apiserver. Zero leaves
+	// the client-go default.
+	QPS float32
+	// Burst is the token-bucket burst over QPS. Zero leaves the client-go default.
+	Burst int
+	// PerCallTimeout bounds a single remote request (rest.Config.Timeout) so one
+	// hung remote cannot wedge a reconcile worker indefinitely. Zero leaves no
+	// client-level timeout (callers still pass request contexts).
+	PerCallTimeout time.Duration
+}
+
+// apply writes the non-zero tuning fields onto cfg. A zero field is left as-is
+// so client-go's own default applies (graceful degradation, no magic literal).
+func (t ClientTuning) apply(cfg *rest.Config) {
+	if t.QPS > 0 {
+		cfg.QPS = t.QPS
+	}
+	if t.Burst > 0 {
+		cfg.Burst = t.Burst
+	}
+	if t.PerCallTimeout > 0 {
+		cfg.Timeout = t.PerCallTimeout
+	}
+}
+
+// CacheOptions configures the remote informer cache for a workload-cluster
+// client. It is supplied by the caller (the control-plane wiring) rather than
+// hardcoded here: this package must not import the placement package (which
+// already imports it), and the cached kinds / origin selector are placement
+// concerns. An empty CachedKinds set selects the never-caching client, so the
+// transport degrades gracefully when no cache is wired.
+type CacheOptions struct {
+	// CachedKinds are the GroupKinds served from the background informer cache
+	// instead of live reads. Pods are rejected by NewSelectivelyCachingClient.
+	CachedKinds sets.Set[schema.GroupKind]
+	// DefaultSelector scopes every cached kind to a label selector (the
+	// placement-origin selector, so the cache holds only this control plane's
+	// derived objects — not every object of the kind on the remote cluster).
+	// Nil caches unfiltered.
+	DefaultSelector labels.Selector
+	// Indexes are field indexes registered on the cache before it starts.
+	Indexes []CacheIndexOption
+}
+
+// enabled reports whether a real (selectively-caching) client should be built.
+func (o CacheOptions) enabled() bool {
+	return o.CachedKinds.Len() > 0
+}
+
+// reconnectBackoff bundles the two backoffs that govern (re)establishing a
+// remote connection, mirroring the Kueue MultiKueue cluster controller: an
+// establish backoff that bounds how long the initial watch attempt waits before
+// it is abandoned and retried, and a retry backoff that spaces failed
+// connection attempts. The operative values are config-driven; the constructor
+// supplies graceful-degradation fallbacks (see defaultReconnectBackoff).
+type reconnectBackoff struct {
+	// establishInitial is the first establish-watch timeout; it grows by
+	// establishFactor up to establishMax.
+	establishInitial time.Duration
+	establishMax     time.Duration
+	establishFactor  float64
+	// retryInitial is the first inter-attempt retry delay; it doubles up to
+	// retryMax. retryInitial==0 means "retry immediately on the first failure".
+	retryInitial time.Duration
+	retryMax     time.Duration
+}
+
+// controllerConfig is the resolved, internal timing configuration the
+// reconciler runs with. It is assembled from functional Options at Setup; every
+// field has a graceful-degradation fallback (the Default* consts) applied by
+// resolveConfig so an unset option never injects a magic literal mid-package.
+type controllerConfig struct {
+	// healthInterval is the steady-state re-probe cadence.
+	healthInterval time.Duration
+	// connectionGracePeriod (a.k.a. worker-lost timeout) is how long a
+	// previously-reachable cluster tolerates transient probe failures before it
+	// is flipped Ready=False and disconnected.
+	connectionGracePeriod time.Duration
+	// eventsBatchPeriod debounces Secret-change re-enqueues: a rotated kubeconfig
+	// Secret often updates several keys in quick succession, and batching folds
+	// that burst into one reconcile.
+	eventsBatchPeriod time.Duration
+	// reconnect governs (re)establish/retry backoff for the remote transport.
+	reconnect reconnectBackoff
+}
+
+// Option mutates the reconciler's timing configuration at Setup: the
+// events-batch debounce and the reconnect backoff. The health interval and
+// worker-lost grace are set via the Reconciler struct fields and seeded into the
+// config by resolveConfig.
+type Option func(*controllerConfig)
+
+// WithEventsBatchPeriod overrides the Secret-change debounce window.
+func WithEventsBatchPeriod(d time.Duration) Option {
+	return func(c *controllerConfig) { c.eventsBatchPeriod = d }
+}
+
+// WithReconnectBackoff overrides the establish/retry backoff for the remote
+// transport. Any non-positive component falls back to its default in
+// resolveConfig.
+func WithReconnectBackoff(b ReconnectBackoffConfig) Option {
+	return func(c *controllerConfig) {
+		if b.EstablishInitial > 0 {
+			c.reconnect.establishInitial = b.EstablishInitial
+		}
+		if b.EstablishMax > 0 {
+			c.reconnect.establishMax = b.EstablishMax
+		}
+		if b.EstablishFactor > 0 {
+			c.reconnect.establishFactor = b.EstablishFactor
+		}
+		// retryInitial may legitimately be 0 ("retry immediately"); only a
+		// negative is nonsense and ignored.
+		if b.RetryInitial >= 0 {
+			c.reconnect.retryInitial = b.RetryInitial
+		}
+		if b.RetryMax > 0 {
+			c.reconnect.retryMax = b.RetryMax
+		}
+	}
+}
+
+// ReconnectBackoffConfig is the public shape callers pass to
+// WithReconnectBackoff (mirrors reconnectBackoff but is exported / flag-friendly).
+type ReconnectBackoffConfig struct {
+	EstablishInitial time.Duration
+	EstablishMax     time.Duration
+	EstablishFactor  float64
+	RetryInitial     time.Duration
+	RetryMax         time.Duration
+}
+
+// defaultReconnectBackoff is the graceful-degradation fallback for the remote
+// transport backoff. It mirrors the Kueue MultiKueue schedule: establish starts
+// at 1m and doubles to a 10m cap; retry starts immediately (0) and doubles in
+// 5s increments up to ~5m20s. These are fallbacks only — the operative values
+// are config-driven via WithReconnectBackoff.
+func defaultReconnectBackoff() reconnectBackoff {
+	return reconnectBackoff{
+		establishInitial: DefaultEstablishInitialTimeout,
+		establishMax:     DefaultEstablishMaxTimeout,
+		establishFactor:  defaultEstablishFactor,
+		retryInitial:     0,
+		retryMax:         DefaultReconnectRetryMax,
+	}
+}
+
+// resolveConfig builds the internal controllerConfig from options, then fills
+// any still-unset field with its graceful-degradation default. Fields the
+// Reconciler already carries (HealthInterval, ConnectionGracePeriod) seed the
+// config so the existing struct-field API keeps working; an Option, when given,
+// wins over the seeded field.
+func (r *Reconciler) resolveConfig(opts ...Option) controllerConfig {
+	c := controllerConfig{
+		healthInterval:        r.HealthInterval,
+		connectionGracePeriod: r.ConnectionGracePeriod,
+		reconnect:             defaultReconnectBackoff(),
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	if c.healthInterval <= 0 {
+		c.healthInterval = DefaultHealthInterval
+	}
+	// connectionGracePeriod==0 means "use the default"; a negative value is an
+	// explicit "disable grace" and is preserved.
+	if c.connectionGracePeriod == 0 {
+		c.connectionGracePeriod = DefaultConnectionGracePeriod
+	}
+	if c.eventsBatchPeriod <= 0 {
+		c.eventsBatchPeriod = DefaultEventsBatchPeriod
+	}
+	if c.reconnect.establishInitial <= 0 {
+		c.reconnect.establishInitial = DefaultEstablishInitialTimeout
+	}
+	if c.reconnect.establishMax <= 0 {
+		c.reconnect.establishMax = DefaultEstablishMaxTimeout
+	}
+	if c.reconnect.establishFactor <= 0 {
+		c.reconnect.establishFactor = defaultEstablishFactor
+	}
+	if c.reconnect.retryMax <= 0 {
+		c.reconnect.retryMax = DefaultReconnectRetryMax
+	}
+	return c
+}

--- a/pkg/controller/v1beta1/workloadcluster/options_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/options_test.go
@@ -196,6 +196,18 @@ func (b *blockingWatchClient) Watch(ctx context.Context, _ client.ObjectList, _ 
 	return nil, ctx.Err()
 }
 
+// stubbornWatchClient simulates a broken client that ignores context
+// cancellation. establishWatch must still return at its timeout.
+type stubbornWatchClient struct {
+	client.WithWatch
+	release <-chan struct{}
+}
+
+func (s *stubbornWatchClient) Watch(context.Context, client.ObjectList, ...client.ListOption) (watch.Interface, error) {
+	<-s.release
+	return nil, errors.New("released")
+}
+
 // immediateWatchClient returns an empty watch right away (success path).
 type immediateWatchClient struct {
 	client.WithWatch
@@ -211,6 +223,16 @@ func TestEstablishWatch_TimesOut(t *testing.T) {
 	require.ErrorIs(t, err, errWatchEstablishTimeout)
 }
 
+func TestEstablishWatch_TimeoutDoesNotWaitForClientCancellation(t *testing.T) {
+	release := make(chan struct{})
+	c := &stubbornWatchClient{WithWatch: fake.NewClientBuilder().Build(), release: release}
+	started := time.Now()
+	_, err := establishWatch(context.Background(), c, &corev1.PodList{}, 20*time.Millisecond)
+	require.ErrorIs(t, err, errWatchEstablishTimeout)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	close(release)
+}
+
 func TestEstablishWatch_Succeeds(t *testing.T) {
 	c := &immediateWatchClient{WithWatch: fake.NewClientBuilder().Build()}
 	w, err := establishWatch(context.Background(), c, &corev1.PodList{}, time.Second)
@@ -223,9 +245,10 @@ func TestEstablishWatch_Succeeds(t *testing.T) {
 // (nil,false,nil) rather than erroring.
 func TestManager_EstablishWatch_NotConnected(t *testing.T) {
 	m := NewManager(scheme(t))
-	w, connected, err := m.EstablishWatch(context.Background(), "nope", &corev1.PodList{}, 1)
+	w, generation, connected, err := m.EstablishWatch(context.Background(), "nope", &corev1.PodList{}, 1)
 	require.NoError(t, err)
 	assert.False(t, connected)
+	assert.Zero(t, generation)
 	assert.Nil(t, w)
 }
 
@@ -244,8 +267,9 @@ func TestManager_EstablishWatch_TimesOut(t *testing.T) {
 	}
 	require.NoError(t, m.Connect(context.Background(), "c1", []byte("kc")))
 
-	_, connected, err := m.EstablishWatch(context.Background(), "c1", &corev1.PodList{}, 1)
+	_, generation, connected, err := m.EstablishWatch(context.Background(), "c1", &corev1.PodList{}, 1)
 	assert.True(t, connected)
+	assert.NotZero(t, generation)
 	require.ErrorIs(t, err, errWatchEstablishTimeout)
 }
 

--- a/pkg/controller/v1beta1/workloadcluster/options_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/options_test.go
@@ -1,0 +1,336 @@
+package workloadcluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// errProbe is a sentinel returned by failing test probes.
+var errProbe = errors.New("dial tcp: timeout")
+
+// validKubeconfigRealCA is like validKubeconfig but carries a real (throwaway)
+// CA PEM in certificate-authority-data, so client.NewWithWatch can actually load
+// the root certificates — needed by buildRemoteClient tests that construct a
+// live client (the dummy "ZHVtbXk=" CA in validKubeconfig fails PEM parsing).
+const validKubeconfigRealCA = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://example.com
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJWRENCKzZBREFnRUNBZ0VCTUFvR0NDcUdTTTQ5QkFNQ01CSXhFREFPQmdOVkJBTVRCM1JsYzNRdFkyRXcKSGhjTk1qWXdOakkyTVRrek5UTXpXaGNOTWpZd05qSTNNakF6TlRNeldqQVNNUkF3RGdZRFZRUURFd2QwWlhOMApMV05oTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFa2hDVzNvckdaV2xzOWlwUUVUWjFPZFJnClA4T0xEQlR3Z3U3ckJTcVc1M0JxMkx1TU1VNEV0c1pXVVB1YzVkOStncHk1M1NXUTQxbm8vRnc4RmNjRXJxTkMKTUVBd0RnWURWUjBQQVFIL0JBUURBZ0lFTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRktBVwo3TWpCUVB3Q0JMTnBSb2loa2lUaW1HSnRNQW9HQ0NxR1NNNDlCQU1DQTBnQU1FVUNJRUZ1Nm5vYUNEZDBYZDdNCmRkN3JlOVlBenVMblpReS92L1VjSEJwVWo4eDVBaUVBN2dackFMQjRrYmhlUnNyQlk0UHVjV1ZzZHhJQk0vS3kKQ0s4RXhUZzFwRlk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+contexts:
+- name: ctx
+  context: {cluster: c, user: u}
+current-context: ctx
+users:
+- name: u
+  user:
+    token: abc123
+`
+
+// --- ClientTuning -----------------------------------------------------------
+
+// TestClientTuning_Apply: non-zero fields land on the rest.Config; zero fields
+// are left untouched so client-go's own default applies (no magic literal).
+func TestClientTuning_Apply(t *testing.T) {
+	cfg := &rest.Config{}
+	ClientTuning{QPS: 50, Burst: 100, PerCallTimeout: 7 * time.Second}.apply(cfg)
+	assert.EqualValues(t, 50, cfg.QPS)
+	assert.EqualValues(t, 100, cfg.Burst)
+	assert.Equal(t, 7*time.Second, cfg.Timeout)
+
+	// Zero tuning leaves the config's fields untouched.
+	cfg2 := &rest.Config{QPS: 3, Burst: 6, Timeout: time.Second}
+	ClientTuning{}.apply(cfg2)
+	assert.EqualValues(t, 3, cfg2.QPS, "zero QPS must not overwrite an existing value")
+	assert.EqualValues(t, 6, cfg2.Burst, "zero Burst must not overwrite an existing value")
+	assert.Equal(t, time.Second, cfg2.Timeout, "zero timeout must not overwrite an existing value")
+}
+
+// TestManager_SetClientTuning_RoundTrips confirms the setter stores the tuning
+// that buildRemoteClient later reads.
+func TestManager_SetClientTuning_RoundTrips(t *testing.T) {
+	m := NewManager(scheme(t))
+	m.SetClientTuning(ClientTuning{QPS: 50, Burst: 100, PerCallTimeout: 7 * time.Second})
+	m.mu.RLock()
+	got := m.tuning
+	m.mu.RUnlock()
+	assert.EqualValues(t, 50, got.QPS)
+	assert.EqualValues(t, 100, got.Burst)
+	assert.Equal(t, 7*time.Second, got.PerCallTimeout)
+}
+
+// --- CacheOptions -----------------------------------------------------------
+
+func isvcGK() schema.GroupKind {
+	return schema.GroupKind{Group: "ome.io", Kind: "InferenceService"}
+}
+
+func TestCacheOptions_EnabledOnlyWhenKindsPresent(t *testing.T) {
+	assert.False(t, CacheOptions{}.enabled(), "empty options must not enable caching")
+	assert.False(t, CacheOptions{CachedKinds: sets.New[schema.GroupKind]()}.enabled(),
+		"empty kind set must not enable caching")
+	assert.True(t, CacheOptions{CachedKinds: sets.New(isvcGK())}.enabled(),
+		"a non-empty kind set enables caching")
+}
+
+// TestBuildRemoteClient_NeverCachingWhenNoKinds: with no CacheOptions, the
+// default builder returns a never-caching client (no cache handler support) and
+// a no-op cancel.
+func TestBuildRemoteClient_NeverCachingWhenNoKinds(t *testing.T) {
+	m := NewManager(scheme(t))
+	cl, cancel, err := m.buildRemoteClient(context.Background(), []byte(validKubeconfigRealCA), m.scheme)
+	require.NoError(t, err)
+	require.NotNil(t, cancel)
+	cancel() // must be safe to call
+	// A never-caching client rejects cache event handlers.
+	_, err = cl.AddCacheEventHandler(context.Background(), &corev1.Pod{}, nil)
+	assert.Error(t, err, "never-caching client must reject cache handlers")
+}
+
+// TestBuildRemoteClient_SelectivelyCachingWhenKinds: with CacheOptions naming a
+// cached kind, the builder constructs a selectively-caching client and returns a
+// real (non-nil) cancel that tears the background cache down. cache.New does not
+// dial the apiserver, so this is hermetic; cancel() stops the (idle) informers.
+func TestBuildRemoteClient_SelectivelyCachingWhenKinds(t *testing.T) {
+	m := NewManager(scheme(t))
+	sel := labels.SelectorFromSet(labels.Set{"ome.io/placement-origin": "x"})
+	m.SetCacheOptions(CacheOptions{CachedKinds: sets.New(isvcGK()), DefaultSelector: sel})
+
+	ctx, baseCancel := context.WithCancel(context.Background())
+	defer baseCancel()
+	cl, cancel, err := m.buildRemoteClient(ctx, []byte(validKubeconfigRealCA), m.scheme)
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+	require.NotNil(t, cancel)
+	cancel() // tears the cache down; must not panic
+
+	// A selectively-caching client accepts a handler for a cached kind (it errors
+	// only for non-cached kinds); proving it is NOT the never-caching wrapper.
+	_, err = cl.AddCacheEventHandler(context.Background(), &corev1.Pod{}, nil)
+	assert.Error(t, err, "Pod is not a cached kind, so a handler for it must error")
+}
+
+// TestBuildRemoteClient_CacheRejectsPods: configuring Pod as a cached kind is
+// refused by the underlying NewSelectivelyCachingClient guard.
+func TestBuildRemoteClient_CacheRejectsPods(t *testing.T) {
+	m := NewManager(scheme(t))
+	m.SetCacheOptions(CacheOptions{CachedKinds: sets.New(corev1.SchemeGroupVersion.WithKind("Pod").GroupKind())})
+	_, _, err := m.buildRemoteClient(context.Background(), []byte(validKubeconfigRealCA), m.scheme)
+	require.Error(t, err, "the builder must surface the cache's Pod-ban")
+}
+
+// TestManager_SetCacheOptions_RoundTrips confirms the setter stores the cache
+// options buildRemoteClient later reads (selector + kinds).
+func TestManager_SetCacheOptions_RoundTrips(t *testing.T) {
+	m := NewManager(scheme(t))
+	sel := labels.SelectorFromSet(labels.Set{"ome.io/placement-origin": "x"})
+	m.SetCacheOptions(CacheOptions{CachedKinds: sets.New(isvcGK()), DefaultSelector: sel})
+	m.mu.RLock()
+	got := m.cacheOpts
+	m.mu.RUnlock()
+	assert.True(t, got.enabled())
+	assert.True(t, got.CachedKinds.Has(isvcGK()))
+	require.NotNil(t, got.DefaultSelector)
+}
+
+// --- reconnect backoff ------------------------------------------------------
+
+func TestRetryAfter_Schedule(t *testing.T) {
+	b := defaultReconnectBackoff()
+	// 0 on the first (zero) failure, then 5s doubling to the 5m20s cap.
+	assert.Equal(t, time.Duration(0), b.retryAfter(0))
+	assert.Equal(t, 5*time.Second, b.retryAfter(1))
+	assert.Equal(t, 10*time.Second, b.retryAfter(2))
+	assert.Equal(t, 20*time.Second, b.retryAfter(3))
+	assert.Equal(t, 40*time.Second, b.retryAfter(4))
+	assert.Equal(t, 80*time.Second, b.retryAfter(5))
+	assert.Equal(t, 160*time.Second, b.retryAfter(6))
+	assert.Equal(t, 320*time.Second, b.retryAfter(7))
+	// Saturates at the cap and never overflows for large attempt counts.
+	assert.Equal(t, DefaultReconnectRetryMax, b.retryAfter(8))
+	assert.Equal(t, DefaultReconnectRetryMax, b.retryAfter(100))
+}
+
+func TestEstablishWaitTime_Schedule(t *testing.T) {
+	b := defaultReconnectBackoff()
+	// attempt<=1 -> initial; doubling up to the 10m cap.
+	assert.Equal(t, 1*time.Minute, b.establishWaitTime(0))
+	assert.Equal(t, 1*time.Minute, b.establishWaitTime(1))
+	assert.Equal(t, 2*time.Minute, b.establishWaitTime(2))
+	assert.Equal(t, 4*time.Minute, b.establishWaitTime(3))
+	assert.Equal(t, 8*time.Minute, b.establishWaitTime(4))
+	assert.Equal(t, DefaultEstablishMaxTimeout, b.establishWaitTime(5))
+	assert.Equal(t, DefaultEstablishMaxTimeout, b.establishWaitTime(50))
+}
+
+// --- establishWatch ---------------------------------------------------------
+
+// blockingWatchClient embeds a fake WithWatch but its Watch blocks until the
+// passed context is cancelled, so establishWatch's timeout path fires
+// deterministically.
+type blockingWatchClient struct {
+	client.WithWatch
+}
+
+func (b *blockingWatchClient) Watch(ctx context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// immediateWatchClient returns an empty watch right away (success path).
+type immediateWatchClient struct {
+	client.WithWatch
+}
+
+func (i *immediateWatchClient) Watch(_ context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+	return watch.NewEmptyWatch(), nil
+}
+
+func TestEstablishWatch_TimesOut(t *testing.T) {
+	c := &blockingWatchClient{WithWatch: fake.NewClientBuilder().Build()}
+	_, err := establishWatch(context.Background(), c, &corev1.PodList{}, 20*time.Millisecond)
+	require.ErrorIs(t, err, errWatchEstablishTimeout)
+}
+
+func TestEstablishWatch_Succeeds(t *testing.T) {
+	c := &immediateWatchClient{WithWatch: fake.NewClientBuilder().Build()}
+	w, err := establishWatch(context.Background(), c, &corev1.PodList{}, time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	w.Stop() // cancelOnStopWatcher.Stop must not panic
+}
+
+// TestManager_EstablishWatch_NotConnected: a cluster with no client returns
+// (nil,false,nil) rather than erroring.
+func TestManager_EstablishWatch_NotConnected(t *testing.T) {
+	m := NewManager(scheme(t))
+	w, connected, err := m.EstablishWatch(context.Background(), "nope", &corev1.PodList{}, 1)
+	require.NoError(t, err)
+	assert.False(t, connected)
+	assert.Nil(t, w)
+}
+
+// TestManager_EstablishWatch_TimesOut wires a connected blocking client and a
+// tiny establish timeout so the establish half of the backoff fires.
+func TestManager_EstablishWatch_TimesOut(t *testing.T) {
+	m := NewManager(scheme(t))
+	m.SetReconnectBackoff(reconnectBackoff{
+		establishInitial: 20 * time.Millisecond,
+		establishMax:     20 * time.Millisecond,
+		establishFactor:  2,
+		retryMax:         DefaultReconnectRetryMax,
+	})
+	m.newClient = func(_ context.Context, _ []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		return &blockingCachingClient{blockingWatchClient: &blockingWatchClient{WithWatch: fake.NewClientBuilder().Build()}}, func() {}, nil
+	}
+	require.NoError(t, m.Connect(context.Background(), "c1", []byte("kc")))
+
+	_, connected, err := m.EstablishWatch(context.Background(), "c1", &corev1.PodList{}, 1)
+	assert.True(t, connected)
+	require.ErrorIs(t, err, errWatchEstablishTimeout)
+}
+
+// blockingCachingClient adapts blockingWatchClient to SelectivelyCachingClient
+// (its Watch blocks; AddCacheEventHandler is unused by these tests).
+type blockingCachingClient struct {
+	*blockingWatchClient
+}
+
+func (b *blockingCachingClient) AddCacheEventHandler(context.Context, client.Object, toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+// --- functional options -----------------------------------------------------
+
+// TestResolveConfig_Defaults: with no options and no struct fields set, every
+// knob falls back to its graceful-degradation default.
+func TestResolveConfig_Defaults(t *testing.T) {
+	r := &Reconciler{}
+	c := r.resolveConfig()
+	assert.Equal(t, DefaultHealthInterval, c.healthInterval)
+	assert.Equal(t, DefaultConnectionGracePeriod, c.connectionGracePeriod)
+	assert.Equal(t, DefaultEventsBatchPeriod, c.eventsBatchPeriod)
+	assert.Equal(t, DefaultEstablishInitialTimeout, c.reconnect.establishInitial)
+	assert.Equal(t, DefaultEstablishMaxTimeout, c.reconnect.establishMax)
+	assert.Equal(t, DefaultReconnectRetryMax, c.reconnect.retryMax)
+}
+
+// TestResolveConfig_SeedsAndOptions: health interval and grace are seeded from
+// the Reconciler struct fields; the events-batch and reconnect knobs come from
+// options and override the defaults.
+func TestResolveConfig_SeedsAndOptions(t *testing.T) {
+	r := &Reconciler{HealthInterval: 2 * time.Millisecond, ConnectionGracePeriod: 3 * time.Millisecond}
+	c := r.resolveConfig(
+		WithEventsBatchPeriod(4*time.Millisecond),
+		WithReconnectBackoff(ReconnectBackoffConfig{
+			EstablishInitial: 5 * time.Millisecond,
+			EstablishMax:     6 * time.Millisecond,
+			EstablishFactor:  2,
+			RetryInitial:     7 * time.Millisecond,
+			RetryMax:         8 * time.Millisecond,
+		}),
+	)
+	assert.Equal(t, 2*time.Millisecond, c.healthInterval)
+	assert.Equal(t, 3*time.Millisecond, c.connectionGracePeriod)
+	assert.Equal(t, 4*time.Millisecond, c.eventsBatchPeriod)
+	assert.Equal(t, 5*time.Millisecond, c.reconnect.establishInitial)
+	assert.Equal(t, 6*time.Millisecond, c.reconnect.establishMax)
+	assert.Equal(t, 7*time.Millisecond, c.reconnect.retryInitial)
+	assert.Equal(t, 8*time.Millisecond, c.reconnect.retryMax)
+}
+
+// TestResolveConfig_NegativeGraceDisables: a negative ConnectionGracePeriod is a
+// deliberate "disable grace" and must be preserved (not replaced by the default).
+func TestResolveConfig_NegativeGraceDisables(t *testing.T) {
+	r := &Reconciler{ConnectionGracePeriod: -1}
+	c := r.resolveConfig()
+	assert.Equal(t, time.Duration(-1), c.connectionGracePeriod)
+}
+
+// TestReconcile_RetryBackoffSpacesRequeue: consecutive connection failures (with
+// no live connection to hold) requeue with the growing retry backoff rather than
+// the steady health interval.
+func TestReconcile_RetryBackoffSpacesRequeue(t *testing.T) {
+	s := scheme(t)
+	wc := wcWithSecret("c1")
+	secret := kcSecret(validKubeconfig)
+	r, _ := newReconciler(s, func(context.Context, []byte) error { return errProbe }, wc, secret)
+	// Resolve a tiny, deterministic retry backoff so the schedule is checkable.
+	cfg := r.resolveConfig(WithReconnectBackoff(ReconnectBackoffConfig{
+		RetryInitial: time.Second,
+		RetryMax:     time.Hour,
+	}))
+	r.cfg = &cfg
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "c1"}}
+	res1, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, time.Second, res1.RequeueAfter, "first failure -> retryInitial")
+
+	res2, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Second, res2.RequeueAfter, "second failure -> doubled")
+
+	res3, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, 4*time.Second, res3.RequeueAfter, "third failure -> doubled again")
+}

--- a/pkg/controller/v1beta1/workloadcluster/options_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/options_test.go
@@ -293,6 +293,7 @@ func TestResolveConfig_Defaults(t *testing.T) {
 	assert.Equal(t, DefaultHealthInterval, c.healthInterval)
 	assert.Equal(t, DefaultConnectionGracePeriod, c.connectionGracePeriod)
 	assert.Equal(t, DefaultEventsBatchPeriod, c.eventsBatchPeriod)
+	assert.Equal(t, DefaultProbeTimeout, c.probeTimeout)
 	assert.Equal(t, DefaultEstablishInitialTimeout, c.reconnect.establishInitial)
 	assert.Equal(t, DefaultEstablishMaxTimeout, c.reconnect.establishMax)
 	assert.Equal(t, DefaultReconnectRetryMax, c.reconnect.retryMax)
@@ -320,6 +321,22 @@ func TestResolveConfig_SeedsAndOptions(t *testing.T) {
 	assert.Equal(t, 6*time.Millisecond, c.reconnect.establishMax)
 	assert.Equal(t, 7*time.Millisecond, c.reconnect.retryInitial)
 	assert.Equal(t, 8*time.Millisecond, c.reconnect.retryMax)
+}
+
+// TestProbeTimeout_ConfiguredValueWins: the probe budget is config-driven — the
+// configured per-call value reaches the reachability probe, and only an unset
+// knob falls back to the in-package default.
+func TestProbeTimeout_ConfiguredValueWins(t *testing.T) {
+	r := &Reconciler{}
+	assert.Equal(t, DefaultProbeTimeout, r.probeTimeout())
+
+	r = &Reconciler{ProbeTimeout: 250 * time.Millisecond}
+	assert.Equal(t, 250*time.Millisecond, r.probeTimeout(), "struct field must apply before Setup")
+
+	c := r.resolveConfig()
+	assert.Equal(t, 250*time.Millisecond, c.probeTimeout, "struct field must seed the resolved config")
+	r.cfg = &c
+	assert.Equal(t, 250*time.Millisecond, r.probeTimeout(), "resolved config must win after Setup")
 }
 
 // TestResolveConfig_NegativeGraceDisables: a negative ConnectionGracePeriod is a

--- a/pkg/controller/v1beta1/workloadcluster/remoteclient.go
+++ b/pkg/controller/v1beta1/workloadcluster/remoteclient.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -43,6 +44,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
+
+// DefaultRemoteCacheSyncTimeout bounds the initial informer LIST/sync during a
+// connection build. A remote cache that cannot start must fail the connection
+// rather than leave later reads or handler registration blocked indefinitely.
+const DefaultRemoteCacheSyncTimeout = time.Minute
 
 // cacheIndexOption defines a field to index on the cache before starting
 type CacheIndexOption struct {
@@ -176,18 +182,34 @@ func NewSelectivelyCachingClient(
 
 	var synced atomic.Bool
 
+	runCtx, cancelRun := context.WithCancel(ctx)
+	startErr := make(chan error, 1)
 	go func() {
-		if err := remoteCache.Start(ctx); err != nil {
-			ctrl.LoggerFrom(ctx).Error(err, "Remote cache execution failed")
-		}
+		defer cancelRun()
+		startErr <- remoteCache.Start(runCtx)
 	}()
-
-	go func() {
-		if remoteCache.WaitForCacheSync(ctx) {
-			synced.Store(true)
-			ctrl.LoggerFrom(ctx).V(2).Info("Remote cache successfully synchronized")
+	syncCtx, cancelSync := context.WithTimeout(runCtx, DefaultRemoteCacheSyncTimeout)
+	defer cancelSync()
+	syncDone := make(chan bool, 1)
+	go func() { syncDone <- remoteCache.WaitForCacheSync(syncCtx) }()
+	select {
+	case err := <-startErr:
+		if err == nil {
+			err = errors.New("remote cache stopped before initial synchronization")
 		}
-	}()
+		cancelRun()
+		return nil, fmt.Errorf("starting remote cache: %w", err)
+	case ok := <-syncDone:
+		if !ok {
+			cancelRun()
+			if err := syncCtx.Err(); err != nil {
+				return nil, fmt.Errorf("synchronizing remote cache: %w", err)
+			}
+			return nil, errors.New("synchronizing remote cache failed")
+		}
+		synced.Store(true)
+		ctrl.LoggerFrom(ctx).V(2).Info("Remote cache successfully synchronized")
+	}
 
 	cachedClient := &selectivelyCachingClient{
 		WithWatch:    directClient,

--- a/pkg/controller/v1beta1/workloadcluster/remoteclient.go
+++ b/pkg/controller/v1beta1/workloadcluster/remoteclient.go
@@ -1,0 +1,202 @@
+// This file is copied and adapted from kubernetes-sigs/kueue
+// (pkg/controller/admissionchecks/multikueue/remote_client.go), Apache-2.0.
+// Synced from kueue commit ab2dff32b (2026-06-20); re-diff against upstream
+// before editing or extending.
+// It provides a controller-runtime client that selectively caches chosen
+// kinds via a background informer cache, used by the WorkloadCluster
+// connection Manager.
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadcluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// cacheIndexOption defines a field to index on the cache before starting
+type CacheIndexOption struct {
+	Object       client.Object
+	Field        string
+	ExtractValue client.IndexerFunc
+}
+
+// SelectivelyCachingClient embeds standard WithWatch and adds direct event handler
+// registration capabilities for cached informers.
+type SelectivelyCachingClient interface {
+	client.WithWatch
+	// AddCacheEventHandler registers resource event handlers on the cache's underlying informer.
+	// Returns an error if the object kind is not cached.
+	AddCacheEventHandler(ctx context.Context, obj client.Object, handler toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error)
+}
+
+type neverCachingClient struct {
+	client.WithWatch
+}
+
+func (c *neverCachingClient) AddCacheEventHandler(ctx context.Context, obj client.Object, handler toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error) {
+	return nil, errors.New("NeverCachingClient does not support watch event handlers")
+}
+
+// NewNeverCachingClient just wraps around a client. Useful for unit tests.
+func NewNeverCachingClient(fakeClient client.WithWatch) SelectivelyCachingClient {
+	return &neverCachingClient{
+		WithWatch: fakeClient,
+	}
+}
+
+type selectivelyCachingClient struct {
+	client.WithWatch
+	cachedReader client.Reader
+	cache        cache.Cache
+	scheme       *runtime.Scheme
+	cachedKinds  sets.Set[schema.GroupKind]
+	synced       *atomic.Bool
+}
+
+func (c *selectivelyCachingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	gk := gvk.GroupKind()
+	if c.cachedKinds.Has(gk) && (c.synced.Load() || c.cache.WaitForCacheSync(ctx)) {
+		return c.cachedReader.Get(ctx, key, obj, opts...)
+	}
+	return c.WithWatch.Get(ctx, key, obj, opts...)
+}
+
+func (c *selectivelyCachingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	gvk, err := apiutil.GVKForObject(list, c.scheme)
+	if err != nil {
+		return err
+	}
+	gk := gvk.GroupKind()
+	gk.Kind = strings.TrimSuffix(gk.Kind, "List")
+	if c.cachedKinds.Has(gk) && (c.synced.Load() || c.cache.WaitForCacheSync(ctx)) {
+		return c.cachedReader.List(ctx, list, opts...)
+	}
+	return c.WithWatch.List(ctx, list, opts...)
+}
+
+func (c *selectivelyCachingClient) AddCacheEventHandler(ctx context.Context, obj client.Object, handler toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error) {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return nil, err
+	}
+	gk := gvk.GroupKind()
+	if !c.cachedKinds.Has(gk) {
+		return nil, fmt.Errorf("kind %s is not cached", gvk.String())
+	}
+	inf, err := c.cache.GetInformer(ctx, obj)
+	if err != nil {
+		return nil, fmt.Errorf("getting informer for caching: %w", err)
+	}
+	return inf.AddEventHandler(handler)
+}
+
+// podGroupKind is the GroupKind the remote cache must never hold: across many
+// large clusters the Pod informer alone would dwarf everything the placer reads
+// (aggregated derived-ISVC status, not remote Pods).
+var podGroupKind = corev1.SchemeGroupVersion.WithKind("Pod").GroupKind()
+
+// NewSelectivelyCachingClient constructs the background cache, registers indexes,
+// starts it in the background, and returns the client.
+//
+// defaultSelector scopes every cached kind to the caller-supplied label selector
+// (mirrors the manager cache's placement-origin scoping); pass nil to cache
+// unfiltered. There is intentionally no in-code default selector — the value is
+// the caller's to supply, per the repo's no-magic-values rule. Caching Pods is
+// rejected outright: the remote cache must never LIST+WATCH cluster-wide Pods.
+func NewSelectivelyCachingClient(
+	ctx context.Context,
+	restConfig *rest.Config,
+	directClient client.WithWatch,
+	scheme *runtime.Scheme,
+	cachedKinds sets.Set[schema.GroupKind],
+	indexes []CacheIndexOption,
+	defaultSelector labels.Selector,
+) (SelectivelyCachingClient, error) {
+	if cachedKinds.Has(podGroupKind) {
+		return nil, fmt.Errorf("refusing to cache kind %s: the remote cache must never hold cluster-wide Pods", podGroupKind.String())
+	}
+
+	cacheOpts := cache.Options{
+		Scheme: scheme,
+		// Strip managedFields from every cached object (typically a large
+		// fraction of each object's serialized size and never read here),
+		// mirroring the manager cache in cmd/manager/main.go.
+		DefaultTransform: cache.TransformStripManagedFields(),
+	}
+	if defaultSelector != nil {
+		cacheOpts.DefaultLabelSelector = defaultSelector
+	}
+
+	remoteCache, err := cache.New(restConfig, cacheOpts)
+	if err != nil {
+		return nil, fmt.Errorf("creating remote cache: %w", err)
+	}
+
+	for _, opt := range indexes {
+		err = remoteCache.IndexField(ctx, opt.Object, opt.Field, opt.ExtractValue)
+		if err != nil {
+			return nil, fmt.Errorf("registering index for %s on %s: %w", opt.Field, opt.Object.GetObjectKind().GroupVersionKind().Kind, err)
+		}
+	}
+
+	var synced atomic.Bool
+
+	go func() {
+		if err := remoteCache.Start(ctx); err != nil {
+			ctrl.LoggerFrom(ctx).Error(err, "Remote cache execution failed")
+		}
+	}()
+
+	go func() {
+		if remoteCache.WaitForCacheSync(ctx) {
+			synced.Store(true)
+			ctrl.LoggerFrom(ctx).V(2).Info("Remote cache successfully synchronized")
+		}
+	}()
+
+	cachedClient := &selectivelyCachingClient{
+		WithWatch:    directClient,
+		cachedReader: remoteCache,
+		cache:        remoteCache,
+		scheme:       scheme,
+		cachedKinds:  cachedKinds,
+		synced:       &synced,
+	}
+
+	return cachedClient, nil
+}

--- a/pkg/controller/v1beta1/workloadcluster/remoteclient_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/remoteclient_test.go
@@ -1,0 +1,40 @@
+package workloadcluster
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNeverCachingClient_NoCacheHandler(t *testing.T) {
+	fc := fake.NewClientBuilder().Build()
+	c := NewNeverCachingClient(fc)
+	if _, err := c.AddCacheEventHandler(context.Background(), &corev1.Pod{}, nil); err == nil {
+		t.Errorf("AddCacheEventHandler on NeverCachingClient: got nil error, want error")
+	}
+}
+
+// NewSelectivelyCachingClient must refuse to cache Pods before any cluster
+// contact: a cluster-wide Pod informer is exactly the OOM the remote cache
+// guards against. The guard returns before cache.New, so a nil restConfig
+// proves it short-circuits.
+func TestNewSelectivelyCachingClient_RejectsPodKind(t *testing.T) {
+	podGK := schema.GroupKind{Group: "", Kind: "Pod"}
+	_, err := NewSelectivelyCachingClient(
+		context.Background(),
+		(*rest.Config)(nil),
+		fake.NewClientBuilder().Build(),
+		nil,
+		sets.New(podGK),
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatalf("NewSelectivelyCachingClient with Pod in cachedKinds: got nil error, want rejection")
+	}
+}

--- a/pkg/controller/v1beta1/workloadcluster/watchfunnel.go
+++ b/pkg/controller/v1beta1/workloadcluster/watchfunnel.go
@@ -1,0 +1,364 @@
+// The cross-cluster status watch-funnel below is adapted from
+// kubernetes-sigs/kueue (pkg/controller/admissionchecks/multikueue/
+// multikueuecluster.go startWatcher/queueWorkloadEvent and workload.go
+// source.Channel), Apache-2.0: a per-remote-cluster watch whose events are
+// resolved to a LOCAL object key and pushed onto a buffered channel the
+// local controller consumes via source.Channel, so cross-cluster status
+// converges on events rather than a fixed poll.
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadcluster
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	toolscache "k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// DefaultFunnelResyncInterval is the fallback cadence at which the StatusFunnel
+// reconciles its per-cluster watch set against the Manager's connected clusters
+// (establishing a watch for a newly-connected cluster, dropping one for a
+// departed cluster). It is NOT the status-convergence latency — events flow as
+// they happen — only how often newly-connected clusters are noticed. The
+// operative value is config-driven (functional option); this is the
+// graceful-degradation default.
+const DefaultFunnelResyncInterval = 10 * time.Second
+
+// DefaultFunnelBufferSize is the fallback depth of the buffered event channel
+// the funnel pushes resolved local keys onto. Small and bounded on purpose: a
+// burst of remote status churn must not let the funnel accumulate unbounded
+// memory, and a dropped event is harmless because the long safety-requeue on
+// the consumer re-reconciles regardless. The operative value is config-driven;
+// this is the graceful-degradation default.
+const DefaultFunnelBufferSize = 10
+
+// LocalKeyResolver maps a remote object delivered by a workload-cluster informer
+// to the LOCAL (control-plane) object key the funnel should re-reconcile, and
+// reports whether the object is one this control plane owns. It is injected by
+// the caller (the placement package, which owns the origin/control-plane label
+// semantics) so this package does not import placement — mirroring how
+// CacheOptions injects the cached kinds and origin selector. Returning ok=false
+// drops the event (an object we did not derive, or one lacking the origin
+// marker).
+type LocalKeyResolver func(remote client.Object) (local types.NamespacedName, ok bool)
+
+// FunnelConfig is the caller-supplied configuration for a StatusFunnel. The
+// watched kind, the empty list/object constructors, the origin-scoped watch
+// selector, and the remote-to-local key resolver are all placement concerns
+// supplied here rather than hardcoded, so this package stays free of placement
+// imports and of magic values.
+type FunnelConfig struct {
+	// NewList returns a fresh empty list of the watched (cached) kind, used to
+	// drive EstablishWatch.
+	NewList func() client.ObjectList
+	// NewObject returns a fresh empty object of the watched (cached) kind, used to
+	// register the cache event handler via AddCacheEventHandler and as the stub
+	// carried on the emitted GenericEvent.
+	NewObject func() client.Object
+	// Resolve maps a remote object to the local key to re-reconcile. Required.
+	Resolve LocalKeyResolver
+	// WatchSelector scopes the establish-watch (and is expected to match the
+	// cache's DefaultSelector) to this control plane's derived objects. Nil
+	// watches unfiltered — but the caller should pass the origin selector so the
+	// remote apiserver only streams objects this control plane owns.
+	WatchSelector labels.Selector
+	// ResyncInterval overrides how often the watch set is reconciled against the
+	// connected clusters. Zero falls back to DefaultFunnelResyncInterval.
+	ResyncInterval time.Duration
+	// BufferSize overrides the event channel depth. Zero (or negative) falls back
+	// to DefaultFunnelBufferSize.
+	BufferSize int
+}
+
+// StatusFunnel turns remote workload-cluster derived-object events into local
+// reconcile triggers. For every connected cluster it (1) confirms the
+// origin-scoped remote watch can be established — bounded by the Manager's
+// configured establish timeout and spaced by the retry backoff on failure — and
+// then (2) registers a cache event handler on that cluster's derived-object
+// informer; each delivered event is resolved to the LOCAL object key and pushed
+// onto a small buffered channel the placement controller consumes via
+// source.Channel. The established watch additionally serves as a liveness
+// signal: when it ends while the manager is still running, the cluster is
+// re-established.
+//
+// It implements sigs.k8s.io/controller-runtime/pkg/manager.Runnable so the cmd
+// wires it with mgr.Add(funnel); Start blocks until its context is cancelled.
+type StatusFunnel struct {
+	mgr *Manager
+	cfg FunnelConfig
+
+	events chan event.GenericEvent
+
+	mu      sync.Mutex
+	watched map[string]context.CancelFunc // cluster -> cancel for its watch goroutine
+}
+
+// NewStatusFunnel constructs a funnel over the given Manager. The buffered event
+// channel is created up front so Events() is safe to wire into source.Channel
+// before Start runs.
+func NewStatusFunnel(mgr *Manager, cfg FunnelConfig) *StatusFunnel {
+	size := cfg.BufferSize
+	if size <= 0 {
+		size = DefaultFunnelBufferSize
+	}
+	return &StatusFunnel{
+		mgr:     mgr,
+		cfg:     cfg,
+		events:  make(chan event.GenericEvent, size),
+		watched: map[string]context.CancelFunc{},
+	}
+}
+
+// Events returns the receive end of the funnel's buffered channel. Wire it into
+// the consuming controller with source.Channel; the funnel pushes a
+// GenericEvent carrying a stub local object (name/namespace set) for each remote
+// derived change it resolves to one of this control plane's sources.
+func (f *StatusFunnel) Events() <-chan event.GenericEvent {
+	return f.events
+}
+
+// resyncInterval returns the configured watch-set reconcile cadence, falling
+// back to the package default.
+func (f *StatusFunnel) resyncInterval() time.Duration {
+	if f.cfg.ResyncInterval > 0 {
+		return f.cfg.ResyncInterval
+	}
+	return DefaultFunnelResyncInterval
+}
+
+// Start runs the funnel until ctx is cancelled. It periodically reconciles the
+// set of watched clusters against the Manager's connected set, then tears every
+// watch down on shutdown. Implements manager.Runnable.
+func (f *StatusFunnel) Start(ctx context.Context) error {
+	// The funnel cannot operate without a resolver or kind constructors; rather
+	// than push a nil-laden event, no-op gracefully (degrade to the consumer's
+	// safety requeue) so a partially-wired manager still starts.
+	if f.cfg.Resolve == nil || f.cfg.NewList == nil || f.cfg.NewObject == nil {
+		ctrl.LoggerFrom(ctx).Info("status funnel not fully configured; cross-cluster status will rely on the safety requeue")
+		<-ctx.Done()
+		return nil
+	}
+
+	ticker := time.NewTicker(f.resyncInterval())
+	defer ticker.Stop()
+
+	f.reconcileWatches(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			f.stopAll()
+			return nil
+		case <-ticker.C:
+			f.reconcileWatches(ctx)
+		}
+	}
+}
+
+// reconcileWatches starts a watch goroutine for every newly-connected cluster
+// and cancels the goroutine for every cluster that has since disconnected.
+func (f *StatusFunnel) reconcileWatches(ctx context.Context) {
+	connected := make(map[string]struct{})
+	for _, name := range f.mgr.Connected() {
+		connected[name] = struct{}{}
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Drop watches for clusters no longer connected.
+	for name, cancel := range f.watched {
+		if _, ok := connected[name]; !ok {
+			cancel()
+			delete(f.watched, name)
+		}
+	}
+	// Start watches for clusters not yet watched.
+	for name := range connected {
+		if _, ok := f.watched[name]; ok {
+			continue
+		}
+		wctx, cancel := context.WithCancel(ctx)
+		f.watched[name] = cancel
+		go f.watchCluster(wctx, name)
+	}
+}
+
+// stopAll cancels every per-cluster watch goroutine. Called on Start shutdown.
+func (f *StatusFunnel) stopAll() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for name, cancel := range f.watched {
+		cancel()
+		delete(f.watched, name)
+	}
+}
+
+// watchCluster maintains the watch for one cluster until ctx is cancelled: it
+// establishes the origin-scoped remote watch (bounded by the establish timeout,
+// retry-backoff-spaced on failure), registers the cache event handler once, then
+// blocks on the established watch as a liveness signal, re-establishing when it
+// ends. The cache handler registration is idempotent across re-establishment.
+func (f *StatusFunnel) watchCluster(ctx context.Context, cluster string) {
+	log := ctrl.LoggerFrom(ctx).WithValues("cluster", cluster)
+	backoff := f.mgr.ReconnectBackoff()
+
+	var failed uint
+	handlerRegistered := false
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		// Space retries after a failure with the configured retry backoff so a
+		// persistently-unwatchable cluster is not hammered.
+		if d := backoff.retryAfter(failed); d > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(d):
+			}
+		}
+
+		w, connected, err := f.mgr.EstablishWatch(ctx, cluster, f.cfg.NewList(), int(failed)+1, f.watchListOpts()...)
+		if !connected {
+			// The cluster disconnected out from under us; the resync loop will
+			// drop this goroutine. Stop trying.
+			return
+		}
+		if err != nil {
+			failed++
+			log.V(2).Info("status funnel: establish watch failed; backing off", "failedAttempts", failed, "err", err.Error())
+			continue
+		}
+		failed = 0
+
+		// Register the cache event handler once the watch is confirmed
+		// establishable. This is the steady-state event source; the established
+		// watch below is held only as a liveness signal.
+		if !handlerRegistered {
+			if err := f.registerCacheHandler(ctx, cluster); err != nil {
+				// The handler could not be registered (kind not cached / cache not
+				// ready). Abandon the established watch and retry with backoff.
+				w.Stop()
+				failed++
+				log.V(2).Info("status funnel: register cache handler failed; backing off", "failedAttempts", failed, "err", err.Error())
+				continue
+			}
+			handlerRegistered = true
+			log.V(2).Info("status funnel: cache event handler registered")
+		}
+
+		// Block on the established watch as a liveness probe. Its events are not
+		// pushed (the cache handler already covers them); when the stream ends and
+		// the context is still live, loop back to re-establish.
+		f.drainUntilEnd(ctx, w)
+		if ctx.Err() != nil {
+			return
+		}
+		log.V(2).Info("status funnel: watch ended; re-establishing")
+	}
+}
+
+// watchListOpts builds the list options for EstablishWatch: scope the stream to
+// this control plane's derived objects via the origin selector when supplied.
+func (f *StatusFunnel) watchListOpts() []client.ListOption {
+	if f.cfg.WatchSelector == nil {
+		return nil
+	}
+	return []client.ListOption{client.MatchingLabelsSelector{Selector: f.cfg.WatchSelector}}
+}
+
+// drainUntilEnd reads (and discards) the liveness watch's result channel until
+// it closes or the context is cancelled. Discarding is intentional: the cache
+// event handler is the event source, and draining here prevents the watch's
+// buffer from filling while it serves purely as an end-of-stream signal.
+func (f *StatusFunnel) drainUntilEnd(ctx context.Context, w watch.Interface) {
+	defer w.Stop()
+	results := w.ResultChan()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-results:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+// registerCacheHandler installs the resolve-and-push event handler on the
+// cluster's derived-object cache informer. Add/Update/Delete all re-trigger the
+// local source: a derived appearing, changing status, or vanishing on a workload
+// cluster are each events the placer must observe.
+func (f *StatusFunnel) registerCacheHandler(ctx context.Context, cluster string) error {
+	cl, ok := f.mgr.ClientFor(cluster)
+	if !ok {
+		return fmt.Errorf("cluster %q is not connected", cluster)
+	}
+	h := toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { f.push(ctx, obj) },
+		UpdateFunc: func(_, newObj any) { f.push(ctx, newObj) },
+		DeleteFunc: func(obj any) { f.push(ctx, deletedObject(obj)) },
+	}
+	_, err := cl.AddCacheEventHandler(ctx, f.cfg.NewObject(), h)
+	return err
+}
+
+// push resolves a remote object to its local key and, if it is one of this
+// control plane's deriveds, enqueues a GenericEvent carrying a stub local object
+// (name/namespace only — the consumer re-reads the live object). The send is
+// non-blocking: when the buffered channel is full the event is DROPPED rather
+// than blocking the informer's handler goroutine. A dropped event only delays
+// convergence to the consumer's long safety requeue; blocking the shared
+// informer callback would stall every other handler on that cache.
+func (f *StatusFunnel) push(ctx context.Context, obj any) {
+	co, ok := obj.(client.Object)
+	if !ok || co == nil {
+		return
+	}
+	key, ok := f.cfg.Resolve(co)
+	if !ok {
+		return
+	}
+	stub := f.cfg.NewObject()
+	stub.SetNamespace(key.Namespace)
+	stub.SetName(key.Name)
+	select {
+	case f.events <- event.GenericEvent{Object: stub}:
+	default:
+		ctrl.LoggerFrom(ctx).V(4).Info("status funnel: event channel full, dropping (safety requeue will recover)",
+			"namespace", key.Namespace, "name", key.Name)
+	}
+}
+
+// deletedObject unwraps a cache tombstone (DeletedFinalStateUnknown) to the
+// underlying object so a delete event resolves the same way an add/update does.
+func deletedObject(obj any) any {
+	if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
+		return tombstone.Obj
+	}
+	return obj
+}

--- a/pkg/controller/v1beta1/workloadcluster/watchfunnel.go
+++ b/pkg/controller/v1beta1/workloadcluster/watchfunnel.go
@@ -226,7 +226,7 @@ func (f *StatusFunnel) watchCluster(ctx context.Context, cluster string) {
 	backoff := f.mgr.ReconnectBackoff()
 
 	var failed uint
-	handlerRegistered := false
+	var handlerGeneration uint64
 	for {
 		if ctx.Err() != nil {
 			return
@@ -241,11 +241,13 @@ func (f *StatusFunnel) watchCluster(ctx context.Context, cluster string) {
 			}
 		}
 
-		w, connected, err := f.mgr.EstablishWatch(ctx, cluster, f.cfg.NewList(), int(failed)+1, f.watchListOpts()...)
+		w, generation, connected, err := f.mgr.EstablishWatch(ctx, cluster, f.cfg.NewList(), int(failed)+1, f.watchListOpts()...)
 		if !connected {
-			// The cluster disconnected out from under us; the resync loop will
-			// drop this goroutine. Stop trying.
-			return
+			// A disconnect can race with an immediate reconnect. Keep this watch
+			// slot alive and retry until the resync loop cancels it, so a reconnect
+			// before the next resync cannot leave a stale f.watched entry.
+			failed++
+			continue
 		}
 		if err != nil {
 			failed++
@@ -257,8 +259,8 @@ func (f *StatusFunnel) watchCluster(ctx context.Context, cluster string) {
 		// Register the cache event handler once the watch is confirmed
 		// establishable. This is the steady-state event source; the established
 		// watch below is held only as a liveness signal.
-		if !handlerRegistered {
-			if err := f.registerCacheHandler(ctx, cluster); err != nil {
+		if handlerGeneration != generation {
+			if err := f.registerCacheHandler(ctx, cluster, generation); err != nil {
 				// The handler could not be registered (kind not cached / cache not
 				// ready). Abandon the established watch and retry with backoff.
 				w.Stop()
@@ -266,8 +268,8 @@ func (f *StatusFunnel) watchCluster(ctx context.Context, cluster string) {
 				log.V(2).Info("status funnel: register cache handler failed; backing off", "failedAttempts", failed, "err", err.Error())
 				continue
 			}
-			handlerRegistered = true
-			log.V(2).Info("status funnel: cache event handler registered")
+			handlerGeneration = generation
+			log.V(2).Info("status funnel: cache event handler registered", "generation", generation)
 		}
 
 		// Block on the established watch as a liveness probe. Its events are not
@@ -313,10 +315,13 @@ func (f *StatusFunnel) drainUntilEnd(ctx context.Context, w watch.Interface) {
 // cluster's derived-object cache informer. Add/Update/Delete all re-trigger the
 // local source: a derived appearing, changing status, or vanishing on a workload
 // cluster are each events the placer must observe.
-func (f *StatusFunnel) registerCacheHandler(ctx context.Context, cluster string) error {
-	cl, ok := f.mgr.ClientFor(cluster)
+func (f *StatusFunnel) registerCacheHandler(ctx context.Context, cluster string, generation uint64) error {
+	cl, currentGeneration, ok := f.mgr.clientForGeneration(cluster)
 	if !ok {
 		return fmt.Errorf("cluster %q is not connected", cluster)
+	}
+	if currentGeneration != generation {
+		return fmt.Errorf("cluster %q client changed from generation %d to %d", cluster, generation, currentGeneration)
 	}
 	h := toolscache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj any) { f.push(ctx, obj) },

--- a/pkg/controller/v1beta1/workloadcluster/watchfunnel_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/watchfunnel_test.go
@@ -1,0 +1,298 @@
+package workloadcluster
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	toolscache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// originResolver is a test resolver: it accepts objects carrying a non-empty
+// "origin" label and maps them to their own namespace/name (mirroring how the
+// real derived-ISVC resolver works), and rejects the rest.
+func originResolver(obj client.Object) (types.NamespacedName, bool) {
+	if obj == nil || obj.GetLabels()["origin"] == "" {
+		return types.NamespacedName{}, false
+	}
+	return types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, true
+}
+
+func testFunnel(buffer int) *StatusFunnel {
+	return NewStatusFunnel(NewManager(nil), FunnelConfig{
+		NewList:    func() client.ObjectList { return &corev1.ConfigMapList{} },
+		NewObject:  func() client.Object { return &corev1.ConfigMap{} },
+		Resolve:    originResolver,
+		BufferSize: buffer,
+	})
+}
+
+// TestFunnel_PushResolvesAndEmits: an object the resolver accepts produces a
+// GenericEvent on the channel carrying the resolved LOCAL key (namespace/name).
+func TestFunnel_PushResolvesAndEmits(t *testing.T) {
+	f := testFunnel(4)
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "team-a", Name: "llama", Labels: map[string]string{"origin": "uid-1"},
+	}}
+	f.push(context.Background(), obj)
+
+	select {
+	case ev := <-f.Events():
+		if ev.Object == nil {
+			t.Fatalf("emitted event has nil object")
+		}
+		if ev.Object.GetNamespace() != "team-a" || ev.Object.GetName() != "llama" {
+			t.Errorf("emitted key = %s/%s, want team-a/llama", ev.Object.GetNamespace(), ev.Object.GetName())
+		}
+	default:
+		t.Fatalf("expected an event on the channel, got none")
+	}
+}
+
+// TestFunnel_PushDropsUnresolved: an object the resolver rejects (no origin
+// marker) produces NO event — the funnel never re-reconciles off a foreign object.
+func TestFunnel_PushDropsUnresolved(t *testing.T) {
+	f := testFunnel(4)
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "user-owned"}}
+	f.push(context.Background(), obj)
+
+	select {
+	case ev := <-f.Events():
+		t.Fatalf("expected no event for unresolved object, got %v", ev.Object)
+	default:
+	}
+}
+
+// TestFunnel_PushNonObject: a non-client.Object payload (defensive) is dropped
+// without panic.
+func TestFunnel_PushNonObject(t *testing.T) {
+	f := testFunnel(4)
+	f.push(context.Background(), "not an object")
+	f.push(context.Background(), nil)
+	select {
+	case ev := <-f.Events():
+		t.Fatalf("expected no event for non-object payloads, got %v", ev.Object)
+	default:
+	}
+}
+
+// TestFunnel_PushDropsWhenFull: with a full buffer the push is non-blocking and
+// drops the overflow rather than wedging the informer callback. The buffered
+// events remain; the dropped one is simply absent.
+func TestFunnel_PushDropsWhenFull(t *testing.T) {
+	f := testFunnel(2)
+	mk := func(name string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns", Name: name, Labels: map[string]string{"origin": "u"},
+		}}
+	}
+	// Fill the buffer (2) then overflow with a 3rd; push must not block.
+	done := make(chan struct{})
+	go func() {
+		f.push(context.Background(), mk("a"))
+		f.push(context.Background(), mk("b"))
+		f.push(context.Background(), mk("c")) // dropped (buffer full)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("push blocked on a full channel; want non-blocking drop")
+	}
+
+	// Exactly the two buffered events are present.
+	if got := drainNames(f); len(got) != 2 {
+		t.Errorf("buffered events = %d (%v), want 2", len(got), got)
+	}
+}
+
+func drainNames(f *StatusFunnel) []string {
+	var names []string
+	for {
+		select {
+		case ev := <-f.Events():
+			names = append(names, ev.Object.GetName())
+		default:
+			return names
+		}
+	}
+}
+
+// TestFunnel_WatchListOpts: when a selector is configured the establish-watch is
+// scoped by it; without one no options are passed (watch unfiltered).
+func TestFunnel_WatchListOpts(t *testing.T) {
+	// No selector => no options.
+	f := testFunnel(1)
+	if opts := f.watchListOpts(); len(opts) != 0 {
+		t.Errorf("watchListOpts with no selector = %d opts, want 0", len(opts))
+	}
+
+	// Selector => exactly one MatchingLabelsSelector option carrying it.
+	req, err := labels.NewRequirement("origin", selection.Exists, nil)
+	if err != nil {
+		t.Fatalf("building requirement: %v", err)
+	}
+	sel := labels.NewSelector().Add(*req)
+	f2 := NewStatusFunnel(NewManager(nil), FunnelConfig{
+		NewList:       func() client.ObjectList { return &corev1.ConfigMapList{} },
+		NewObject:     func() client.Object { return &corev1.ConfigMap{} },
+		Resolve:       originResolver,
+		WatchSelector: sel,
+	})
+	opts := f2.watchListOpts()
+	if len(opts) != 1 {
+		t.Fatalf("watchListOpts with selector = %d opts, want 1", len(opts))
+	}
+	lo := &client.ListOptions{}
+	opts[0].ApplyToList(lo)
+	if lo.LabelSelector == nil || !lo.LabelSelector.Matches(labels.Set{"origin": "x"}) {
+		t.Errorf("watchListOpts selector did not carry the configured selector")
+	}
+}
+
+// TestFunnel_DeletedObjectUnwrapsTombstone: a cache DeletedFinalStateUnknown
+// tombstone resolves to the wrapped object so a delete event is handled like an
+// add/update.
+func TestFunnel_DeletedObjectUnwrapsTombstone(t *testing.T) {
+	inner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "m"}}
+	tombstone := toolscache.DeletedFinalStateUnknown{Key: "ns/m", Obj: inner}
+	got := deletedObject(tombstone)
+	if got != any(inner) {
+		t.Errorf("deletedObject(tombstone) = %v, want the wrapped object", got)
+	}
+	// A plain object passes through unchanged.
+	if got := deletedObject(inner); got != any(inner) {
+		t.Errorf("deletedObject(plain) = %v, want the object itself", got)
+	}
+}
+
+// TestFunnel_DefaultBufferSize: a zero/negative buffer falls back to the default
+// depth (no panic, channel usable).
+func TestFunnel_DefaultBufferSize(t *testing.T) {
+	f := NewStatusFunnel(NewManager(nil), FunnelConfig{
+		NewObject: func() client.Object { return &corev1.ConfigMap{} },
+		Resolve:   originResolver,
+	})
+	if cap(f.events) != DefaultFunnelBufferSize {
+		t.Errorf("default buffer cap = %d, want %d", cap(f.events), DefaultFunnelBufferSize)
+	}
+}
+
+// TestFunnel_StartNoOpWhenUnconfigured: a funnel missing its resolver/kind
+// constructors must start and block (degrade to the consumer's safety requeue)
+// rather than panic, and must return promptly on context cancel.
+func TestFunnel_StartNoOpWhenUnconfigured(t *testing.T) {
+	f := NewStatusFunnel(NewManager(nil), FunnelConfig{}) // no Resolve/NewList/NewObject
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- f.Start(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start returned %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Start did not return after context cancel")
+	}
+}
+
+// fakeWatchClient is a SelectivelyCachingClient that returns a fake watcher from
+// Watch and records the cache event handler so a test can drive informer events
+// through the funnel's resolve+push path without a real apiserver.
+type fakeWatchClient struct {
+	SelectivelyCachingClient
+	mu      sync.Mutex
+	watcher *watch.FakeWatcher
+	handler toolscache.ResourceEventHandler
+}
+
+func (c *fakeWatchClient) Watch(_ context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.watcher = watch.NewFake()
+	return c.watcher, nil
+}
+
+func (c *fakeWatchClient) AddCacheEventHandler(_ context.Context, _ client.Object, h toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.handler = h
+	return nil, nil
+}
+
+func (c *fakeWatchClient) getHandler() toolscache.ResourceEventHandler {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.handler
+}
+
+// TestFunnel_WatchClusterRegistersHandlerAndPushes drives the full per-cluster
+// path: establish the watch via the Manager, register the cache handler, then a
+// cache Add of an owned object resolves to its local key and lands on the
+// channel. A short-circuit establish backoff keeps the test fast.
+func TestFunnel_WatchClusterRegistersHandlerAndPushes(t *testing.T) {
+	fc := &fakeWatchClient{}
+	m := NewManager(runtime.NewScheme())
+	m.newClient = func(_ context.Context, _ []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		return fc, func() {}, nil
+	}
+	// Retry/establish backoff with no establish wait so EstablishWatch returns
+	// immediately; retry is irrelevant on the success path.
+	m.SetReconnectBackoff(reconnectBackoff{
+		establishInitial: time.Second, establishMax: time.Second, establishFactor: 2,
+		retryInitial: time.Millisecond, retryMax: time.Millisecond,
+	})
+	if err := m.Connect(context.Background(), "c1", []byte("kc")); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	f := NewStatusFunnel(m, FunnelConfig{
+		NewList:    func() client.ObjectList { return &corev1.ConfigMapList{} },
+		NewObject:  func() client.Object { return &corev1.ConfigMap{} },
+		Resolve:    originResolver,
+		BufferSize: 4,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go f.watchCluster(ctx, "c1")
+
+	// Wait for the handler to be registered (establishment confirmed first).
+	var h toolscache.ResourceEventHandler
+	deadline := time.After(2 * time.Second)
+	for h == nil {
+		select {
+		case <-deadline:
+			t.Fatalf("cache handler was never registered")
+		default:
+			h = fc.getHandler()
+			if h == nil {
+				time.Sleep(5 * time.Millisecond)
+			}
+		}
+	}
+
+	// Drive an informer Add of an owned object through the handler.
+	h.OnAdd(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "team-a", Name: "llama", Labels: map[string]string{"origin": "uid-1"},
+	}}, false)
+
+	select {
+	case ev := <-f.Events():
+		if ev.Object.GetNamespace() != "team-a" || ev.Object.GetName() != "llama" {
+			t.Errorf("emitted key = %s/%s, want team-a/llama", ev.Object.GetNamespace(), ev.Object.GetName())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("no event after informer Add of an owned object")
+	}
+}

--- a/pkg/controller/v1beta1/workloadcluster/watchfunnel_test.go
+++ b/pkg/controller/v1beta1/workloadcluster/watchfunnel_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -236,6 +238,25 @@ func (c *fakeWatchClient) getHandler() toolscache.ResourceEventHandler {
 	return c.handler
 }
 
+func (c *fakeWatchClient) stopWatcher() {
+	c.mu.Lock()
+	w := c.watcher
+	c.mu.Unlock()
+	if w != nil {
+		w.Stop()
+	}
+}
+
+func waitForHandler(t *testing.T, c *fakeWatchClient) toolscache.ResourceEventHandler {
+	t.Helper()
+	var h toolscache.ResourceEventHandler
+	require.Eventually(t, func() bool {
+		h = c.getHandler()
+		return h != nil
+	}, 2*time.Second, 5*time.Millisecond, "cache handler was never registered")
+	return h
+}
+
 // TestFunnel_WatchClusterRegistersHandlerAndPushes drives the full per-cluster
 // path: establish the watch via the Manager, register the cache handler, then a
 // cache Add of an owned object resolves to its local key and lands on the
@@ -268,19 +289,7 @@ func TestFunnel_WatchClusterRegistersHandlerAndPushes(t *testing.T) {
 	go f.watchCluster(ctx, "c1")
 
 	// Wait for the handler to be registered (establishment confirmed first).
-	var h toolscache.ResourceEventHandler
-	deadline := time.After(2 * time.Second)
-	for h == nil {
-		select {
-		case <-deadline:
-			t.Fatalf("cache handler was never registered")
-		default:
-			h = fc.getHandler()
-			if h == nil {
-				time.Sleep(5 * time.Millisecond)
-			}
-		}
-	}
+	h := waitForHandler(t, fc)
 
 	// Drive an informer Add of an owned object through the handler.
 	h.OnAdd(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
@@ -294,5 +303,51 @@ func TestFunnel_WatchClusterRegistersHandlerAndPushes(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("no event after informer Add of an owned object")
+	}
+}
+
+func TestFunnel_WatchClusterRegistersHandlerAfterClientReplacement(t *testing.T) {
+	first := &fakeWatchClient{}
+	second := &fakeWatchClient{}
+	m := NewManager(runtime.NewScheme())
+	m.newClient = func(_ context.Context, raw []byte, _ *runtime.Scheme) (SelectivelyCachingClient, context.CancelFunc, error) {
+		fc := first
+		if string(raw) == "B" {
+			fc = second
+		}
+		return fc, fc.stopWatcher, nil
+	}
+	m.SetReconnectBackoff(reconnectBackoff{
+		establishInitial: time.Second, establishMax: time.Second, establishFactor: 2,
+		retryInitial: time.Millisecond, retryMax: time.Millisecond,
+	})
+	require.NoError(t, m.Connect(context.Background(), "c1", []byte("A")))
+
+	f := NewStatusFunnel(m, FunnelConfig{
+		NewList:    func() client.ObjectList { return &corev1.ConfigMapList{} },
+		NewObject:  func() client.Object { return &corev1.ConfigMap{} },
+		Resolve:    originResolver,
+		BufferSize: 4,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go f.watchCluster(ctx, "c1")
+	waitForHandler(t, first)
+
+	// Leave a real disconnected gap before reconnecting. The per-cluster loop
+	// must keep retrying, and the replacement cache needs its own handler.
+	m.Disconnect("c1")
+	time.Sleep(20 * time.Millisecond)
+	require.NoError(t, m.Connect(context.Background(), "c1", []byte("B")))
+	h := waitForHandler(t, second)
+
+	h.OnAdd(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "team-a", Name: "replacement", Labels: map[string]string{"origin": "uid-2"},
+	}}, false)
+	select {
+	case ev := <-f.Events():
+		assert.Equal(t, "replacement", ev.Object.GetName())
+	case <-time.After(2 * time.Second):
+		t.Fatal("replacement client handler did not emit an event")
 	}
 }


### PR DESCRIPTION
**Part 2 of 5** — depends on #726 (merge that first).

Adds the WorkloadCluster registry/transport: per-member remote clients, connection health tracking, reconnect backoff, an optional scoped cache with a status watch funnel, and an exec-credential policy gate. Runs as a manager Runnable so remote clients and cache informers share the controller-manager lifecycle and disconnect cleanly on shutdown.

> Squash-only repo: this PR's diff currently also includes #726's commit. Once #726 merges, I'll rebase this branch onto `main` so only the WorkloadCluster commit remains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WorkloadCluster connection management with secure kubeconfig validation and reachability checks.
  * Added automatic remote client connection, reconnection, lifecycle cleanup, and configurable retry backoff.
  * Added selective remote resource caching and cross-cluster status event forwarding.
  * Added permissions for WorkloadCluster resources and status updates.
* **Bug Fixes**
  * Improved handling of transient connection and configuration failures while preserving healthy connections.
* **Tests**
  * Added comprehensive coverage for connection security, reconciliation, caching, retries, and cross-cluster watch events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->