### PR TITLE
[Core] Multi-cluster: placement + endpoint

### DIFF
--- a/charts/ome-resources/templates/ome-controller/rbac/role.yaml
+++ b/charts/ome-resources/templates/ome-controller/rbac/role.yaml
@@ -92,6 +92,18 @@ rules:
   - patch
   - update
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - keda.sh
   resources:
   - scaledobjects

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -92,6 +92,18 @@ rules:
   - patch
   - update
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - keda.sh
   resources:
   - scaledobjects

--- a/pkg/controller/v1beta1/placement/admission.go
+++ b/pkg/controller/v1beta1/placement/admission.go
@@ -1,0 +1,112 @@
+package placement
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector"
+)
+
+// componentIRStatuses fetches the authoritative InferenceReplica status for
+// every declared component of isvc via the given workload-cluster reader. The
+// derived ISVC and its per-component InferenceReplicas live on the same workload
+// cluster, so `reads` must be that cluster's client. A missing IR yields a nil
+// map entry, which the predicates treat as "no status yet" — the same way the
+// pre-migration code treated an absent ISVC status copy. The authoritative IR
+// status is the source of truth; the ISVC's mirrored LifecycleStatus is no
+// longer read.
+func componentIRStatuses(ctx context.Context, reads client.Reader, isvc *v1beta1.InferenceService) (map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus, error) {
+	out := make(map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus)
+	for _, c := range declaredComponents(isvc) {
+		st, err := irprojector.ComponentIRStatus(ctx, reads, isvc.Namespace, isvc.Name, c)
+		if err != nil {
+			return nil, err
+		}
+		out[c] = st
+	}
+	return out, nil
+}
+
+// AnyInstanceAdmitted reports whether any component of the (derived) ISVC has at
+// least one Instance that has left the Kueue admission gate. Retained as a
+// low-level predicate (and for single-component callers); the placement
+// winner uses AllComponentsAdmitted, which is correct for multi-component (PD)
+// services. `statuses` is the authoritative per-component IR status assembled by
+// componentIRStatuses.
+func AnyInstanceAdmitted(statuses map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus) bool {
+	for _, st := range statuses {
+		if componentHasAdmittedInstance(st) {
+			return true
+		}
+	}
+	return false
+}
+
+// AllComponentsAdmitted reports whether EVERY component the derived ISVC declares
+// in its spec has at least one admitted Instance. This is the win
+// signal: a cluster wins only once Kueue has admitted all of the service's
+// components there. For a PD service (engine + decoder) this prevents declaring a
+// winner while the engine is admitted but the decoder is still gated — which
+// would otherwise delete the losers prematurely and strand a half-placed
+// service. A service with no declared components is never a winner. `statuses` is
+// the authoritative per-component IR status assembled by componentIRStatuses.
+func AllComponentsAdmitted(isvc *v1beta1.InferenceService, statuses map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus) bool {
+	declared := declaredComponents(isvc)
+	if len(declared) == 0 {
+		return false
+	}
+	for _, comp := range declared {
+		if !componentHasAdmittedInstance(statuses[comp]) {
+			return false
+		}
+	}
+	return true
+}
+
+// admittedReplicaCount returns how many instances in an IR status are admitted
+// (their pods cleared the Kueue gate) — the per-home admitted-replica count
+// Split accounts against the desired floor. Zero for a nil status.
+func admittedReplicaCount(st *v1beta1.InferenceReplicaStatus) int32 {
+	if st == nil {
+		return 0
+	}
+	var n int32
+	for i := range st.InstanceStatuses {
+		if st.InstanceStatuses[i].Admitted {
+			n++
+		}
+	}
+	return n
+}
+
+// componentHasAdmittedInstance reports whether an authoritative IR status has at
+// least one Instance that has left the Kueue admission gate. A nil status (IR
+// not found yet) reports false.
+func componentHasAdmittedInstance(st *v1beta1.InferenceReplicaStatus) bool {
+	if st == nil {
+		return false
+	}
+	for _, inst := range st.InstanceStatuses {
+		if inst.Admitted {
+			return true
+		}
+	}
+	return false
+}
+
+// declaredComponents returns the components present on the ISVC spec.
+func declaredComponents(isvc *v1beta1.InferenceService) []v1beta1.ComponentType {
+	var out []v1beta1.ComponentType
+	if isvc.Spec.Engine != nil {
+		out = append(out, v1beta1.EngineComponent)
+	}
+	if isvc.Spec.Decoder != nil {
+		out = append(out, v1beta1.DecoderComponent)
+	}
+	if isvc.Spec.Router != nil {
+		out = append(out, v1beta1.RouterComponent)
+	}
+	return out
+}

--- a/pkg/controller/v1beta1/placement/admission_test.go
+++ b/pkg/controller/v1beta1/placement/admission_test.go
@@ -1,0 +1,113 @@
+package placement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// isvcWithInstances builds a derived ISVC declaring `component` with an empty
+// Lifecycle summary. Used by the controller reconcile tests that seed a derived
+// ISVC on a worker cluster; the per-instance data now lives on the paired
+// InferenceReplica (see irWithInstances), which the predicates read via
+// ComponentIRStatus. The variadic arg is retained for call-site symmetry with
+// irWithInstances but no longer populates the ISVC.
+func isvcWithInstances(component v1beta1.ComponentType, _ ...bool) *v1beta1.InferenceService {
+	isvc := &v1beta1.InferenceService{
+		Status: v1beta1.InferenceServiceStatus{
+			Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+				component: {Lifecycle: &v1beta1.LifecycleStatus{}},
+			},
+		},
+	}
+	declareComponent(isvc, component)
+	return isvc
+}
+
+// admittedStatusMap builds the authoritative per-component IR status map the
+// placement predicates now consume, mirroring what the reconcile assembles from
+// the workload cluster's InferenceReplicas.
+func admittedStatusMap(component v1beta1.ComponentType, admitted ...bool) map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus {
+	insts := make([]v1beta1.OMENativeInstanceStatus, len(admitted))
+	for i, a := range admitted {
+		insts[i] = v1beta1.OMENativeInstanceStatus{Index: int32(i), Admitted: a}
+	}
+	return map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus{
+		component: {InstanceStatuses: insts},
+	}
+}
+
+// irWithInstances builds an InferenceReplica named "svc-<component>" in "prod"
+// (matching the derived ISVC the reconcile tests use) whose status carries the
+// given admitted instances, for seeding on a worker fake client so the reconcile
+// reads it via ComponentIRStatus.
+func irWithInstances(component v1beta1.ComponentType, admitted ...bool) *v1beta1.InferenceReplica {
+	insts := make([]v1beta1.OMENativeInstanceStatus, len(admitted))
+	for i, a := range admitted {
+		insts[i] = v1beta1.OMENativeInstanceStatus{Index: int32(i), Admitted: a}
+	}
+	return &v1beta1.InferenceReplica{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "svc-" + string(component)},
+		Status:     v1beta1.InferenceReplicaStatus{InstanceStatuses: insts},
+	}
+}
+
+// declareComponent adds a minimal spec block for component so AllComponentsAdmitted
+// (which reads declared components off the spec) sees it as declared.
+func declareComponent(isvc *v1beta1.InferenceService, component v1beta1.ComponentType) {
+	switch component {
+	case v1beta1.EngineComponent:
+		isvc.Spec.Engine = &v1beta1.EngineSpec{}
+	case v1beta1.DecoderComponent:
+		isvc.Spec.Decoder = &v1beta1.DecoderSpec{}
+	case v1beta1.RouterComponent:
+		isvc.Spec.Router = &v1beta1.RouterSpec{}
+	}
+}
+
+func TestAllComponentsAdmitted(t *testing.T) {
+	engine := &v1beta1.InferenceService{}
+	declareComponent(engine, v1beta1.EngineComponent)
+
+	// single declared component, admitted -> true.
+	assert.True(t, AllComponentsAdmitted(engine, admittedStatusMap(v1beta1.EngineComponent, false, true)))
+	// single declared component, all gated -> false.
+	assert.False(t, AllComponentsAdmitted(engine, admittedStatusMap(v1beta1.EngineComponent, false, false)))
+	// no declared components -> never a winner.
+	assert.False(t, AllComponentsAdmitted(&v1beta1.InferenceService{}, nil))
+
+	// PD: engine admitted but decoder still gated -> NOT a winner.
+	pd := &v1beta1.InferenceService{}
+	declareComponent(pd, v1beta1.EngineComponent)
+	pd.Spec.Decoder = &v1beta1.DecoderSpec{}
+	mixed := map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus{
+		v1beta1.EngineComponent:  {InstanceStatuses: []v1beta1.OMENativeInstanceStatus{{Index: 0, Admitted: true}}},
+		v1beta1.DecoderComponent: {InstanceStatuses: []v1beta1.OMENativeInstanceStatus{{Index: 0, Admitted: false}}},
+	}
+	assert.False(t, AllComponentsAdmitted(pd, mixed), "engine admitted, decoder gated must not win")
+
+	// PD: both admitted -> winner.
+	both := map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus{
+		v1beta1.EngineComponent:  {InstanceStatuses: []v1beta1.OMENativeInstanceStatus{{Index: 0, Admitted: true}}},
+		v1beta1.DecoderComponent: {InstanceStatuses: []v1beta1.OMENativeInstanceStatus{{Index: 0, Admitted: true}}},
+	}
+	assert.True(t, AllComponentsAdmitted(pd, both), "both components admitted must win")
+
+	// declared component with no status entry yet -> false (no panic).
+	missingStatus := &v1beta1.InferenceService{Spec: v1beta1.InferenceServiceSpec{Engine: &v1beta1.EngineSpec{}}}
+	assert.False(t, AllComponentsAdmitted(missingStatus, nil))
+}
+
+func TestAnyInstanceAdmitted(t *testing.T) {
+	// at least one admitted instance -> true.
+	assert.True(t, AnyInstanceAdmitted(admittedStatusMap(v1beta1.EngineComponent, false, true)))
+	// all gated -> false.
+	assert.False(t, AnyInstanceAdmitted(admittedStatusMap(v1beta1.EngineComponent, false, false)))
+	// no statuses -> false.
+	assert.False(t, AnyInstanceAdmitted(nil))
+	// component present but nil status -> false (no panic).
+	assert.False(t, AnyInstanceAdmitted(map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus{v1beta1.EngineComponent: nil}))
+}

--- a/pkg/controller/v1beta1/placement/constants.go
+++ b/pkg/controller/v1beta1/placement/constants.go
@@ -1,0 +1,66 @@
+// Package placement implements the multi-cluster control-plane fan-out controller:
+// it places an InferenceService onto a workload cluster and mirrors its status.
+package placement
+
+import "sigs.k8s.io/ome/pkg/constants"
+
+// PlacementControllerName names the fan-out placement controller — explicit so
+// it doesn't collide with other InferenceService-watching controllers on the
+// derived name "inferenceservice".
+const PlacementControllerName = "placement"
+
+const (
+	// AcceleratorRequirementsAnnotation holds a label-selector string of the
+	// accelerator/capability labels a candidate WorkloadCluster MUST satisfy
+	// for this ISVC (e.g. "gpu=gb300"). Candidate clusters are
+	// those whose labels satisfy the ISVC's accelerator requirements; an ISVC
+	// that declares no requirement (neither this nor ClusterSelectorAnnotation)
+	// is NOT fanned out fleet-wide. The value is user/GitOps-supplied — there is
+	// no in-code default (eventually the control plane resolves it from
+	// spec.model + selected runtime; until then it is expressed here).
+	AcceleratorRequirementsAnnotation = "ome.io/accelerator-requirements"
+
+	// ClusterSelectorAnnotation holds an optional extra label-selector string
+	// (e.g. "provider=cloud-a") AND-ed onto the accelerator requirements to further
+	// narrow candidate clusters (operator-imposed routing). It does NOT, on its
+	// own, make an ISVC eligible for fleet-wide fan-out.
+	ClusterSelectorAnnotation = "ome.io/cluster-selector"
+
+	// LocalQueueAnnotation names the Kueue LocalQueue the derived workload's
+	// pods join on the target cluster. Defaults to DefaultLocalQueue.
+	LocalQueueAnnotation = "ome.io/local-queue"
+	DefaultLocalQueue    = "default"
+
+	// PlacementOriginLabel marks a derived ISVC as created by this control
+	// plane (for tracking + future GC). Value: the source ISVC's origin id.
+	PlacementOriginLabel = "ome.io/placement-origin"
+	// PlacementOriginUIDAnnotation records the source ISVC UID on the derived ISVC.
+	PlacementOriginUIDAnnotation = "ome.io/placement-origin-uid"
+	// PlacementControlPlaneLabel records WHICH control plane created a derived
+	// ISVC. Its value is the operator-supplied control-plane identity
+	// (config-driven via --placement-control-plane-id / the chart, no in-code
+	// default). When multiple control planes share a workload cluster, the GC
+	// sweep filters on this label so each control plane only reaps its OWN
+	// deriveds and never another's. Empty identity degrades gracefully: nothing
+	// is stamped and the GC keeps its single-control-plane (origin-UID-only)
+	// behavior.
+	PlacementControlPlaneLabel = "ome.io/placement-control-plane"
+
+	// PlacementFinalizer lets the controller delete the derived ISVC before the
+	// source ISVC is removed.
+	PlacementFinalizer = "ome.io/placement"
+)
+
+// controlPlaneOnlyAnnotations are ome.io directives that drive the CONTROL
+// plane's placement decision and must NOT ride along onto the derived ISVC,
+// where the worker cluster's reconciler would (re)interpret them: the
+// placement selectors (candidate selection is the control plane's job) and the
+// rollout operator-verbs (promote/rollback advance one shared rollout, owned by
+// the control plane — a copy on every candidate would each consume the verb).
+// Stripped by DeriveISVC.
+var controlPlaneOnlyAnnotations = []string{
+	AcceleratorRequirementsAnnotation,
+	ClusterSelectorAnnotation,
+	constants.RolloutPromoteAnnotation,
+	constants.RolloutRollbackAnnotation,
+}

--- a/pkg/controller/v1beta1/placement/controller.go
+++ b/pkg/controller/v1beta1/placement/controller.go
@@ -1,0 +1,1415 @@
+package placement
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"math"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/client-go/util/workqueue"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/workloadcluster"
+)
+
+const (
+	// DefaultPlacementRequeue is the fallback status-refresh poll cadence used
+	// when Reconciler.Requeue is unset. The operative value is supplied by the
+	// manager flag / chart; this is the graceful-degradation default.
+	DefaultPlacementRequeue = 30 * time.Second
+
+	// DefaultPlaceTimeout is the fallback per-cluster fan-out apply deadline used
+	// when Reconciler.PlaceTimeout is unset. The operative value is supplied by
+	// the manager flag / chart; this is the graceful-degradation default that
+	// keeps one wedged remote from stalling the apply to its healthy peers.
+	DefaultPlaceTimeout = 10 * time.Second
+
+	// DefaultWinnerLostGrace is the fallback grace window used when
+	// Reconciler.WinnerLostGracePeriod is unset. The operative value is supplied
+	// by the manager flag / chart; this is the graceful-degradation default that
+	// lets a transient winner-derived gap heal before re-racing.
+	DefaultWinnerLostGrace = 1 * time.Minute
+)
+
+// placementResult is the status the reconciler writes for one pass.
+type placementResult struct {
+	winner     string
+	phase      v1beta1.PlacementPhase
+	candidates []v1beta1.CandidatePlacement
+	url        *apis.URL // published endpoint; mirrored to BOTH status.placement.endpoint and status.url
+}
+
+// ClusterClients is the subset of *workloadcluster.Manager the placer needs.
+// *workloadcluster.Manager satisfies it; tests inject a fake.
+type ClusterClients interface {
+	ClientFor(name string) (workloadcluster.SelectivelyCachingClient, bool)
+	Connected() []string
+}
+
+// Reconciler is the control-plane fan-out controller. It clones the
+// derived ISVC onto every matched candidate cluster, lets each cluster's Kueue
+// gate the pods, declares the first candidate (by sorted name) whose Kueue admits
+// the pods the winner, deletes the losers, and re-places if the winner is later
+// lost. It runs ONLY on the control-plane cluster, where the local ISVC->pods
+// reconciler is disabled. Status refresh is event-driven via the remote
+// watch funnel, with a poll fallback (the Requeue cadence).
+type Reconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Log      logr.Logger
+	Clusters ClusterClients
+	// Requeue is the status-refresh poll cadence; defaults to DefaultPlacementRequeue.
+	Requeue time.Duration
+	// ControlPlaneID is this control plane's identity, stamped onto every derived
+	// ISVC (PlacementControlPlaneLabel) so the GC sweep only reaps deriveds THIS
+	// control plane created. Config-driven (manager flag / chart); empty leaves
+	// the stamp off and keeps single-control-plane behavior.
+	ControlPlaneID string
+	// MaxConcurrentReconciles caps parallel placement reconciles (distinct ISVCs
+	// only — controller-runtime serializes per object key, so independent ISVCs
+	// reconcile in parallel safely). Each reconcile fans out across remote
+	// clusters, so the single-worker default serializes the whole fleet behind
+	// one slow remote; raising this lets independent ISVCs make progress
+	// concurrently. Sourced from a flag/chart value; no in-code default. Zero
+	// (unset) preserves controller-runtime's single-worker default.
+	MaxConcurrentReconciles int
+	// PlaceTimeout bounds a single per-cluster placeOn during fan-out so one
+	// stuck/slow remote cannot block the apply to the healthy candidates. The
+	// operative value is supplied by the manager flag / chart; zero (unset) falls
+	// back to DefaultPlaceTimeout (graceful degradation, no magic literal in the
+	// hot path).
+	PlaceTimeout time.Duration
+	// WinnerLostGracePeriod is how long the controller waits, after the sticky
+	// winner's derived first appears ABSENT on a connected winner cluster, before
+	// giving up on it and re-racing. It rides out a transient gap (the worker
+	// recreating the derived, a brief apiserver hiccup) so a momentary blip does
+	// not tear down a healthy placement and re-fan-out the whole candidate set.
+	// A genuinely-deleted derived re-races once the window elapses. Config-driven
+	// (manager flag / chart); zero (unset) falls back to DefaultWinnerLostGrace.
+	WinnerLostGracePeriod time.Duration
+
+	// DispatcherMode selects the fan-out BREADTH policy: AllAtOnce clones onto
+	// every matched candidate at once (the historical behavior); Incremental
+	// probes the candidates in batches. Config-driven (manager flag / chart);
+	// empty/unrecognized degrades gracefully to all-at-once via dispatcherFor, so
+	// absent config preserves the existing fleet-wide fan-out.
+	DispatcherMode DispatcherMode
+	// DispatcherStepSize is how many additional candidates the Incremental
+	// dispatcher nominates per round. Only consulted in Incremental mode.
+	// Config-driven (manager flag / chart); a non-positive value makes the walk
+	// advance by one candidate per round (graceful degradation, no magic literal).
+	DispatcherStepSize int
+	// DispatcherRoundTimeout bounds how long one Incremental round is given for a
+	// nominated cluster to win before the next batch is added. Only consulted in
+	// Incremental mode. Config-driven (manager flag / chart); a non-positive value
+	// lets each pass advance with no enforced dwell.
+	DispatcherRoundTimeout time.Duration
+
+	// dispatcher is the resolved breadth policy (built once from DispatcherMode on
+	// first use). It is the nomination step fanOut applies to. dispatcherOnce
+	// guards lazy construction so the Reconciler stays usable when assembled as a
+	// bare struct literal (the cmd wiring and the tests both do that) without a
+	// constructor.
+	dispatcher     Dispatcher
+	dispatcherOnce sync.Once
+
+	// winnerLostSince tracks, per source-ISVC UID, the first time this controller
+	// observed the sticky winner's derived ABSENT on a connected winner cluster.
+	// It is the in-memory backing for WinnerLostGracePeriod: the PlacementStatus
+	// API carries no such timestamp and this package may not extend it, so the
+	// grace clock lives here. A control-plane restart loses the marker and the
+	// grace window simply restarts — strictly conservative (it only ever delays a
+	// re-race), never destructive. Entries are cleared the moment the derived is
+	// seen again or the winner is re-raced.
+	winnerLostSince sync.Map // map[types.UID]time.Time
+
+	// converge is the resolved status-convergence configuration assembled at
+	// SetupWithManager from ConvergeOptions (the remote watch-funnel channel plus
+	// the batch/safety timings). Nil until Setup runs — the helper methods fall
+	// back to the Requeue struct field + package defaults so a Reconciler built
+	// directly (unit tests) keeps working without Setup.
+	converge *convergeConfig
+}
+
+// +kubebuilder:rbac:groups=ome.io,resources=inferenceservices,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=ome.io,resources=inferenceservices/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ome.io,resources=inferenceservices/finalizers,verbs=update
+// +kubebuilder:rbac:groups=ome.io,resources=workloadclusters,verbs=get;list;watch
+
+// Reconcile maps an apiserver optimistic-lock conflict to a clean requeue. The
+// control plane runs several controllers that write the same source
+// InferenceService — this placer writes status and its finalizer, the endpoint
+// publisher writes its own finalizer — so a write can lose a resourceVersion
+// race. That is benign and self-corrects on the requeue, so it must not surface
+// as an error-level "Reconciler error" (misleading log noise). All other results
+// pass through unchanged.
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	res, err := r.reconcile(ctx, request)
+	if apierrors.IsConflict(err) {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return res, err
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	isvc := &v1beta1.InferenceService{}
+	if err := r.Get(ctx, request.NamespacedName, isvc); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Source already gone. The winner-lost grace marker is keyed by UID
+			// (unknown here) and is cleared in reconcileDelete once the finalizer
+			// runs; the worst case if that never ran is one stale map entry that
+			// never grows (a re-created ISVC gets a fresh UID), so nothing to do.
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !isvc.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, isvc)
+	}
+
+	if controllerutil.AddFinalizer(isvc, PlacementFinalizer) {
+		if err := r.Update(ctx, isvc); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	clusters := &v1beta1.WorkloadClusterList{}
+	if err := r.List(ctx, clusters); err != nil {
+		return ctrl.Result{}, err
+	}
+	candidates, reason, err := MatchCandidates(isvc, clusters.Items)
+	if err != nil || len(candidates) == 0 {
+		// Surface WHY there are no candidates (malformed selector / no
+		// requirements declared / no Ready clusters / no match) so the empty
+		// set is diagnosable instead of an indistinguishable Pending.
+		r.Log.Info("no placement candidates", "isvc", isvc.Namespace+"/"+isvc.Name,
+			"reason", reason, "error", err)
+		return r.writePlacement(ctx, isvc, placementResult{phase: v1beta1.PlacementPhasePending})
+	}
+
+	// Branch on placement mode. Each mode owns its own reconcile: Single keeps one
+	// winner (sticky race + loser sweep); All keeps every home that admits. Split
+	// is not yet implemented — hold Pending rather than silently run it as Single,
+	// so an operator never mistakes an un-split placement for a split one.
+	switch mode := placementMode(isvc); mode {
+	case v1beta1.PlacementModeSingle:
+		return r.reconcileSingle(ctx, isvc, candidates)
+	case v1beta1.PlacementModeAll:
+		return r.reconcileAll(ctx, isvc, candidates)
+	case v1beta1.PlacementModeSplit:
+		return r.reconcileSplit(ctx, isvc, candidates)
+	default:
+		r.Log.Info("placement mode not supported by this build; holding Pending",
+			"mode", mode, "isvc", isvc.Namespace+"/"+isvc.Name)
+		return r.writePlacement(ctx, isvc, placementResult{phase: v1beta1.PlacementPhasePending})
+	}
+}
+
+// reconcileSingle implements PlacementModeSingle: fan out to the candidates, race
+// on Kueue admission, keep the first fully-admitted cluster (lexical tie-break),
+// sweep the losers, and hold that winner sticky across polls — re-racing only if
+// it is lost (derived deleted, or admission lost past the grace window). This is
+// the default mode.
+func (r *Reconciler) reconcileSingle(ctx context.Context, isvc *v1beta1.InferenceService, candidates []string) (ctrl.Result, error) {
+	// Sticky winner: keep the current winner while its derived ISVC still
+	// exists and it remains a candidate. Otherwise fall through to re-race.
+	if winner := winnerCluster(isvc); winner != "" && slices.Contains(candidates, winner) {
+		state, derived, err := r.getWinnerDerived(ctx, winner, isvc)
+		if err != nil {
+			// A transient remote GET error must NOT abort the reconcile or be
+			// misread as "derived gone" (which would prematurely re-race and
+			// sweep losers). Hold the existing placement and retry next poll.
+			r.Log.Error(err, "sticky winner: remote get failed; holding placement", "cluster", winner, "isvc", isvc.Namespace+"/"+isvc.Name)
+			return ctrl.Result{RequeueAfter: r.requeue()}, nil
+		}
+		switch state {
+		case winnerDisconnected:
+			// The winner cluster is not reachable this pass. This is NOT evidence
+			// the derived was deleted — re-racing now would tear down a healthy
+			// placement on a transport flap. Hold the placement and retry; the
+			// grace clock is deliberately NOT armed (it tracks absence on a
+			// CONNECTED winner, not a disconnected transport).
+			r.Log.Info("sticky winner: cluster disconnected; holding placement", "cluster", winner, "isvc", isvc.Namespace+"/"+isvc.Name)
+			return ctrl.Result{RequeueAfter: r.requeue()}, nil
+
+		case winnerDerivedPresent:
+			cl, ok := r.Clusters.ClientFor(winner)
+			if !ok {
+				// Winner disconnected between the derived GET and now; hold
+				// rather than judge its state on partial data (consistent with
+				// the winnerDisconnected handling above).
+				r.Log.Info("sticky winner: cluster client unavailable; holding placement", "cluster", winner, "isvc", isvc.Namespace+"/"+isvc.Name)
+				return ctrl.Result{RequeueAfter: r.requeue()}, nil
+			}
+			// Read the authoritative per-component IR status from the winner
+			// cluster (source of truth; the derived ISVC no longer mirrors it).
+			statuses, err := componentIRStatuses(ctx, cl, derived)
+			if err != nil {
+				// A transient IR read error must not be misread as terminal
+				// failure; hold and retry next poll.
+				r.Log.Error(err, "sticky winner: reading IR statuses failed; holding placement", "cluster", winner, "isvc", isvc.Namespace+"/"+isvc.Name)
+				return ctrl.Result{RequeueAfter: r.requeue()}, nil
+			}
+			if IsTerminallyFailed(derived, statuses) {
+				// The placement itself failed; surface it and stop. Do NOT
+				// re-place into a hot fail-loop — needs human/spec action.
+				u := endpointFor(derived)
+				if u == nil {
+					u = isvc.Status.URL
+				}
+				return r.writePlacement(ctx, isvc, placementResult{
+					winner: winner, phase: v1beta1.PlacementPhaseFailed,
+					candidates: []v1beta1.CandidatePlacement{{Cluster: winner, Phase: v1beta1.CandidatePhaseAdmitted}},
+					url:        u,
+				})
+			}
+			// The winner must still hold its Kueue admission. If it lost it (e.g.
+			// preemption evicted every instance of a component), the placement is no
+			// longer live even though the derived object exists. Ride out a transient
+			// dip (rollout, brief re-gate) with the same grace window a vanished
+			// derived uses, then re-race off the healthy candidates. Without this a
+			// preempted winner is reported Placed forever while serving nothing.
+			if !AllComponentsAdmitted(derived, statuses) {
+				if remaining := r.graceRemaining(isvc.UID, time.Now()); remaining > 0 {
+					r.Log.Info("sticky winner: lost admission; within grace window, holding placement",
+						"cluster", winner, "isvc", isvc.Namespace+"/"+isvc.Name, "graceRemaining", remaining)
+					return ctrl.Result{RequeueAfter: min(remaining, r.requeue())}, nil
+				}
+				r.clearGrace(isvc.UID)
+				r.Log.Info("sticky winner: lost admission past grace window; re-racing",
+					"cluster", winner, "isvc", isvc.Namespace+"/"+isvc.Name)
+				break // exit the switch; fall through to the re-race path below
+			}
+			// Admitted and present: healthy. Drop any pending grace marker, re-apply
+			// on the winner, and sweep any stray derived on the other candidates
+			// (origin-guarded, so a same-named user ISVC is safe).
+			r.clearGrace(isvc.UID)
+			if err := r.placeOnBounded(ctx, cl, isvc); err != nil {
+				return ctrl.Result{}, err
+			}
+			r.deleteLosers(ctx, isvc, candidates, winner)
+			return r.writePlacement(ctx, isvc, placedResult(winner, derived, isvc))
+
+		case winnerDerivedAbsent:
+			// The winner is connected but its derived is gone. Distinguish a
+			// transient gap (worker recreating it, brief apiserver blip) from a
+			// genuine deletion by holding the placement until the grace window
+			// elapses; only then re-race. Without this, a momentary disappearance
+			// would re-fan-out the whole candidate set and churn the placement.
+			if remaining := r.graceRemaining(isvc.UID, time.Now()); remaining > 0 {
+				r.Log.Info("sticky winner: derived absent; within grace window, holding placement",
+					"cluster", winner, "isvc", isvc.Namespace+"/"+isvc.Name, "graceRemaining", remaining)
+				// Requeue when the grace window is due to expire (or at the poll
+				// cadence, whichever is sooner) so re-placement is not deferred a
+				// full poll past the deadline.
+				return ctrl.Result{RequeueAfter: min(remaining, r.requeue())}, nil
+			}
+			// Grace elapsed: the winner is genuinely lost. Clear the marker and
+			// fall through to re-race.
+			r.clearGrace(isvc.UID)
+			r.Log.Info("sticky winner: derived absent past grace window; re-racing", "cluster", winner, "isvc", isvc.Namespace+"/"+isvc.Name)
+		}
+	}
+
+	// Nominate the subset of candidates to clone onto this pass. AllAtOnce
+	// nominates the whole set (unchanged fleet-wide fan-out); Incremental probes
+	// in batches and may ask us to hold between rounds. fanOut then acts on the
+	// nominated set rather than directly on all candidates.
+	nominated, hold := r.nominate().Nominate(isvc.UID, candidates, time.Now())
+	if len(nominated) == 0 {
+		return r.writePlacement(ctx, isvc, placementResult{phase: v1beta1.PlacementPhasePending})
+	}
+
+	// Fan out to the connected nominated candidates.
+	placed, err := r.fanOut(ctx, isvc, nominated)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(placed) == 0 {
+		return r.writePlacement(ctx, isvc, placementResult{phase: v1beta1.PlacementPhasePending})
+	}
+
+	// Race: the first placed candidate whose derived ISVC reports an admitted
+	// instance wins.
+	winner, err := r.findWinner(ctx, isvc, placed)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if winner == "" {
+		cands := make([]v1beta1.CandidatePlacement, 0, len(placed))
+		for _, c := range placed {
+			cands = append(cands, v1beta1.CandidatePlacement{Cluster: c, Phase: v1beta1.CandidatePhasePlaced})
+		}
+		res, err := r.writePlacement(ctx, isvc, placementResult{phase: v1beta1.PlacementPhaseRacing, candidates: cands})
+		if err == nil {
+			// Racing is an active wait for Kueue admission, so re-poll at the fast
+			// cadence to observe the winner promptly. writePlacement otherwise
+			// returns the long steady-state backstop, which only suffices when the
+			// status funnel event-drives re-reconciles; without the funnel that
+			// would leave the race unresolved until the backstop fires.
+			res.RequeueAfter = r.requeue()
+			// An incremental round in flight re-evaluates when it is due to elapse
+			// (or the poll cadence, whichever is sooner) so the next batch is
+			// nominated without waiting a full poll past the round deadline.
+			if hold > 0 {
+				res.RequeueAfter = min(hold, res.RequeueAfter)
+			}
+		}
+		return res, err
+	}
+
+	// Winner: sweep the losers (every candidate cluster except the winner;
+	// each delete is origin-guarded so only our derived copies are removed).
+	r.deleteLosers(ctx, isvc, candidates, winner)
+	wd, _, err := r.getDerived(ctx, winner, isvc)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	return r.writePlacement(ctx, isvc, placedResult(winner, wd, isvc))
+}
+
+// placementMode returns the ISVC's placement cardinality, defaulting to Single
+// when spec.placement is unset or its mode is empty (the legacy/annotation path).
+func placementMode(isvc *v1beta1.InferenceService) v1beta1.PlacementMode {
+	if p := isvc.Spec.Placement; p != nil && p.Mode != "" {
+		return p.Mode
+	}
+	return v1beta1.PlacementModeSingle
+}
+
+// reconcileAll implements PlacementModeAll: run the ISVC on EVERY candidate that
+// admits and keep them all. There is no single winner and no loser sweep — a
+// candidate that has not admitted yet is retained and keeps trying (capacity may
+// free up), and a home that later loses admission simply drops out of the served
+// set while the others continue. All is best-effort: the placement is Placed
+// once at least one home is admitted, and stays Racing only while every home is
+// still gated; it never fails just because some candidate cannot admit.
+//
+// There is deliberately no sticky-winner / re-race path here: those protect the
+// single-home invariant, which All does not have. Each home is independent.
+func (r *Reconciler) reconcileAll(ctx context.Context, isvc *v1beta1.InferenceService, candidates []string) (ctrl.Result, error) {
+	placed, err := r.fanOut(ctx, isvc, candidates)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(placed) == 0 {
+		return r.writePlacement(ctx, isvc, placementResult{phase: v1beta1.PlacementPhasePending})
+	}
+
+	cands := make([]v1beta1.CandidatePlacement, 0, len(placed))
+	admitted := 0
+	for _, c := range placed {
+		derived, ok, err := r.getDerived(ctx, c, isvc)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !ok {
+			continue
+		}
+		cl, ok := r.Clusters.ClientFor(c)
+		if !ok {
+			continue
+		}
+		statuses, err := componentIRStatuses(ctx, cl, derived)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if AllComponentsAdmitted(derived, statuses) {
+			admitted++
+			cands = append(cands, v1beta1.CandidatePlacement{
+				Cluster: c, Phase: v1beta1.CandidatePhaseAdmitted, Endpoint: endpointFor(derived),
+			})
+			continue
+		}
+		cands = append(cands, v1beta1.CandidatePlacement{Cluster: c, Phase: v1beta1.CandidatePhasePlaced})
+	}
+
+	phase := v1beta1.PlacementPhaseRacing
+	if admitted > 0 {
+		phase = v1beta1.PlacementPhasePlaced
+	}
+	// No top-level winner cluster/URL in All: the per-home endpoints in
+	// candidates[] are the source of truth (Cluster/Endpoint stay empty).
+	res, err := r.writePlacement(ctx, isvc, placementResult{phase: phase, candidates: cands})
+	// Re-poll at the normal cadence while ANY home is still gated. All admits
+	// homes independently and at different times, so a home that admits AFTER the
+	// first must be observed without waiting for the long steady-state backstop —
+	// even once the placement is Placed on the earlier home(s). Once every home is
+	// admitted, writePlacement's backstop requeue stands.
+	if err == nil && admitted < len(cands) {
+		res.RequeueAfter = r.requeue()
+	}
+	return res, err
+}
+
+// reconcileSplit implements PlacementModeSplit: distribute the desired replica
+// count (spec.placement.split.replicas, else the engine floor minReplicas)
+// across candidate clusters. It requests a target on each, lets that cluster's
+// Kueue admit as many whole-gang replicas as fit, keeps every home that admits
+// >=1, and sums admitted until the floor is met. Packed by default — fill the
+// fewest clusters in preference order, spilling the remainder to the next;
+// Balanced (spec.placement.split.spread) apportions an even share across all
+// candidates. The endpoint weight follows each home's ready replicas.
+//
+// Distribution is a single ordered pass with no over-admission trim and no
+// deficit re-apportionment beyond that pass — it converges to >= floor
+// admitted, Packed, and accepts transient overshoot. Like All, there is no
+// sticky winner or re-race: each home is independent.
+func (r *Reconciler) reconcileSplit(ctx context.Context, isvc *v1beta1.InferenceService, candidates []string) (ctrl.Result, error) {
+	desired := splitDesiredReplicas(isvc)
+	if desired <= 0 {
+		// No floor declared — nothing to distribute.
+		return r.writePlacement(ctx, isvc, placementResult{phase: v1beta1.PlacementPhasePending})
+	}
+	// Split mode implies spec.placement is set; the split sub-block may be nil
+	// (defaults: distribute the floor, Packed, uncapped, no anti-sliver floor).
+	var maxPer, minPer int32
+	spread := false
+	if sp := isvc.Spec.Placement.Split; sp != nil {
+		maxPer, minPer, spread = sp.MaxReplicasPerCluster, sp.MinReplicasPerCluster, sp.Spread
+	}
+	scaleComps := splitScaleComponents(isvc)
+
+	// Phase 1 — observe each candidate's current derived: admitted + ready replica
+	// counts and the home endpoint. Observing BEFORE (re)apportioning is what lets
+	// the loop both fill a deficit and trim over-admission in the same pass. A
+	// disconnected candidate is not observable this pass; a sub-minPer sliver is
+	// counted as zero (dropped below).
+	type homeObs struct {
+		admitted, ready int32
+		endpoint        *apis.URL
+		present, sliver bool
+	}
+	obs := make(map[string]*homeObs, len(candidates))
+	admitted := make(map[string]int32, len(candidates))
+	for _, c := range candidates {
+		o := &homeObs{}
+		obs[c] = o
+		cl, ok := r.Clusters.ClientFor(c)
+		if !ok {
+			continue // disconnected; retry next poll
+		}
+		derived, ok, err := r.getDerived(ctx, c, isvc)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !ok {
+			continue // no derived yet
+		}
+		o.present = true
+		statuses, err := componentIRStatuses(ctx, cl, derived)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		o.admitted = splitAdmittedReplicas(scaleComps, statuses)
+		o.ready = splitReadyReplicas(scaleComps, statuses)
+		o.endpoint = endpointFor(derived)
+		admitted[c] = o.admitted
+		if minPer > 0 && o.admitted > 0 && o.admitted < minPer {
+			// Sub-floor sliver: do not count it toward the floor; it is swept below.
+			o.sliver = true
+			admitted[c] = 0
+		}
+	}
+
+	// Phase 2 — apportion the desired count into a per-cluster target request.
+	targets := splitApportion(candidates, admitted, desired, maxPer, spread)
+
+	// Phase 3 — apply: request the target on kept clusters, sweep the rest, and
+	// record per-home status from the observed counts.
+	var admittedTotal int32
+	cands := make([]v1beta1.CandidatePlacement, 0, len(candidates))
+	for _, c := range candidates {
+		o := obs[c]
+		if o.sliver || targets[c] <= 0 {
+			// Sliver, or not needed (Packed floor met / trimmed away): sweep any derived.
+			if o.present {
+				if err := r.deleteDerivedOn(ctx, c, isvc); err != nil {
+					r.Log.Error(err, "split: sweep cluster failed", "cluster", c, "isvc", isvc.Namespace+"/"+isvc.Name)
+				}
+			}
+			continue
+		}
+		cl, ok := r.Clusters.ClientFor(c)
+		if !ok {
+			continue // disconnected; retry next poll
+		}
+		if err := r.placeOnReplicasBounded(ctx, cl, isvc, targets[c], maxPer); err != nil {
+			r.Log.Error(err, "split: place failed on cluster", "cluster", c, "isvc", isvc.Namespace+"/"+isvc.Name)
+			continue // per-cluster tolerated, like fanOut
+		}
+		if o.admitted == 0 {
+			// Gated so far: keep trying; record a placed (not-yet-admitted) candidate.
+			cands = append(cands, v1beta1.CandidatePlacement{Cluster: c, Phase: v1beta1.CandidatePhasePlaced})
+			continue
+		}
+		// Count admitted toward the floor, capped by the target — a trimmed home is
+		// on its way down to target, so do not credit the excess it still shows.
+		counted := o.admitted
+		if counted > targets[c] {
+			counted = targets[c]
+		}
+		admittedTotal += counted
+		cands = append(cands, v1beta1.CandidatePlacement{
+			Cluster:          c,
+			Phase:            v1beta1.CandidatePhaseAdmitted,
+			Endpoint:         o.endpoint,
+			AdmittedReplicas: o.admitted,
+			ReadyReplicas:    o.ready,
+		})
+	}
+
+	phase := v1beta1.PlacementPhaseRacing
+	if admittedTotal > 0 {
+		phase = v1beta1.PlacementPhasePlaced
+	}
+	res, err := r.writePlacement(ctx, isvc, placementResult{phase: phase, candidates: cands})
+	if err == nil && admittedTotal < desired {
+		// Floor not yet met (homes still gated / capacity filling in): re-poll at
+		// the normal cadence rather than the long steady-state backstop.
+		res.RequeueAfter = r.requeue()
+	}
+	return res, err
+}
+
+// splitApportion computes each candidate's target replica REQUEST for Split.
+// admitted[c] is the replicas currently admitted on c (0 if none). A target of 0
+// means "do not use this cluster" (sweep). Preference order is the candidates
+// slice order. Two Packed regimes plus Balanced:
+//
+//   - TRIM (sum admitted >= desired): pin each cluster to min(admitted,
+//     remaining) in preference order — keep the preferred clusters full and shed
+//     the excess from the least-preferred, so requests sum to exactly desired and
+//     no gated remainder can push the admitted total any higher. This is what
+//     converges transient over-admission back down.
+//   - FILL (sum admitted < desired): over-request the remaining deficit on each
+//     cluster in preference order (Kueue admits what fits); already-admitted
+//     replicas close the deficit. Over-admission from gated remainders admitting
+//     later is cleaned up by TRIM on the next pass.
+//   - Balanced (spread): request an even ceil(desired/n) share on every candidate.
+func splitApportion(candidates []string, admitted map[string]int32, desired, maxPer int32, spread bool) map[string]int32 {
+	targets := make(map[string]int32, len(candidates))
+	capTo := func(v int32) int32 {
+		if maxPer > 0 && v > maxPer {
+			return maxPer
+		}
+		return v
+	}
+	if spread {
+		share := capTo(ceilDiv(desired, int32(len(candidates))))
+		for _, c := range candidates {
+			targets[c] = share
+		}
+		return targets
+	}
+	var total int32
+	for _, c := range candidates {
+		total += admitted[c]
+	}
+	remaining := desired
+	if total >= desired {
+		for _, c := range candidates { // TRIM
+			t := capTo(min32(admitted[c], remaining))
+			targets[c] = t
+			remaining -= t
+		}
+		return targets
+	}
+	for _, c := range candidates { // FILL
+		if remaining <= 0 {
+			targets[c] = 0
+			continue
+		}
+		targets[c] = capTo(remaining)
+		remaining -= admitted[c]
+	}
+	return targets
+}
+
+func min32(a, b int32) int32 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// splitDesiredReplicas is the Split desired replica count: spec.placement.split.
+// replicas when set, else the engine component's minReplicas (the guaranteed
+// floor). Zero when neither is declared.
+func splitDesiredReplicas(isvc *v1beta1.InferenceService) int32 {
+	if p := isvc.Spec.Placement; p != nil && p.Split != nil && p.Split.Replicas != nil {
+		return *p.Split.Replicas
+	}
+	if isvc.Spec.Engine != nil && isvc.Spec.Engine.MinReplicas != nil {
+		return int32(*isvc.Spec.Engine.MinReplicas)
+	}
+	return 0
+}
+
+// splitScaleComponents are the replica-scaled components whose admitted/ready
+// counts define a Split home's replica count: Engine and, for a PD service, the
+// Decoder — a replica is the coordinated pair. Router is excluded (a shared
+// front-end, not per-replica). Falls back to the first declared component when
+// neither Engine nor Decoder is present (unusual for Split).
+func splitScaleComponents(isvc *v1beta1.InferenceService) []v1beta1.ComponentType {
+	var cs []v1beta1.ComponentType
+	if isvc.Spec.Engine != nil {
+		cs = append(cs, v1beta1.EngineComponent)
+	}
+	if isvc.Spec.Decoder != nil {
+		cs = append(cs, v1beta1.DecoderComponent)
+	}
+	if len(cs) == 0 {
+		if dc := declaredComponents(isvc); len(dc) > 0 {
+			cs = append(cs, dc[0])
+		}
+	}
+	return cs
+}
+
+// splitAdmittedReplicas is a home's admitted replica count: the MIN admitted
+// instances across the scaled components, since a PD replica is admitted only
+// when BOTH its engine and decoder instances are (an engine-only home is just
+// the engine count). Zero when no scaled component is declared.
+func splitAdmittedReplicas(comps []v1beta1.ComponentType, statuses map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus) int32 {
+	if len(comps) == 0 {
+		return 0
+	}
+	mn := int32(math.MaxInt32)
+	for _, c := range comps {
+		if n := admittedReplicaCount(statuses[c]); n < mn {
+			mn = n
+		}
+	}
+	return mn
+}
+
+// splitReadyReplicas is a home's ready replica count (the endpoint weight): the
+// MIN ReadyReplicas across the scaled components, for the same pairing reason.
+func splitReadyReplicas(comps []v1beta1.ComponentType, statuses map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus) int32 {
+	if len(comps) == 0 {
+		return 0
+	}
+	mn := int32(math.MaxInt32)
+	for _, c := range comps {
+		var r int32
+		if st := statuses[c]; st != nil {
+			r = st.ReadyReplicas
+		}
+		if r < mn {
+			mn = r
+		}
+	}
+	return mn
+}
+
+// ceilDiv is integer ceiling division; b <= 0 returns a (no split).
+func ceilDiv(a, b int32) int32 {
+	if b <= 0 {
+		return a
+	}
+	return (a + b - 1) / b
+}
+
+// fanOut ensures the derived ISVC exists on each connected candidate. A
+// per-cluster failure does not abort the others — one bad cluster must not deny
+// the race to the healthy ones. Returns the clusters actually placed on; returns
+// an error only when connected candidates existed but ALL failed.
+//
+// Fault isolation (scale hardening): the connected-cluster set is snapshotted
+// ONCE before the loop so membership does not shift mid-fan-out, and each placeOn
+// runs under a per-cluster deadline (placeTimeout) so a single wedged/slow remote
+// — one whose apiserver hangs rather than returning an error — cannot stall the
+// apply to its healthy peers. A cluster that is not connected at snapshot time is
+// silently skipped and retried next poll; a connected cluster whose apply errors
+// or deadlines out is recorded as a per-cluster error (logged, tolerated) and
+// likewise retried. Neither is allowed to block the race for the healthy ones.
+func (r *Reconciler) fanOut(ctx context.Context, isvc *v1beta1.InferenceService, candidates []string) ([]string, error) {
+	// Snapshot connectivity up front: a stable view for this whole fan-out, so a
+	// cluster connecting/disconnecting mid-loop can't make membership inconsistent
+	// between the skip check here and the per-cluster apply below.
+	connected := connectedSet(r.Clusters)
+
+	var placed []string
+	var errs []error
+	for _, c := range candidates {
+		if !connected[c] {
+			continue // not connected this pass; the next poll re-attempts it
+		}
+		cl, ok := r.Clusters.ClientFor(c)
+		if !ok {
+			continue // disconnected between snapshot and lookup; skip
+		}
+		if err := r.placeOnBounded(ctx, cl, isvc); err != nil {
+			r.Log.Error(err, "fan out failed on cluster", "cluster", c, "isvc", isvc.Namespace+"/"+isvc.Name)
+			errs = append(errs, fmt.Errorf("%q: %w", c, err))
+			continue
+		}
+		placed = append(placed, c)
+	}
+	if len(placed) == 0 && len(errs) > 0 {
+		return nil, fmt.Errorf("fan out %s/%s failed on all connected candidates: %w", isvc.Namespace, isvc.Name, errors.Join(errs...))
+	}
+	return placed, nil
+}
+
+// placeOnBounded runs placeOn under a per-cluster deadline so one stuck remote
+// cannot block the fan-out to the healthy candidates. A deadline overrun surfaces
+// as a (wrapped) context.DeadlineExceeded error the caller records per-cluster
+// and retries next poll.
+func (r *Reconciler) placeOnBounded(ctx context.Context, cl client.Client, isvc *v1beta1.InferenceService) error {
+	cctx, cancel := context.WithTimeout(ctx, r.placeTimeout())
+	defer cancel()
+	return r.placeOn(cctx, cl, isvc)
+}
+
+// placeOnReplicasBounded runs placeOnReplicas under the per-cluster deadline
+// (Split's per-cluster apportioned apply).
+func (r *Reconciler) placeOnReplicasBounded(ctx context.Context, cl client.Client, isvc *v1beta1.InferenceService, replicas, maxPer int32) error {
+	cctx, cancel := context.WithTimeout(ctx, r.placeTimeout())
+	defer cancel()
+	return r.placeOnReplicas(cctx, cl, isvc, replicas, maxPer)
+}
+
+// connectedSet snapshots the currently-connected cluster names as a set for O(1)
+// membership checks during a single fan-out pass.
+func connectedSet(clusters ClusterClients) map[string]bool {
+	names := clusters.Connected()
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		set[n] = true
+	}
+	return set
+}
+
+// findWinner returns the winning cluster: the first placed candidate, in sorted
+// candidate order, whose derived ISVC reports EVERY declared component admitted,
+// or "" if none is fully admitted yet. Requiring all components (not just one
+// instance) prevents a PD service from being declared placed while only the
+// engine has cleared Kueue and the decoder is still gated. When several clusters
+// fully admit near-simultaneously the lowest-named candidate wins — a
+// deterministic tie-break, not literally "first in wall-clock time".
+func (r *Reconciler) findWinner(ctx context.Context, isvc *v1beta1.InferenceService, placed []string) (string, error) {
+	for _, c := range placed {
+		derived, ok, err := r.getDerived(ctx, c, isvc)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			continue
+		}
+		cl, ok := r.Clusters.ClientFor(c)
+		if !ok {
+			continue
+		}
+		// Read the authoritative per-component IR status from candidate cluster
+		// c (source of truth; the derived ISVC no longer mirrors it).
+		statuses, err := componentIRStatuses(ctx, cl, derived)
+		if err != nil {
+			return "", err
+		}
+		if AllComponentsAdmitted(derived, statuses) {
+			return c, nil
+		}
+	}
+	return "", nil
+}
+
+// deleteLosers best-effort deletes THIS ISVC's derived copy on each cluster in
+// clusters except keep. deleteDerivedOn only ever deletes an object that carries
+// this source ISVC's origin label, so a same-named ISVC a user created directly
+// on a workload cluster is never touched (cross-tenant data-loss guard).
+//
+// Per-cluster failures are tolerated (like fanOut): one slow/unreachable cluster
+// must not block loser cleanup on the healthy ones, and must NOT block recording
+// the winner. Failures are logged; the next poll retries, and the GC sweep is a
+// backstop. Callers that must confirm full teardown (reconcileDelete) verify the
+// derived is actually gone separately rather than relying on the return here.
+func (r *Reconciler) deleteLosers(ctx context.Context, isvc *v1beta1.InferenceService, clusters []string, keep string) {
+	for _, c := range clusters {
+		if c == keep {
+			continue
+		}
+		if err := r.deleteDerivedOn(ctx, c, isvc); err != nil {
+			r.Log.Error(err, "loser cleanup failed on cluster (will retry next poll)", "cluster", c, "isvc", isvc.Namespace+"/"+isvc.Name)
+		}
+	}
+}
+
+// getDerived fetches the derived ISVC on a cluster. Returns ok=false if the
+// cluster is not connected or the object does not exist.
+func (r *Reconciler) getDerived(ctx context.Context, cluster string, isvc *v1beta1.InferenceService) (*v1beta1.InferenceService, bool, error) {
+	cl, ok := r.Clusters.ClientFor(cluster)
+	if !ok {
+		return nil, false, nil
+	}
+	derived := &v1beta1.InferenceService{}
+	if err := cl.Get(ctx, types.NamespacedName{Namespace: isvc.Namespace, Name: isvc.Name}, derived); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return derived, true, nil
+}
+
+// winnerDerivedState is the outcome of inspecting the sticky winner's derived
+// ISVC, with the disconnected case kept DISTINCT from the genuinely-absent case
+// (which getDerived collapses into ok=false). The winner-lost grace logic must
+// treat a disconnected winner as transient (hold, no grace clock) and only run
+// the grace clock when the derived is absent on a CONNECTED winner.
+type winnerDerivedState int
+
+const (
+	// winnerDisconnected: the winner cluster has no live client this pass
+	// (transport flap / not yet (re)connected). Transient — not evidence the
+	// derived was deleted.
+	winnerDisconnected winnerDerivedState = iota
+	// winnerDerivedPresent: the winner is connected and its derived exists.
+	winnerDerivedPresent
+	// winnerDerivedAbsent: the winner is connected but its derived is NotFound.
+	// This is the only state that arms the winner-lost grace clock.
+	winnerDerivedAbsent
+)
+
+// getWinnerDerived inspects the sticky winner's derived ISVC, distinguishing a
+// disconnected winner from a connected-but-absent derived so the caller can
+// apply the grace window only to a genuine disappearance. A transient GET error
+// is returned as an error (caller holds placement and requeues) rather than
+// misread as absence.
+func (r *Reconciler) getWinnerDerived(ctx context.Context, cluster string, isvc *v1beta1.InferenceService) (winnerDerivedState, *v1beta1.InferenceService, error) {
+	cl, ok := r.Clusters.ClientFor(cluster)
+	if !ok {
+		return winnerDisconnected, nil, nil
+	}
+	derived := &v1beta1.InferenceService{}
+	if err := cl.Get(ctx, types.NamespacedName{Namespace: isvc.Namespace, Name: isvc.Name}, derived); err != nil {
+		if apierrors.IsNotFound(err) {
+			return winnerDerivedAbsent, nil, nil
+		}
+		return winnerDisconnected, nil, err
+	}
+	return winnerDerivedPresent, derived, nil
+}
+
+// placeOn creates-or-updates the derived ISVC on the target cluster. The control
+// plane owns the derived Spec and the metadata keys IT stamps (origin markers,
+// Kueue queue/serving gating); it does NOT own the rest of the object's labels
+// and annotations. The worker-cluster reconciler adds its own metadata (status
+// bookkeeping annotations, generated labels) to the derived object, so this
+// merges the control-plane-owned keys into the existing maps rather than
+// replacing them wholesale — preserving worker-side reconciler state across the
+// poll-driven re-apply.
+func (r *Reconciler) placeOn(ctx context.Context, cl client.Client, src *v1beta1.InferenceService) error {
+	return r.applyDerived(ctx, cl, src, DeriveISVC(src, r.ControlPlaneID))
+}
+
+// placeOnReplicas is placeOn with a Split per-cluster apportioned replica band
+// pinned onto the derived's scalable components before the apply: replicas is
+// this home's share (the floor), maxPer the per-cluster ceiling (0 = uncapped).
+func (r *Reconciler) placeOnReplicas(ctx context.Context, cl client.Client, src *v1beta1.InferenceService, replicas, maxPer int32) error {
+	d := DeriveISVC(src, r.ControlPlaneID)
+	setDerivedReplicas(d, replicas, maxPer)
+	return r.applyDerived(ctx, cl, src, d)
+}
+
+// applyDerived create-or-updates the derived ISVC `desired` on the target
+// cluster.
+func (r *Reconciler) applyDerived(ctx context.Context, cl client.Client, src, desired *v1beta1.InferenceService) error {
+	target := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace}}
+	_, err := controllerutil.CreateOrUpdate(ctx, cl, target, func() error {
+		// Origin-guard the apply, mirroring the origin guard on the delete path
+		// (deleteDerivedOn): a target that already exists (CreateOrUpdate's Get
+		// populated it, so ResourceVersion is set) and is NOT a derived of THIS
+		// source must not be overwritten. Without this, a same-named ISVC a user
+		// created directly on the workload cluster — or another control plane's
+		// object — would have its Spec replaced and origin markers stamped onto
+		// it (cross-tenant data loss). Returning an error makes CreateOrUpdate a
+		// no-op write and surfaces per-cluster like any other fan-out failure. A
+		// first-time create (empty ResourceVersion) and a re-apply of our own
+		// derived (isOurDerived true) both proceed.
+		if target.ResourceVersion != "" && !isOurDerived(target, src) {
+			return fmt.Errorf("refusing to overwrite non-derived InferenceService %s/%s on candidate cluster: not a placement derived of control plane %q",
+				target.Namespace, target.Name, r.ControlPlaneID)
+		}
+		target.Labels = mergeOwnedKeys(target.Labels, desired.Labels)
+		target.Annotations = mergeOwnedKeys(target.Annotations, desired.Annotations)
+		target.Spec = desired.Spec
+		return nil
+	})
+	return err
+}
+
+// mergeOwnedKeys overlays the control-plane-owned keys (from desired) onto the
+// existing map without dropping keys the worker-cluster reconciler added. nil
+// existing maps are initialized only when there is something to set.
+func mergeOwnedKeys(existing, owned map[string]string) map[string]string {
+	if len(owned) == 0 {
+		return existing
+	}
+	if existing == nil {
+		existing = make(map[string]string, len(owned))
+	}
+	for k, v := range owned {
+		existing[k] = v
+	}
+	return existing
+}
+
+// deleteDerivedOn best-effort deletes the derived ISVC on a cluster, but ONLY
+// if the object actually present there is a copy this control plane derived from
+// THIS source ISVC (it carries our origin label set to the source UID). It never
+// deletes by identity alone: a same-named ISVC a user created directly on the
+// workload cluster, or a copy derived from a different source UID, is left
+// untouched. The UID precondition on Delete closes the read-then-delete race so
+// a concurrently-recreated object isn't deleted out from under its owner.
+func (r *Reconciler) deleteDerivedOn(ctx context.Context, cluster string, isvc *v1beta1.InferenceService) error {
+	cl, ok := r.Clusters.ClientFor(cluster)
+	if !ok {
+		return nil
+	}
+	derived := &v1beta1.InferenceService{}
+	if err := cl.Get(ctx, types.NamespacedName{Namespace: isvc.Namespace, Name: isvc.Name}, derived); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if !isOurDerived(derived, isvc) {
+		// Same-named object that is NOT ours: do not delete (cross-tenant guard).
+		return nil
+	}
+	uid := derived.UID
+	opts := []client.DeleteOption{}
+	if uid != "" {
+		opts = append(opts, client.Preconditions{UID: &uid})
+	}
+	if err := cl.Delete(ctx, derived, opts...); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// isOurDerived reports whether derived is a placement copy this control plane
+// created from src (its origin label/annotation equals src's UID). The empty UID
+// case (e.g. a fake/source without a server-assigned UID) requires the marker to
+// be present and non-empty, never matches a blank.
+func isOurDerived(derived, src *v1beta1.InferenceService) bool {
+	want := string(src.UID)
+	if want == "" {
+		return false
+	}
+	return derived.Labels[PlacementOriginLabel] == want ||
+		derived.Annotations[PlacementOriginUIDAnnotation] == want
+}
+
+func (r *Reconciler) reconcileDelete(ctx context.Context, isvc *v1beta1.InferenceService) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(isvc, PlacementFinalizer) {
+		return ctrl.Result{}, nil
+	}
+	// Clean up our derived copy on every currently-connected cluster. The delete
+	// is origin-guarded, so it only removes copies derived from THIS source. A
+	// cluster that is disconnected at delete time can't be cleaned now; it is
+	// reaped later by the GC sweep (the source UID is gone once the finalizer is
+	// removed), so we don't block teardown on an unreachable cluster.
+	//
+	// We do, however, hold the finalizer if a CONNECTED cluster errored on
+	// cleanup: dropping the finalizer then would orphan a still-reachable derived
+	// (and the GC only catches it on its slower cadence). Requeue and retry.
+	connected := r.Clusters.Connected()
+	r.deleteLosers(ctx, isvc, connected, "")
+	if remaining, err := r.derivedRemainingOnConnected(ctx, isvc, connected); err != nil {
+		return ctrl.Result{}, err
+	} else if remaining {
+		// A connected cluster still holds our derived (transient delete error
+		// tolerated by deleteLosers). Keep the finalizer; retry on the next poll.
+		return ctrl.Result{RequeueAfter: r.requeue()}, nil
+	}
+	controllerutil.RemoveFinalizer(isvc, PlacementFinalizer)
+	if err := r.Update(ctx, isvc); err != nil {
+		return ctrl.Result{}, err
+	}
+	// Teardown complete: drop any winner-lost grace marker so the in-memory map
+	// does not retain an entry for a now-deleted source ISVC.
+	r.clearGrace(isvc.UID)
+	// Likewise drop any incremental-dispatcher round state for this source so its
+	// in-memory map does not retain an entry for a now-deleted ISVC.
+	if f, ok := r.nominate().(forgetRoundState); ok {
+		f.forget(isvc.UID)
+	}
+	return ctrl.Result{}, nil
+}
+
+// derivedRemainingOnConnected reports whether any connected cluster still holds
+// our derived copy of isvc. Used during teardown to decide whether the finalizer
+// can be safely removed. A transient GET error is reported as an error (caller
+// requeues) rather than silently treated as "gone".
+func (r *Reconciler) derivedRemainingOnConnected(ctx context.Context, isvc *v1beta1.InferenceService, connected []string) (bool, error) {
+	for _, c := range connected {
+		derived, exists, err := r.getDerived(ctx, c, isvc)
+		if err != nil {
+			return false, err
+		}
+		if exists && isOurDerived(derived, isvc) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// writePlacement sets status.placement (+ the mirrored status.url) for one pass,
+// retrying on conflict since the local object may change during the
+// cross-cluster fan-out/race. Returns the long safety requeue: steady-state
+// status convergence is event-driven (the remote watch funnel re-reconciles
+// this source when a derived's status changes), so this is only the backstop
+// re-read for a missed event, not the former fixed status poll.
+func (r *Reconciler) writePlacement(ctx context.Context, isvc *v1beta1.InferenceService, res placementResult) (ctrl.Result, error) {
+	key := client.ObjectKeyFromObject(isvc)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cur := &v1beta1.InferenceService{}
+		if err := r.Get(ctx, key, cur); err != nil {
+			return err
+		}
+		if cur.Status.Placement == nil {
+			cur.Status.Placement = &v1beta1.PlacementStatus{}
+		}
+		cur.Status.Placement.Cluster = res.winner
+		cur.Status.Placement.Phase = res.phase
+		cur.Status.Placement.Candidates = res.candidates
+		cur.Status.Placement.Endpoint = res.url
+		cur.Status.URL = res.url
+		return r.Status().Update(ctx, cur)
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: r.safetyRequeue()}, nil
+}
+
+// endpointFor returns the winner's externally-addressable URL from its derived
+// ISVC status, or nil until the worker reports one.
+func endpointFor(derived *v1beta1.InferenceService) *apis.URL {
+	if derived == nil {
+		return nil
+	}
+	return derived.Status.URL
+}
+
+// placedResult builds the Placed status for winner. The endpoint is sticky: if
+// the winner's derived has no URL this pass (transient worker-status gap), the
+// last-published URL (from the in-memory isvc) is kept rather than cleared, so
+// an external LB watching status.url does not see a spurious deroute.
+func placedResult(winner string, derived, isvc *v1beta1.InferenceService) placementResult {
+	u := endpointFor(derived)
+	if u == nil {
+		u = isvc.Status.URL // keep last-known endpoint
+	}
+	return placementResult{
+		winner: winner, phase: v1beta1.PlacementPhasePlaced,
+		candidates: []v1beta1.CandidatePlacement{{Cluster: winner, Phase: v1beta1.CandidatePhaseAdmitted, Endpoint: u}},
+		url:        u,
+	}
+}
+
+func winnerCluster(isvc *v1beta1.InferenceService) string {
+	if isvc.Status.Placement == nil {
+		return ""
+	}
+	return isvc.Status.Placement.Cluster
+}
+
+func (r *Reconciler) requeue() time.Duration {
+	if r.Requeue > 0 {
+		return r.Requeue
+	}
+	return DefaultPlacementRequeue
+}
+
+func (r *Reconciler) placeTimeout() time.Duration {
+	if r.PlaceTimeout > 0 {
+		return r.PlaceTimeout
+	}
+	return DefaultPlaceTimeout
+}
+
+func (r *Reconciler) winnerLostGrace() time.Duration {
+	if r.WinnerLostGracePeriod > 0 {
+		return r.WinnerLostGracePeriod
+	}
+	return DefaultWinnerLostGrace
+}
+
+// nominate returns the resolved fan-out breadth policy, building it once from the
+// configured DispatcherMode (and, for Incremental, the step size / round timeout).
+// An empty/unrecognized mode degrades to all-at-once. Lazily constructed so the
+// Reconciler works as a bare struct literal without a dedicated constructor.
+func (r *Reconciler) nominate() Dispatcher {
+	r.dispatcherOnce.Do(func() {
+		r.dispatcher = dispatcherFor(r.DispatcherMode, r.DispatcherStepSize, r.DispatcherRoundTimeout)
+	})
+	return r.dispatcher
+}
+
+// graceRemaining records (on first observation) and reports how long is LEFT in
+// the winner-lost grace window for this source ISVC. The clock starts the first
+// time the winner's derived is seen absent on a connected winner; subsequent
+// observations reuse that start. A non-positive return means the window has
+// elapsed (caller should re-race). now is injected so tests can drive the clock
+// without sleeping.
+func (r *Reconciler) graceRemaining(uid types.UID, now time.Time) time.Duration {
+	v, _ := r.winnerLostSince.LoadOrStore(uid, now)
+	since := v.(time.Time)
+	return r.winnerLostGrace() - now.Sub(since)
+}
+
+// clearGrace drops any winner-lost grace marker for this source ISVC. Called
+// whenever the derived is observed present again, or once the winner is re-raced,
+// so the next disappearance starts a fresh window rather than inheriting a stale
+// start time.
+func (r *Reconciler) clearGrace(uid types.UID) {
+	r.winnerLostSince.Delete(uid)
+}
+
+// SetupWithManager wires the placer: reconcile ISVCs, re-enqueue the
+// placement-eligible ISVCs whose candidate set is affected when a WorkloadCluster
+// changes in a placement-relevant way (new/removed capacity, readiness flip, or
+// label change), and — when a status watch-funnel channel is supplied via
+// WithStatusEvents — re-enqueue a source ISVC when its derived's status changes
+// on a workload cluster. The predicate suppresses the per-heartbeat status
+// writes (the WorkloadCluster reconciler re-stamps Ready every health interval)
+// so a routine heartbeat does NOT fan out to every ISVC.
+//
+// ConvergeOptions keep the funnel channel and the status timing knobs (batch
+// debounce, long safety requeue) injectable so tests can wire a fake channel and
+// shrink the windows; an unset option degrades to the package default.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts ...ConvergeOption) error {
+	cfg := resolveConvergeConfig(opts...)
+	r.converge = &cfg
+
+	// Register the field index that marks ISVCs declaring placement requirements,
+	// so a cluster change lists only those (not every cached ISVC) before the
+	// per-ISVC candidate check in isvcsForClusterChange.
+	if err := registerPlacementEligibleIndex(context.Background(), mgr.GetFieldIndexer()); err != nil {
+		return err
+	}
+	b := ctrl.NewControllerManagedBy(mgr).
+		Named(PlacementControllerName).
+		For(&v1beta1.InferenceService{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		Watches(&v1beta1.WorkloadCluster{}, handler.EnqueueRequestsFromMapFunc(r.isvcsForClusterChange),
+			builder.WithPredicates(placementRelevantClusterChange))
+	// Consume the remote watch-funnel channel: each event already carries the
+	// LOCAL source key (resolved funnel-side), so the handler just enqueues that
+	// key, debounced by the batch period so a burst of derived-status updates for
+	// one ISVC folds into a single reconcile.
+	if cfg.statusEvents != nil {
+		b = b.WatchesRawSource(source.Channel(cfg.statusEvents, r.statusEventHandler(cfg.batchPeriod)))
+	}
+	return b.Complete(r)
+}
+
+// statusEventHandler enqueues the funnel-resolved local key with the configured
+// batch debounce. The event Object's namespace/name is the source ISVC key (the
+// funnel resolved it from the remote derived), so no remote/label work happens
+// here on the hot path.
+func (r *Reconciler) statusEventHandler(batchPeriod time.Duration) handler.EventHandler {
+	return handler.Funcs{
+		GenericFunc: func(_ context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			if e.Object == nil {
+				return
+			}
+			req := ctrl.Request{NamespacedName: types.NamespacedName{
+				Namespace: e.Object.GetNamespace(),
+				Name:      e.Object.GetName(),
+			}}
+			if batchPeriod > 0 {
+				q.AddAfter(req, batchPeriod)
+			} else {
+				q.Add(req)
+			}
+		},
+	}
+}
+
+// placementRelevantClusterChange admits WorkloadCluster events that can change
+// placement decisions: create/delete (capacity appears/disappears) and updates
+// that flip the Ready condition status or change labels. It drops the routine
+// status heartbeat (the health-probe re-stamp of an unchanged Ready condition),
+// which would otherwise re-enqueue every control-plane ISVC on each probe.
+var placementRelevantClusterChange = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldWC, ok1 := e.ObjectOld.(*v1beta1.WorkloadCluster)
+		newWC, ok2 := e.ObjectNew.(*v1beta1.WorkloadCluster)
+		if !ok1 || !ok2 {
+			return true // unexpected type: fail safe by re-enqueuing
+		}
+		if clusterReady(oldWC) != clusterReady(newWC) {
+			return true
+		}
+		return !maps.Equal(oldWC.Labels, newWC.Labels)
+	},
+}
+
+// clusterReady reports whether the WorkloadCluster's Ready condition is True.
+func clusterReady(wc *v1beta1.WorkloadCluster) bool {
+	return apimeta.IsStatusConditionTrue(wc.Status.Conditions, v1beta1.WorkloadClusterReady)
+}
+
+// placementEligibleIndexField is the controller-runtime cache field-index name
+// keyed on whether an ISVC declares ANY placement requirement (and is therefore
+// eligible for the cross-cluster fan-out). Without it, a WorkloadCluster change
+// lists EVERY cached InferenceService — including single-cluster ISVCs that carry
+// no placement annotations and can never be a candidate — and re-enqueues them
+// all; with it, MatchingFields narrows the list to the fan-out-eligible ISVCs in
+// O(eligible), and isvcsForClusterChange then filters to those for which THIS
+// cluster is (or was) a candidate.
+//
+// The field name is an internal index identifier (a code constant), not a
+// behavioral/user-facing value — no config surface is required.
+const placementEligibleIndexField = "ome.io/placement-eligible"
+
+// placementEligibleIndexValue is the indexed value for an ISVC that declares a
+// placement requirement. A constant truthy token; the index only ever maps the
+// eligible ISVCs (the extractor returns nil for the rest, leaving them unindexed).
+const placementEligibleIndexValue = "true"
+
+// placementEligibleIndexExtractor is the cache IndexerFunc for
+// placementEligibleIndexField. It returns the truthy token for an ISVC that
+// declares an accelerator-requirements or cluster-selector annotation (the same
+// signal MatchCandidates uses to decide fan-out eligibility), and nil otherwise
+// so non-placement ISVCs stay out of the index.
+func placementEligibleIndexExtractor(obj client.Object) []string {
+	isvc, ok := obj.(*v1beta1.InferenceService)
+	if !ok {
+		return nil
+	}
+	if !declaresPlacementRequirement(isvc) {
+		return nil
+	}
+	return []string{placementEligibleIndexValue}
+}
+
+// declaresPlacementRequirement reports whether the ISVC is eligible for
+// cross-cluster fan-out — it declares a requirement or cluster selector via
+// spec.placement or the legacy annotations. Uses placementInputs so it stays in
+// lockstep with requirementSelector (the source of truth for what counts as a
+// requirement); a divergence would index ISVCs the matcher ignores, or vice versa.
+func declaresPlacementRequirement(isvc *v1beta1.InferenceService) bool {
+	requirements, clusterSelector := placementInputs(isvc)
+	return requirements != "" || clusterSelector != ""
+}
+
+// registerPlacementEligibleIndex installs placementEligibleIndexField on the
+// supplied indexer (mgr.GetFieldIndexer()). Call once during manager setup,
+// before Start, so isvcsForClusterChange resolves fan-out-eligible ISVCs through
+// the index instead of scanning every cached InferenceService.
+func registerPlacementEligibleIndex(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &v1beta1.InferenceService{}, placementEligibleIndexField, placementEligibleIndexExtractor)
+}
+
+// isvcsForClusterChange maps a WorkloadCluster change to the reconcile requests
+// for the placement-eligible ISVCs whose candidate set is affected by that
+// cluster. It narrows to fan-out-eligible ISVCs via the field index, then keeps
+// only those for which the changed cluster is (or just stopped being) a
+// candidate:
+//
+//   - selector MATCHES the changed cluster's labels: the cluster may now be a
+//     candidate (entering the set on a label add / readiness flip), or remains one
+//     (a label change elsewhere on the cluster) — re-evaluate.
+//   - status already REFERENCES the changed cluster (winner or candidate): the
+//     change may be the cluster LEAVING the set (a label removed so the selector
+//     no longer matches, or readiness flipped away). The event carries only the
+//     post-change object, so a selector check alone would miss the departure; the
+//     status reference catches it so the placement re-races off the lost cluster.
+//
+// An ISVC that is neither a current/possible candidate nor placed on the cluster
+// is not enqueued — the change cannot affect its placement.
+func (r *Reconciler) isvcsForClusterChange(ctx context.Context, obj client.Object) []ctrl.Request {
+	wc, ok := obj.(*v1beta1.WorkloadCluster)
+	if !ok {
+		return nil
+	}
+	clusterName := wc.GetName()
+	clusterLabels := labels.Set(wc.GetLabels())
+
+	list := &v1beta1.InferenceServiceList{}
+	if err := r.List(ctx, list, client.MatchingFields{placementEligibleIndexField: placementEligibleIndexValue}); err != nil {
+		r.Log.Error(err, "fan-out cluster event: list placement-eligible ISVCs failed", "cluster", clusterName)
+		return nil
+	}
+	reqs := make([]ctrl.Request, 0, len(list.Items))
+	for i := range list.Items {
+		isvc := &list.Items[i]
+		if !clusterAffectsISVC(isvc, clusterName, clusterLabels) {
+			continue
+		}
+		reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: isvc.Namespace, Name: isvc.Name}})
+	}
+	return reqs
+}
+
+// clusterAffectsISVC reports whether a change to the named cluster (with the
+// given post-change labels) can affect this ISVC's placement: either the ISVC's
+// requirement selector matches the cluster's labels (it is/becomes a candidate),
+// or the ISVC's status already references the cluster (it is/was placed there and
+// must re-evaluate if the cluster is leaving the candidate set). A malformed
+// selector is treated as "affects" (fail safe: re-enqueue so the reconcile can
+// surface the malformed-selector status).
+func clusterAffectsISVC(isvc *v1beta1.InferenceService, clusterName string, clusterLabels labels.Set) bool {
+	if isvcStatusReferencesCluster(isvc, clusterName) {
+		return true
+	}
+	sel, hasReq, err := requirementSelector(isvc)
+	if err != nil {
+		return true // malformed selector: fail safe by re-enqueuing
+	}
+	if !hasReq {
+		return false // not fanned out fleet-wide; the cluster cannot be a candidate
+	}
+	return sel.Matches(clusterLabels)
+}
+
+// isvcStatusReferencesCluster reports whether the ISVC's placement status names
+// the cluster as its winner or among its fan-out candidates — i.e. the ISVC is
+// currently placed on (or racing on) that cluster.
+func isvcStatusReferencesCluster(isvc *v1beta1.InferenceService, clusterName string) bool {
+	p := isvc.Status.Placement
+	if p == nil {
+		return false
+	}
+	if p.Cluster == clusterName {
+		return true
+	}
+	for i := range p.Candidates {
+		if p.Candidates[i].Cluster == clusterName {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/v1beta1/placement/controller.go
+++ b/pkg/controller/v1beta1/placement/controller.go
@@ -207,6 +207,12 @@ func (r *Reconciler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		// set is diagnosable instead of an indistinguishable Pending.
 		r.Log.Info("no placement candidates", "isvc", isvc.Namespace+"/"+isvc.Name,
 			"reason", reason, "error", err)
+		if err == nil && reason == MatchReasonNoReadyClusters && isvc.Status.Placement != nil {
+			// Fleet readiness is sampled and can disappear for one health interval.
+			// Preserve the last-known placement (including its endpoint and homes)
+			// rather than publishing Pending and derouting still-serving traffic.
+			return ctrl.Result{RequeueAfter: r.requeue()}, nil
+		}
 		return r.writePlacement(ctx, isvc, placementResult{phase: v1beta1.PlacementPhasePending})
 	}
 
@@ -424,7 +430,8 @@ func (r *Reconciler) reconcileAll(ctx context.Context, isvc *v1beta1.InferenceSe
 	for _, c := range placed {
 		derived, ok, err := r.getDerived(ctx, c, isvc)
 		if err != nil {
-			return ctrl.Result{}, err
+			r.Log.Error(err, "all: reading derived failed; skipping home", "cluster", c, "isvc", isvc.Namespace+"/"+isvc.Name)
+			continue
 		}
 		if !ok {
 			continue
@@ -435,7 +442,8 @@ func (r *Reconciler) reconcileAll(ctx context.Context, isvc *v1beta1.InferenceSe
 		}
 		statuses, err := componentIRStatuses(ctx, cl, derived)
 		if err != nil {
-			return ctrl.Result{}, err
+			r.Log.Error(err, "all: reading IR statuses failed; skipping home", "cluster", c, "isvc", isvc.Namespace+"/"+isvc.Name)
+			continue
 		}
 		if AllComponentsAdmitted(derived, statuses) {
 			admitted++
@@ -514,7 +522,8 @@ func (r *Reconciler) reconcileSplit(ctx context.Context, isvc *v1beta1.Inference
 		}
 		derived, ok, err := r.getDerived(ctx, c, isvc)
 		if err != nil {
-			return ctrl.Result{}, err
+			r.Log.Error(err, "split: reading derived failed; skipping observation", "cluster", c, "isvc", isvc.Namespace+"/"+isvc.Name)
+			continue
 		}
 		if !ok {
 			continue // no derived yet
@@ -522,7 +531,9 @@ func (r *Reconciler) reconcileSplit(ctx context.Context, isvc *v1beta1.Inference
 		o.present = true
 		statuses, err := componentIRStatuses(ctx, cl, derived)
 		if err != nil {
-			return ctrl.Result{}, err
+			r.Log.Error(err, "split: reading IR statuses failed; skipping observation", "cluster", c, "isvc", isvc.Namespace+"/"+isvc.Name)
+			o.present = false
+			continue
 		}
 		o.admitted = splitAdmittedReplicas(scaleComps, statuses)
 		o.ready = splitReadyReplicas(scaleComps, statuses)

--- a/pkg/controller/v1beta1/placement/controller.go
+++ b/pkg/controller/v1beta1/placement/controller.go
@@ -80,6 +80,14 @@ type Reconciler struct {
 	Scheme   *runtime.Scheme
 	Log      logr.Logger
 	Clusters ClusterClients
+	// APIReader is the live (uncached) reader used to re-read the control-plane
+	// ISVC inside the conflict-retry loop. This controller and the endpoint
+	// publisher both write this object, so a 409 here is genuine external
+	// contention: the apiserver holds a newer ResourceVersion than the informer
+	// has observed, and re-reading the cache would resubmit the same stale base
+	// for the whole backoff. Required: SetupWithManager defaults it to
+	// mgr.GetAPIReader() and rejects a reconciler still missing it.
+	APIReader client.Reader
 	// Requeue is the status-refresh poll cadence; defaults to DefaultPlacementRequeue.
 	Requeue time.Duration
 	// ControlPlaneID is this control plane's identity, stamped onto every derived
@@ -1101,7 +1109,7 @@ func (r *Reconciler) writePlacement(ctx context.Context, isvc *v1beta1.Inference
 	key := client.ObjectKeyFromObject(isvc)
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		cur := &v1beta1.InferenceService{}
-		if err := r.Get(ctx, key, cur); err != nil {
+		if err := r.APIReader.Get(ctx, key, cur); err != nil {
 			return err
 		}
 		if cur.Status.Placement == nil {
@@ -1223,6 +1231,13 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts ...ConvergeOption) 
 	cfg := resolveConvergeConfig(opts...)
 	r.converge = &cfg
 
+	if r.APIReader == nil {
+		r.APIReader = mgr.GetAPIReader()
+	}
+	if err := r.validateWiring(); err != nil {
+		return err
+	}
+
 	// Register the field index that marks ISVCs declaring placement requirements,
 	// so a cluster change lists only those (not every cached ISVC) before the
 	// per-ISVC candidate check in isvcsForClusterChange.
@@ -1243,6 +1258,16 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts ...ConvergeOption) 
 		b = b.WatchesRawSource(source.Channel(cfg.statusEvents, r.statusEventHandler(cfg.batchPeriod)))
 	}
 	return b.Complete(r)
+}
+
+// validateWiring rejects a mis-wired reconciler at setup. The live reader is a
+// correctness dependency, not a convenience: without it the conflict-retry loop
+// re-reads a stale cached base and burns its whole backoff on the same 409.
+func (r *Reconciler) validateWiring() error {
+	if r.APIReader == nil {
+		return fmt.Errorf("placement: APIReader (live, uncached reader) must be wired")
+	}
+	return nil
 }
 
 // statusEventHandler enqueues the funnel-resolved local key with the configured

--- a/pkg/controller/v1beta1/placement/controller_test.go
+++ b/pkg/controller/v1beta1/placement/controller_test.go
@@ -1,0 +1,1620 @@
+package placement
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/workloadcluster"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(s))
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	return s
+}
+
+type fakeClusters struct {
+	m map[string]workloadcluster.SelectivelyCachingClient
+}
+
+func (f fakeClusters) ClientFor(name string) (workloadcluster.SelectivelyCachingClient, bool) {
+	c, ok := f.m[name]
+	return c, ok
+}
+
+func (f fakeClusters) Connected() []string {
+	names := make([]string, 0, len(f.m))
+	for n := range f.m {
+		names = append(names, n)
+	}
+	return names
+}
+
+func readyWC(name string, labels map[string]string) *v1beta1.WorkloadCluster {
+	return &v1beta1.WorkloadCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Status: v1beta1.WorkloadClusterStatus{Conditions: []metav1.Condition{
+			{Type: v1beta1.WorkloadClusterReady, Status: metav1.ConditionTrue, Reason: "Reachable"},
+		}},
+	}
+}
+
+func srcISVC(selector string) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc", Namespace: "prod", UID: "uid-1",
+			Annotations: map[string]string{ClusterSelectorAnnotation: selector},
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Engine: &v1beta1.EngineSpec{Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Name: "ome-container", Image: "img"}}},
+		},
+	}
+}
+
+// emptyWorker is a fresh fake worker client (status subresource registered).
+func emptyWorker(s *runtime.Scheme) client.WithWatch {
+	return fakeclient.NewClientBuilder().WithScheme(s).WithStatusSubresource(&v1beta1.InferenceService{}).Build()
+}
+
+// workerWithAdmittedDerived returns a worker whose derived ISVC already reports
+// an admitted engine instance (it won the race).
+func workerWithAdmittedDerived(t *testing.T, s *runtime.Scheme) client.WithWatch {
+	t.Helper()
+	derived := isvcWithInstances(v1beta1.EngineComponent, true) // from admission_test.go
+	derived.Namespace = "prod"
+	derived.Name = "svc"
+	derived.Labels = map[string]string{PlacementOriginLabel: "uid-1"}
+	// The reconcile reads admission from the authoritative IR on the worker
+	// cluster, so seed it alongside the derived ISVC.
+	engineIR := irWithInstances(v1beta1.EngineComponent, true)
+	w := fakeclient.NewClientBuilder().WithScheme(s).
+		WithStatusSubresource(&v1beta1.InferenceService{}).
+		WithObjects(derived, engineIR).Build()
+	// Ensure the admitted status is stored (if the builder didn't persist it).
+	cur := &v1beta1.InferenceService{}
+	require.NoError(t, w.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, cur))
+	if len(cur.Status.Components) == 0 {
+		cur.Status = derived.Status
+		require.NoError(t, w.Status().Update(context.Background(), cur))
+	}
+	return w
+}
+
+func newPlacer(s *runtime.Scheme, clusters ClusterClients, objs ...client.Object) (*Reconciler, client.Client) {
+	c := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(objs...).WithStatusSubresource(&v1beta1.InferenceService{}).Build()
+	return &Reconciler{Client: c, Scheme: s, Log: log.Log, Clusters: clusters, Requeue: time.Second}, c
+}
+
+func req() ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "prod", Name: "svc"}}
+}
+
+func hasDerived(t *testing.T, w client.Client) bool {
+	t.Helper()
+	o := &v1beta1.InferenceService{}
+	err := w.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, o)
+	if apierrors.IsNotFound(err) {
+		return false
+	}
+	require.NoError(t, err)
+	return true
+}
+
+func cpPlacement(t *testing.T, cp client.Client) *v1beta1.PlacementStatus {
+	t.Helper()
+	o := &v1beta1.InferenceService{}
+	require.NoError(t, cp.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, o))
+	return o.Status.Placement
+}
+
+func workerWithAdmittedURL(t *testing.T, s *runtime.Scheme, host string) client.WithWatch {
+	t.Helper()
+	derived := isvcWithInstances(v1beta1.EngineComponent, true)
+	derived.Namespace, derived.Name = "prod", "svc"
+	derived.Labels = map[string]string{PlacementOriginLabel: "uid-1"}
+	derived.Status.URL = &apis.URL{Scheme: "https", Host: host}
+	engineIR := irWithInstances(v1beta1.EngineComponent, true)
+	w := fakeclient.NewClientBuilder().WithScheme(s).
+		WithStatusSubresource(&v1beta1.InferenceService{}).WithObjects(derived, engineIR).Build()
+	cur := &v1beta1.InferenceService{}
+	require.NoError(t, w.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, cur))
+	if cur.Status.URL == nil {
+		cur.Status = derived.Status
+		require.NoError(t, w.Status().Update(context.Background(), cur))
+	}
+	return w
+}
+
+func cpStatusURL(t *testing.T, cp client.Client) *apis.URL {
+	t.Helper()
+	o := &v1beta1.InferenceService{}
+	require.NoError(t, cp.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, o))
+	return o.Status.URL
+}
+
+func TestReconcile_NoCandidate(t *testing.T) {
+	s := testScheme(t)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"), readyWC("cloud-a", map[string]string{"gpu": "h100"}))
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePending, p.Phase)
+}
+
+func TestReconcile_FansOutToAllCandidates(t *testing.T) {
+	s := testScheme(t)
+	wa, wb := emptyWorker(s), emptyWorker(s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	assert.True(t, hasDerived(t, wa), "derived on a")
+	assert.True(t, hasDerived(t, wb), "derived on b")
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhaseRacing, p.Phase)
+	assert.Empty(t, p.Cluster)
+	assert.Len(t, p.Candidates, 2)
+}
+
+// TestReconcile_RacingRequeuesAtPollCadence guards the convergence bug where a
+// race in progress requeued at the long steady-state safety backstop
+// (DefaultStatusSafetyRequeue, 10m) instead of the fast poll cadence. With the
+// status funnel off (the default), that backstop is the only re-trigger, so the
+// winner is not observed until it fires — the race appears stuck. Racing must
+// re-poll at r.requeue() (the harness's 1s).
+func TestReconcile_RacingRequeuesAtPollCadence(t *testing.T) {
+	s := testScheme(t)
+	wa, wb := emptyWorker(s), emptyWorker(s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	require.Equal(t, v1beta1.PlacementPhaseRacing, cpPlacement(t, cp).Phase)
+	assert.Equal(t, time.Second, res.RequeueAfter,
+		"racing must requeue at the poll cadence, not the steady-state backstop")
+	assert.Less(t, res.RequeueAfter, DefaultStatusSafetyRequeue)
+}
+
+func TestReconcile_FirstAdmittedWinsAndDeletesLosers(t *testing.T) {
+	s := testScheme(t)
+	wa := emptyWorker(s)
+	wb := workerWithAdmittedDerived(t, s) // b already admitted -> winner
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, "b", p.Cluster)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	assert.False(t, hasDerived(t, wa), "loser a's derived deleted")
+	assert.True(t, hasDerived(t, wb), "winner b's derived kept")
+}
+
+func TestReconcile_StickyWinner(t *testing.T) {
+	s := testScheme(t)
+	wa := emptyWorker(s)
+	wb := workerWithAdmittedDerived(t, s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, cp := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, "b", p.Cluster)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	assert.False(t, hasDerived(t, wa), "sticky winner must NOT fan out to a")
+	assert.True(t, hasDerived(t, wb))
+}
+
+// When the winner's derived is gone on a CONNECTED winner cluster, the
+// controller holds the existing placement for the grace window (riding out a
+// transient gap) before re-racing. With a non-trivial grace, the first pass
+// holds: the winner is retained, no re-fan-out, and a requeue is scheduled.
+func TestReconcile_WinnerLostWithinGraceHolds(t *testing.T) {
+	s := testScheme(t)
+	wa, wb := emptyWorker(s), emptyWorker(s) // b's derived is GONE (winner lost)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, cp := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+	r.WinnerLostGracePeriod = time.Minute // non-trivial: first pass is within grace
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	assert.Positive(t, res.RequeueAfter, "requeues to re-check after grace")
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, "b", p.Cluster, "winner held during grace")
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase, "phase held during grace")
+	assert.False(t, hasDerived(t, wa), "must NOT re-fan-out to a within grace")
+}
+
+// Once the winner-lost grace window has elapsed (the derived stayed gone on the
+// connected winner), the controller gives up on the winner and re-races: it
+// clears the winner and re-fans-out to every candidate.
+func TestReconcile_ReplaceOnWinnerLostAfterGrace(t *testing.T) {
+	s := testScheme(t)
+	wa, wb := emptyWorker(s), emptyWorker(s) // b's derived is GONE (winner lost)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, cp := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+	r.WinnerLostGracePeriod = time.Minute
+	// Pre-seed the grace clock so the window is already elapsed on this pass.
+	r.winnerLostSince.Store(isvc.UID, time.Now().Add(-2*time.Minute))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Empty(t, p.Cluster, "lost winner cleared after grace")
+	assert.Equal(t, v1beta1.PlacementPhaseRacing, p.Phase)
+	assert.True(t, hasDerived(t, wa), "re-fanned out to a")
+	assert.True(t, hasDerived(t, wb), "re-fanned out to b")
+	// Marker cleared once re-raced.
+	_, ok := r.winnerLostSince.Load(isvc.UID)
+	assert.False(t, ok, "grace marker cleared after re-race")
+}
+
+// workerWithUnadmittedDerived returns a worker whose derived ISVC exists but
+// whose engine IR reports NO admitted instance — the shape of a winner that
+// Kueue preempted (pods evicted back behind the admission gate).
+func workerWithUnadmittedDerived(t *testing.T, s *runtime.Scheme) client.WithWatch {
+	t.Helper()
+	derived := isvcWithInstances(v1beta1.EngineComponent)
+	derived.Namespace, derived.Name = "prod", "svc"
+	derived.Labels = map[string]string{PlacementOriginLabel: "uid-1"}
+	engineIR := irWithInstances(v1beta1.EngineComponent, false) // present, NOT admitted
+	return fakeclient.NewClientBuilder().WithScheme(s).
+		WithStatusSubresource(&v1beta1.InferenceService{}).WithObjects(derived, engineIR).Build()
+}
+
+func TestReconcile_WinnerLostAdmissionWithinGraceHolds(t *testing.T) {
+	s := testScheme(t)
+	wa := emptyWorker(s)
+	wb := workerWithUnadmittedDerived(t, s) // b's derived present but de-admitted (preempted)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, cp := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+	r.WinnerLostGracePeriod = time.Minute // first pass arms the clock, within window
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	assert.Positive(t, res.RequeueAfter, "requeues to re-check after grace")
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, "b", p.Cluster, "winner held during grace")
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase, "phase held during grace")
+	assert.False(t, hasDerived(t, wa), "must NOT re-fan-out to a while within grace")
+}
+
+func TestReconcile_WinnerLostAdmissionReRacesAfterGrace(t *testing.T) {
+	s := testScheme(t)
+	wa := emptyWorker(s)
+	wb := workerWithUnadmittedDerived(t, s) // b's derived present but de-admitted (preempted)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, cp := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+	r.WinnerLostGracePeriod = time.Minute
+	// Pre-seed the grace clock so the window is already elapsed on this pass.
+	r.winnerLostSince.Store(isvc.UID, time.Now().Add(-2*time.Minute))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Empty(t, p.Cluster, "de-admitted winner cleared after grace")
+	assert.Equal(t, v1beta1.PlacementPhaseRacing, p.Phase)
+	assert.True(t, hasDerived(t, wa), "re-fanned out to a after grace")
+	_, ok := r.winnerLostSince.Load(isvc.UID)
+	assert.False(t, ok, "grace marker cleared after re-race")
+}
+
+func TestReconcile_WinnerFailedSurfacesFailed(t *testing.T) {
+	s := testScheme(t)
+	// b's derived ISVC reports an engine instance Phase=Failed.
+	derivedFailed := isvcWithPhases(v1beta1.EngineComponent, v1beta1.OMENativeInstanceFailed)
+	derivedFailed.Namespace = "prod"
+	derivedFailed.Name = "svc"
+	derivedFailed.Labels = map[string]string{PlacementOriginLabel: "uid-1"}
+	// The reconcile reads the Failed phase from the authoritative IR on the
+	// worker cluster; seed it alongside the derived ISVC.
+	failedIR := irWithPhases(v1beta1.EngineComponent, v1beta1.OMENativeInstanceFailed)
+	wb := fakeclient.NewClientBuilder().WithScheme(s).
+		WithStatusSubresource(&v1beta1.InferenceService{}).
+		WithObjects(derivedFailed, failedIR).Build()
+	// Ensure the failed status is persisted.
+	cur := &v1beta1.InferenceService{}
+	require.NoError(t, wb.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, cur))
+	cur.Status = derivedFailed.Status
+	require.NoError(t, wb.Status().Update(context.Background(), cur))
+
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, cp := newPlacer(s, clusters, isvc, readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhaseFailed, p.Phase, "placement escalated to Failed")
+	assert.Equal(t, "b", p.Cluster, "failed cluster recorded")
+	assert.True(t, hasDerived(t, wb), "failed derived kept (not deleted)")
+}
+
+func TestReconcile_StickyWinnerSweepsStrayLoser(t *testing.T) {
+	s := testScheme(t)
+	// a is connected and carries a STRAY derived (origin-labeled), not in status.
+	wa := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(&v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod", Labels: map[string]string{PlacementOriginLabel: "uid-1"}},
+	}).Build()
+	wb := workerWithAdmittedDerived(t, s) // winner b, admitted
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}}, // a is NOT listed
+	}
+	r, cp := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	assert.False(t, hasDerived(t, wa), "stray derived on non-winner cluster a must be swept even though it's not in status.Candidates")
+	assert.True(t, hasDerived(t, wb), "winner b kept")
+	p := cpPlacement(t, cp)
+	assert.Equal(t, "b", p.Cluster)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+}
+
+func TestReconcile_DeleteRemovesDerivedEverywhere(t *testing.T) {
+	s := testScheme(t)
+	wa := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(&v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod", Labels: map[string]string{PlacementOriginLabel: "uid-1"}},
+	}).Build()
+	wb := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(&v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod", Labels: map[string]string{PlacementOriginLabel: "uid-1"}},
+	}).Build()
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b",
+		Candidates: []v1beta1.CandidatePlacement{
+			{Cluster: "a", Phase: v1beta1.CandidatePhasePlaced}, {Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted},
+		},
+	}
+	r, cp := newPlacer(s, clusters, isvc)
+
+	require.NoError(t, cp.Delete(context.Background(), isvc)) // finalizer -> DeletionTimestamp
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	assert.False(t, hasDerived(t, wa), "derived removed from a")
+	assert.False(t, hasDerived(t, wb), "derived removed from b")
+	got := &v1beta1.InferenceService{}
+	err = cp.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, got)
+	assert.True(t, apierrors.IsNotFound(err), "CP ISVC gone after finalizer cleared")
+}
+
+// createFailClient wraps a fake client but fails every Create (simulates a
+// cluster that rejects the derived ISVC).
+type createFailClient struct {
+	client.WithWatch
+}
+
+func (c createFailClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return apierrors.NewInternalError(errors.New("create rejected"))
+}
+
+func TestReconcile_FanOutPartialFailureStillRaces(t *testing.T) {
+	s := testScheme(t)
+	// a rejects Create; b accepts.
+	wa := createFailClient{WithWatch: fakeclient.NewClientBuilder().WithScheme(s).Build()}
+	wb := emptyWorker(s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err, "one bad cluster must not fail the whole reconcile")
+
+	assert.True(t, hasDerived(t, wb), "healthy cluster b still got the derived")
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhaseRacing, p.Phase)
+}
+
+func TestReconcile_PublishesEndpointWhenAdmitted(t *testing.T) {
+	s := testScheme(t)
+	wa := emptyWorker(s)
+	wb := workerWithAdmittedURL(t, s, "svc.prod.b.example")
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	assert.Equal(t, "b", p.Cluster)
+	require.NotNil(t, p.Endpoint)
+	assert.Equal(t, "svc.prod.b.example", p.Endpoint.Host)
+	u := cpStatusURL(t, cp)
+	require.NotNil(t, u)
+	assert.Equal(t, "svc.prod.b.example", u.Host)
+
+	// The winner's per-candidate Endpoint is populated too (the per-home model
+	// All/Split build on; in Single the top-level Endpoint stays authoritative).
+	require.Len(t, p.Candidates, 1)
+	assert.Equal(t, "b", p.Candidates[0].Cluster)
+	require.NotNil(t, p.Candidates[0].Endpoint)
+	assert.Equal(t, "svc.prod.b.example", p.Candidates[0].Endpoint.Host)
+}
+
+func TestReconcile_PlacedButNoEndpointYet(t *testing.T) {
+	s := testScheme(t)
+	wa := emptyWorker(s)
+	wb := workerWithAdmittedDerived(t, s) // admitted, but NO status.url
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	assert.Nil(t, p.Endpoint)
+	assert.Nil(t, cpStatusURL(t, cp))
+}
+
+func TestReconcile_ClearsEndpointOnWinnerLost(t *testing.T) {
+	s := testScheme(t)
+	wa, wb := emptyWorker(s), emptyWorker(s) // b's derived GONE
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	oldURL := &apis.URL{Scheme: "https", Host: "old.example"}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced, Endpoint: oldURL,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	isvc.Status.URL = oldURL
+	r, cp := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+	r.WinnerLostGracePeriod = time.Minute
+	// Grace already elapsed: the endpoint is cleared only once we genuinely
+	// re-race (a transient gap within grace keeps the sticky endpoint).
+	r.winnerLostSince.Store(isvc.UID, time.Now().Add(-2*time.Minute))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhaseRacing, p.Phase)
+	assert.Nil(t, p.Endpoint)
+	assert.Nil(t, cpStatusURL(t, cp))
+}
+
+// Within the grace window the sticky endpoint MUST survive a transient
+// winner-derived gap: an external LB watching status.url must not see a spurious
+// deroute on a momentary blip.
+func TestReconcile_StickyEndpointSurvivesWinnerGapWithinGrace(t *testing.T) {
+	s := testScheme(t)
+	wb := emptyWorker(s) // b's derived GONE this pass (transient)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	oldURL := &apis.URL{Scheme: "https", Host: "svc.prod.b.example"}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced, Endpoint: oldURL,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	isvc.Status.URL = oldURL
+	r, cp := newPlacer(s, clusters, isvc, readyWC("b", map[string]string{"gpu": "gb300"}))
+	r.WinnerLostGracePeriod = time.Minute // within grace on first pass
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	assert.Positive(t, res.RequeueAfter)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase, "placement held during grace")
+	require.NotNil(t, p.Endpoint, "sticky endpoint survives a transient gap within grace")
+	assert.Equal(t, "svc.prod.b.example", p.Endpoint.Host)
+}
+
+func TestReconcile_StickyEndpointPersistsAcrossTransientGap(t *testing.T) {
+	s := testScheme(t)
+	wb := workerWithAdmittedDerived(t, s) // admitted, NO status.url this pass
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	prior := &apis.URL{Scheme: "https", Host: "svc.prod.b.example"}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced, Endpoint: prior,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	isvc.Status.URL = prior
+	r, cp := newPlacer(s, clusters, isvc, readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	// The newPlacer fake client should persist the initial status, but ensure it:
+	got := &v1beta1.InferenceService{}
+	require.NoError(t, cp.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, got))
+	if got.Status.URL == nil || got.Status.Placement == nil {
+		got.Status = isvc.Status
+		require.NoError(t, cp.Status().Update(context.Background(), got))
+	}
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	require.NotNil(t, p.Endpoint, "sticky: endpoint must survive a transient worker-URL gap")
+	assert.Equal(t, "svc.prod.b.example", p.Endpoint.Host)
+	require.NotNil(t, cpStatusURL(t, cp))
+}
+
+func TestReconcile_EndpointPreservedOnFailed(t *testing.T) {
+	s := testScheme(t)
+	// derived: engine instance Failed, but a status.url is present.
+	derived := isvcWithPhases(v1beta1.EngineComponent, v1beta1.OMENativeInstanceFailed)
+	derived.Namespace, derived.Name = "prod", "svc"
+	derived.Labels = map[string]string{PlacementOriginLabel: "uid-1"}
+	derived.Status.URL = &apis.URL{Scheme: "https", Host: "svc.prod.b.example"}
+	failedIR := irWithPhases(v1beta1.EngineComponent, v1beta1.OMENativeInstanceFailed)
+	wb := fakeclient.NewClientBuilder().WithScheme(s).
+		WithStatusSubresource(&v1beta1.InferenceService{}).WithObjects(derived, failedIR).Build()
+	cur := &v1beta1.InferenceService{}
+	require.NoError(t, wb.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, cur))
+	if cur.Status.URL == nil {
+		cur.Status = derived.Status
+		require.NoError(t, wb.Status().Update(context.Background(), cur))
+	}
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, cp := newPlacer(s, clusters, isvc, readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhaseFailed, p.Phase)
+	require.NotNil(t, p.Endpoint, "Failed placement keeps routing to its still-addressable URL")
+	assert.Equal(t, "svc.prod.b.example", p.Endpoint.Host)
+}
+
+func TestEndpointFor_NilSafe(t *testing.T) {
+	assert.Nil(t, endpointFor(nil))
+	assert.Nil(t, endpointFor(&v1beta1.InferenceService{}))
+}
+
+// deleteFailClient fails every Delete (simulates a cluster that errors on
+// loser cleanup).
+type deleteFailClient struct {
+	client.WithWatch
+}
+
+func (c deleteFailClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return apierrors.NewInternalError(errors.New("delete rejected"))
+}
+
+// getFailClient fails every Get (simulates a transient remote read error).
+type getFailClient struct {
+	client.WithWatch
+}
+
+func (c getFailClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return apierrors.NewInternalError(errors.New("get rejected"))
+}
+
+// foreignDerived builds a same-named ISVC NOT created by this control plane (no
+// origin label, or an origin label for a different source UID).
+func foreignDerived(originUID string) *v1beta1.InferenceService {
+	o := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod"}}
+	if originUID != "" {
+		o.Labels = map[string]string{PlacementOriginLabel: originUID}
+	}
+	return o
+}
+
+// Cross-tenant data-loss guard: the loser sweep must NOT delete a same-named
+// ISVC on a connected NON-candidate cluster that this control plane did not
+// derive. deleteLosers sweeps only candidate clusters and deleteDerivedOn is
+// origin-guarded, so a user's same-named ISVC on an unrelated connected
+// cluster survives.
+func TestReconcile_LoserSweepDoesNotTouchForeignISVCOnNonCandidate(t *testing.T) {
+	s := testScheme(t)
+	// "other" is connected but NOT a candidate (label does not match the
+	// selector) and carries a user-created same-named ISVC with no origin label.
+	wOther := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(foreignDerived("")).Build()
+	wb := workerWithAdmittedDerived(t, s) // winner (candidate)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"other": workloadcluster.NewNeverCachingClient(wOther),
+		"b":     workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"),
+		readyWC("other", map[string]string{"gpu": "h100"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	assert.True(t, hasDerived(t, wOther), "foreign same-named ISVC on non-candidate connected cluster must NOT be deleted")
+	assert.True(t, hasDerived(t, wb), "winner kept")
+	assert.Equal(t, "b", cpPlacement(t, cp).Cluster)
+}
+
+// Even on a candidate (loser) cluster, an object derived from a
+// DIFFERENT source UID must survive the origin-guarded sweep.
+func TestReconcile_LoserSweepDoesNotDeleteOtherSourceDerived(t *testing.T) {
+	s := testScheme(t)
+	// a is a candidate and holds an ISVC derived from a different source.
+	wa := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(foreignDerived("some-other-uid")).Build()
+	wb := workerWithAdmittedDerived(t, s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	// Make this a sticky-winner pass so a's foreign object is only ever subject
+	// to the loser sweep (not adopted by a fan-out CreateOrUpdate).
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, _ := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	assert.True(t, hasDerived(t, wa), "derived owned by a different source UID must NOT be deleted")
+}
+
+// Bug: deleteLosers must tolerate a per-cluster delete failure instead of
+// aborting the whole reconcile on the first error.
+func TestReconcile_LoserCleanupToleratesPerClusterError(t *testing.T) {
+	s := testScheme(t)
+	// a holds OUR stray derived but errors on Delete; the reconcile must still
+	// succeed (place the winner) rather than abort.
+	wa := deleteFailClient{WithWatch: fakeclient.NewClientBuilder().WithScheme(s).
+		WithObjects(&v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+			Name: "svc", Namespace: "prod", Labels: map[string]string{PlacementOriginLabel: "uid-1"}}}).Build()}
+	wb := workerWithAdmittedDerived(t, s) // winner
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err, "a single loser-cluster delete error must not abort the reconcile")
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, cpPlacement(t, cp).Phase)
+	assert.Equal(t, "b", cpPlacement(t, cp).Cluster)
+}
+
+// Bug: a transient remote GET error in the sticky-winner path must hold the
+// existing placement and requeue, not abort and not re-race.
+func TestReconcile_StickyWinnerTransientGetHoldsPlacement(t *testing.T) {
+	s := testScheme(t)
+	wa := emptyWorker(s)
+	wb := getFailClient{WithWatch: emptyWorker(s)} // winner's GET fails transiently
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, cp := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err, "transient remote GET error must not abort the reconcile")
+	assert.Positive(t, res.RequeueAfter, "should requeue to retry")
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, "b", p.Cluster, "existing placement held")
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	assert.False(t, hasDerived(t, wa), "must NOT re-race / fan out to a on a transient read error")
+}
+
+// Bug: placeOn must merge control-plane-owned metadata onto the derived rather
+// than clobbering worker-added labels/annotations every poll.
+func TestPlaceOn_PreservesWorkerMetadata(t *testing.T) {
+	s := testScheme(t)
+	// Pre-existing derived that IS ours (carries the origin marker) plus a
+	// worker-added label + annotation the worker reconciler stamped on it.
+	existing := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+		Name: "svc", Namespace: "prod",
+		Labels:      map[string]string{"worker.io/managed": "yes", PlacementOriginLabel: "uid-1"},
+		Annotations: map[string]string{"worker.io/state": "bookkeeping"},
+	}}
+	w := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(existing).Build()
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(w),
+	}}
+	r, _ := newPlacer(s, clusters, srcISVC(""))
+
+	require.NoError(t, r.placeOn(context.Background(), w, srcISVC("")))
+
+	got := &v1beta1.InferenceService{}
+	require.NoError(t, w.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, got))
+	assert.Equal(t, "yes", got.Labels["worker.io/managed"], "worker label preserved")
+	assert.Equal(t, "bookkeeping", got.Annotations["worker.io/state"], "worker annotation preserved")
+	assert.Equal(t, "uid-1", got.Labels[PlacementOriginLabel], "control-plane origin label set")
+}
+
+// Bug (cross-tenant data loss): placeOn must NOT overwrite a same-named ISVC on
+// the candidate cluster that is NOT a derived of this control plane (a user's
+// own ISVC, or another control plane's object). The apply must abort — leaving
+// the foreign object's Spec untouched and unstamped — mirroring the origin guard
+// already on the delete path.
+func TestPlaceOn_RefusesToClobberForeignISVC(t *testing.T) {
+	s := testScheme(t)
+	// A foreign object: same name/namespace, NO origin markers, a distinct Spec.
+	foreign := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc", Namespace: "prod",
+			Labels:      map[string]string{"owner": "some-user"},
+			Annotations: map[string]string{"note": "hand-rolled"},
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Router: &v1beta1.RouterSpec{Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Name: "user-container", Image: "user-img"}}},
+		},
+	}
+	w := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(foreign).Build()
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(w),
+	}}
+	r, _ := newPlacer(s, clusters, srcISVC(""))
+
+	err := r.placeOn(context.Background(), w, srcISVC(""))
+	require.Error(t, err, "placeOn must refuse to clobber a foreign same-named ISVC")
+
+	got := &v1beta1.InferenceService{}
+	require.NoError(t, w.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, got))
+	// Foreign Spec is unchanged: still the user's router, no engine stamped in.
+	assert.NotNil(t, got.Spec.Router, "foreign Spec preserved (router intact)")
+	assert.Nil(t, got.Spec.Engine, "foreign Spec preserved (no engine grafted on)")
+	// No origin markers stamped onto the foreign object.
+	assert.Empty(t, got.Labels[PlacementOriginLabel], "origin label not stamped on foreign object")
+	assert.Empty(t, got.Annotations[PlacementOriginUIDAnnotation], "origin annotation not stamped on foreign object")
+	assert.Equal(t, "some-user", got.Labels["owner"], "foreign label untouched")
+}
+
+// placeOn must update OUR OWN existing derived (origin marker present) normally,
+// without erroring — the guard distinguishes our derived from a foreign object.
+func TestPlaceOn_UpdatesOwnDerived(t *testing.T) {
+	s := testScheme(t)
+	existing := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+		Name: "svc", Namespace: "prod",
+		Labels: map[string]string{PlacementOriginLabel: "uid-1"},
+	}}
+	w := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(existing).Build()
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(w),
+	}}
+	r, _ := newPlacer(s, clusters, srcISVC(""))
+
+	require.NoError(t, r.placeOn(context.Background(), w, srcISVC("")), "re-apply of our own derived must succeed")
+
+	got := &v1beta1.InferenceService{}
+	require.NoError(t, w.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, got))
+	assert.NotNil(t, got.Spec.Engine, "desired Spec applied to our derived")
+	assert.Equal(t, "uid-1", got.Labels[PlacementOriginLabel], "origin label retained")
+}
+
+// placeOn must create the derived when no object exists on the candidate.
+func TestPlaceOn_CreatesWhenAbsent(t *testing.T) {
+	s := testScheme(t)
+	w := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(w),
+	}}
+	r, _ := newPlacer(s, clusters, srcISVC(""))
+
+	require.NoError(t, r.placeOn(context.Background(), w, srcISVC("")), "first-time create must succeed")
+
+	got := &v1beta1.InferenceService{}
+	require.NoError(t, w.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, got))
+	assert.NotNil(t, got.Spec.Engine, "derived created with desired Spec")
+	assert.Equal(t, "uid-1", got.Labels[PlacementOriginLabel], "origin label stamped on created derived")
+}
+
+// Bug: reconcileDelete must NOT remove the finalizer while a connected cluster
+// still holds our derived because its delete errored (would orphan it). It
+// requeues instead.
+func TestReconcileDelete_HoldsFinalizerWhenConnectedDeleteFails(t *testing.T) {
+	s := testScheme(t)
+	wa := deleteFailClient{WithWatch: fakeclient.NewClientBuilder().WithScheme(s).
+		WithObjects(&v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+			Name: "svc", Namespace: "prod", Labels: map[string]string{PlacementOriginLabel: "uid-1"}}}).Build()}
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	r, cp := newPlacer(s, clusters, isvc, readyWC("a", map[string]string{"gpu": "gb300"}))
+	require.NoError(t, cp.Delete(context.Background(), isvc)) // -> DeletionTimestamp (finalizer present)
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	assert.Positive(t, res.RequeueAfter, "should requeue to retry teardown")
+
+	got := &v1beta1.InferenceService{}
+	require.NoError(t, cp.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, got))
+	assert.Contains(t, got.Finalizers, PlacementFinalizer, "finalizer held while connected cluster still holds derived")
+}
+
+// Winner-lost grace: a DISCONNECTED winner must be treated as transient
+// — the controller holds the placement and requeues, and crucially does NOT arm
+// the grace clock (which tracks absence on a CONNECTED winner). A transport flap
+// must never tear down a healthy placement or even start counting toward a
+// re-race.
+func TestReconcile_StickyWinnerDisconnectedHoldsWithoutArmingGrace(t *testing.T) {
+	s := testScheme(t)
+	// Winner "b" is a Ready candidate WorkloadCluster but is NOT in the connected
+	// client set (transport flap): ClientFor("b") -> (nil, false).
+	wa := emptyWorker(s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, cp := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+	r.WinnerLostGracePeriod = time.Nanosecond // even a ~zero grace must not re-race a disconnected winner
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	assert.Positive(t, res.RequeueAfter, "disconnected winner: hold and requeue")
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, "b", p.Cluster, "disconnected winner held, not cleared")
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	assert.False(t, hasDerived(t, wa), "must NOT re-race / fan out to a on a disconnected winner")
+	_, armed := r.winnerLostSince.Load(isvc.UID)
+	assert.False(t, armed, "grace clock must NOT be armed for a disconnected winner")
+}
+
+// Winner-lost grace: once the derived reappears on the connected winner, any pending grace
+// marker is cleared so a later disappearance starts a fresh window.
+func TestReconcile_StickyWinnerPresentClearsGraceMarker(t *testing.T) {
+	s := testScheme(t)
+	wa := emptyWorker(s)
+	wb := workerWithAdmittedDerived(t, s) // present + admitted
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	r, cp := newPlacer(s, clusters, isvc,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+	// Pre-seed a stale grace marker (as if the derived had briefly vanished).
+	r.winnerLostSince.Store(isvc.UID, time.Now())
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, cpPlacement(t, cp).Phase)
+	_, ok := r.winnerLostSince.Load(isvc.UID)
+	assert.False(t, ok, "grace marker cleared once derived is present again")
+}
+
+// Fault isolation: a candidate that is NOT in the connected snapshot is
+// skipped during fan-out — its absence must not block placing on the connected
+// candidates, and the placement still proceeds to Racing.
+func TestReconcile_FanOutSkipsDisconnectedCandidate(t *testing.T) {
+	s := testScheme(t)
+	// Both "a" and "b" are Ready candidates, but only "a" is connected.
+	wa := emptyWorker(s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err, "a disconnected candidate must not fail the reconcile")
+
+	assert.True(t, hasDerived(t, wa), "connected candidate a got the derived")
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhaseRacing, p.Phase)
+}
+
+// Index: isvcsForClusterChange enqueues an ISVC only when the changed
+// cluster is (or could become) one of its candidates — its requirement selector
+// matches the cluster's labels — and skips ISVCs the cluster cannot affect.
+func TestIsvcsForClusterChange_EnqueuesOnlyMatchingCandidates(t *testing.T) {
+	s := testScheme(t)
+	// match: selector gpu=gb300 matches the changed cluster.
+	match := srcISVCNamed("match", map[string]string{AcceleratorRequirementsAnnotation: "gpu=gb300"})
+	// noMatch: requires a different accelerator; the changed cluster is not a candidate.
+	noMatch := srcISVCNamed("nomatch", map[string]string{AcceleratorRequirementsAnnotation: "gpu=h100"})
+	// noReq: declares no placement requirement; never fanned out, must be excluded
+	// (and is not even in the index).
+	noReq := srcISVCNamed("noreq", nil)
+
+	c := indexedPlacementClient(t, s, match, noMatch, noReq)
+	r := &Reconciler{Client: c, Scheme: s, Log: log.Log}
+
+	changed := readyWC("b", map[string]string{"gpu": "gb300"})
+	reqs := r.isvcsForClusterChange(context.Background(), changed)
+
+	got := requestNames(reqs)
+	assert.Contains(t, got, "match", "ISVC whose selector matches the changed cluster is enqueued")
+	assert.NotContains(t, got, "nomatch", "ISVC whose selector does not match is skipped")
+	assert.NotContains(t, got, "noreq", "ISVC with no placement requirement is skipped")
+}
+
+// Index: an ISVC whose status references the changed cluster (it is
+// placed/racing there) is enqueued even when the post-change labels no longer
+// match its selector — this is the "cluster leaving the candidate set" case the
+// event's post-change object alone would miss.
+func TestIsvcsForClusterChange_EnqueuesStatusReferencedClusterOnLabelLoss(t *testing.T) {
+	s := testScheme(t)
+	// Selector requires gpu=gb300, but the changed cluster has LOST that label.
+	// The ISVC is currently placed on "b", so it must be re-evaluated.
+	placed := srcISVCNamed("placed", map[string]string{AcceleratorRequirementsAnnotation: "gpu=gb300"})
+	placed.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "b", Phase: v1beta1.PlacementPhasePlaced,
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted}},
+	}
+	c := indexedPlacementClient(t, s, placed)
+	r := &Reconciler{Client: c, Scheme: s, Log: log.Log}
+
+	// Changed cluster "b" no longer carries gpu=gb300 (label removed).
+	changed := readyWC("b", map[string]string{"gpu": "h100"})
+	reqs := r.isvcsForClusterChange(context.Background(), changed)
+
+	assert.Contains(t, requestNames(reqs), "placed",
+		"ISVC placed on the cluster is re-enqueued even when the cluster's new labels no longer match its selector")
+}
+
+// Index: the field-index extractor marks exactly the requirement-
+// declaring ISVCs (and leaves the rest unindexed).
+func TestPlacementEligibleIndexExtractor(t *testing.T) {
+	withAccel := srcISVCNamed("a", map[string]string{AcceleratorRequirementsAnnotation: "gpu=gb300"})
+	withSelector := srcISVCNamed("b", map[string]string{ClusterSelectorAnnotation: "provider=cloud-a"})
+	withNone := srcISVCNamed("c", nil)
+
+	assert.Equal(t, []string{placementEligibleIndexValue}, placementEligibleIndexExtractor(withAccel))
+	assert.Equal(t, []string{placementEligibleIndexValue}, placementEligibleIndexExtractor(withSelector))
+	assert.Nil(t, placementEligibleIndexExtractor(withNone))
+	// Wrong type yields no index entry.
+	assert.Nil(t, placementEligibleIndexExtractor(&v1beta1.WorkloadCluster{}))
+}
+
+// srcISVCNamed builds a placement source ISVC with a given name and annotation
+// set (nil annotations => no placement requirement).
+func srcISVCNamed(name string, annotations map[string]string) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "prod", UID: types.UID("uid-" + name),
+			Annotations: annotations,
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Engine: &v1beta1.EngineSpec{Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Name: "ome-container", Image: "img"}}},
+		},
+	}
+}
+
+// indexedPlacementClient builds a fake control-plane client with the placement-
+// eligible field index registered (mirroring what cmd/manager installs on the
+// manager cache), so isvcsForClusterChange's MatchingFields list resolves.
+func indexedPlacementClient(t *testing.T, s *runtime.Scheme, objs ...client.Object) client.Client {
+	t.Helper()
+	return fakeclient.NewClientBuilder().WithScheme(s).
+		WithIndex(&v1beta1.InferenceService{}, placementEligibleIndexField, placementEligibleIndexExtractor).
+		WithObjects(objs...).
+		Build()
+}
+
+func requestNames(reqs []ctrl.Request) []string {
+	out := make([]string, 0, len(reqs))
+	for _, r := range reqs {
+		out = append(out, r.Name)
+	}
+	return out
+}
+
+// hangingClient blocks every Create until the (per-cluster) context deadline
+// fires, simulating a wedged remote apiserver that neither succeeds nor returns
+// an error promptly.
+type hangingClient struct {
+	client.WithWatch
+}
+
+func (c hangingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// Fault isolation: a wedged remote whose apply hangs is bounded by the
+// per-cluster PlaceTimeout and skipped, so the healthy peer still gets the
+// derived and the reconcile completes (Racing) instead of stalling on the stuck
+// cluster.
+func TestReconcile_FanOutBoundsStuckClusterAndProceeds(t *testing.T) {
+	s := testScheme(t)
+	wa := hangingClient{WithWatch: fakeclient.NewClientBuilder().WithScheme(s).Build()} // wedged
+	wb := emptyWorker(s)                                                                // healthy
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVC("gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+	r.PlaceTimeout = 50 * time.Millisecond // bound the wedged apply tightly for the test
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, err := r.Reconcile(context.Background(), req())
+		assert.NoError(t, err, "a wedged cluster must not fail the whole reconcile")
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconcile blocked on a stuck cluster; per-cluster timeout did not fire")
+	}
+
+	assert.True(t, hasDerived(t, wb), "healthy cluster b still got the derived despite the wedged peer")
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhaseRacing, p.Phase)
+}
+
+// srcISVCMode builds a source ISVC that drives placement through the structured
+// spec.placement field with the given mode + requirement selector.
+func srcISVCMode(mode v1beta1.PlacementMode, requirements string) *v1beta1.InferenceService {
+	i := srcISVC("")
+	i.Annotations = nil
+	i.Spec.Placement = &v1beta1.PlacementSpec{Mode: mode, Requirements: requirements}
+	return i
+}
+
+// workerWithGatedDerived returns a worker whose derived ISVC exists but whose
+// engine IR reports no admitted instance — a home that fanned out but is still
+// gated behind Kueue admission.
+func workerWithGatedDerived(t *testing.T, s *runtime.Scheme) client.WithWatch {
+	t.Helper()
+	derived := isvcWithInstances(v1beta1.EngineComponent)
+	derived.Namespace, derived.Name = "prod", "svc"
+	derived.Labels = map[string]string{PlacementOriginLabel: "uid-1"}
+	engineIR := irWithInstances(v1beta1.EngineComponent, false) // present, NOT admitted
+	return fakeclient.NewClientBuilder().WithScheme(s).
+		WithStatusSubresource(&v1beta1.InferenceService{}).WithObjects(derived, engineIR).Build()
+}
+
+func candidatesByCluster(cs []v1beta1.CandidatePlacement) map[string]v1beta1.CandidatePlacement {
+	m := map[string]v1beta1.CandidatePlacement{}
+	for _, c := range cs {
+		m[c.Cluster] = c
+	}
+	return m
+}
+
+// TestReconcile_AllModeKeepsEveryAdmittedHome: mode All places on every candidate
+// that admits, keeps them all (no sweep, no single winner), and records each
+// home's own endpoint.
+func TestReconcile_AllModeKeepsEveryAdmittedHome(t *testing.T) {
+	s := testScheme(t)
+	wa := workerWithAdmittedURL(t, s, "svc.a.example")
+	wb := workerWithAdmittedURL(t, s, "svc.b.example")
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVCMode(v1beta1.PlacementModeAll, "gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	assert.True(t, hasDerived(t, wa), "home a kept (no sweep)")
+	assert.True(t, hasDerived(t, wb), "home b kept (no sweep)")
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	assert.Empty(t, p.Cluster, "All has no single winner cluster")
+	require.Len(t, p.Candidates, 2)
+	by := candidatesByCluster(p.Candidates)
+	require.Contains(t, by, "a")
+	require.Contains(t, by, "b")
+	assert.Equal(t, v1beta1.CandidatePhaseAdmitted, by["a"].Phase)
+	require.NotNil(t, by["a"].Endpoint)
+	assert.Equal(t, "svc.a.example", by["a"].Endpoint.Host)
+	assert.Equal(t, v1beta1.CandidatePhaseAdmitted, by["b"].Phase)
+	require.NotNil(t, by["b"].Endpoint)
+	assert.Equal(t, "svc.b.example", by["b"].Endpoint.Host)
+}
+
+// TestReconcile_AllModePartialAdmitStaysPlaced: one home admitted, one still
+// gated -> Placed (>=1 admitted), neither swept, gated home has no endpoint yet.
+func TestReconcile_AllModePartialAdmitStaysPlaced(t *testing.T) {
+	s := testScheme(t)
+	wa := workerWithAdmittedURL(t, s, "svc.a.example") // admitted
+	wb := workerWithGatedDerived(t, s)                 // present but gated
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVCMode(v1beta1.PlacementModeAll, "gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	assert.True(t, hasDerived(t, wa))
+	assert.True(t, hasDerived(t, wb), "gated home is NOT swept")
+	// A home still gated must keep the placement re-polling (not fall to the long
+	// steady-state backstop) so a home that admits later is observed promptly.
+	assert.Positive(t, res.RequeueAfter, "re-polls while a home is still gated")
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase, ">=1 admitted -> Placed")
+	by := candidatesByCluster(p.Candidates)
+	assert.Equal(t, v1beta1.CandidatePhaseAdmitted, by["a"].Phase)
+	assert.Equal(t, v1beta1.CandidatePhasePlaced, by["b"].Phase)
+	assert.Nil(t, by["b"].Endpoint, "gated home has no endpoint yet")
+}
+
+// TestReconcile_AllModeRacingWhileAllGated: no home admitted yet -> Racing, both
+// kept, fast requeue.
+func TestReconcile_AllModeRacingWhileAllGated(t *testing.T) {
+	s := testScheme(t)
+	wa, wb := emptyWorker(s), emptyWorker(s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVCMode(v1beta1.PlacementModeAll, "gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	assert.True(t, hasDerived(t, wa))
+	assert.True(t, hasDerived(t, wb))
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhaseRacing, p.Phase)
+	assert.Empty(t, p.Cluster)
+	assert.Len(t, p.Candidates, 2)
+	assert.Positive(t, res.RequeueAfter, "racing re-polls fast")
+}
+
+// TestReconcile_UnsupportedModeHoldsPending: Split (not yet implemented) is held
+// Pending, not silently run as Single — nothing is fanned out.
+func TestReconcile_UnsupportedModeHoldsPending(t *testing.T) {
+	s := testScheme(t)
+	wa := emptyWorker(s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVCMode(v1beta1.PlacementModeSplit, "gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	assert.False(t, hasDerived(t, wa), "unsupported mode fans out to nothing")
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePending, p.Phase)
+}
+
+// srcISVCSplit builds a Split-mode source ISVC with the fleet-wide desired
+// replica count set via spec.placement.split.replicas.
+func srcISVCSplit(requirements string, replicas int32) *v1beta1.InferenceService {
+	i := srcISVC("")
+	i.Annotations = nil
+	i.Spec.Placement = &v1beta1.PlacementSpec{
+		Mode:         v1beta1.PlacementModeSplit,
+		Requirements: requirements,
+		Split:        &v1beta1.SplitSpec{Replicas: &replicas},
+	}
+	return i
+}
+
+// workerWithReplicas returns a worker whose derived engine IR reports `admitted`
+// admitted instances and `ready` ready replicas, with an addressable status.URL.
+// Models a home that Kueue admitted a fraction of the requested replicas.
+func workerWithReplicas(t *testing.T, s *runtime.Scheme, host string, admitted, ready int32) client.WithWatch {
+	t.Helper()
+	derived := isvcWithInstances(v1beta1.EngineComponent)
+	derived.Namespace, derived.Name = "prod", "svc"
+	derived.Labels = map[string]string{PlacementOriginLabel: "uid-1"}
+	derived.Status.URL = &apis.URL{Scheme: "https", Host: host}
+	flags := make([]bool, admitted)
+	for i := range flags {
+		flags[i] = true
+	}
+	ir := irWithInstances(v1beta1.EngineComponent, flags...)
+	ir.Status.ReadyReplicas = ready
+	w := fakeclient.NewClientBuilder().WithScheme(s).
+		WithStatusSubresource(&v1beta1.InferenceService{}).WithObjects(derived, ir).Build()
+	cur := &v1beta1.InferenceService{}
+	require.NoError(t, w.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, cur))
+	if cur.Status.URL == nil {
+		cur.Status = derived.Status
+		require.NoError(t, w.Status().Update(context.Background(), cur))
+	}
+	return w
+}
+
+func TestSplitDesiredReplicas(t *testing.T) {
+	// spec.placement.split.replicas wins.
+	assert.Equal(t, int32(4), splitDesiredReplicas(srcISVCSplit("gpu=gb300", 4)))
+	// Falls back to the engine floor when split.replicas is unset.
+	i := srcISVCMode(v1beta1.PlacementModeSplit, "gpu=gb300")
+	i.Spec.Engine.MinReplicas = ptr.To(3)
+	assert.Equal(t, int32(3), splitDesiredReplicas(i))
+	// Zero when neither is declared.
+	assert.Equal(t, int32(0), splitDesiredReplicas(srcISVCMode(v1beta1.PlacementModeSplit, "gpu=gb300")))
+}
+
+// TestReconcile_SplitPackedFillsAcrossHomes: N=3 packed across two homes that
+// admit 2 and 1 — both kept with per-home admitted/ready counts, and the
+// apportioned replica count is applied to each home's derived.
+func TestReconcile_SplitPackedFillsAcrossHomes(t *testing.T) {
+	s := testScheme(t)
+	wa := workerWithReplicas(t, s, "svc.a.example", 2, 2)
+	wb := workerWithReplicas(t, s, "svc.b.example", 1, 1)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVCSplit("gpu=gb300", 3),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	assert.Empty(t, p.Cluster, "Split has no single winner cluster")
+	by := candidatesByCluster(p.Candidates)
+	require.Contains(t, by, "a")
+	require.Contains(t, by, "b")
+	assert.Equal(t, int32(2), by["a"].AdmittedReplicas)
+	assert.Equal(t, int32(2), by["a"].ReadyReplicas)
+	require.NotNil(t, by["a"].Endpoint)
+	assert.Equal(t, int32(1), by["b"].AdmittedReplicas)
+	assert.Equal(t, int32(1), by["b"].ReadyReplicas)
+
+	// Both homes are already admitted summing to the floor, so this is a TRIM
+	// pass: each home is pinned to its admitted count (no over-request / gated
+	// remainder), and the apportioned count lands on the derived engine.
+	da := &v1beta1.InferenceService{}
+	require.NoError(t, wa.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, da))
+	require.NotNil(t, da.Spec.Engine.MinReplicas)
+	assert.Equal(t, 2, *da.Spec.Engine.MinReplicas, "home pinned to its admitted count")
+}
+
+// TestReconcile_SplitMaxPerClusterCapsDerivedCeiling: maxReplicasPerCluster is
+// the hard per-cluster ceiling, so it clamps each home's derived MaxReplicas
+// DOWN from the declared engine.maxReplicas — the home may burst up to the cap
+// locally, never past it. Min stays the apportioned share (a=2, b=1 for floor 3).
+func TestReconcile_SplitMaxPerClusterCapsDerivedCeiling(t *testing.T) {
+	s := testScheme(t)
+	wa := workerWithReplicas(t, s, "svc.a.example", 2, 2)
+	wb := workerWithReplicas(t, s, "svc.b.example", 1, 1)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	src := srcISVCSplit("gpu=gb300", 3)
+	src.Spec.Engine.MaxReplicas = 9 // declared ceiling the cap must override
+	src.Spec.Placement.Split.MaxReplicasPerCluster = 2
+	r, cp := newPlacer(s, clusters, src,
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	require.Equal(t, v1beta1.PlacementPhasePlaced, cpPlacement(t, cp).Phase)
+	get := func(w client.Client) *v1beta1.InferenceService {
+		d := &v1beta1.InferenceService{}
+		require.NoError(t, w.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, d))
+		return d
+	}
+	da, db := get(wa), get(wb)
+	assert.Equal(t, 2, da.Spec.Engine.MaxReplicas, "home a ceiling clamped to the cap, not 9")
+	assert.Equal(t, 2, db.Spec.Engine.MaxReplicas, "home b ceiling clamped to the cap, not 9")
+	require.NotNil(t, da.Spec.Engine.MinReplicas)
+	require.NotNil(t, db.Spec.Engine.MinReplicas)
+	assert.Equal(t, 2, *da.Spec.Engine.MinReplicas, "a floor = its share")
+	assert.Equal(t, 1, *db.Spec.Engine.MinReplicas, "b floor = its share")
+}
+
+// TestReconcile_SplitTrimsOverAdmission: two homes admit 4 and 2 but the floor
+// is 4 — TRIM keeps the preferred home full (4) and sheds the excess from the
+// least-preferred (b scaled to 0 / swept), converging the request sum to 4.
+func TestReconcile_SplitTrimsOverAdmission(t *testing.T) {
+	s := testScheme(t)
+	wa := workerWithReplicas(t, s, "svc.a.example", 4, 4)
+	wb := workerWithReplicas(t, s, "svc.b.example", 2, 2)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVCSplit("gpu=gb300", 4),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	// a keeps the whole floor; b is trimmed away (target 0 -> derived swept).
+	da := &v1beta1.InferenceService{}
+	require.NoError(t, wa.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, da))
+	require.NotNil(t, da.Spec.Engine.MinReplicas)
+	assert.Equal(t, 4, *da.Spec.Engine.MinReplicas, "preferred home kept full")
+	assert.False(t, hasDerived(t, wb), "excess least-preferred home trimmed away")
+	by := candidatesByCluster(p.Candidates)
+	require.Contains(t, by, "a")
+	assert.NotContains(t, by, "b")
+}
+
+func TestSplitApportion(t *testing.T) {
+	cs := []string{"a", "b", "c"}
+	adm := func(a, b, c int32) map[string]int32 { return map[string]int32{"a": a, "b": b, "c": c} }
+
+	// FILL from empty: Packed over-requests the whole floor on the frontier;
+	// already-admitted replicas shrink what later clusters are asked for.
+	assert.Equal(t, map[string]int32{"a": 6, "b": 6, "c": 6}, splitApportion(cs, adm(0, 0, 0), 6, 0, false),
+		"all gated -> each candidate over-requested the deficit (trim converges later)")
+	assert.Equal(t, map[string]int32{"a": 6, "b": 2, "c": 2}, splitApportion(cs, adm(4, 0, 0), 6, 0, false),
+		"a holds 4 -> b/c asked for the remaining 2")
+
+	// TRIM: admitted >= floor -> pin preferred full, shed least-preferred.
+	assert.Equal(t, map[string]int32{"a": 4, "b": 0, "c": 0}, splitApportion(cs, adm(4, 2, 0), 4, 0, false),
+		"floor met by a -> b's excess trimmed to 0")
+	assert.Equal(t, map[string]int32{"a": 3, "b": 2, "c": 0}, splitApportion(cs, adm(3, 3, 3), 5, 0, false),
+		"pin a=3, b=2, shed c")
+
+	// maxPerCluster caps each request.
+	assert.Equal(t, map[string]int32{"a": 3, "b": 3, "c": 3}, splitApportion(cs, adm(0, 0, 0), 9, 3, false),
+		"cap forces the fill to spread across clusters")
+
+	// Balanced (spread): even share on every candidate.
+	assert.Equal(t, map[string]int32{"a": 2, "b": 2, "c": 2}, splitApportion(cs, adm(0, 0, 0), 6, 0, true))
+}
+
+// TestReconcile_SplitPackedSkipsUnneededCluster: N=2 met entirely by home a, so
+// candidate b is not used (no derived, not a home).
+func TestReconcile_SplitPackedSkipsUnneededCluster(t *testing.T) {
+	s := testScheme(t)
+	wa := workerWithReplicas(t, s, "svc.a.example", 2, 2)
+	wb := emptyWorker(s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVCSplit("gpu=gb300", 2),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	require.Len(t, p.Candidates, 1, "floor met by a; b not used")
+	assert.Equal(t, "a", p.Candidates[0].Cluster)
+	assert.Equal(t, int32(2), p.Candidates[0].AdmittedReplicas)
+	assert.False(t, hasDerived(t, wb), "unneeded cluster b is not placed on")
+}
+
+// TestReconcile_SplitRacingWhileAllGated: nothing admitted yet -> Racing, homes
+// retained as placed candidates, fast requeue.
+func TestReconcile_SplitRacingWhileAllGated(t *testing.T) {
+	s := testScheme(t)
+	wa, wb := emptyWorker(s), emptyWorker(s)
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(wa),
+		"b": workloadcluster.NewNeverCachingClient(wb),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVCSplit("gpu=gb300", 2),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhaseRacing, p.Phase)
+	assert.Positive(t, res.RequeueAfter, "keeps filling while the floor is unmet")
+	assert.True(t, hasDerived(t, wa))
+	assert.True(t, hasDerived(t, wb))
+}
+
+func TestSplitScaleComponentsAndAccounting(t *testing.T) {
+	// Engine-only ISVC -> just the engine.
+	eng := srcISVCSplit("gpu=gb300", 3)
+	assert.Equal(t, []v1beta1.ComponentType{v1beta1.EngineComponent}, splitScaleComponents(eng))
+
+	// PD ISVC (engine + decoder) -> both are scaled components.
+	pd := srcISVCSplit("gpu=gb300", 3)
+	pd.Spec.Decoder = &v1beta1.DecoderSpec{}
+	assert.Equal(t, []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}, splitScaleComponents(pd))
+
+	// A PD replica is admitted only when BOTH components admit that instance, so
+	// the count is the MIN across components: 3 engine + 2 decoder = 2 pairs.
+	es := irWithInstances(v1beta1.EngineComponent, true, true, true).Status
+	es.ReadyReplicas = 3
+	ds := irWithInstances(v1beta1.DecoderComponent, true, true).Status
+	ds.ReadyReplicas = 1
+	statuses := map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus{
+		v1beta1.EngineComponent:  &es,
+		v1beta1.DecoderComponent: &ds,
+	}
+	comps := []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent}
+	assert.Equal(t, int32(2), splitAdmittedReplicas(comps, statuses), "min admitted = complete pairs")
+	assert.Equal(t, int32(1), splitReadyReplicas(comps, statuses), "min ready across components")
+
+	// Engine-only accounting is just the engine's counts.
+	assert.Equal(t, int32(3), splitAdmittedReplicas([]v1beta1.ComponentType{v1beta1.EngineComponent}, statuses))
+}

--- a/pkg/controller/v1beta1/placement/controller_test.go
+++ b/pkg/controller/v1beta1/placement/controller_test.go
@@ -102,7 +102,7 @@ func workerWithAdmittedDerived(t *testing.T, s *runtime.Scheme) client.WithWatch
 
 func newPlacer(s *runtime.Scheme, clusters ClusterClients, objs ...client.Object) (*Reconciler, client.Client) {
 	c := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(objs...).WithStatusSubresource(&v1beta1.InferenceService{}).Build()
-	return &Reconciler{Client: c, Scheme: s, Log: log.Log, Clusters: clusters, Requeue: time.Second}, c
+	return &Reconciler{Client: c, APIReader: c, Scheme: s, Log: log.Log, Clusters: clusters, Requeue: time.Second}, c
 }
 
 func req() ctrl.Request {

--- a/pkg/controller/v1beta1/placement/controller_test.go
+++ b/pkg/controller/v1beta1/placement/controller_test.go
@@ -748,6 +748,18 @@ func (c getFailClient) Get(ctx context.Context, key client.ObjectKey, obj client
 	return apierrors.NewInternalError(errors.New("get rejected"))
 }
 
+// irGetFailClient allows derived-ISVC reads but fails authoritative IR reads.
+type irGetFailClient struct {
+	client.WithWatch
+}
+
+func (c irGetFailClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*v1beta1.InferenceReplica); ok {
+		return apierrors.NewInternalError(errors.New("IR get rejected"))
+	}
+	return c.WithWatch.Get(ctx, key, obj, opts...)
+}
+
 // foreignDerived builds a same-named ISVC NOT created by this control plane (no
 // origin label, or an origin label for a different source UID).
 func foreignDerived(originUID string) *v1beta1.InferenceService {
@@ -1078,6 +1090,30 @@ func TestReconcile_FanOutSkipsDisconnectedCandidate(t *testing.T) {
 	assert.Equal(t, v1beta1.PlacementPhaseRacing, p.Phase)
 }
 
+func TestReconcile_NoReadyClustersPreservesLastKnownPlacement(t *testing.T) {
+	s := testScheme(t)
+	isvc := srcISVC("gpu=gb300")
+	isvc.Finalizers = []string{PlacementFinalizer}
+	isvc.Status.Placement = &v1beta1.PlacementStatus{
+		Cluster: "a", Phase: v1beta1.PlacementPhasePlaced, Endpoint: apis.HTTPS("svc.a.example"),
+		Candidates: []v1beta1.CandidatePlacement{{Cluster: "a", Phase: v1beta1.CandidatePhaseAdmitted, Endpoint: apis.HTTPS("svc.a.example")}},
+	}
+	isvc.Status.URL = apis.HTTPS("svc.a.example")
+	wc := readyWC("a", map[string]string{"gpu": "gb300"})
+	wc.Status.Conditions[0].Status = metav1.ConditionFalse
+	r, cp := newPlacer(s, fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{}}, isvc, wc)
+
+	res, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	assert.Positive(t, res.RequeueAfter)
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	assert.Equal(t, "a", p.Cluster)
+	require.NotNil(t, cpStatusURL(t, cp))
+	assert.Equal(t, "svc.a.example", cpStatusURL(t, cp).Host)
+}
+
 // Index: isvcsForClusterChange enqueues an ISVC only when the changed
 // cluster is (or could become) one of its candidates — its requirement selector
 // matches the cluster's labels — and skips ISVCs the cluster cannot affect.
@@ -1317,6 +1353,27 @@ func TestReconcile_AllModePartialAdmitStaysPlaced(t *testing.T) {
 	assert.Nil(t, by["b"].Endpoint, "gated home has no endpoint yet")
 }
 
+func TestReconcile_AllModeRemoteIRFailureDoesNotHideHealthyHome(t *testing.T) {
+	s := testScheme(t)
+	bad := irGetFailClient{WithWatch: workerWithAdmittedURL(t, s, "svc.a.example")}
+	good := workerWithAdmittedURL(t, s, "svc.b.example")
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(bad),
+		"b": workloadcluster.NewNeverCachingClient(good),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVCMode(v1beta1.PlacementModeAll, "gpu=gb300"),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("b", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	by := candidatesByCluster(p.Candidates)
+	assert.NotContains(t, by, "a")
+	assert.Equal(t, v1beta1.CandidatePhaseAdmitted, by["b"].Phase)
+}
+
 // TestReconcile_AllModeRacingWhileAllGated: no home admitted yet -> Racing, both
 // kept, fast requeue.
 func TestReconcile_AllModeRacingWhileAllGated(t *testing.T) {
@@ -1449,6 +1506,26 @@ func TestReconcile_SplitPackedFillsAcrossHomes(t *testing.T) {
 	require.NoError(t, wa.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "svc"}, da))
 	require.NotNil(t, da.Spec.Engine.MinReplicas)
 	assert.Equal(t, 2, *da.Spec.Engine.MinReplicas, "home pinned to its admitted count")
+}
+
+func TestReconcile_SplitRemoteIRFailureDoesNotAbortHealthyHome(t *testing.T) {
+	s := testScheme(t)
+	good := workerWithReplicas(t, s, "svc.a.example", 1, 1)
+	bad := irGetFailClient{WithWatch: workerWithReplicas(t, s, "svc.z.example", 1, 1)}
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"a": workloadcluster.NewNeverCachingClient(good),
+		"z": workloadcluster.NewNeverCachingClient(bad),
+	}}
+	r, cp := newPlacer(s, clusters, srcISVCSplit("gpu=gb300", 1),
+		readyWC("a", map[string]string{"gpu": "gb300"}), readyWC("z", map[string]string{"gpu": "gb300"}))
+
+	_, err := r.Reconcile(context.Background(), req())
+	require.NoError(t, err)
+	p := cpPlacement(t, cp)
+	require.NotNil(t, p)
+	assert.Equal(t, v1beta1.PlacementPhasePlaced, p.Phase)
+	by := candidatesByCluster(p.Candidates)
+	assert.Equal(t, v1beta1.CandidatePhaseAdmitted, by["a"].Phase)
 }
 
 // TestReconcile_SplitMaxPerClusterCapsDerivedCeiling: maxReplicasPerCluster is

--- a/pkg/controller/v1beta1/placement/derive.go
+++ b/pkg/controller/v1beta1/placement/derive.go
@@ -1,0 +1,112 @@
+package placement
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// DeriveISVC builds a derived InferenceService from a control-plane source
+// ISVC. The derived object is suitable for placement onto a workload cluster:
+//   - Identity (name/ns) preserved so the worker cluster can address it.
+//   - Server-side fields cleared (UID, ResourceVersion, generation, etc.).
+//   - Origin markers added (PlacementOriginLabel, PlacementOriginUIDAnnotation).
+//   - Control-plane identity stamped (PlacementControlPlaneLabel) when controlPlaneID
+//     is non-empty, so the GC sweep only reaps deriveds THIS control plane created.
+//   - Kueue gating stamped on component pod metadata (the queue-name label).
+//   - Control-plane-only directives removed (placement selectors + rollout verbs)
+//     so the worker reconciler does not (re)act on the control plane's decisions.
+func DeriveISVC(src *v1beta1.InferenceService, controlPlaneID string) *v1beta1.InferenceService {
+	d := src.DeepCopy()
+
+	// Clear server-side / control-plane state.
+	d.ResourceVersion = ""
+	d.UID = ""
+	d.Generation = 0
+	d.CreationTimestamp = metav1.Time{}
+	d.DeletionTimestamp = nil
+	d.OwnerReferences = nil
+	d.Finalizers = nil
+	d.ManagedFields = nil
+	d.Status = v1beta1.InferenceServiceStatus{}
+
+	// Resolve queue name: from LocalQueueAnnotation or default.
+	queue := src.Annotations[LocalQueueAnnotation]
+	if queue == "" {
+		queue = DefaultLocalQueue
+	}
+
+	// Add origin markers.
+	if d.Labels == nil {
+		d.Labels = make(map[string]string)
+	}
+	d.Labels[PlacementOriginLabel] = string(src.UID)
+	// Stamp the control-plane identity so GC across shared workload clusters can
+	// tell our deriveds apart from another control plane's. Config-driven, no
+	// in-code default: an empty id leaves the label unset (single-CP behavior).
+	if controlPlaneID != "" {
+		d.Labels[PlacementControlPlaneLabel] = controlPlaneID
+	}
+	if d.Annotations == nil {
+		d.Annotations = make(map[string]string)
+	}
+	d.Annotations[PlacementOriginUIDAnnotation] = string(src.UID)
+	// Strip control-plane-only directives so they do not ride along to the
+	// worker (placement selectors + rollout operator verbs).
+	for _, k := range controlPlaneOnlyAnnotations {
+		delete(d.Annotations, k)
+	}
+
+	// Stamp Kueue gating on each component.
+	if d.Spec.Engine != nil {
+		stampQueue(&d.Spec.Engine.ComponentExtensionSpec, queue)
+	}
+	if d.Spec.Decoder != nil {
+		stampQueue(&d.Spec.Decoder.ComponentExtensionSpec, queue)
+	}
+	if d.Spec.Router != nil {
+		stampQueue(&d.Spec.Router.ComponentExtensionSpec, queue)
+	}
+
+	return d
+}
+
+// setDerivedReplicas pins Split's apportioned replica band on a derived ISVC's
+// scalable components: MinReplicas becomes this home's share of the floor (Kueue
+// admits as many as fit), and MaxReplicas becomes the per-cluster ceiling so the
+// home can autoscale UP locally under load but no further. maxPer > 0 is the hard
+// ceiling from spec.placement.split.maxReplicasPerCluster; maxPer <= 0 means no
+// cap was declared, so the component's own MaxReplicas stands (only raised to
+// keep Max >= Min). The apportioned share is always <= maxPer (splitApportion
+// caps it), so Min <= Max holds. Applied to Engine and, when present, Decoder (a
+// PD pair scales 1:1).
+func setDerivedReplicas(d *v1beta1.InferenceService, replicas, maxPer int32) {
+	n := int(replicas)
+	apply := func(c *v1beta1.ComponentExtensionSpec) {
+		c.MinReplicas = ptr.To(n)
+		switch {
+		case maxPer > 0:
+			c.MaxReplicas = int(maxPer)
+		case c.MaxReplicas < n:
+			c.MaxReplicas = n
+		}
+	}
+	if d.Spec.Engine != nil {
+		apply(&d.Spec.Engine.ComponentExtensionSpec)
+	}
+	if d.Spec.Decoder != nil {
+		apply(&d.Spec.Decoder.ComponentExtensionSpec)
+	}
+}
+
+// stampQueue adds the Kueue queue-name label to a component's pod metadata.
+// That label is what Kueue's pod integration keys on to gate the pods; it is the
+// sole Kueue stamp the derived ISVC needs.
+func stampQueue(comp *v1beta1.ComponentExtensionSpec, queue string) {
+	if comp.Labels == nil {
+		comp.Labels = make(map[string]string)
+	}
+	comp.Labels[constants.KueueQueueLabelKey] = queue
+}

--- a/pkg/controller/v1beta1/placement/derive_test.go
+++ b/pkg/controller/v1beta1/placement/derive_test.go
@@ -1,0 +1,121 @@
+package placement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestDeriveISVC(t *testing.T) {
+	src := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc", Namespace: "prod", UID: "uid-123",
+			ResourceVersion: "999",
+			Annotations: map[string]string{
+				LocalQueueAnnotation:                "serving-lq",
+				AcceleratorRequirementsAnnotation:   "gpu=gb300",
+				ClusterSelectorAnnotation:           "provider=cloud-a",
+				constants.RolloutPromoteAnnotation:  "full",
+				constants.RolloutRollbackAnnotation: "true",
+				constants.NetworkVisibility:         "cluster-local", // an ingress override that SHOULD ride along
+			},
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Engine: &v1beta1.EngineSpec{
+				Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Name: "ome-container", Image: "img"}},
+			},
+			Decoder: &v1beta1.DecoderSpec{
+				Runner: &v1beta1.RunnerSpec{Container: corev1.Container{Name: "ome-container", Image: "img"}},
+			},
+		},
+	}
+
+	d := DeriveISVC(src, "cp-east")
+
+	// identity preserved (worker addresses it by the same name/ns).
+	assert.Equal(t, "svc", d.Name)
+	assert.Equal(t, "prod", d.Namespace)
+	// server-side fields cleared.
+	assert.Empty(t, d.ResourceVersion)
+	assert.Empty(t, string(d.UID))
+	assert.True(t, d.Status.DeepCopy() != nil) // status is a fresh zero value (compiles regardless)
+	// origin markers.
+	assert.NotEmpty(t, d.Labels[PlacementOriginLabel])
+	assert.Equal(t, "uid-123", d.Annotations[PlacementOriginUIDAnnotation])
+	// control-plane identity stamped from the supplied id.
+	assert.Equal(t, "cp-east", d.Labels[PlacementControlPlaneLabel])
+	// Kueue queue-name label stamped on the engine component pod metadata
+	// (the sole Kueue stamp).
+	require.NotNil(t, d.Spec.Engine)
+	assert.Equal(t, "serving-lq", d.Spec.Engine.ComponentExtensionSpec.Labels[constants.KueueQueueLabelKey])
+	// ...and on the decoder component too.
+	require.NotNil(t, d.Spec.Decoder)
+	assert.Equal(t, "serving-lq", d.Spec.Decoder.ComponentExtensionSpec.Labels[constants.KueueQueueLabelKey])
+	// control-plane-only directives are dropped on the derived object: the
+	// placement selectors and the rollout operator verbs.
+	for _, k := range []string{
+		AcceleratorRequirementsAnnotation, ClusterSelectorAnnotation,
+		constants.RolloutPromoteAnnotation, constants.RolloutRollbackAnnotation,
+	} {
+		_, has := d.Annotations[k]
+		assert.Falsef(t, has, "control-plane-only annotation %q must be stripped", k)
+	}
+	// ...but a legitimate worker-side serving directive (ingress visibility)
+	// rides along untouched.
+	assert.Equal(t, "cluster-local", d.Annotations[constants.NetworkVisibility])
+
+	// queue defaulting: no LocalQueueAnnotation -> DefaultLocalQueue.
+	src2 := src.DeepCopy()
+	delete(src2.Annotations, LocalQueueAnnotation)
+	d2 := DeriveISVC(src2, "")
+	assert.Equal(t, DefaultLocalQueue, d2.Spec.Engine.ComponentExtensionSpec.Labels[constants.KueueQueueLabelKey])
+	// empty control-plane id leaves the identity label unset (single-CP behavior).
+	_, hasCP := d2.Labels[PlacementControlPlaneLabel]
+	assert.False(t, hasCP)
+
+	// source must not be mutated (deep copy).
+	assert.Nil(t, src.Spec.Engine.ComponentExtensionSpec.Labels, "source ISVC must be untouched")
+}
+
+func TestSetDerivedReplicas(t *testing.T) {
+	newISVC := func(engMax int, withDecoder bool) *v1beta1.InferenceService {
+		i := &v1beta1.InferenceService{Spec: v1beta1.InferenceServiceSpec{
+			Engine: &v1beta1.EngineSpec{ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MaxReplicas: engMax}},
+		}}
+		if withDecoder {
+			i.Spec.Decoder = &v1beta1.DecoderSpec{ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MaxReplicas: engMax}}
+		}
+		return i
+	}
+
+	// maxPer > 0: the cap is the hard per-cluster ceiling on every scaled
+	// component — clamping the declared MaxReplicas DOWN — while Min is this
+	// home's apportioned share. A PD pair is capped 1:1.
+	d := newISVC(9, true)
+	setDerivedReplicas(d, 1, 2)
+	require.NotNil(t, d.Spec.Engine.MinReplicas)
+	assert.Equal(t, 1, *d.Spec.Engine.MinReplicas)
+	assert.Equal(t, 2, d.Spec.Engine.MaxReplicas, "cap clamps the ceiling down from 9")
+	require.NotNil(t, d.Spec.Decoder.MinReplicas)
+	assert.Equal(t, 1, *d.Spec.Decoder.MinReplicas)
+	assert.Equal(t, 2, d.Spec.Decoder.MaxReplicas, "decoder capped 1:1 with engine")
+
+	// maxPer <= 0 (no cap declared): the component's own MaxReplicas stands.
+	d = newISVC(5, false)
+	setDerivedReplicas(d, 2, 0)
+	assert.Equal(t, 2, *d.Spec.Engine.MinReplicas)
+	assert.Equal(t, 5, d.Spec.Engine.MaxReplicas, "uncapped -> declared ceiling preserved")
+
+	// maxPer <= 0 and the share exceeds the declared ceiling: raise Max to keep
+	// Max >= Min (the request must be honorable).
+	d = newISVC(1, false)
+	setDerivedReplicas(d, 3, 0)
+	assert.Equal(t, 3, *d.Spec.Engine.MinReplicas)
+	assert.Equal(t, 3, d.Spec.Engine.MaxReplicas, "uncapped -> Max raised to keep Max >= Min")
+}

--- a/pkg/controller/v1beta1/placement/dispatcher.go
+++ b/pkg/controller/v1beta1/placement/dispatcher.go
@@ -1,0 +1,207 @@
+package placement
+
+import (
+	"slices"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// DispatcherMode selects how many of the matched candidates to race at once.
+// Config-driven; an empty/unrecognized mode degrades to AllAtOnce, so absent
+// config preserves the historical fleet-wide fan-out.
+type DispatcherMode string
+
+const (
+	// DispatcherModeAllAtOnce clones onto every matched candidate at once; the
+	// fastest to admit wins. The historical default.
+	DispatcherModeAllAtOnce DispatcherMode = "AllAtOnce"
+
+	// DispatcherModeIncremental clones onto candidates in sorted batches (step per
+	// round, bounded by a round timeout), widening only if none admits — trades
+	// latency for a smaller blast radius on large fleets.
+	DispatcherModeIncremental DispatcherMode = "Incremental"
+)
+
+// Dispatcher turns the matched candidate set for one source ISVC into the subset
+// to clone onto this pass; fanOut applies to whatever Nominate returns. It
+// returns the nominated subset (a prefix of candidates, in sorted order) and an
+// advisory hold: a non-zero requeue delay asking the caller to wait before
+// widening (an incremental round still in progress), zero to use the normal poll.
+// now is injected so the round clock is testable without sleeping.
+type Dispatcher interface {
+	Nominate(key types.UID, candidates []string, now time.Time) (nominated []string, hold time.Duration)
+}
+
+// dispatcherFor returns the Dispatcher for a configured mode. An empty or
+// unrecognized mode falls back to all-at-once (graceful degradation: absent or
+// bad config preserves the historical fleet-wide fan-out instead of failing or
+// silently switching strategy). stepSize and roundTimeout are only consulted by
+// the incremental dispatcher; they are supplied by the caller from config with
+// their own absent-config fallbacks, so this constructor adds no magic literals.
+func dispatcherFor(mode DispatcherMode, stepSize int, roundTimeout time.Duration) Dispatcher {
+	if mode == DispatcherModeIncremental {
+		return newIncrementalDispatcher(stepSize, roundTimeout)
+	}
+	return allAtOnceDispatcher{}
+}
+
+// allAtOnceDispatcher nominates every matched candidate in a single round. It
+// holds no state and never asks the caller to wait, so the placement reconcile
+// behaves exactly as it did before the dispatcher split.
+type allAtOnceDispatcher struct{}
+
+func (allAtOnceDispatcher) Nominate(_ types.UID, candidates []string, _ time.Time) ([]string, time.Duration) {
+	return candidates, 0
+}
+
+// incrementalDispatcher nominates candidates in sorted batches of stepSize, one
+// batch per round, giving each round roundTimeout for a nominated cluster to win
+// before the next batch is added. Round state is in-memory, keyed by source-ISVC
+// UID (the status API has no nominated-clusters field). A control-plane restart
+// restarts the walk from the first batch — conservative, never destructive
+// (fanOut is idempotent, the loser sweep origin-guarded).
+type incrementalDispatcher struct {
+	// stepSize is how many additional candidates are nominated per round. It is
+	// config-supplied (resolved by the caller); this type does not invent a
+	// default. A non-positive step would make no progress, so Nominate coerces it
+	// to advance by at least one candidate per round rather than wedging.
+	stepSize int
+	// roundTimeout bounds how long one batch is given to produce a winner before
+	// the next batch is added. Config-supplied; a non-positive timeout means every
+	// pass may advance (no enforced dwell) rather than blocking forever.
+	roundTimeout time.Duration
+
+	mu sync.Mutex
+	// rounds tracks, per source-ISVC UID, the nominated set so far and when the
+	// current (newest) batch was nominated. The clock starts when a batch is
+	// added and gates when the next batch may be.
+	rounds map[types.UID]*incrementalRound
+}
+
+// incrementalRound is the in-memory per-ISVC bookkeeping for the incremental
+// walk: the clusters nominated so far and when the latest batch was admitted to
+// the set.
+type incrementalRound struct {
+	nominated  []string
+	roundStart time.Time
+}
+
+func newIncrementalDispatcher(stepSize int, roundTimeout time.Duration) *incrementalDispatcher {
+	return &incrementalDispatcher{
+		stepSize:     stepSize,
+		roundTimeout: roundTimeout,
+		rounds:       make(map[types.UID]*incrementalRound),
+	}
+}
+
+// Nominate widens the in-memory nominated set one batch per round: the first
+// pass nominates the leading batch and starts the round clock; within
+// roundTimeout it returns the same set plus the remaining hold; once the round
+// elapses it appends the next batch. candidates is assumed sorted, so the
+// nominated set is always a prefix of it (deterministic, never un-nominated);
+// candidates that left the fleet are dropped from the retained set.
+func (d *incrementalDispatcher) Nominate(key types.UID, candidates []string, now time.Time) ([]string, time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if len(candidates) == 0 {
+		// Nothing to nominate; clear any stale round so a later re-match starts
+		// fresh rather than inheriting an empty/elapsed window.
+		delete(d.rounds, key)
+		return nil, 0
+	}
+
+	r, found := d.rounds[key]
+	if found {
+		// Reconcile the retained set against the current candidates: keep only the
+		// clusters that are still candidates (a departed cluster must not stay
+		// nominated), preserving the established order.
+		r.nominated = intersectOrdered(r.nominated, candidates)
+	}
+	if !found || len(r.nominated) == 0 {
+		// First batch (or the retained set emptied because every prior nominee
+		// left): nominate the leading batch and start the round clock.
+		first := slices.Clone(candidates[:d.batchEnd(0, len(candidates))])
+		d.rounds[key] = &incrementalRound{nominated: first, roundStart: now}
+		// If the leading batch already covers every candidate there is nothing left
+		// to widen to, so impose no hold (consistent with the full-set case below).
+		if len(first) >= len(candidates) {
+			return slices.Clone(first), 0
+		}
+		return slices.Clone(first), d.roundTimeout
+	}
+
+	// Already nominated everything? Nothing left to widen to; surface the full set
+	// with no hold so the caller falls back to its normal poll cadence.
+	if len(r.nominated) >= len(candidates) {
+		return slices.Clone(r.nominated), 0
+	}
+
+	// A batch is in flight. Hold until the round elapses, then add the next batch.
+	if remaining := d.roundTimeout - now.Sub(r.roundStart); remaining > 0 {
+		return slices.Clone(r.nominated), remaining
+	}
+
+	end := d.batchEnd(len(r.nominated), len(candidates))
+	r.nominated = slices.Clone(candidates[:end])
+	r.roundStart = now
+	// If the set is now full there is nothing more to widen to; return no hold.
+	if len(r.nominated) >= len(candidates) {
+		return slices.Clone(r.nominated), 0
+	}
+	return slices.Clone(r.nominated), d.roundTimeout
+}
+
+// forget drops any in-memory round state for an ISVC. Called when the source is
+// deleted (its placement is being torn down) so the map does not retain an entry
+// for a gone ISVC. A re-created ISVC gets a fresh UID and so a fresh walk.
+func (d *incrementalDispatcher) forget(key types.UID) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.rounds, key)
+}
+
+// batchEnd returns the exclusive upper bound of the nominated prefix after
+// growing from have to have+step, clamped to total. step is coerced to at least
+// one so a misconfigured non-positive step still makes forward progress (one
+// candidate per round) instead of stalling the walk.
+func (d *incrementalDispatcher) batchEnd(have, total int) int {
+	step := d.stepSize
+	if step < 1 {
+		step = 1
+	}
+	end := have + step
+	if end > total {
+		end = total
+	}
+	return end
+}
+
+// intersectOrdered returns the elements of keep that are still present in the
+// allowed set, preserving keep's order. Used to drop departed clusters from the
+// retained nominated set without reordering the survivors.
+func intersectOrdered(keep, allowed []string) []string {
+	if len(keep) == 0 {
+		return keep
+	}
+	allow := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		allow[a] = struct{}{}
+	}
+	out := keep[:0:0]
+	for _, k := range keep {
+		if _, ok := allow[k]; ok {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// forgetRoundState is the optional capability a stateful dispatcher exposes so
+// the reconciler can drop per-ISVC bookkeeping on teardown. The all-at-once
+// dispatcher is stateless and does not implement it; the incremental one does.
+type forgetRoundState interface {
+	forget(key types.UID)
+}

--- a/pkg/controller/v1beta1/placement/dispatcher_test.go
+++ b/pkg/controller/v1beta1/placement/dispatcher_test.go
@@ -1,0 +1,232 @@
+package placement
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const testUID types.UID = "uid-disp"
+
+func TestDispatcherFor_DefaultsToAllAtOnce(t *testing.T) {
+	// Empty and unrecognized modes both degrade to all-at-once (graceful
+	// fallback: absent/bad config preserves the historical fleet-wide fan-out).
+	for _, mode := range []DispatcherMode{"", "bogus", DispatcherModeAllAtOnce} {
+		d := dispatcherFor(mode, 0, 0)
+		_, isAllAtOnce := d.(allAtOnceDispatcher)
+		assert.True(t, isAllAtOnce, "mode %q should resolve to all-at-once", mode)
+	}
+}
+
+func TestDispatcherFor_IncrementalSelected(t *testing.T) {
+	d := dispatcherFor(DispatcherModeIncremental, 2, time.Minute)
+	_, isIncremental := d.(*incrementalDispatcher)
+	assert.True(t, isIncremental, "Incremental mode should resolve to the incremental dispatcher")
+}
+
+func TestAllAtOnce_NominatesEverythingNoHold(t *testing.T) {
+	d := allAtOnceDispatcher{}
+	cands := []string{"a", "b", "c"}
+	got, hold := d.Nominate(testUID, cands, time.Now())
+	assert.Equal(t, cands, got, "all-at-once nominates the whole candidate set")
+	assert.Zero(t, hold, "all-at-once never asks the caller to wait")
+}
+
+func TestAllAtOnce_EmptyCandidates(t *testing.T) {
+	d := allAtOnceDispatcher{}
+	got, hold := d.Nominate(testUID, nil, time.Now())
+	assert.Empty(t, got)
+	assert.Zero(t, hold)
+}
+
+func TestIncremental_FirstBatchAndHold(t *testing.T) {
+	d := newIncrementalDispatcher(2, time.Minute)
+	now := time.Now()
+	cands := []string{"a", "b", "c", "d", "e"}
+
+	got, hold := d.Nominate(testUID, cands, now)
+	assert.Equal(t, []string{"a", "b"}, got, "first round nominates the leading step-size batch")
+	assert.Equal(t, time.Minute, hold, "first round holds for the full round timeout")
+}
+
+func TestIncremental_HoldsWithinRoundThenWidens(t *testing.T) {
+	d := newIncrementalDispatcher(2, time.Minute)
+	start := time.Now()
+	cands := []string{"a", "b", "c", "d", "e"}
+
+	// Round 1: first batch.
+	got, _ := d.Nominate(testUID, cands, start)
+	assert.Equal(t, []string{"a", "b"}, got)
+
+	// Still within the round: same set, shrinking hold, no widening.
+	got, hold := d.Nominate(testUID, cands, start.Add(30*time.Second))
+	assert.Equal(t, []string{"a", "b"}, got, "within the round the nominated set does not grow")
+	assert.Equal(t, 30*time.Second, hold, "hold reports the remaining round time")
+
+	// Round elapsed: next batch is appended and the clock restarts.
+	got, hold = d.Nominate(testUID, cands, start.Add(time.Minute+time.Second))
+	assert.Equal(t, []string{"a", "b", "c", "d"}, got, "after the round elapses the next batch is added")
+	assert.Equal(t, time.Minute, hold, "a fresh round holds for the full timeout again")
+}
+
+func TestIncremental_WalksToExhaustionThenNoHold(t *testing.T) {
+	d := newIncrementalDispatcher(2, time.Minute)
+	tm := time.Now()
+	cands := []string{"a", "b", "c", "d", "e"}
+	advance := func() ([]string, time.Duration) {
+		tm = tm.Add(time.Minute + time.Second)
+		return d.Nominate(testUID, cands, tm)
+	}
+
+	got, _ := d.Nominate(testUID, cands, tm) // a,b
+	assert.Equal(t, []string{"a", "b"}, got)
+	got, _ = advance() // a,b,c,d
+	assert.Equal(t, []string{"a", "b", "c", "d"}, got)
+
+	// Final partial batch (only "e" left): set becomes full, so no further hold.
+	got, hold := advance()
+	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, got, "the trailing partial batch completes the set")
+	assert.Zero(t, hold, "a full nominated set imposes no further wait")
+
+	// Subsequent passes keep returning the full set with no hold (nothing to widen).
+	got, hold = advance()
+	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, got)
+	assert.Zero(t, hold)
+}
+
+func TestIncremental_StepSizeCoveringAllInOneRound(t *testing.T) {
+	// A step size >= the candidate count nominates everything in the first round
+	// and imposes no hold (already full).
+	d := newIncrementalDispatcher(10, time.Minute)
+	cands := []string{"a", "b", "c"}
+	got, hold := d.Nominate(testUID, cands, time.Now())
+	assert.Equal(t, cands, got)
+	assert.Zero(t, hold, "a first batch that already covers every candidate imposes no hold")
+}
+
+func TestIncremental_NonPositiveStepAdvancesByOne(t *testing.T) {
+	// A misconfigured non-positive step must still make forward progress: one
+	// candidate per round, not a wedged empty walk.
+	d := newIncrementalDispatcher(0, time.Minute)
+	start := time.Now()
+	cands := []string{"a", "b", "c"}
+
+	got, _ := d.Nominate(testUID, cands, start)
+	assert.Equal(t, []string{"a"}, got, "non-positive step nominates one candidate")
+
+	got, _ = d.Nominate(testUID, cands, start.Add(time.Minute+time.Second))
+	assert.Equal(t, []string{"a", "b"}, got, "and advances by one each round")
+}
+
+func TestIncremental_NonPositiveRoundTimeoutAdvancesEveryPass(t *testing.T) {
+	// With no enforced dwell, each pass may add the next batch immediately.
+	d := newIncrementalDispatcher(1, 0)
+	now := time.Now()
+	cands := []string{"a", "b", "c"}
+
+	got, hold := d.Nominate(testUID, cands, now)
+	assert.Equal(t, []string{"a"}, got)
+	assert.Zero(t, hold, "a non-positive round timeout imposes no hold")
+
+	got, _ = d.Nominate(testUID, cands, now)
+	assert.Equal(t, []string{"a", "b"}, got, "the next pass advances without waiting")
+}
+
+func TestIncremental_DroppedCandidateLeavesNominatedSet(t *testing.T) {
+	d := newIncrementalDispatcher(2, time.Minute)
+	start := time.Now()
+
+	// Round 1 nominates a,b.
+	got, _ := d.Nominate(testUID, []string{"a", "b", "c", "d"}, start)
+	assert.Equal(t, []string{"a", "b"}, got)
+
+	// "a" leaves the fleet. It must not stay nominated; the retained set keeps
+	// only surviving candidates (here "b"), in order.
+	got, hold := d.Nominate(testUID, []string{"b", "c", "d"}, start.Add(30*time.Second))
+	assert.Equal(t, []string{"b"}, got, "a departed cluster is dropped from the retained set")
+	assert.Equal(t, 30*time.Second, hold, "the round clock is unaffected by the membership change")
+}
+
+func TestIncremental_AllNomineesLeaveRestartsWalk(t *testing.T) {
+	d := newIncrementalDispatcher(2, time.Minute)
+	start := time.Now()
+
+	got, _ := d.Nominate(testUID, []string{"a", "b", "c", "d"}, start)
+	assert.Equal(t, []string{"a", "b"}, got)
+
+	// Both nominees leave; the retained set empties, so the walk restarts from the
+	// leading batch of the new candidate set and the round clock resets.
+	got, hold := d.Nominate(testUID, []string{"c", "d", "e"}, start.Add(30*time.Second))
+	assert.Equal(t, []string{"c", "d"}, got, "an emptied retained set restarts the walk from the new leading batch")
+	assert.Equal(t, time.Minute, hold, "the restarted walk starts a fresh round")
+}
+
+func TestIncremental_EmptyCandidatesClearsRound(t *testing.T) {
+	d := newIncrementalDispatcher(2, time.Minute)
+	start := time.Now()
+
+	got, _ := d.Nominate(testUID, []string{"a", "b", "c"}, start)
+	assert.Equal(t, []string{"a", "b"}, got)
+
+	// Candidate set drains to empty (no Ready cluster matches now).
+	got, hold := d.Nominate(testUID, nil, start.Add(time.Second))
+	assert.Empty(t, got)
+	assert.Zero(t, hold)
+
+	// When candidates reappear the walk starts fresh (the stale round was cleared),
+	// not mid-stream past an elapsed clock.
+	got, hold = d.Nominate(testUID, []string{"a", "b", "c"}, start.Add(2*time.Second))
+	assert.Equal(t, []string{"a", "b"}, got, "a re-matched ISVC restarts from the first batch")
+	assert.Equal(t, time.Minute, hold)
+}
+
+func TestIncremental_ForgetResetsWalk(t *testing.T) {
+	d := newIncrementalDispatcher(2, time.Minute)
+	start := time.Now()
+	cands := []string{"a", "b", "c", "d"}
+
+	got, _ := d.Nominate(testUID, cands, start)
+	assert.Equal(t, []string{"a", "b"}, got)
+
+	d.forget(testUID)
+
+	// After forgetting, the next pass starts a fresh walk from the first batch.
+	got, hold := d.Nominate(testUID, cands, start.Add(30*time.Second))
+	assert.Equal(t, []string{"a", "b"}, got, "forget drops round state so the walk restarts")
+	assert.Equal(t, time.Minute, hold)
+}
+
+func TestIncremental_PerISVCIsolation(t *testing.T) {
+	// Two ISVCs walk independently; advancing one must not move the other.
+	d := newIncrementalDispatcher(1, time.Minute)
+	start := time.Now()
+	const uidA types.UID = "uid-a"
+	const uidB types.UID = "uid-b"
+	cands := []string{"x", "y", "z"}
+
+	gotA, _ := d.Nominate(uidA, cands, start)
+	assert.Equal(t, []string{"x"}, gotA)
+
+	// Advance A only.
+	gotA, _ = d.Nominate(uidA, cands, start.Add(time.Minute+time.Second))
+	assert.Equal(t, []string{"x", "y"}, gotA)
+
+	// B is still on its first batch — A's progress did not leak across.
+	gotB, _ := d.Nominate(uidB, cands, start.Add(time.Minute+time.Second))
+	assert.Equal(t, []string{"x"}, gotB, "each ISVC's walk is isolated by UID")
+}
+
+func TestIncremental_ReturnedSlicesAreCopies(t *testing.T) {
+	// Mutating a returned slice must not corrupt the dispatcher's retained set.
+	d := newIncrementalDispatcher(3, time.Minute)
+	cands := []string{"a", "b", "c", "d"}
+	got, _ := d.Nominate(testUID, cands, time.Now())
+	wantFirst := []string{"a", "b", "c"}
+	assert.Equal(t, wantFirst, got)
+
+	got[0] = "MUTATED"
+	got2, _ := d.Nominate(testUID, cands, time.Now())
+	assert.Equal(t, wantFirst, got2, "a caller mutating the returned slice must not affect retained state")
+}

--- a/pkg/controller/v1beta1/placement/endpoint/config.go
+++ b/pkg/controller/v1beta1/placement/endpoint/config.go
@@ -63,7 +63,7 @@ type HostTemplateData struct {
 // Without a global gateway there is nothing to attach a route to, so the backend
 // stays off rather than guessing one.
 func (c Config) IsEnabled() bool {
-	return strings.TrimSpace(c.GlobalGateway) != ""
+	return strings.TrimSpace(c.GlobalGateway) != "" && c.BackendPort > 0
 }
 
 // GlobalHostFor returns the global host to program for isvc: the explicit

--- a/pkg/controller/v1beta1/placement/endpoint/config.go
+++ b/pkg/controller/v1beta1/placement/endpoint/config.go
@@ -1,0 +1,90 @@
+package endpoint
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+const (
+	// GlobalHostAnnotation pins an explicit global host for one InferenceService,
+	// overriding Config.GlobalHostTemplate. When neither this nor a usable
+	// template yields a host, the service is not published.
+	GlobalHostAnnotation = "ome.io/global-host"
+)
+
+// Config holds the operator-supplied, config-driven inputs the endpoint
+// publisher needs. Every behavioral value lives here (manager flags / chart /
+// GitOps), never as a literal in code: an absent value degrades gracefully
+// (publishing is skipped) rather than silently injecting a magic host, gateway,
+// or port.
+//
+// +kubebuilder:object:generate=false
+type Config struct {
+	// GlobalHostTemplate renders the global host for an InferenceService that does
+	// not set GlobalHostAnnotation. A text/template evaluated against
+	// HostTemplateData (e.g. "{{.Name}}.{{.Namespace}}.global.example"). Empty
+	// disables template-derived hosts: such services publish only if they carry an
+	// explicit GlobalHostAnnotation.
+	GlobalHostTemplate string
+
+	// GlobalGateway is the Gateway the published HTTPRoute attaches to, in
+	// "namespace/name" form (the global-traffic gateway on the control-plane
+	// cluster). Empty disables the Gateway API backend entirely (Reconcile
+	// no-ops, IsEnabled()==false) — the publisher never invents a gateway.
+	GlobalGateway string
+
+	// RouteNamespace is the namespace the published HTTPRoute and its backing
+	// ExternalName Service are created in. Empty falls back to the
+	// InferenceService's own namespace (so the route is co-located with — and
+	// garbage-collected alongside — its source object by default).
+	RouteNamespace string
+
+	// BackendPort is the port on the winning cluster's ingress the global host
+	// routes to. Zero leaves the HTTPRoute backendRef port unset (invalid for a
+	// Gateway API backend); supply it via config.
+	BackendPort int32
+
+	// Labels are stamped onto every resource the publisher creates, so an
+	// operator can select/observe published backends. Optional.
+	Labels map[string]string
+}
+
+// HostTemplateData is the field set GlobalHostTemplate is evaluated against.
+type HostTemplateData struct {
+	Name      string
+	Namespace string
+}
+
+// IsEnabled reports whether the Gateway API backend is configured enough to run.
+// Without a global gateway there is nothing to attach a route to, so the backend
+// stays off rather than guessing one.
+func (c Config) IsEnabled() bool {
+	return strings.TrimSpace(c.GlobalGateway) != ""
+}
+
+// GlobalHostFor returns the global host to program for isvc: the explicit
+// GlobalHostAnnotation if set, otherwise GlobalHostTemplate rendered against the
+// ISVC's name/namespace. Returns "" (no error) when neither yields a host; the
+// caller treats that as "not publishable" and skips it.
+func (c Config) GlobalHostFor(isvc *v1beta1.InferenceService) (string, error) {
+	if h := strings.TrimSpace(isvc.Annotations[GlobalHostAnnotation]); h != "" {
+		return h, nil
+	}
+	tmplText := strings.TrimSpace(c.GlobalHostTemplate)
+	if tmplText == "" {
+		return "", nil
+	}
+	tmpl, err := template.New("globalHost").Parse(tmplText)
+	if err != nil {
+		return "", fmt.Errorf("parse globalHostTemplate %q: %w", tmplText, err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, HostTemplateData{Name: isvc.Name, Namespace: isvc.Namespace}); err != nil {
+		return "", fmt.Errorf("render globalHostTemplate %q: %w", tmplText, err)
+	}
+	return strings.TrimSpace(buf.String()), nil
+}

--- a/pkg/controller/v1beta1/placement/endpoint/config_test.go
+++ b/pkg/controller/v1beta1/placement/endpoint/config_test.go
@@ -13,7 +13,8 @@ import (
 func TestConfig_IsEnabled(t *testing.T) {
 	assert.False(t, Config{}.IsEnabled(), "no gateway -> disabled")
 	assert.False(t, Config{GlobalGateway: "  "}.IsEnabled(), "whitespace gateway -> disabled")
-	assert.True(t, Config{GlobalGateway: "ns/gw"}.IsEnabled())
+	assert.False(t, Config{GlobalGateway: "ns/gw"}.IsEnabled(), "missing backend port -> disabled")
+	assert.True(t, Config{GlobalGateway: "ns/gw", BackendPort: 8080}.IsEnabled())
 }
 
 func TestConfig_GlobalHostFor(t *testing.T) {

--- a/pkg/controller/v1beta1/placement/endpoint/config_test.go
+++ b/pkg/controller/v1beta1/placement/endpoint/config_test.go
@@ -1,0 +1,54 @@
+package endpoint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestConfig_IsEnabled(t *testing.T) {
+	assert.False(t, Config{}.IsEnabled(), "no gateway -> disabled")
+	assert.False(t, Config{GlobalGateway: "  "}.IsEnabled(), "whitespace gateway -> disabled")
+	assert.True(t, Config{GlobalGateway: "ns/gw"}.IsEnabled())
+}
+
+func TestConfig_GlobalHostFor(t *testing.T) {
+	isvc := func(ann map[string]string) *v1beta1.InferenceService {
+		return &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod", Annotations: ann}}
+	}
+
+	t.Run("annotation overrides template", func(t *testing.T) {
+		cfg := Config{GlobalHostTemplate: "{{.Name}}.{{.Namespace}}.global.example"}
+		h, err := cfg.GlobalHostFor(isvc(map[string]string{GlobalHostAnnotation: "pinned.example"}))
+		require.NoError(t, err)
+		assert.Equal(t, "pinned.example", h)
+	})
+
+	t.Run("template render", func(t *testing.T) {
+		cfg := Config{GlobalHostTemplate: "{{.Name}}.{{.Namespace}}.global.example"}
+		h, err := cfg.GlobalHostFor(isvc(nil))
+		require.NoError(t, err)
+		assert.Equal(t, "svc.prod.global.example", h)
+	})
+
+	t.Run("no template and no annotation -> empty (not publishable, no magic default)", func(t *testing.T) {
+		h, err := Config{}.GlobalHostFor(isvc(nil))
+		require.NoError(t, err)
+		assert.Equal(t, "", h)
+	})
+
+	t.Run("empty template with annotation still publishes", func(t *testing.T) {
+		h, err := Config{}.GlobalHostFor(isvc(map[string]string{GlobalHostAnnotation: "pinned.example"}))
+		require.NoError(t, err)
+		assert.Equal(t, "pinned.example", h)
+	})
+
+	t.Run("bad template -> error", func(t *testing.T) {
+		_, err := Config{GlobalHostTemplate: "{{.Nope"}.GlobalHostFor(isvc(nil))
+		assert.Error(t, err)
+	})
+}

--- a/pkg/controller/v1beta1/placement/endpoint/constants.go
+++ b/pkg/controller/v1beta1/placement/endpoint/constants.go
@@ -1,0 +1,31 @@
+package endpoint
+
+// PlacementEndpointControllerName names the endpoint publisher — explicit so it
+// doesn't collide with the placement controller (both watch InferenceService).
+const PlacementEndpointControllerName = "placement-endpoint"
+
+const (
+	// ManagedByLabel marks the HTTPRoute + ExternalName Service the endpoint
+	// publisher creates, so they are discoverable (kubectl get -l ...) and the
+	// reconciler can recognize what it owns. Stamped on every published resource.
+	ManagedByLabel = "ome.io/managed-by"
+	// ManagedByValue is the ManagedByLabel value for the endpoint publisher.
+	ManagedByValue = "placement-endpoint"
+
+	// PlacementClusterLabel records which WorkloadCluster a published backend
+	// Service points at. Per-Service (each home carries its own), so the value is
+	// that home's cluster; observational.
+	PlacementClusterLabel = "ome.io/placement-cluster"
+
+	// PlacementEndpointISVCLabel records which source InferenceService a published
+	// resource belongs to. In All/Split a service has MANY per-home backend
+	// Services, so teardown and stale-home GC list by this label rather than a
+	// single fixed name.
+	PlacementEndpointISVCLabel = "ome.io/placement-endpoint-isvc"
+
+	// EndpointFinalizer keeps a placed InferenceService around long enough for the
+	// publisher to tear down its global-traffic backend before the object is
+	// removed. Distinct from the placement controller's own finalizer so the two
+	// controllers' teardown order is independent.
+	EndpointFinalizer = "ome.io/placement-endpoint"
+)

--- a/pkg/controller/v1beta1/placement/endpoint/constants.go
+++ b/pkg/controller/v1beta1/placement/endpoint/constants.go
@@ -22,6 +22,10 @@ const (
 	// Services, so teardown and stale-home GC list by this label rather than a
 	// single fixed name.
 	PlacementEndpointISVCLabel = "ome.io/placement-endpoint-isvc"
+	// PlacementEndpointISVCNamespaceLabel records the source InferenceService
+	// namespace. Name alone is not unique when RouteNamespace co-locates
+	// resources from multiple source namespaces.
+	PlacementEndpointISVCNamespaceLabel = "ome.io/placement-endpoint-isvc-namespace"
 
 	// EndpointFinalizer keeps a placed InferenceService around long enough for the
 	// publisher to tear down its global-traffic backend before the object is

--- a/pkg/controller/v1beta1/placement/endpoint/controller.go
+++ b/pkg/controller/v1beta1/placement/endpoint/controller.go
@@ -1,0 +1,252 @@
+package endpoint
+
+import (
+	"context"
+	"net"
+	"sort"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// Reconciler watches InferenceServices on the control-plane cluster and, when an
+// ISVC is Placed (status.placement reports a winner and an addressable
+// endpoint), programs the configured Publisher so the global host resolves to
+// the winner's ingress. It repoints the backend on re-placement and tears it
+// down when the ISVC is no longer placed or is deleted. When the Publisher's
+// backend is not configured (no global gateway), Reconcile no-ops.
+type Reconciler struct {
+	client.Client
+	Log logr.Logger
+	// Publisher is the global-traffic backend. Required.
+	Publisher EndpointPublisher
+	// Config supplies the config-driven host/gateway/port/namespace inputs.
+	Config Config
+}
+
+// +kubebuilder:rbac:groups=ome.io,resources=inferenceservices,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=ome.io,resources=inferenceservices/finalizers,verbs=update
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	isvc := &v1beta1.InferenceService{}
+	if err := r.Get(ctx, req.NamespacedName, isvc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Backend not configured: do nothing, and do not strand a finalizer.
+	if !r.Config.IsEnabled() {
+		if controllerutil.ContainsFinalizer(isvc, EndpointFinalizer) && isvc.DeletionTimestamp.IsZero() {
+			controllerutil.RemoveFinalizer(isvc, EndpointFinalizer)
+			if err := r.Update(ctx, isvc); err != nil {
+				return requeueOnConflict(err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !isvc.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, isvc)
+	}
+
+	target, ok, err := r.resolveTarget(isvc)
+	if err != nil {
+		// A bad global-host template is the operator's config error; surface it
+		// and retry on the next change/poll rather than hot-looping.
+		r.Log.Error(err, "endpoint: resolve target failed", "isvc", req.String())
+		return ctrl.Result{}, nil
+	}
+
+	if !ok {
+		// Not placed (or no usable host yet): ensure any previously-published
+		// backend is removed, then drop the finalizer so an ISVC that never
+		// publishes is not held.
+		return r.reconcileUnpublish(ctx, isvc)
+	}
+
+	if err := r.ensureFinalizer(ctx, isvc); err != nil {
+		return requeueOnConflict(err)
+	}
+	if err := r.Publisher.Publish(ctx, isvc, target); err != nil {
+		return ctrl.Result{}, err
+	}
+	r.Log.Info("endpoint published", "isvc", req.String(), "backend", r.Publisher.Name(),
+		"globalHost", target.GlobalHost, "homes", len(target.Homes))
+	return ctrl.Result{}, nil
+}
+
+// resolveTarget builds the publication Target from status.placement. ok is false
+// when the ISVC is not in a publishable state: not Placed, no winner cluster, no
+// addressable endpoint host yet, or no global host resolvable from config. In
+// every not-ok case the caller tears down any stale backend rather than leaving
+// the global host pointed at a cluster that no longer wins.
+func (r *Reconciler) resolveTarget(isvc *v1beta1.InferenceService) (Target, bool, error) {
+	host, err := r.Config.GlobalHostFor(isvc)
+	if err != nil {
+		return Target{}, false, err
+	}
+	if host == "" {
+		return Target{}, false, nil
+	}
+	pl := isvc.Status.Placement
+	if pl == nil || pl.Phase != v1beta1.PlacementPhasePlaced {
+		return Target{}, false, nil
+	}
+	homes := homesFromPlacement(pl)
+	if len(homes) == 0 {
+		// Placed but no home is addressable yet — nothing concrete to point at.
+		return Target{}, false, nil
+	}
+	return Target{GlobalHost: host, Homes: homes}, true, nil
+}
+
+// homesFromPlacement extracts the serving homes — admitted candidates that
+// report an addressable endpoint — from a placement status, sorted by cluster
+// for a deterministic route. This is the uniform source for both Single (one
+// winner candidate) and All/Split (one per serving cluster). It falls back to
+// the top-level cluster/endpoint for a status that predates per-candidate
+// endpoints, so a legacy Single placement still publishes.
+func homesFromPlacement(pl *v1beta1.PlacementStatus) []Home {
+	var homes []Home
+	for i := range pl.Candidates {
+		c := &pl.Candidates[i]
+		if c.Phase == v1beta1.CandidatePhaseAdmitted && c.Endpoint != nil && c.Endpoint.Host != "" {
+			homes = append(homes, Home{Cluster: c.Cluster, BackendHost: hostOnly(c.Endpoint.Host), Weight: c.ReadyReplicas})
+		}
+	}
+	if len(homes) == 0 && pl.Cluster != "" && pl.Endpoint != nil && pl.Endpoint.Host != "" {
+		homes = append(homes, Home{Cluster: pl.Cluster, BackendHost: hostOnly(pl.Endpoint.Host)})
+	}
+	sort.Slice(homes, func(i, j int) bool { return homes[i].Cluster < homes[j].Cluster })
+	return homes
+}
+
+// hostOnly strips a port from an endpoint host. A URL's Host is "host:port"
+// when the endpoint carries an explicit port (e.g.
+// "svc.ns.svc.cluster.local:8000"), but the backend ExternalName Service takes a
+// BARE hostname — the port is supplied separately from Config.BackendPort — so a
+// host:port here makes the Service spec.externalName fail RFC-1123 validation.
+func hostOnly(h string) string {
+	if host, _, err := net.SplitHostPort(h); err == nil {
+		return host
+	}
+	return h
+}
+
+func (r *Reconciler) reconcileUnpublish(ctx context.Context, isvc *v1beta1.InferenceService) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(isvc, EndpointFinalizer) {
+		// Never published; nothing to clean and no finalizer to drop.
+		return ctrl.Result{}, nil
+	}
+	if err := r.Publisher.Unpublish(ctx, isvc); err != nil {
+		return ctrl.Result{}, err
+	}
+	controllerutil.RemoveFinalizer(isvc, EndpointFinalizer)
+	if err := r.Update(ctx, isvc); err != nil {
+		return requeueOnConflict(err)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) reconcileDelete(ctx context.Context, isvc *v1beta1.InferenceService) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(isvc, EndpointFinalizer) {
+		return ctrl.Result{}, nil
+	}
+	if err := r.Publisher.Unpublish(ctx, isvc); err != nil {
+		return ctrl.Result{}, err
+	}
+	controllerutil.RemoveFinalizer(isvc, EndpointFinalizer)
+	if err := r.Update(ctx, isvc); err != nil {
+		return requeueOnConflict(err)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) ensureFinalizer(ctx context.Context, isvc *v1beta1.InferenceService) error {
+	if controllerutil.AddFinalizer(isvc, EndpointFinalizer) {
+		return r.Update(ctx, isvc)
+	}
+	return nil
+}
+
+// requeueOnConflict turns an optimistic-lock conflict on the ISVC into a clean
+// requeue instead of a returned error. The endpoint publisher and the placement
+// controller both update the same source ISVC — the placer writes status, this
+// writes the finalizer — so the finalizer Update can lose a resourceVersion race
+// during the place transition. That is benign and self-corrects on the requeue
+// (the next pass re-reads the fresh object), so it must NOT surface as an
+// error-level "Reconciler error": that is misleading log noise and trips the
+// suite's write-conflict gate. Any other error is returned unchanged.
+func requeueOnConflict(err error) (ctrl.Result, error) {
+	if apierrors.IsConflict(err) {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{}, err
+}
+
+// SetupWithManager wires the controller: reconcile ISVCs, but only react to
+// events that can change a publication decision — placement-status changes,
+// deletions, and the global-host annotation — so routine ISVC spec churn does
+// not re-publish on every reconcile.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Named explicitly so it doesn't collide with the placement controller
+	// (both do For(&InferenceService{})).
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(PlacementEndpointControllerName).
+		For(&v1beta1.InferenceService{}, builder.WithPredicates(placementPublishChange)).
+		Complete(r)
+}
+
+// placementPublishChange admits ISVC events that can change what the publisher
+// programs: any create/delete, and updates that change status.placement (winner,
+// phase, or endpoint) or the global-host annotation. Other spec/status churn is
+// dropped so the publisher is not re-driven needlessly.
+var placementPublishChange = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldISVC, ok1 := e.ObjectOld.(*v1beta1.InferenceService)
+		newISVC, ok2 := e.ObjectNew.(*v1beta1.InferenceService)
+		if !ok1 || !ok2 {
+			return true // unexpected type: fail safe
+		}
+		if !placementEqual(oldISVC.Status.Placement, newISVC.Status.Placement) {
+			return true
+		}
+		if oldISVC.Annotations[GlobalHostAnnotation] != newISVC.Annotations[GlobalHostAnnotation] {
+			return true
+		}
+		// React to deletion entering (finalizer teardown) even if placement is
+		// otherwise unchanged.
+		return oldISVC.DeletionTimestamp.IsZero() != newISVC.DeletionTimestamp.IsZero()
+	},
+}
+
+// placementEqual reports whether two PlacementStatus values agree on the fields
+// the publisher consumes: phase, winner cluster, and the endpoint host.
+func placementEqual(a, b *v1beta1.PlacementStatus) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Phase != b.Phase || a.Cluster != b.Cluster {
+		return false
+	}
+	return endpointHost(a) == endpointHost(b)
+}
+
+func endpointHost(pl *v1beta1.PlacementStatus) string {
+	if pl == nil || pl.Endpoint == nil {
+		return ""
+	}
+	return pl.Endpoint.Host
+}

--- a/pkg/controller/v1beta1/placement/endpoint/controller.go
+++ b/pkg/controller/v1beta1/placement/endpoint/controller.go
@@ -3,6 +3,7 @@ package endpoint
 import (
 	"context"
 	"net"
+	"slices"
 	"sort"
 
 	"github.com/go-logr/logr"
@@ -49,6 +50,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Backend not configured: do nothing, and do not strand a finalizer.
 	if !r.Config.IsEnabled() {
 		if controllerutil.ContainsFinalizer(isvc, EndpointFinalizer) && isvc.DeletionTimestamp.IsZero() {
+			if err := r.Publisher.Unpublish(ctx, isvc); err != nil {
+				return ctrl.Result{}, err
+			}
 			controllerutil.RemoveFinalizer(isvc, EndpointFinalizer)
 			if err := r.Update(ctx, isvc); err != nil {
 				return requeueOnConflict(err)
@@ -233,7 +237,8 @@ var placementPublishChange = predicate.Funcs{
 }
 
 // placementEqual reports whether two PlacementStatus values agree on the fields
-// the publisher consumes: phase, winner cluster, and the endpoint host.
+// the publisher consumes: phase, winner cluster, endpoint host, and the
+// candidate-derived serving homes (including weights).
 func placementEqual(a, b *v1beta1.PlacementStatus) bool {
 	if a == nil || b == nil {
 		return a == b
@@ -241,7 +246,7 @@ func placementEqual(a, b *v1beta1.PlacementStatus) bool {
 	if a.Phase != b.Phase || a.Cluster != b.Cluster {
 		return false
 	}
-	return endpointHost(a) == endpointHost(b)
+	return endpointHost(a) == endpointHost(b) && slices.Equal(homesFromPlacement(a), homesFromPlacement(b))
 }
 
 func endpointHost(pl *v1beta1.PlacementStatus) string {

--- a/pkg/controller/v1beta1/placement/endpoint/controller_name_test.go
+++ b/pkg/controller/v1beta1/placement/endpoint/controller_name_test.go
@@ -1,0 +1,55 @@
+package endpoint_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/placement"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/placement/endpoint"
+)
+
+// TestEndpointPublisher_NoControllerNameCollision guards the control-plane crash
+// where the placement controller and the endpoint publisher — both
+// For(&InferenceService{}) — auto-derived the same name "inferenceservice" and
+// controller-runtime rejected the duplicate. Register a stand-in under the
+// placement name plus the real publisher on one manager; assert the names differ
+// and there's no collision. A non-connecting rest.Config suffices — setup only
+// registers controllers; nothing dials the apiserver until mgr.Start.
+func TestEndpointPublisher_NoControllerNameCollision(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+
+	mgr, err := ctrl.NewManager(&rest.Config{Host: "http://127.0.0.1:1"}, ctrl.Options{
+		Scheme:  scheme,
+		Metrics: metricsserver.Options{BindAddress: "0"}, // disable metrics server
+	})
+	require.NoError(t, err)
+
+	// Stand-in for the placement controller (its real name, also For(ISVC)).
+	noop := reconcile.Func(func(context.Context, reconcile.Request) (reconcile.Result, error) {
+		return reconcile.Result{}, nil
+	})
+	require.NoError(t,
+		ctrl.NewControllerManagedBy(mgr).
+			Named(placement.PlacementControllerName).
+			For(&v1beta1.InferenceService{}).
+			Complete(noop),
+		"stand-in placement controller")
+
+	// Names must differ (the fix).
+	require.NotEqual(t, placement.PlacementControllerName, endpoint.PlacementEndpointControllerName)
+
+	// The endpoint publisher must register under a DISTINCT name.
+	require.NoError(t,
+		(&endpoint.Reconciler{Client: mgr.GetClient(), Log: logr.Discard()}).SetupWithManager(mgr),
+		"endpoint publisher must not collide with the 'inferenceservice' controller name")
+}

--- a/pkg/controller/v1beta1/placement/endpoint/controller_test.go
+++ b/pkg/controller/v1beta1/placement/endpoint/controller_test.go
@@ -186,6 +186,23 @@ func TestReconcile_BackendDisabledIsNoOp(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err), "no backend programmed when gateway unconfigured")
 }
 
+func TestReconcile_BackendDisabledCleansPublishedResources(t *testing.T) {
+	cfg := baseConfig()
+	r, c := newReconciler(t, cfg, placedISVC("cluster-a", "svc.prod.cloud-a.example"))
+	reconcile(t, r)
+
+	r.Config.GlobalGateway = ""
+	reconcile(t, r)
+
+	err := c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, &gatewayapiv1.HTTPRoute{})
+	assert.True(t, apierrors.IsNotFound(err), "disabled backend removes the published route")
+	err = c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-a", Namespace: "prod"}, &corev1.Service{})
+	assert.True(t, apierrors.IsNotFound(err), "disabled backend removes published Services")
+	cur := &v1beta1.InferenceService{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc", Namespace: "prod"}, cur))
+	assert.NotContains(t, cur.Finalizers, EndpointFinalizer)
+}
+
 func TestReconcile_NoGlobalHostNeverPublishes(t *testing.T) {
 	cfg := baseConfig()
 	cfg.GlobalHostTemplate = "" // no template, ISVC has no annotation -> no host
@@ -305,6 +322,19 @@ func TestPlacementPublishChange(t *testing.T) {
 		old := base.DeepCopy()
 		nw := base.DeepCopy()
 		nw.Status.Placement.Endpoint = apis.HTTPS("other.example")
+		assert.True(t, placementPublishChange.Update(updateEvent(old, nw)))
+	})
+
+	t.Run("candidate-only change passes", func(t *testing.T) {
+		old := base.DeepCopy()
+		nw := base.DeepCopy()
+		old.Status.Placement.Cluster = ""
+		old.Status.Placement.Endpoint = nil
+		old.Status.Placement.Candidates = []v1beta1.CandidatePlacement{{
+			Cluster: "cloud-a", Phase: v1beta1.CandidatePhaseAdmitted, Endpoint: apis.HTTPS("a.example"), ReadyReplicas: 1,
+		}}
+		nw.Status.Placement = old.Status.Placement.DeepCopy()
+		nw.Status.Placement.Candidates[0].ReadyReplicas = 2
 		assert.True(t, placementPublishChange.Update(updateEvent(old, nw)))
 	})
 

--- a/pkg/controller/v1beta1/placement/endpoint/controller_test.go
+++ b/pkg/controller/v1beta1/placement/endpoint/controller_test.go
@@ -1,0 +1,332 @@
+package endpoint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// placedISVC builds a control-plane ISVC whose placement reports a winner with
+// an addressable endpoint (the publishable state).
+func placedISVC(cluster, backendHost string) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod", UID: "uid-1"},
+		Status: v1beta1.InferenceServiceStatus{
+			Placement: &v1beta1.PlacementStatus{
+				Phase:    v1beta1.PlacementPhasePlaced,
+				Cluster:  cluster,
+				Endpoint: apis.HTTPS(backendHost),
+			},
+		},
+	}
+}
+
+func newReconciler(t *testing.T, cfg Config, objs ...client.Object) (*Reconciler, client.Client) {
+	t.Helper()
+	s := pubScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).
+		WithStatusSubresource(&v1beta1.InferenceService{}).
+		WithObjects(objs...).Build()
+	return &Reconciler{
+		Client:    c,
+		Log:       log.Log,
+		Publisher: NewGatewayAPIPublisher(c, cfg),
+		Config:    cfg,
+	}, c
+}
+
+func reconcile(t *testing.T, r *Reconciler) {
+	t.Helper()
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "svc", Namespace: "prod"}})
+	require.NoError(t, err)
+}
+
+func updateEvent(old, nw *v1beta1.InferenceService) event.UpdateEvent {
+	return event.UpdateEvent{ObjectOld: old, ObjectNew: nw}
+}
+
+func TestReconcile_PlacedPublishesAndFinalizes(t *testing.T) {
+	r, c := newReconciler(t, baseConfig(), placedISVC("cluster-a", "svc.prod.cloud-a.example"))
+
+	reconcile(t, r)
+
+	// HTTPRoute + ExternalName Service created.
+	route := &gatewayapiv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, route))
+	assert.Equal(t, gatewayapiv1.Hostname("svc.prod.global.example"), route.Spec.Hostnames[0])
+	svc := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-a", Namespace: "prod"}, svc))
+	assert.Equal(t, "svc.prod.cloud-a.example", svc.Spec.ExternalName)
+
+	// Finalizer added so teardown can run before the ISVC is removed.
+	got := &v1beta1.InferenceService{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc", Namespace: "prod"}, got))
+	assert.True(t, controllerutil.ContainsFinalizer(got, EndpointFinalizer))
+}
+
+func TestReconcile_RepointsOnReplacement(t *testing.T) {
+	r, c := newReconciler(t, baseConfig(), placedISVC("cluster-a", "svc.prod.cloud-a.example"))
+	reconcile(t, r)
+
+	// Simulate the placement controller re-homing onto a new cluster.
+	cur := &v1beta1.InferenceService{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc", Namespace: "prod"}, cur))
+	cur.Status.Placement.Cluster = "cluster-b"
+	cur.Status.Placement.Endpoint = apis.HTTPS("svc.prod.cloud-b.example")
+	require.NoError(t, c.Status().Update(context.Background(), cur))
+
+	reconcile(t, r)
+
+	svc := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-b", Namespace: "prod"}, svc))
+	assert.Equal(t, "svc.prod.cloud-b.example", svc.Spec.ExternalName, "ExternalName repointed to new winner")
+	assert.Equal(t, "cluster-b", svc.Labels[PlacementClusterLabel])
+	// The old winner's per-home Service is garbage-collected.
+	errOld := c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-a", Namespace: "prod"}, &corev1.Service{})
+	assert.True(t, apierrors.IsNotFound(errOld), "old winner's Service GC'd on re-home")
+}
+
+func TestReconcile_UnplacedTearsDownAndDropsFinalizer(t *testing.T) {
+	r, c := newReconciler(t, baseConfig(), placedISVC("cluster-a", "svc.prod.cloud-a.example"))
+	reconcile(t, r) // publish + finalizer
+
+	// Placement regresses to Racing (winner lost). Publisher must tear down.
+	cur := &v1beta1.InferenceService{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc", Namespace: "prod"}, cur))
+	cur.Status.Placement.Phase = v1beta1.PlacementPhaseRacing
+	cur.Status.Placement.Cluster = ""
+	cur.Status.Placement.Endpoint = nil
+	require.NoError(t, c.Status().Update(context.Background(), cur))
+
+	reconcile(t, r)
+
+	err := c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, &gatewayapiv1.HTTPRoute{})
+	assert.True(t, apierrors.IsNotFound(err), "stale route removed when winner lost")
+	got := &v1beta1.InferenceService{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc", Namespace: "prod"}, got))
+	assert.False(t, controllerutil.ContainsFinalizer(got, EndpointFinalizer), "finalizer dropped after teardown")
+}
+
+func TestReconcile_PendingNeverPublishes(t *testing.T) {
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod", UID: "uid-1"},
+		Status:     v1beta1.InferenceServiceStatus{Placement: &v1beta1.PlacementStatus{Phase: v1beta1.PlacementPhasePending}},
+	}
+	r, c := newReconciler(t, baseConfig(), isvc)
+
+	reconcile(t, r)
+
+	err := c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, &gatewayapiv1.HTTPRoute{})
+	assert.True(t, apierrors.IsNotFound(err))
+	got := &v1beta1.InferenceService{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc", Namespace: "prod"}, got))
+	assert.False(t, controllerutil.ContainsFinalizer(got, EndpointFinalizer),
+		"an ISVC that never publishes is not held by a finalizer")
+}
+
+func TestReconcile_PlacedButNoEndpointYet(t *testing.T) {
+	// Winner declared, but the worker has not reported a URL yet -> nothing
+	// concrete to point at, so we do not publish (and do not strand a finalizer).
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod", UID: "uid-1"},
+		Status: v1beta1.InferenceServiceStatus{Placement: &v1beta1.PlacementStatus{
+			Phase: v1beta1.PlacementPhasePlaced, Cluster: "cluster-a", Endpoint: nil,
+		}},
+	}
+	r, c := newReconciler(t, baseConfig(), isvc)
+
+	reconcile(t, r)
+
+	err := c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, &gatewayapiv1.HTTPRoute{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestReconcile_DeletionTearsDown(t *testing.T) {
+	r, c := newReconciler(t, baseConfig(), placedISVC("cluster-a", "svc.prod.cloud-a.example"))
+	reconcile(t, r) // publish + finalizer
+
+	// Delete the ISVC; with the finalizer present it sticks around for teardown.
+	cur := &v1beta1.InferenceService{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc", Namespace: "prod"}, cur))
+	require.NoError(t, c.Delete(context.Background(), cur))
+
+	reconcile(t, r)
+
+	err := c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-a", Namespace: "prod"}, &corev1.Service{})
+	assert.True(t, apierrors.IsNotFound(err), "backend Service deleted on ISVC deletion")
+	// Finalizer removed -> the fake client now actually deletes the ISVC.
+	err = c.Get(context.Background(), types.NamespacedName{Name: "svc", Namespace: "prod"}, &v1beta1.InferenceService{})
+	assert.True(t, apierrors.IsNotFound(err), "ISVC removed after finalizer dropped")
+}
+
+func TestReconcile_BackendDisabledIsNoOp(t *testing.T) {
+	cfg := baseConfig()
+	cfg.GlobalGateway = "" // backend not configured
+	r, c := newReconciler(t, cfg, placedISVC("cluster-a", "svc.prod.cloud-a.example"))
+
+	reconcile(t, r)
+
+	err := c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, &gatewayapiv1.HTTPRoute{})
+	assert.True(t, apierrors.IsNotFound(err), "no backend programmed when gateway unconfigured")
+}
+
+func TestReconcile_NoGlobalHostNeverPublishes(t *testing.T) {
+	cfg := baseConfig()
+	cfg.GlobalHostTemplate = "" // no template, ISVC has no annotation -> no host
+	r, c := newReconciler(t, cfg, placedISVC("cluster-a", "svc.prod.cloud-a.example"))
+
+	reconcile(t, r)
+
+	err := c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, &gatewayapiv1.HTTPRoute{})
+	assert.True(t, apierrors.IsNotFound(err), "no host resolvable -> nothing published (no magic default)")
+}
+
+func TestResolveTarget(t *testing.T) {
+	r := &Reconciler{Config: baseConfig()}
+
+	t.Run("placed + endpoint -> ok", func(t *testing.T) {
+		tgt, ok, err := r.resolveTarget(placedISVC("cloud-a", "h.example"))
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, "svc.prod.global.example", tgt.GlobalHost)
+		require.Len(t, tgt.Homes, 1)
+		assert.Equal(t, "cloud-a", tgt.Homes[0].Cluster)
+		assert.Equal(t, "h.example", tgt.Homes[0].BackendHost)
+	})
+
+	t.Run("nil placement -> not ok", func(t *testing.T) {
+		_, ok, err := r.resolveTarget(&v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod"}})
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("All: admitted candidates -> one home each, sorted", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod"},
+			Status: v1beta1.InferenceServiceStatus{Placement: &v1beta1.PlacementStatus{
+				Phase: v1beta1.PlacementPhasePlaced, // no top-level winner in All
+				Candidates: []v1beta1.CandidatePlacement{
+					{Cluster: "workload-2", Phase: v1beta1.CandidatePhaseAdmitted, Endpoint: apis.HTTPS("b.example")},
+					{Cluster: "workload-1", Phase: v1beta1.CandidatePhaseAdmitted, Endpoint: apis.HTTPS("a.example")},
+					{Cluster: "workload-3", Phase: v1beta1.CandidatePhasePlaced}, // gated: not a home
+				},
+			}},
+		}
+		tgt, ok, err := r.resolveTarget(isvc)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Len(t, tgt.Homes, 2, "only admitted+addressable candidates are homes")
+		assert.Equal(t, "workload-1", tgt.Homes[0].Cluster, "sorted by cluster")
+		assert.Equal(t, "a.example", tgt.Homes[0].BackendHost)
+		assert.Equal(t, "workload-2", tgt.Homes[1].Cluster)
+		assert.Equal(t, "b.example", tgt.Homes[1].BackendHost)
+	})
+
+	t.Run("placed but no addressable home -> not ok", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod"},
+			Status: v1beta1.InferenceServiceStatus{Placement: &v1beta1.PlacementStatus{
+				Phase:      v1beta1.PlacementPhasePlaced,
+				Candidates: []v1beta1.CandidatePlacement{{Cluster: "workload-1", Phase: v1beta1.CandidatePhasePlaced}},
+			}},
+		}
+		_, ok, err := r.resolveTarget(isvc)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("endpoint host with a port -> port stripped for the backend", func(t *testing.T) {
+		// A URL Host is "host:port" when the endpoint carries a port; the backend
+		// ExternalName Service needs a BARE host (port comes from Config.BackendPort).
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod"},
+			Status: v1beta1.InferenceServiceStatus{Placement: &v1beta1.PlacementStatus{
+				Phase: v1beta1.PlacementPhasePlaced,
+				Candidates: []v1beta1.CandidatePlacement{
+					{Cluster: "cloud-a", Phase: v1beta1.CandidatePhaseAdmitted, Endpoint: apis.HTTPS("svc.inf-prod.svc.cluster.local:8000")},
+				},
+			}},
+		}
+		tgt, ok, err := r.resolveTarget(isvc)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Len(t, tgt.Homes, 1)
+		assert.Equal(t, "svc.inf-prod.svc.cluster.local", tgt.Homes[0].BackendHost,
+			"port stripped so spec.externalName stays RFC-1123 valid")
+	})
+
+	t.Run("Split: per-home ready replicas become home weights", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod"},
+			Status: v1beta1.InferenceServiceStatus{Placement: &v1beta1.PlacementStatus{
+				Phase: v1beta1.PlacementPhasePlaced,
+				Candidates: []v1beta1.CandidatePlacement{
+					{Cluster: "a", Phase: v1beta1.CandidatePhaseAdmitted, Endpoint: apis.HTTPS("a.example"), ReadyReplicas: 5},
+					{Cluster: "b", Phase: v1beta1.CandidatePhaseAdmitted, Endpoint: apis.HTTPS("b.example"), ReadyReplicas: 2},
+				},
+			}},
+		}
+		tgt, ok, err := r.resolveTarget(isvc)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Len(t, tgt.Homes, 2)
+		assert.Equal(t, int32(5), tgt.Homes[0].Weight, "home a weight = its ready replicas")
+		assert.Equal(t, int32(2), tgt.Homes[1].Weight, "home b weight = its ready replicas")
+	})
+}
+
+func TestPlacementPublishChange(t *testing.T) {
+	base := placedISVC("cloud-a", "h.example")
+
+	t.Run("phase change passes", func(t *testing.T) {
+		old := base.DeepCopy()
+		nw := base.DeepCopy()
+		nw.Status.Placement.Phase = v1beta1.PlacementPhaseRacing
+		assert.True(t, placementPublishChange.Update(updateEvent(old, nw)))
+	})
+
+	t.Run("endpoint host change passes", func(t *testing.T) {
+		old := base.DeepCopy()
+		nw := base.DeepCopy()
+		nw.Status.Placement.Endpoint = apis.HTTPS("other.example")
+		assert.True(t, placementPublishChange.Update(updateEvent(old, nw)))
+	})
+
+	t.Run("unrelated spec churn is dropped", func(t *testing.T) {
+		old := base.DeepCopy()
+		nw := base.DeepCopy()
+		nw.Labels = map[string]string{"unrelated": "x"}
+		assert.False(t, placementPublishChange.Update(updateEvent(old, nw)))
+	})
+
+	t.Run("global-host annotation change passes", func(t *testing.T) {
+		old := base.DeepCopy()
+		nw := base.DeepCopy()
+		nw.Annotations = map[string]string{GlobalHostAnnotation: "pinned.example"}
+		assert.True(t, placementPublishChange.Update(updateEvent(old, nw)))
+	})
+
+	t.Run("deletion entering passes", func(t *testing.T) {
+		old := base.DeepCopy()
+		nw := base.DeepCopy()
+		now := metav1.Now()
+		nw.DeletionTimestamp = &now
+		assert.True(t, placementPublishChange.Update(updateEvent(old, nw)))
+	})
+}

--- a/pkg/controller/v1beta1/placement/endpoint/gatewayapi.go
+++ b/pkg/controller/v1beta1/placement/endpoint/gatewayapi.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"maps"
@@ -60,15 +61,34 @@ func NewGatewayAPIPublisher(c client.Client, cfg Config) *GatewayAPIPublisher {
 
 func (p *GatewayAPIPublisher) Name() string { return "GatewayAPI" }
 
-// routeName is the HTTPRoute name for an InferenceService ("<isvc>-global").
-func routeName(isvc *v1beta1.InferenceService) string {
-	return isvc.Name + resourceSuffix
+// resourceBaseName is stable and unique for the source InferenceService. When
+// resources are co-located in a shared RouteNamespace, a hash of namespace/name
+// prevents same-name sources from colliding.
+func (p *GatewayAPIPublisher) resourceBaseName(isvc *v1beta1.InferenceService) string {
+	base := isvc.Name
+	if p.routeNamespace(isvc) != isvc.Namespace {
+		sum := sha256.Sum256([]byte(isvc.Namespace + "/" + isvc.Name))
+		base = fmt.Sprintf("%s-%x", isvc.Name, sum[:4])
+	}
+	return base
 }
 
-// serviceName is the per-home ExternalName Service name for a cluster
-// ("<isvc>-global-<cluster>").
-func serviceName(isvc *v1beta1.InferenceService, cluster string) string {
-	return isvc.Name + resourceSuffix + "-" + cluster
+func boundedResourceName(name string) string {
+	if len(name) <= 63 {
+		return name
+	}
+	sum := sha256.Sum256([]byte(name))
+	return fmt.Sprintf("%s-%x", strings.TrimRight(name[:54], "-"), sum[:4])
+}
+
+// routeName is the HTTPRoute name for an InferenceService.
+func (p *GatewayAPIPublisher) routeName(isvc *v1beta1.InferenceService) string {
+	return boundedResourceName(p.resourceBaseName(isvc) + resourceSuffix)
+}
+
+// serviceName is the per-home ExternalName Service name for a cluster.
+func (p *GatewayAPIPublisher) serviceName(isvc *v1beta1.InferenceService, cluster string) string {
+	return boundedResourceName(p.resourceBaseName(isvc) + resourceSuffix + "-" + cluster)
 }
 
 // routeNamespace resolves the namespace the published resources live in: the
@@ -83,10 +103,14 @@ func (p *GatewayAPIPublisher) routeNamespace(isvc *v1beta1.InferenceService) str
 // Publish reconciles the per-home ExternalName Services and the HTTPRoute so the
 // global host load-balances across exactly target.Homes.
 func (p *GatewayAPIPublisher) Publish(ctx context.Context, isvc *v1beta1.InferenceService, target Target) error {
-	if err := p.applyServices(ctx, isvc, target); err != nil {
+	desired, err := p.ensureServices(ctx, isvc, target)
+	if err != nil {
 		return err
 	}
-	return p.applyRoute(ctx, isvc, target)
+	if err := p.applyRoute(ctx, isvc, target); err != nil {
+		return err
+	}
+	return p.pruneServices(ctx, isvc, desired)
 }
 
 // Unpublish deletes the HTTPRoute and every per-home Service this publisher owns
@@ -95,9 +119,9 @@ func (p *GatewayAPIPublisher) Publish(ctx context.Context, isvc *v1beta1.Inferen
 func (p *GatewayAPIPublisher) Unpublish(ctx context.Context, isvc *v1beta1.InferenceService) error {
 	ns := p.routeNamespace(isvc)
 	var errs []error
-	route := &gatewayapiv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: routeName(isvc), Namespace: ns}}
+	route := &gatewayapiv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: p.routeName(isvc), Namespace: ns}}
 	if err := p.client.Delete(ctx, route); err != nil && !apierrors.IsNotFound(err) {
-		errs = append(errs, fmt.Errorf("delete global HTTPRoute %s/%s: %w", ns, routeName(isvc), err))
+		errs = append(errs, fmt.Errorf("delete global HTTPRoute %s/%s: %w", ns, p.routeName(isvc), err))
 	}
 	owned, err := p.ownedServices(ctx, isvc)
 	if err != nil {
@@ -118,18 +142,22 @@ func (p *GatewayAPIPublisher) Unpublish(ctx context.Context, isvc *v1beta1.Infer
 func (p *GatewayAPIPublisher) ownedServices(ctx context.Context, isvc *v1beta1.InferenceService) ([]corev1.Service, error) {
 	list := &corev1.ServiceList{}
 	if err := p.client.List(ctx, list, client.InNamespace(p.routeNamespace(isvc)),
-		client.MatchingLabels{ManagedByLabel: ManagedByValue, PlacementEndpointISVCLabel: isvc.Name}); err != nil {
+		client.MatchingLabels{
+			ManagedByLabel:                      ManagedByValue,
+			PlacementEndpointISVCLabel:          isvc.Name,
+			PlacementEndpointISVCNamespaceLabel: isvc.Namespace,
+		}); err != nil {
 		return nil, fmt.Errorf("list global backend Services for %s/%s: %w", isvc.Namespace, isvc.Name, err)
 	}
 	return list.Items, nil
 }
 
-// applyServices ensures exactly one ExternalName Service per home exists, then
-// deletes any owned Service no longer backing a home (a home that left).
-func (p *GatewayAPIPublisher) applyServices(ctx context.Context, isvc *v1beta1.InferenceService, target Target) error {
+// ensureServices creates or updates every desired backend before the route is
+// changed. It returns the desired names for the post-route prune step.
+func (p *GatewayAPIPublisher) ensureServices(ctx context.Context, isvc *v1beta1.InferenceService, target Target) (map[string]struct{}, error) {
 	desired := make(map[string]Home, len(target.Homes))
 	for _, h := range target.Homes {
-		desired[serviceName(isvc, h.Cluster)] = h
+		desired[p.serviceName(isvc, h.Cluster)] = h
 	}
 	// Apply in a stable order so behavior is deterministic.
 	names := make([]string, 0, len(desired))
@@ -139,10 +167,20 @@ func (p *GatewayAPIPublisher) applyServices(ctx context.Context, isvc *v1beta1.I
 	sort.Strings(names)
 	for _, name := range names {
 		if err := p.applyService(ctx, isvc, name, desired[name]); err != nil {
-			return err
+			return nil, err
 		}
 	}
+	keep := make(map[string]struct{}, len(desired))
+	for name := range desired {
+		keep[name] = struct{}{}
+	}
+	return keep, nil
+}
 
+// pruneServices removes departed homes only after the HTTPRoute no longer
+// references them, avoiding a window where the route points at a missing
+// Service.
+func (p *GatewayAPIPublisher) pruneServices(ctx context.Context, isvc *v1beta1.InferenceService, desired map[string]struct{}) error {
 	owned, err := p.ownedServices(ctx, isvc)
 	if err != nil {
 		return err
@@ -265,7 +303,7 @@ func (p *GatewayAPIPublisher) buildHTTPRoute(isvc *v1beta1.InferenceService, tar
 			BackendRef: gatewayapiv1.BackendRef{
 				BackendObjectReference: gatewayapiv1.BackendObjectReference{
 					Kind:      ptr.To(gatewayapiv1.Kind(constants.ServiceKind)),
-					Name:      gatewayapiv1.ObjectName(serviceName(isvc, h.Cluster)),
+					Name:      gatewayapiv1.ObjectName(p.serviceName(isvc, h.Cluster)),
 					Namespace: (*gatewayapiv1.Namespace)(&backendNS),
 					Port:      &port,
 				},
@@ -276,7 +314,7 @@ func (p *GatewayAPIPublisher) buildHTTPRoute(isvc *v1beta1.InferenceService, tar
 
 	return &gatewayapiv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      routeName(isvc),
+			Name:      p.routeName(isvc),
 			Namespace: backendNS,
 			Labels:    p.baseLabels(isvc),
 		},
@@ -311,6 +349,7 @@ func (p *GatewayAPIPublisher) baseLabels(isvc *v1beta1.InferenceService) map[str
 	maps.Copy(out, p.config.Labels)
 	out[ManagedByLabel] = ManagedByValue
 	out[PlacementEndpointISVCLabel] = isvc.Name
+	out[PlacementEndpointISVCNamespaceLabel] = isvc.Namespace
 	return out
 }
 

--- a/pkg/controller/v1beta1/placement/endpoint/gatewayapi.go
+++ b/pkg/controller/v1beta1/placement/endpoint/gatewayapi.go
@@ -1,0 +1,336 @@
+package endpoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+const (
+	// resourceSuffix names the backing resources the Gateway API publisher
+	// creates for an InferenceService. The HTTPRoute is "<isvc>-global"; each
+	// per-home ExternalName Service is "<isvc>-global-<cluster>" — distinct from
+	// the per-cluster ingress resources OME's normal ingress reconciler emits
+	// ("<isvc>", "<isvc>-engine", ...) so the two never collide.
+	resourceSuffix = "-global"
+)
+
+// GatewayAPIPublisher implements EndpointPublisher by programming, on the
+// control-plane cluster, one Gateway API HTTPRoute per InferenceService whose
+// backends are ExternalName Services aliasing each serving workload cluster's
+// ingress host. Because the homes' ingresses live on other clusters, an
+// ExternalName Service is the portable, implementation-agnostic way to name an
+// off-cluster backend a Gateway API HTTPRoute can reference (no vendor-specific
+// external-backend CRD).
+//
+// Single mode yields one backend Service and a single-backendRef route; All/Split
+// yield one Service per home and a route that load-balances across all of them
+// (equal weight today). As homes come and go the Service set is reconciled — new
+// homes get a Service, departed homes' Services are garbage-collected — and the
+// route's backendRefs track the current set. Teardown removes the route and every
+// per-home Service.
+type GatewayAPIPublisher struct {
+	client client.Client
+	config Config
+}
+
+var _ EndpointPublisher = (*GatewayAPIPublisher)(nil)
+
+// NewGatewayAPIPublisher constructs the Gateway API backend. The client is the
+// control-plane cluster client (the global gateway and the published resources
+// live there).
+func NewGatewayAPIPublisher(c client.Client, cfg Config) *GatewayAPIPublisher {
+	return &GatewayAPIPublisher{client: c, config: cfg}
+}
+
+func (p *GatewayAPIPublisher) Name() string { return "GatewayAPI" }
+
+// routeName is the HTTPRoute name for an InferenceService ("<isvc>-global").
+func routeName(isvc *v1beta1.InferenceService) string {
+	return isvc.Name + resourceSuffix
+}
+
+// serviceName is the per-home ExternalName Service name for a cluster
+// ("<isvc>-global-<cluster>").
+func serviceName(isvc *v1beta1.InferenceService, cluster string) string {
+	return isvc.Name + resourceSuffix + "-" + cluster
+}
+
+// routeNamespace resolves the namespace the published resources live in: the
+// configured RouteNamespace, or the ISVC's own namespace when unset.
+func (p *GatewayAPIPublisher) routeNamespace(isvc *v1beta1.InferenceService) string {
+	if ns := strings.TrimSpace(p.config.RouteNamespace); ns != "" {
+		return ns
+	}
+	return isvc.Namespace
+}
+
+// Publish reconciles the per-home ExternalName Services and the HTTPRoute so the
+// global host load-balances across exactly target.Homes.
+func (p *GatewayAPIPublisher) Publish(ctx context.Context, isvc *v1beta1.InferenceService, target Target) error {
+	if err := p.applyServices(ctx, isvc, target); err != nil {
+		return err
+	}
+	return p.applyRoute(ctx, isvc, target)
+}
+
+// Unpublish deletes the HTTPRoute and every per-home Service this publisher owns
+// for the ISVC. Missing resources are tolerated so a double-teardown (finalizer +
+// a re-queued unplaced pass) is a no-op.
+func (p *GatewayAPIPublisher) Unpublish(ctx context.Context, isvc *v1beta1.InferenceService) error {
+	ns := p.routeNamespace(isvc)
+	var errs []error
+	route := &gatewayapiv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: routeName(isvc), Namespace: ns}}
+	if err := p.client.Delete(ctx, route); err != nil && !apierrors.IsNotFound(err) {
+		errs = append(errs, fmt.Errorf("delete global HTTPRoute %s/%s: %w", ns, routeName(isvc), err))
+	}
+	owned, err := p.ownedServices(ctx, isvc)
+	if err != nil {
+		return errors.Join(append(errs, err)...)
+	}
+	for i := range owned {
+		s := &owned[i]
+		if err := p.client.Delete(ctx, s); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("delete global backend Service %s/%s: %w", s.Namespace, s.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// ownedServices lists the per-home backend Services this publisher created for
+// the ISVC (by the managed-by + per-ISVC labels), so teardown and stale-home GC
+// find them all regardless of how many homes there are.
+func (p *GatewayAPIPublisher) ownedServices(ctx context.Context, isvc *v1beta1.InferenceService) ([]corev1.Service, error) {
+	list := &corev1.ServiceList{}
+	if err := p.client.List(ctx, list, client.InNamespace(p.routeNamespace(isvc)),
+		client.MatchingLabels{ManagedByLabel: ManagedByValue, PlacementEndpointISVCLabel: isvc.Name}); err != nil {
+		return nil, fmt.Errorf("list global backend Services for %s/%s: %w", isvc.Namespace, isvc.Name, err)
+	}
+	return list.Items, nil
+}
+
+// applyServices ensures exactly one ExternalName Service per home exists, then
+// deletes any owned Service no longer backing a home (a home that left).
+func (p *GatewayAPIPublisher) applyServices(ctx context.Context, isvc *v1beta1.InferenceService, target Target) error {
+	desired := make(map[string]Home, len(target.Homes))
+	for _, h := range target.Homes {
+		desired[serviceName(isvc, h.Cluster)] = h
+	}
+	// Apply in a stable order so behavior is deterministic.
+	names := make([]string, 0, len(desired))
+	for n := range desired {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if err := p.applyService(ctx, isvc, name, desired[name]); err != nil {
+			return err
+		}
+	}
+
+	owned, err := p.ownedServices(ctx, isvc)
+	if err != nil {
+		return err
+	}
+	for i := range owned {
+		s := &owned[i]
+		if _, keep := desired[s.Name]; keep {
+			continue
+		}
+		if err := p.client.Delete(ctx, s); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete stale global backend Service %s/%s: %w", s.Namespace, s.Name, err)
+		}
+	}
+	return nil
+}
+
+func (p *GatewayAPIPublisher) applyService(ctx context.Context, isvc *v1beta1.InferenceService, name string, home Home) error {
+	desired := p.buildExternalNameService(isvc, name, home)
+	existing := &corev1.Service{}
+	err := p.client.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		if err := p.client.Create(ctx, desired); err != nil {
+			return fmt.Errorf("create global backend Service %s/%s: %w", desired.Namespace, desired.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	// Repoint (re-placement) or label drift: update in place. Carry the live
+	// ResourceVersion and preserve the cluster-assigned spec fields we do not own.
+	desired.ResourceVersion = existing.ResourceVersion
+	desired.Spec.ClusterIP = existing.Spec.ClusterIP
+	desired.Spec.ClusterIPs = existing.Spec.ClusterIPs
+	if equality.Semantic.DeepEqual(desired.Spec, existing.Spec) &&
+		maps.Equal(desired.Labels, existing.Labels) {
+		return nil
+	}
+	if err := p.client.Update(ctx, desired); err != nil {
+		return fmt.Errorf("update global backend Service %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+	return nil
+}
+
+func (p *GatewayAPIPublisher) applyRoute(ctx context.Context, isvc *v1beta1.InferenceService, target Target) error {
+	desired := p.buildHTTPRoute(isvc, target)
+	existing := &gatewayapiv1.HTTPRoute{}
+	err := p.client.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		if err := p.client.Create(ctx, desired); err != nil {
+			return fmt.Errorf("create global HTTPRoute %s/%s: %w", desired.Namespace, desired.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	desired.ResourceVersion = existing.ResourceVersion
+	if equality.Semantic.DeepEqual(desired.Spec, existing.Spec) &&
+		maps.Equal(desired.Labels, existing.Labels) {
+		return nil
+	}
+	if err := p.client.Update(ctx, desired); err != nil {
+		return fmt.Errorf("update global HTTPRoute %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+	return nil
+}
+
+// buildExternalNameService renders the ExternalName Service that aliases one
+// home cluster's ingress host. The externalName is repointed if the home's
+// backend changes; the Service name is stable per cluster so the HTTPRoute
+// backendRef for that home never has to change.
+func (p *GatewayAPIPublisher) buildExternalNameService(isvc *v1beta1.InferenceService, name string, home Home) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: p.routeNamespace(isvc),
+			Labels:    p.serviceLabels(isvc, home.Cluster),
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: home.BackendHost,
+			Ports: []corev1.ServicePort{{
+				Port: p.config.BackendPort,
+			}},
+		},
+	}
+}
+
+// buildHTTPRoute renders the global HTTPRoute: it attaches to the configured
+// global gateway, matches the global host at root, and forwards to one backend
+// per home (each the home's ExternalName Service), equal weight. Homes are
+// sorted by cluster so the backendRef order is deterministic (stable idempotency
+// comparisons).
+func (p *GatewayAPIPublisher) buildHTTPRoute(isvc *v1beta1.InferenceService, target Target) *gatewayapiv1.HTTPRoute {
+	gwNS, gwName := splitGatewayRef(p.config.GlobalGateway)
+	backendNS := p.routeNamespace(isvc)
+	port := gatewayapiv1.PortNumber(p.config.BackendPort)
+
+	homes := append([]Home(nil), target.Homes...)
+	sort.Slice(homes, func(i, j int) bool { return homes[i].Cluster < homes[j].Cluster })
+
+	// Traffic weight per home. In Split each home carries its ready-replica
+	// count, so traffic follows where replicas landed (a home with 0 ready gets 0
+	// — no traffic until it is serving). When no home carries a weight
+	// (Single/All, or a Split placement before any home is ready) every weight is
+	// zero; Gateway API sends no traffic if ALL backendRef weights are zero, so
+	// fall back to equal weight (1 each) rather than black-holing the route.
+	var totalWeight int32
+	for _, h := range homes {
+		totalWeight += h.Weight
+	}
+	refs := make([]gatewayapiv1.HTTPBackendRef, 0, len(homes))
+	for _, h := range homes {
+		weight := int32(1)
+		if totalWeight > 0 {
+			weight = h.Weight
+		}
+		refs = append(refs, gatewayapiv1.HTTPBackendRef{
+			BackendRef: gatewayapiv1.BackendRef{
+				BackendObjectReference: gatewayapiv1.BackendObjectReference{
+					Kind:      ptr.To(gatewayapiv1.Kind(constants.ServiceKind)),
+					Name:      gatewayapiv1.ObjectName(serviceName(isvc, h.Cluster)),
+					Namespace: (*gatewayapiv1.Namespace)(&backendNS),
+					Port:      &port,
+				},
+				Weight: ptr.To(weight),
+			},
+		})
+	}
+
+	return &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName(isvc),
+			Namespace: backendNS,
+			Labels:    p.baseLabels(isvc),
+		},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+				ParentRefs: []gatewayapiv1.ParentReference{{
+					Group:     (*gatewayapiv1.Group)(&gatewayapiv1.GroupVersion.Group),
+					Kind:      (*gatewayapiv1.Kind)(ptr.To(constants.GatewayKind)),
+					Namespace: (*gatewayapiv1.Namespace)(&gwNS),
+					Name:      gatewayapiv1.ObjectName(gwName),
+				}},
+			},
+			Hostnames: []gatewayapiv1.Hostname{gatewayapiv1.Hostname(target.GlobalHost)},
+			Rules: []gatewayapiv1.HTTPRouteRule{{
+				Matches: []gatewayapiv1.HTTPRouteMatch{{
+					Path: &gatewayapiv1.HTTPPathMatch{
+						Type:  ptr.To(gatewayapiv1.PathMatchPathPrefix),
+						Value: ptr.To("/"),
+					},
+				}},
+				BackendRefs: refs,
+			}},
+		},
+	}
+}
+
+// baseLabels are the ownership markers stamped on every published resource
+// (route + Services): the managed-by marker plus the per-ISVC grouping label,
+// merged over the operator-configured Labels (owned keys win).
+func (p *GatewayAPIPublisher) baseLabels(isvc *v1beta1.InferenceService) map[string]string {
+	out := map[string]string{}
+	maps.Copy(out, p.config.Labels)
+	out[ManagedByLabel] = ManagedByValue
+	out[PlacementEndpointISVCLabel] = isvc.Name
+	return out
+}
+
+// serviceLabels are baseLabels plus the per-home cluster marker (a backend
+// Service points at exactly one cluster).
+func (p *GatewayAPIPublisher) serviceLabels(isvc *v1beta1.InferenceService, cluster string) map[string]string {
+	out := p.baseLabels(isvc)
+	if cluster != "" {
+		out[PlacementClusterLabel] = cluster
+	}
+	return out
+}
+
+// splitGatewayRef parses a "namespace/name" gateway reference. A bare "name"
+// (no slash) resolves to an empty namespace, which Gateway API treats as the
+// route's own namespace.
+func splitGatewayRef(ref string) (namespace, name string) {
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", parts[0]
+}

--- a/pkg/controller/v1beta1/placement/endpoint/gatewayapi_test.go
+++ b/pkg/controller/v1beta1/placement/endpoint/gatewayapi_test.go
@@ -1,0 +1,314 @@
+package endpoint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func pubScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(s))
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	require.NoError(t, gatewayapiv1.Install(s))
+	return s
+}
+
+func testISVC() *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod", UID: "uid-1"},
+	}
+}
+
+func baseConfig() Config {
+	return Config{
+		GlobalHostTemplate: "{{.Name}}.{{.Namespace}}.global.example",
+		GlobalGateway:      "ome-system/global-gw",
+		BackendPort:        8080,
+		Labels:             map[string]string{"team": "platform"},
+	}
+}
+
+// oneHome builds a single-home Target (Single mode shape).
+func oneHome(globalHost, cluster, backendHost string) Target {
+	return Target{GlobalHost: globalHost, Homes: []Home{{Cluster: cluster, BackendHost: backendHost}}}
+}
+
+func TestBuildExternalNameService(t *testing.T) {
+	p := NewGatewayAPIPublisher(nil, baseConfig())
+	isvc := testISVC()
+	home := Home{Cluster: "cluster-a", BackendHost: "svc.prod.cloud-a.example"}
+
+	svc := p.buildExternalNameService(isvc, serviceName(isvc, "cluster-a"), home)
+
+	assert.Equal(t, "svc-global-cluster-a", svc.Name, "per-home Service name carries the cluster")
+	assert.Equal(t, "prod", svc.Namespace, "namespace falls back to the ISVC namespace")
+	assert.Equal(t, corev1.ServiceTypeExternalName, svc.Spec.Type)
+	assert.Equal(t, "svc.prod.cloud-a.example", svc.Spec.ExternalName, "ExternalName aliases the home ingress host")
+	require.Len(t, svc.Spec.Ports, 1)
+	assert.Equal(t, int32(8080), svc.Spec.Ports[0].Port)
+	assert.Equal(t, ManagedByValue, svc.Labels[ManagedByLabel])
+	assert.Equal(t, "cluster-a", svc.Labels[PlacementClusterLabel])
+	assert.Equal(t, "svc", svc.Labels[PlacementEndpointISVCLabel], "per-ISVC grouping label for GC/teardown")
+	assert.Equal(t, "platform", svc.Labels["team"], "operator labels are merged in")
+}
+
+func TestBuildHTTPRoute_SingleHome(t *testing.T) {
+	p := NewGatewayAPIPublisher(nil, baseConfig())
+
+	route := p.buildHTTPRoute(testISVC(), oneHome("svc.prod.global.example", "cluster-a", "svc.prod.cloud-a.example"))
+
+	assert.Equal(t, "svc-global", route.Name)
+	assert.Equal(t, "prod", route.Namespace)
+	require.Len(t, route.Spec.Hostnames, 1)
+	assert.Equal(t, gatewayapiv1.Hostname("svc.prod.global.example"), route.Spec.Hostnames[0])
+	assert.Equal(t, "svc", route.Labels[PlacementEndpointISVCLabel])
+
+	require.Len(t, route.Spec.ParentRefs, 1)
+	pr := route.Spec.ParentRefs[0]
+	require.NotNil(t, pr.Namespace)
+	assert.Equal(t, "ome-system", string(*pr.Namespace), "gateway namespace parsed from namespace/name")
+	assert.Equal(t, "global-gw", string(pr.Name))
+	require.NotNil(t, pr.Kind)
+	assert.Equal(t, constants.GatewayKind, string(*pr.Kind))
+
+	require.Len(t, route.Spec.Rules, 1)
+	require.Len(t, route.Spec.Rules[0].BackendRefs, 1)
+	br := route.Spec.Rules[0].BackendRefs[0]
+	assert.Equal(t, gatewayapiv1.ObjectName("svc-global-cluster-a"), br.Name, "route forwards to the home's ExternalName Service")
+	require.NotNil(t, br.Kind)
+	assert.Equal(t, constants.ServiceKind, string(*br.Kind))
+	require.NotNil(t, br.Port)
+	assert.Equal(t, gatewayapiv1.PortNumber(8080), *br.Port)
+	require.NotNil(t, br.Weight)
+	assert.Equal(t, int32(1), *br.Weight)
+
+	require.Len(t, route.Spec.Rules[0].Matches, 1)
+	require.NotNil(t, route.Spec.Rules[0].Matches[0].Path)
+	assert.Equal(t, "/", *route.Spec.Rules[0].Matches[0].Path.Value)
+}
+
+func TestBuildHTTPRoute_MultiHomeEqualWeightSorted(t *testing.T) {
+	p := NewGatewayAPIPublisher(nil, baseConfig())
+	// Homes passed out of order; the route's backendRefs must be sorted by cluster.
+	target := Target{GlobalHost: "h", Homes: []Home{
+		{Cluster: "cluster-b", BackendHost: "b.example"},
+		{Cluster: "cluster-a", BackendHost: "a.example"},
+	}}
+
+	route := p.buildHTTPRoute(testISVC(), target)
+
+	refs := route.Spec.Rules[0].BackendRefs
+	require.Len(t, refs, 2, "one backendRef per home")
+	assert.Equal(t, gatewayapiv1.ObjectName("svc-global-cluster-a"), refs[0].Name)
+	assert.Equal(t, gatewayapiv1.ObjectName("svc-global-cluster-b"), refs[1].Name)
+	require.NotNil(t, refs[0].Weight)
+	require.NotNil(t, refs[1].Weight)
+	assert.Equal(t, int32(1), *refs[0].Weight, "equal weight across homes")
+	assert.Equal(t, int32(1), *refs[1].Weight)
+}
+
+func TestBuildResources_RouteNamespaceOverride(t *testing.T) {
+	cfg := baseConfig()
+	cfg.RouteNamespace = "ome-gateways"
+	p := NewGatewayAPIPublisher(nil, cfg)
+	isvc := testISVC()
+
+	svc := p.buildExternalNameService(isvc, serviceName(isvc, "c"), Home{Cluster: "c", BackendHost: "b"})
+	route := p.buildHTTPRoute(isvc, oneHome("h", "c", "b"))
+
+	assert.Equal(t, "ome-gateways", svc.Namespace)
+	assert.Equal(t, "ome-gateways", route.Namespace)
+	require.NotNil(t, route.Spec.Rules[0].BackendRefs[0].Namespace)
+	assert.Equal(t, "ome-gateways", string(*route.Spec.Rules[0].BackendRefs[0].Namespace),
+		"backendRef namespace tracks the route namespace")
+}
+
+func TestBuildHTTPRoute_BareGatewayName(t *testing.T) {
+	cfg := baseConfig()
+	cfg.GlobalGateway = "global-gw" // no namespace
+	p := NewGatewayAPIPublisher(nil, cfg)
+
+	route := p.buildHTTPRoute(testISVC(), oneHome("h", "c", "b"))
+
+	pr := route.Spec.ParentRefs[0]
+	require.NotNil(t, pr.Namespace)
+	assert.Equal(t, "", string(*pr.Namespace), "bare gateway name yields empty (route-local) namespace")
+	assert.Equal(t, "global-gw", string(pr.Name))
+}
+
+func TestPublish_SingleHomeCreatesResources(t *testing.T) {
+	s := pubScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	p := NewGatewayAPIPublisher(c, baseConfig())
+	isvc := testISVC()
+
+	require.NoError(t, p.Publish(context.Background(), isvc, oneHome("svc.prod.global.example", "cluster-a", "svc.prod.cloud-a.example")))
+
+	svc := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-a", Namespace: "prod"}, svc))
+	assert.Equal(t, "svc.prod.cloud-a.example", svc.Spec.ExternalName)
+
+	route := &gatewayapiv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, route))
+	assert.Equal(t, gatewayapiv1.Hostname("svc.prod.global.example"), route.Spec.Hostnames[0])
+	require.Len(t, route.Spec.Rules[0].BackendRefs, 1)
+}
+
+func TestPublish_MultiHomeCreatesPerHomeServices(t *testing.T) {
+	s := pubScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	p := NewGatewayAPIPublisher(c, baseConfig())
+	isvc := testISVC()
+	target := Target{GlobalHost: "svc.prod.global.example", Homes: []Home{
+		{Cluster: "cluster-a", BackendHost: "a.example"},
+		{Cluster: "cluster-b", BackendHost: "b.example"},
+	}}
+
+	require.NoError(t, p.Publish(context.Background(), isvc, target))
+
+	a := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-a", Namespace: "prod"}, a))
+	assert.Equal(t, "a.example", a.Spec.ExternalName)
+	b := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-b", Namespace: "prod"}, b))
+	assert.Equal(t, "b.example", b.Spec.ExternalName)
+
+	route := &gatewayapiv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, route))
+	require.Len(t, route.Spec.Rules[0].BackendRefs, 2, "route load-balances across both homes")
+}
+
+func TestPublish_Idempotent(t *testing.T) {
+	s := pubScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	p := NewGatewayAPIPublisher(c, baseConfig())
+	isvc := testISVC()
+	target := oneHome("svc.prod.global.example", "cluster-a", "svc.prod.cloud-a.example")
+
+	require.NoError(t, p.Publish(context.Background(), isvc, target))
+	route := &gatewayapiv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, route))
+	rvBefore := route.ResourceVersion
+
+	require.NoError(t, p.Publish(context.Background(), isvc, target))
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, route))
+	assert.Equal(t, rvBefore, route.ResourceVersion, "identical re-publish must be a no-op")
+}
+
+func TestPublish_HomeLeavesGCsStaleService(t *testing.T) {
+	s := pubScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	p := NewGatewayAPIPublisher(c, baseConfig())
+	isvc := testISVC()
+
+	// Two homes, then one leaves.
+	require.NoError(t, p.Publish(context.Background(), isvc, Target{GlobalHost: "h", Homes: []Home{
+		{Cluster: "cluster-a", BackendHost: "a.example"},
+		{Cluster: "cluster-b", BackendHost: "b.example"},
+	}}))
+	require.NoError(t, p.Publish(context.Background(), isvc, oneHome("h", "cluster-a", "a.example")))
+
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-a", Namespace: "prod"}, &corev1.Service{}),
+		"surviving home's Service kept")
+	err := c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-b", Namespace: "prod"}, &corev1.Service{})
+	assert.True(t, apierrors.IsNotFound(err), "departed home's Service garbage-collected")
+
+	route := &gatewayapiv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, route))
+	require.Len(t, route.Spec.Rules[0].BackendRefs, 1, "route drops the departed home's backendRef")
+}
+
+func TestPublish_WinnerMovesClustersInSingle(t *testing.T) {
+	s := pubScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	p := NewGatewayAPIPublisher(c, baseConfig())
+	isvc := testISVC()
+
+	require.NoError(t, p.Publish(context.Background(), isvc, oneHome("svc.prod.global.example", "cluster-a", "svc.prod.cloud-a.example")))
+	// Single re-placement onto a different cluster: old home's Service is GC'd, new one created.
+	require.NoError(t, p.Publish(context.Background(), isvc, oneHome("svc.prod.global.example", "cluster-b", "svc.prod.cloud-b.example")))
+
+	err := c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-a", Namespace: "prod"}, &corev1.Service{})
+	assert.True(t, apierrors.IsNotFound(err), "old winner's Service GC'd")
+	b := &corev1.Service{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-b", Namespace: "prod"}, b))
+	assert.Equal(t, "svc.prod.cloud-b.example", b.Spec.ExternalName)
+
+	route := &gatewayapiv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, route))
+	require.Len(t, route.Spec.Rules[0].BackendRefs, 1)
+	assert.Equal(t, gatewayapiv1.ObjectName("svc-global-cluster-b"), route.Spec.Rules[0].BackendRefs[0].Name)
+}
+
+func TestUnpublish_DeletesRouteAndAllServices(t *testing.T) {
+	s := pubScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	p := NewGatewayAPIPublisher(c, baseConfig())
+	isvc := testISVC()
+	require.NoError(t, p.Publish(context.Background(), isvc, Target{GlobalHost: "h", Homes: []Home{
+		{Cluster: "cluster-a", BackendHost: "a.example"},
+		{Cluster: "cluster-b", BackendHost: "b.example"},
+	}}))
+
+	require.NoError(t, p.Unpublish(context.Background(), isvc))
+
+	for _, name := range []string{"svc-global-cluster-a", "svc-global-cluster-b"} {
+		err := c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "prod"}, &corev1.Service{})
+		assert.True(t, apierrors.IsNotFound(err), "%s deleted", name)
+	}
+	err := c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, &gatewayapiv1.HTTPRoute{})
+	assert.True(t, apierrors.IsNotFound(err), "HTTPRoute deleted")
+}
+
+func TestUnpublish_MissingIsNoOp(t *testing.T) {
+	s := pubScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	p := NewGatewayAPIPublisher(c, baseConfig())
+	require.NoError(t, p.Unpublish(context.Background(), testISVC()))
+}
+
+func TestBuildHTTPRoute_WeightedByReadyReplicas(t *testing.T) {
+	p := NewGatewayAPIPublisher(nil, baseConfig())
+	// Split: each home carries its ready-replica count -> proportional weights.
+	target := Target{GlobalHost: "h", Homes: []Home{
+		{Cluster: "cluster-a", BackendHost: "a.example", Weight: 3},
+		{Cluster: "cluster-b", BackendHost: "b.example", Weight: 1},
+	}}
+
+	refs := p.buildHTTPRoute(testISVC(), target).Spec.Rules[0].BackendRefs
+	require.Len(t, refs, 2)
+	require.NotNil(t, refs[0].Weight)
+	require.NotNil(t, refs[1].Weight)
+	assert.Equal(t, int32(3), *refs[0].Weight, "cluster-a (sorted first) weighted by its ready replicas")
+	assert.Equal(t, int32(1), *refs[1].Weight, "cluster-b weighted by its ready replicas")
+}
+
+func TestBuildHTTPRoute_UnweightedFallsBackToEqual(t *testing.T) {
+	p := NewGatewayAPIPublisher(nil, baseConfig())
+	// No weights (Single/All, or a Split placement before any home is ready):
+	// every weight is 0, so fall back to equal (1) rather than black-holing.
+	target := Target{GlobalHost: "h", Homes: []Home{
+		{Cluster: "cluster-a", BackendHost: "a.example"},
+		{Cluster: "cluster-b", BackendHost: "b.example"},
+	}}
+
+	refs := p.buildHTTPRoute(testISVC(), target).Spec.Rules[0].BackendRefs
+	require.Len(t, refs, 2)
+	assert.Equal(t, int32(1), *refs[0].Weight)
+	assert.Equal(t, int32(1), *refs[1].Weight)
+}

--- a/pkg/controller/v1beta1/placement/endpoint/gatewayapi_test.go
+++ b/pkg/controller/v1beta1/placement/endpoint/gatewayapi_test.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -53,7 +55,7 @@ func TestBuildExternalNameService(t *testing.T) {
 	isvc := testISVC()
 	home := Home{Cluster: "cluster-a", BackendHost: "svc.prod.cloud-a.example"}
 
-	svc := p.buildExternalNameService(isvc, serviceName(isvc, "cluster-a"), home)
+	svc := p.buildExternalNameService(isvc, p.serviceName(isvc, "cluster-a"), home)
 
 	assert.Equal(t, "svc-global-cluster-a", svc.Name, "per-home Service name carries the cluster")
 	assert.Equal(t, "prod", svc.Namespace, "namespace falls back to the ISVC namespace")
@@ -64,6 +66,7 @@ func TestBuildExternalNameService(t *testing.T) {
 	assert.Equal(t, ManagedByValue, svc.Labels[ManagedByLabel])
 	assert.Equal(t, "cluster-a", svc.Labels[PlacementClusterLabel])
 	assert.Equal(t, "svc", svc.Labels[PlacementEndpointISVCLabel], "per-ISVC grouping label for GC/teardown")
+	assert.Equal(t, "prod", svc.Labels[PlacementEndpointISVCNamespaceLabel])
 	assert.Equal(t, "platform", svc.Labels["team"], "operator labels are merged in")
 }
 
@@ -77,6 +80,7 @@ func TestBuildHTTPRoute_SingleHome(t *testing.T) {
 	require.Len(t, route.Spec.Hostnames, 1)
 	assert.Equal(t, gatewayapiv1.Hostname("svc.prod.global.example"), route.Spec.Hostnames[0])
 	assert.Equal(t, "svc", route.Labels[PlacementEndpointISVCLabel])
+	assert.Equal(t, "prod", route.Labels[PlacementEndpointISVCNamespaceLabel])
 
 	require.Len(t, route.Spec.ParentRefs, 1)
 	pr := route.Spec.ParentRefs[0]
@@ -128,7 +132,7 @@ func TestBuildResources_RouteNamespaceOverride(t *testing.T) {
 	p := NewGatewayAPIPublisher(nil, cfg)
 	isvc := testISVC()
 
-	svc := p.buildExternalNameService(isvc, serviceName(isvc, "c"), Home{Cluster: "c", BackendHost: "b"})
+	svc := p.buildExternalNameService(isvc, p.serviceName(isvc, "c"), Home{Cluster: "c", BackendHost: "b"})
 	route := p.buildHTTPRoute(isvc, oneHome("h", "c", "b"))
 
 	assert.Equal(t, "ome-gateways", svc.Namespace)
@@ -136,6 +140,17 @@ func TestBuildResources_RouteNamespaceOverride(t *testing.T) {
 	require.NotNil(t, route.Spec.Rules[0].BackendRefs[0].Namespace)
 	assert.Equal(t, "ome-gateways", string(*route.Spec.Rules[0].BackendRefs[0].Namespace),
 		"backendRef namespace tracks the route namespace")
+}
+
+type routeUpdateFailClient struct {
+	client.Client
+}
+
+func (c routeUpdateFailClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if _, ok := obj.(*gatewayapiv1.HTTPRoute); ok {
+		return errors.New("route update failed")
+	}
+	return c.Client.Update(ctx, obj, opts...)
 }
 
 func TestBuildHTTPRoute_BareGatewayName(t *testing.T) {
@@ -253,6 +268,45 @@ func TestPublish_WinnerMovesClustersInSingle(t *testing.T) {
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global", Namespace: "prod"}, route))
 	require.Len(t, route.Spec.Rules[0].BackendRefs, 1)
 	assert.Equal(t, gatewayapiv1.ObjectName("svc-global-cluster-b"), route.Spec.Rules[0].BackendRefs[0].Name)
+}
+
+func TestPublish_RouteUpdateFailureKeepsOldBackendService(t *testing.T) {
+	s := pubScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	p := NewGatewayAPIPublisher(c, baseConfig())
+	isvc := testISVC()
+	require.NoError(t, p.Publish(context.Background(), isvc, oneHome("h", "cluster-a", "a.example")))
+
+	p.client = routeUpdateFailClient{Client: c}
+	err := p.Publish(context.Background(), isvc, oneHome("h", "cluster-b", "b.example"))
+	require.Error(t, err)
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "svc-global-cluster-a", Namespace: "prod"}, &corev1.Service{}),
+		"old Service remains while the route still references it")
+}
+
+func TestPublish_SharedRouteNamespaceIsolatesSameNameSources(t *testing.T) {
+	s := pubScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	cfg := baseConfig()
+	cfg.RouteNamespace = "ome-gateways"
+	p := NewGatewayAPIPublisher(c, cfg)
+	a := testISVC()
+	a.Namespace = "team-a"
+	b := testISVC()
+	b.Namespace = "team-b"
+
+	require.NoError(t, p.Publish(context.Background(), a, oneHome("a.global.example", "cluster-a", "a.example")))
+	require.NoError(t, p.Publish(context.Background(), b, oneHome("b.global.example", "cluster-b", "b.example")))
+	assert.NotEqual(t, p.routeName(a), p.routeName(b))
+	assert.NotEqual(t, p.serviceName(a, "cluster-a"), p.serviceName(b, "cluster-b"))
+	ownedA, err := p.ownedServices(context.Background(), a)
+	require.NoError(t, err)
+	require.Len(t, ownedA, 1)
+	assert.Equal(t, "team-a", ownedA[0].Labels[PlacementEndpointISVCNamespaceLabel])
+
+	require.NoError(t, p.Unpublish(context.Background(), a))
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: p.routeName(b), Namespace: "ome-gateways"}, &gatewayapiv1.HTTPRoute{}))
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: p.serviceName(b, "cluster-b"), Namespace: "ome-gateways"}, &corev1.Service{}))
 }
 
 func TestUnpublish_DeletesRouteAndAllServices(t *testing.T) {

--- a/pkg/controller/v1beta1/placement/endpoint/publisher.go
+++ b/pkg/controller/v1beta1/placement/endpoint/publisher.go
@@ -1,0 +1,71 @@
+// Package endpoint programs ONE concrete global-traffic backend so the global
+// host of a multi-cluster InferenceService resolves to whichever workload
+// cluster currently wins the placement race.
+//
+// The control-plane fan-out controller (package placement) already records the
+// winner and the winner's externally-addressable URL in
+// status.placement.{cluster,endpoint}. That is status-only: an external LB has
+// to consume it. This package closes that gap by actually programming a backend
+// — the Gateway API HTTPRoute backend (GatewayAPIPublisher) is the first
+// concrete implementation; the EndpointPublisher interface lets DNS/GSLB
+// backends be added later without touching the reconciler.
+package endpoint
+
+import (
+	"context"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// Target is the resolved publication intent for one InferenceService: the global
+// host to program and the one-or-more serving homes it must resolve to. Built by
+// the reconciler from status.placement and the Config; the EndpointPublisher
+// backend translates it into its own resource(s). Single mode yields exactly one
+// Home; All/Split yield one per serving cluster.
+type Target struct {
+	// GlobalHost is the externally-addressable hostname the publisher programs
+	// (e.g. "my-svc.global.example"). Rendered from Config + the ISVC, never a
+	// baked-in literal.
+	GlobalHost string
+
+	// Homes are the serving clusters the global host resolves to, one per admitted
+	// home. In Single there is exactly one; in All/Split there is one per cluster
+	// currently serving. Never empty when the reconciler decides to publish.
+	Homes []Home
+}
+
+// Home is one serving cluster the global host load-balances across.
+type Home struct {
+	// Cluster is the WorkloadCluster serving this home (labels/logging).
+	Cluster string
+	// BackendHost is that cluster's ingress hostname the global host resolves to —
+	// the host of the home's status endpoint. A bare hostname (no scheme/port);
+	// the backend supplies the port from Config.
+	BackendHost string
+	// Weight is the home's relative traffic share — its ready replicas in Split,
+	// so traffic follows where replicas actually landed. Zero in Single/All (and
+	// for a Split home with no ready replicas yet); the publisher equal-weights
+	// all homes when every weight is zero, so an unweighted placement routes
+	// evenly rather than dropping to no-traffic.
+	Weight int32
+}
+
+// EndpointPublisher programs the global-traffic backend(s) so the global host of
+// a multi-cluster InferenceService points at every serving home (one in Single;
+// several, load-balanced, in All/Split), adjusts the set as homes come and go,
+// and tears it all down when the service is no longer placed. Implementations
+// are backend-specific (Gateway API HTTPRoute today; DNS/GSLB later) and MUST be
+// idempotent: Publish for an unchanged Target is a no-op, and Unpublish for an
+// already-clean service is a no-op.
+type EndpointPublisher interface {
+	// Publish ensures the backend routes target.GlobalHost to
+	// target.BackendHost for isvc, creating or repointing as needed.
+	Publish(ctx context.Context, isvc *v1beta1.InferenceService, target Target) error
+
+	// Unpublish removes any backend resources this publisher created for isvc.
+	// Safe to call when nothing was ever published.
+	Unpublish(ctx context.Context, isvc *v1beta1.InferenceService) error
+
+	// Name identifies the backend for logging/metrics (e.g. "GatewayAPI").
+	Name() string
+}

--- a/pkg/controller/v1beta1/placement/failed.go
+++ b/pkg/controller/v1beta1/placement/failed.go
@@ -1,0 +1,34 @@
+package placement
+
+import "sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+
+// IsTerminallyFailed reports whether the (derived) ISVC's placement has failed
+// in a way that needs human/spec action rather than an automatic re-place. The
+// control plane treats this as a failed placement — distinct from a derived
+// ISVC that was merely deleted (which is re-placed).
+//
+// Two failure surfaces are terminal:
+//   - An OMENative Instance escalated to Phase=Failed (stuck-pod /
+//     InstanceReadyTimeout backstop).
+//   - The model lifecycle reached a terminal model-status (BlockedByFailedLoad
+//     from a failed model load, or InvalidSpec from runtime-selection / spec
+//     validation). These never carry an OMENative Instance failure, so checking
+//     only Instance phases would report them as forever-Pending and re-fan-out
+//     into the same failure on every poll.
+func IsTerminallyFailed(isvc *v1beta1.InferenceService, statuses map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus) bool {
+	for _, st := range statuses {
+		if st == nil {
+			continue
+		}
+		for _, inst := range st.InstanceStatuses {
+			if inst.Phase == v1beta1.OMENativeInstanceFailed {
+				return true
+			}
+		}
+	}
+	switch isvc.Status.ModelStatus.TransitionStatus {
+	case v1beta1.BlockedByFailedLoad, v1beta1.InvalidSpec:
+		return true
+	}
+	return false
+}

--- a/pkg/controller/v1beta1/placement/failed_test.go
+++ b/pkg/controller/v1beta1/placement/failed_test.go
@@ -1,0 +1,81 @@
+package placement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// isvcWithPhases builds a derived ISVC declaring `component` with an empty
+// Lifecycle summary. Used by the controller reconcile tests that seed a derived
+// ISVC on a worker cluster; the per-instance data now lives on the paired
+// InferenceReplica (see irWithPhases), which the predicate reads via
+// ComponentIRStatus. The variadic arg is retained for call-site symmetry with
+// irWithPhases but no longer populates the ISVC.
+func isvcWithPhases(component v1beta1.ComponentType, _ ...v1beta1.OMENativeInstancePhase) *v1beta1.InferenceService {
+	isvc := &v1beta1.InferenceService{
+		Status: v1beta1.InferenceServiceStatus{
+			Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+				component: {Lifecycle: &v1beta1.LifecycleStatus{}},
+			},
+		},
+	}
+	declareComponent(isvc, component)
+	return isvc
+}
+
+// phaseStatusMap builds the authoritative per-component IR status map the
+// IsTerminallyFailed predicate now consumes.
+func phaseStatusMap(component v1beta1.ComponentType, phases ...v1beta1.OMENativeInstancePhase) map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus {
+	insts := make([]v1beta1.OMENativeInstanceStatus, len(phases))
+	for i, p := range phases {
+		insts[i] = v1beta1.OMENativeInstanceStatus{Index: int32(i), Phase: p}
+	}
+	return map[v1beta1.ComponentType]*v1beta1.InferenceReplicaStatus{
+		component: {InstanceStatuses: insts},
+	}
+}
+
+// irWithPhases builds an InferenceReplica named "svc-<component>" in "prod"
+// whose status carries instances at the given phases, for seeding on a worker
+// fake client so the reconcile reads it via ComponentIRStatus.
+func irWithPhases(component v1beta1.ComponentType, phases ...v1beta1.OMENativeInstancePhase) *v1beta1.InferenceReplica {
+	insts := make([]v1beta1.OMENativeInstanceStatus, len(phases))
+	for i, p := range phases {
+		insts[i] = v1beta1.OMENativeInstanceStatus{Index: int32(i), Phase: p}
+	}
+	return &v1beta1.InferenceReplica{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "svc-" + string(component)},
+		Status:     v1beta1.InferenceReplicaStatus{InstanceStatuses: insts},
+	}
+}
+
+func TestIsTerminallyFailed(t *testing.T) {
+	assert.True(t, IsTerminallyFailed(&v1beta1.InferenceService{},
+		phaseStatusMap(v1beta1.EngineComponent, v1beta1.OMENativeInstanceReady, v1beta1.OMENativeInstanceFailed)))
+	assert.False(t, IsTerminallyFailed(&v1beta1.InferenceService{},
+		phaseStatusMap(v1beta1.EngineComponent, v1beta1.OMENativeInstanceReady, v1beta1.OMENativeInstanceCreating)))
+	assert.False(t, IsTerminallyFailed(&v1beta1.InferenceService{}, nil))
+
+	// Non-OMENative failures surface via the model-status transition, with no
+	// failed Instance phase. These must also be terminal so the placement does
+	// not re-fan-out into the same failure forever.
+	blockedLoad := &v1beta1.InferenceService{Status: v1beta1.InferenceServiceStatus{
+		ModelStatus: v1beta1.ModelStatus{TransitionStatus: v1beta1.BlockedByFailedLoad},
+	}}
+	assert.True(t, IsTerminallyFailed(blockedLoad, nil), "model-load failure is terminal")
+
+	invalidSpec := &v1beta1.InferenceService{Status: v1beta1.InferenceServiceStatus{
+		ModelStatus: v1beta1.ModelStatus{TransitionStatus: v1beta1.InvalidSpec},
+	}}
+	assert.True(t, IsTerminallyFailed(invalidSpec, nil), "runtime-selection/spec failure is terminal")
+
+	// In-progress model status is NOT terminal.
+	inProgress := &v1beta1.InferenceService{Status: v1beta1.InferenceServiceStatus{
+		ModelStatus: v1beta1.ModelStatus{TransitionStatus: v1beta1.InProgress},
+	}}
+	assert.False(t, IsTerminallyFailed(inProgress, nil))
+}

--- a/pkg/controller/v1beta1/placement/gc.go
+++ b/pkg/controller/v1beta1/placement/gc.go
@@ -141,7 +141,17 @@ func (g *GCReconciler) sweep(ctx context.Context) error {
 		for _, orphan := range OrphanedDeriveds(live, g.ControlPlaneID, derivedList.Items) {
 			o := orphan
 			o.SetGroupVersionKind(v1beta1.SchemeGroupVersion.WithKind("InferenceService"))
-			if err := cl.Delete(ctx, &o); err != nil && !apierrors.IsNotFound(err) {
+			// Delete the exact object this sweep classified, never whatever now
+			// holds that name. A source deleted and recreated under the same name
+			// gets a fresh UID, so the placer may already have created a LIVE
+			// derived by the time this delete lands; a name-only delete would reap
+			// the running workload it just placed.
+			opts := []client.DeleteOption{}
+			if o.UID != "" {
+				uid := o.UID
+				opts = append(opts, client.Preconditions{UID: &uid})
+			}
+			if err := cl.Delete(ctx, &o, opts...); err != nil && !apierrors.IsNotFound(err) {
 				g.Log.Error(err, "gc: delete orphan derived", "cluster", cluster, "isvc", o.Namespace+"/"+o.Name)
 				continue
 			}

--- a/pkg/controller/v1beta1/placement/gc.go
+++ b/pkg/controller/v1beta1/placement/gc.go
@@ -1,0 +1,178 @@
+package placement
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// DefaultGCInterval is the fallback orphan-sweep cadence used when
+// GCReconciler.Interval is unset. The operative value is supplied by the
+// manager flag / chart; this is the graceful-degradation default.
+const DefaultGCInterval = 5 * time.Minute
+
+// defaultGCPageSize bounds the per-request item count for the paginated
+// control-plane sweep list. Fallback only; override via GCReconciler.PageSize.
+const defaultGCPageSize = 500
+
+// isvcMetadataList returns an empty metadata-only list typed as ome.io
+// InferenceServices, so List deserializes object metadata only (no spec/status).
+func isvcMetadataList() *metav1.PartialObjectMetadataList {
+	l := &metav1.PartialObjectMetadataList{}
+	l.SetGroupVersionKind(v1beta1.SchemeGroupVersion.WithKind("InferenceServiceList"))
+	return l
+}
+
+// GCReconciler periodically sweeps workload clusters for orphaned derived
+// InferenceServices — copies this control plane created whose source ISVC no
+// longer exists (source force-deleted before its finalizer ran, or a cluster
+// was unreachable during deletion). Safety net on top of the finalizer cleanup
+// in the placement Reconciler.
+type GCReconciler struct {
+	// APIReader reads control-plane InferenceServices UNCACHED. sweep() only
+	// reads the control plane (to build the live-UID set) and deletes on remote
+	// clusters — it never writes the control plane, so a Reader suffices. Using
+	// the uncached reader is a safety guarantee: a cold/empty informer cache must
+	// never make sweep classify every derived ISVC as an orphan and delete them.
+	APIReader client.Reader
+	Log       logr.Logger
+	Clusters  ClusterClients
+	// Interval is the sweep cadence; defaults to DefaultGCInterval.
+	Interval time.Duration
+	// PageSize bounds the per-request item count for the paginated control-plane
+	// list; defaults to defaultGCPageSize.
+	PageSize int64
+	// ControlPlaneID scopes the sweep to deriveds THIS control plane created
+	// (those stamped PlacementControlPlaneLabel==ControlPlaneID). When several
+	// control planes share a workload cluster, this stops one control plane from
+	// reaping another's deriveds. Config-driven (manager flag / chart); empty
+	// keeps the single-control-plane behavior (no control-plane filtering, all
+	// origin-labeled deriveds are in scope).
+	ControlPlaneID string
+}
+
+// OrphanedDeriveds returns the derived ISVCs whose origin-UID is not in the set
+// of live control-plane ISVC UIDs. Operates on metadata only — orphan
+// classification and deletion need just the labels/annotations and name/namespace.
+//
+// controlPlaneID scopes ownership: when non-empty, a derived is only a candidate
+// for reaping if its PlacementControlPlaneLabel equals controlPlaneID — so a
+// control plane never classifies ANOTHER control plane's derived (sharing the
+// same workload cluster) as an orphan. An empty controlPlaneID disables the
+// filter (single-control-plane behavior).
+func OrphanedDeriveds(liveUIDs map[string]bool, controlPlaneID string, derived []metav1.PartialObjectMetadata) []metav1.PartialObjectMetadata {
+	var orphans []metav1.PartialObjectMetadata
+	for i := range derived {
+		uid := derived[i].Annotations[PlacementOriginUIDAnnotation]
+		if uid == "" {
+			continue // not a placement-derived object we own
+		}
+		// Ownership scoping: never reap a derived this control plane did not create.
+		if controlPlaneID != "" && derived[i].Labels[PlacementControlPlaneLabel] != controlPlaneID {
+			continue
+		}
+		if !liveUIDs[uid] {
+			orphans = append(orphans, derived[i])
+		}
+	}
+	return orphans
+}
+
+// sweep lists live CP ISVC UIDs, then for each connected cluster deletes
+// origin-labeled derived ISVCs whose source is gone. Both lists are
+// metadata-only so full specs/status are never deserialized.
+func (g *GCReconciler) sweep(ctx context.Context) error {
+	pageSize := g.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultGCPageSize
+	}
+	live := map[string]bool{}
+	continueToken := ""
+	for {
+		cpList := isvcMetadataList()
+		if err := g.APIReader.List(ctx, cpList, client.Limit(pageSize), client.Continue(continueToken)); err != nil {
+			return fmt.Errorf("gc: list control-plane ISVCs: %w", err)
+		}
+		for i := range cpList.Items {
+			live[string(cpList.Items[i].UID)] = true
+		}
+		continueToken = cpList.Continue
+		if continueToken == "" {
+			break
+		}
+	}
+
+	// Safety guard: an empty live-UID set is treated as suspect and the
+	// destructive sweep is skipped. A successful-but-empty List (a transient
+	// apiserver/etcd hiccup, an RBAC/scope regression, or a genuinely-empty
+	// control plane) is indistinguishable here, and reaping every derived on
+	// that signal is unrecoverable. Real source deletions are still cleaned up
+	// by the placement finalizer; this safety net only ever needs to run when
+	// at least one source survives, so requiring a non-empty authoritative list
+	// costs no legitimate cleanup.
+	if len(live) == 0 {
+		g.Log.Info("gc: control-plane ISVC list empty; skipping sweep (suspect/transient)")
+		return nil
+	}
+
+	for _, cluster := range g.Clusters.Connected() {
+		cl, ok := g.Clusters.ClientFor(cluster)
+		if !ok {
+			continue
+		}
+		derivedList := isvcMetadataList()
+		// Scope the list to deriveds created by THIS control plane when an
+		// identity is configured; otherwise list all origin-labeled deriveds.
+		listOpts := []client.ListOption{client.HasLabels{PlacementOriginLabel}}
+		if g.ControlPlaneID != "" {
+			listOpts = append(listOpts, client.MatchingLabels{PlacementControlPlaneLabel: g.ControlPlaneID})
+		}
+		if err := cl.List(ctx, derivedList, listOpts...); err != nil {
+			g.Log.Error(err, "gc: list derived ISVCs", "cluster", cluster)
+			continue
+		}
+		for _, orphan := range OrphanedDeriveds(live, g.ControlPlaneID, derivedList.Items) {
+			o := orphan
+			o.SetGroupVersionKind(v1beta1.SchemeGroupVersion.WithKind("InferenceService"))
+			if err := cl.Delete(ctx, &o); err != nil && !apierrors.IsNotFound(err) {
+				g.Log.Error(err, "gc: delete orphan derived", "cluster", cluster, "isvc", o.Namespace+"/"+o.Name)
+				continue
+			}
+			g.Log.Info("gc: deleted orphan derived ISVC", "cluster", cluster, "isvc", o.Namespace+"/"+o.Name)
+		}
+	}
+	return nil
+}
+
+// Start runs the periodic sweep until ctx is cancelled. Implements
+// manager.Runnable.
+func (g *GCReconciler) Start(ctx context.Context) error {
+	interval := g.Interval
+	if interval <= 0 {
+		interval = DefaultGCInterval
+	}
+	// Sweep once on startup (APIReader is uncached, so this is safe immediately)
+	// rather than waiting a full interval to reap orphans after a restart.
+	if err := g.sweep(ctx); err != nil {
+		g.Log.Error(err, "gc: initial sweep failed")
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := g.sweep(ctx); err != nil {
+				g.Log.Error(err, "gc: sweep failed")
+			}
+		}
+	}
+}

--- a/pkg/controller/v1beta1/placement/gc_test.go
+++ b/pkg/controller/v1beta1/placement/gc_test.go
@@ -9,7 +9,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
@@ -90,6 +92,43 @@ func TestGCSweep_DeletesOrphansOnly(t *testing.T) {
 	err := worker.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "orphan"}, &v1beta1.InferenceService{})
 	assert.True(t, apierrors.IsNotFound(err), "orphan deleted")
 	require.NoError(t, worker.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "live"}, &v1beta1.InferenceService{}), "live kept")
+}
+
+// The sweep must delete the exact object it classified, not whatever holds that
+// name when the delete lands. A source deleted and recreated under the same name
+// gets a fresh UID, so the placer can have a LIVE derived in place by then; a
+// name-only delete would reap the workload it just placed.
+func TestGCSweep_DeletesByUIDPrecondition(t *testing.T) {
+	s := testScheme(t)
+	cp := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(&v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "live", UID: "uid-live"},
+	}).Build()
+	orphan := derivedWithOrigin("orphan", "uid-gone")
+	orphan.UID = "derived-uid"
+
+	var gotOpts []client.DeleteOption
+	worker := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(orphan).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				gotOpts = opts
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).Build()
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"w": workloadcluster.NewNeverCachingClient(worker),
+	}}
+	gc := &GCReconciler{APIReader: cp, Log: log.Log, Clusters: clusters}
+
+	require.NoError(t, gc.sweep(context.Background()))
+
+	var uid *types.UID
+	for _, o := range gotOpts {
+		if p, ok := o.(client.Preconditions); ok {
+			uid = p.UID
+		}
+	}
+	require.NotNil(t, uid, "orphan delete must carry a UID precondition")
+	assert.Equal(t, types.UID("derived-uid"), *uid)
 }
 
 // An empty control-plane ISVC list (transient/partial/suspect response, or a

--- a/pkg/controller/v1beta1/placement/gc_test.go
+++ b/pkg/controller/v1beta1/placement/gc_test.go
@@ -1,0 +1,144 @@
+package placement
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/workloadcluster"
+)
+
+func derivedWithOrigin(name, originUID string) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "prod", Name: name,
+		Labels:      map[string]string{PlacementOriginLabel: originUID},
+		Annotations: map[string]string{PlacementOriginUIDAnnotation: originUID},
+	}}
+}
+
+// derivedFromControlPlane is like derivedWithOrigin but also stamps the
+// control-plane identity, as a real fan-out would.
+func derivedFromControlPlane(name, originUID, controlPlaneID string) *v1beta1.InferenceService {
+	d := derivedWithOrigin(name, originUID)
+	d.Labels[PlacementControlPlaneLabel] = controlPlaneID
+	return d
+}
+
+func TestOrphanedDeriveds(t *testing.T) {
+	live := map[string]bool{"uid-live": true}
+	withOrigin := func(name, originUID string) metav1.PartialObjectMetadata {
+		return metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+			Namespace: "prod", Name: name,
+			Annotations: map[string]string{PlacementOriginUIDAnnotation: originUID},
+		}}
+	}
+	derived := []metav1.PartialObjectMetadata{
+		withOrigin("a", "uid-live"), // source exists -> keep
+		withOrigin("b", "uid-gone"), // source gone -> orphan
+	}
+	orphans := OrphanedDeriveds(live, "", derived)
+	require.Len(t, orphans, 1)
+	assert.Equal(t, "b", orphans[0].Name)
+}
+
+// With a control-plane id set, OrphanedDeriveds must never
+// classify a derived owned by ANOTHER control plane as an orphan, even when its
+// source UID is absent from this control plane's live set.
+func TestOrphanedDeriveds_ControlPlaneScoped(t *testing.T) {
+	live := map[string]bool{"uid-live": true}
+	withCP := func(name, originUID, cp string) metav1.PartialObjectMetadata {
+		return metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+			Namespace: "prod", Name: name,
+			Labels:      map[string]string{PlacementControlPlaneLabel: cp},
+			Annotations: map[string]string{PlacementOriginUIDAnnotation: originUID},
+		}}
+	}
+	derived := []metav1.PartialObjectMetadata{
+		withCP("mine-orphan", "uid-gone", "cp-east"),   // ours, source gone -> orphan
+		withCP("theirs-orphan", "uid-gone", "cp-west"), // theirs, source gone -> NOT ours
+		withCP("mine-live", "uid-live", "cp-east"),     // ours, source live -> keep
+	}
+	orphans := OrphanedDeriveds(live, "cp-east", derived)
+	require.Len(t, orphans, 1)
+	assert.Equal(t, "mine-orphan", orphans[0].Name, "must not reap another control plane's derived")
+}
+
+func TestGCSweep_DeletesOrphansOnly(t *testing.T) {
+	s := testScheme(t)
+	cp := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(&v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "live", UID: "uid-live"},
+	}).Build()
+	worker := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(
+		derivedWithOrigin("live", "uid-live"),
+		derivedWithOrigin("orphan", "uid-gone"),
+	).Build()
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"w": workloadcluster.NewNeverCachingClient(worker),
+	}}
+	gc := &GCReconciler{APIReader: cp, Log: log.Log, Clusters: clusters}
+
+	require.NoError(t, gc.sweep(context.Background()))
+
+	err := worker.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "orphan"}, &v1beta1.InferenceService{})
+	assert.True(t, apierrors.IsNotFound(err), "orphan deleted")
+	require.NoError(t, worker.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "live"}, &v1beta1.InferenceService{}), "live kept")
+}
+
+// An empty control-plane ISVC list (transient/partial/suspect response, or a
+// genuinely-empty control plane) must NOT cause the sweep to reap every
+// derived: an empty live set is treated as suspect, not authoritative.
+func TestGCSweep_EmptyLiveSet_NoDeletes(t *testing.T) {
+	s := testScheme(t)
+	// Control plane has NO ISVCs -> live set is empty.
+	cp := fakeclient.NewClientBuilder().WithScheme(s).Build()
+	worker := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(
+		derivedWithOrigin("a", "uid-1"),
+		derivedWithOrigin("b", "uid-2"),
+	).Build()
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"w": workloadcluster.NewNeverCachingClient(worker),
+	}}
+	gc := &GCReconciler{APIReader: cp, Log: log.Log, Clusters: clusters}
+
+	require.NoError(t, gc.sweep(context.Background()))
+
+	// Both deriveds must survive: an empty live set is suspect, not authoritative.
+	require.NoError(t, worker.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "a"}, &v1beta1.InferenceService{}), "a kept")
+	require.NoError(t, worker.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "b"}, &v1beta1.InferenceService{}), "b kept")
+}
+
+// Two control planes sharing a workload cluster: each GC, scoped by its own
+// ControlPlaneID, must reap ONLY its own orphans and never the other's
+// deriveds — without the scoping, cp-east would reap cp-west's live derived
+// because its source UID is not in cp-east's live set.
+func TestGCSweep_ControlPlaneScoped_DoesNotReapOthers(t *testing.T) {
+	s := testScheme(t)
+	// cp-east's control plane: source "east-live" is live; "east-gone" is gone.
+	cp := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(&v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "east-live", UID: "uid-east-live"},
+	}).Build()
+	worker := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(
+		derivedFromControlPlane("east-live", "uid-east-live", "cp-east"), // ours, live -> keep
+		derivedFromControlPlane("east-gone", "uid-east-gone", "cp-east"), // ours, gone -> reap
+		derivedFromControlPlane("west-svc", "uid-west", "cp-west"),       // theirs -> never touch
+	).Build()
+	clusters := fakeClusters{m: map[string]workloadcluster.SelectivelyCachingClient{
+		"shared": workloadcluster.NewNeverCachingClient(worker),
+	}}
+	gc := &GCReconciler{APIReader: cp, Log: log.Log, Clusters: clusters, ControlPlaneID: "cp-east"}
+
+	require.NoError(t, gc.sweep(context.Background()))
+
+	require.NoError(t, worker.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "east-live"}, &v1beta1.InferenceService{}), "our live derived kept")
+	gerr := worker.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "east-gone"}, &v1beta1.InferenceService{})
+	assert.True(t, apierrors.IsNotFound(gerr), "our orphan reaped")
+	require.NoError(t, worker.Get(context.Background(), types.NamespacedName{Namespace: "prod", Name: "west-svc"}, &v1beta1.InferenceService{}), "other control plane's derived untouched")
+}

--- a/pkg/controller/v1beta1/placement/match.go
+++ b/pkg/controller/v1beta1/placement/match.go
@@ -1,0 +1,107 @@
+package placement
+
+import (
+	"sort"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// MatchReason explains why MatchCandidates produced an empty candidate set, so
+// the caller can surface an actionable status instead of an indistinguishable
+// nil. It is "" when at least one candidate matched.
+type MatchReason string
+
+const (
+	// MatchReasonNoRequirements: the ISVC declared no accelerator/capability
+	// requirements at all. Candidates are the clusters whose
+	// labels SATISFY the ISVC's requirements; with no requirements there is
+	// nothing to satisfy, so we deliberately match NOTHING rather than fan out
+	// to every Ready cluster (the unsafe default this guards against).
+	MatchReasonNoRequirements MatchReason = "NoRequirements"
+	// MatchReasonMalformedSelector: a requirement selector failed to parse.
+	MatchReasonMalformedSelector MatchReason = "MalformedSelector"
+	// MatchReasonNoReadyClusters: requirements were declared but no Ready
+	// WorkloadCluster exists at all.
+	MatchReasonNoReadyClusters MatchReason = "NoReadyClusters"
+	// MatchReasonNoMatch: Ready clusters exist but none satisfy the requirements.
+	MatchReasonNoMatch MatchReason = "NoMatch"
+)
+
+// requirementSelector builds the AND-combined label selector an ISVC's candidate
+// clusters must satisfy: the accelerator/capability requirements
+// (AcceleratorRequirementsAnnotation) intersected with the optional
+// operator-imposed cluster-selector (ClusterSelectorAnnotation). hasReq reports
+// whether the ISVC expressed ANY requirement; an ISVC with no requirement is NOT
+// fanned out fleet-wide (see MatchReasonNoRequirements).
+func requirementSelector(isvc *v1beta1.InferenceService) (sel labels.Selector, hasReq bool, err error) {
+	requirements, clusterSelector := placementInputs(isvc)
+	sel = labels.Everything()
+	for _, raw := range []string{requirements, clusterSelector} {
+		if raw == "" {
+			continue
+		}
+		parsed, perr := labels.Parse(raw)
+		if perr != nil {
+			return nil, false, perr
+		}
+		reqs, _ := parsed.Requirements()
+		sel = sel.Add(reqs...)
+		hasReq = true
+	}
+	return sel, hasReq, nil
+}
+
+// placementInputs returns the (requirements, clusterSelector) label-selector
+// strings for an ISVC, preferring the structured spec.placement over the legacy
+// ome.io/accelerator-requirements and ome.io/cluster-selector annotations. The
+// struct wins WHOLESALE when present (no per-field merge with the annotations),
+// so an ISVC that sets spec.placement is described entirely by it. When
+// spec.placement is nil the annotations remain authoritative.
+func placementInputs(isvc *v1beta1.InferenceService) (requirements, clusterSelector string) {
+	if p := isvc.Spec.Placement; p != nil {
+		return p.Requirements, p.ClusterSelector
+	}
+	return isvc.Annotations[AcceleratorRequirementsAnnotation], isvc.Annotations[ClusterSelectorAnnotation]
+}
+
+// MatchCandidates returns the names (sorted) of Ready WorkloadClusters whose
+// capability labels satisfy the ISVC's accelerator/capability requirements
+// (candidate selection). The requirements are the AND of the ISVC's
+// accelerator-requirements annotation and the optional cluster-selector
+// annotation. An ISVC that declares NO requirement matches NO cluster (it is not
+// fanned out fleet-wide). When the result is empty, the returned MatchReason
+// explains why; err is non-nil only for a malformed selector.
+func MatchCandidates(isvc *v1beta1.InferenceService, clusters []v1beta1.WorkloadCluster) ([]string, MatchReason, error) {
+	sel, hasReq, err := requirementSelector(isvc)
+	if err != nil {
+		return nil, MatchReasonMalformedSelector, err
+	}
+	if !hasReq {
+		return nil, MatchReasonNoRequirements, nil
+	}
+
+	var ready int
+	var out []string
+	for i := range clusters {
+		c := &clusters[i]
+		if !apimeta.IsStatusConditionTrue(c.Status.Conditions, v1beta1.WorkloadClusterReady) {
+			continue
+		}
+		ready++
+		if sel.Matches(labels.Set(c.Labels)) {
+			out = append(out, c.Name)
+		}
+	}
+	sort.Strings(out)
+	switch {
+	case len(out) > 0:
+		return out, "", nil
+	case ready == 0:
+		return nil, MatchReasonNoReadyClusters, nil
+	default:
+		return nil, MatchReasonNoMatch, nil
+	}
+}

--- a/pkg/controller/v1beta1/placement/match_test.go
+++ b/pkg/controller/v1beta1/placement/match_test.go
@@ -1,0 +1,162 @@
+package placement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func wc(name string, ready bool, labels map[string]string) v1beta1.WorkloadCluster {
+	st := metav1.ConditionFalse
+	if ready {
+		st = metav1.ConditionTrue
+	}
+	return v1beta1.WorkloadCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Status: v1beta1.WorkloadClusterStatus{Conditions: []metav1.Condition{
+			{Type: v1beta1.WorkloadClusterReady, Status: st, Reason: "x"},
+		}},
+	}
+}
+
+// isvcReq builds a source ISVC whose accelerator requirement / cluster selector
+// annotations drive candidate matching.
+func isvcReq(accel, selector string) *v1beta1.InferenceService {
+	ann := map[string]string{}
+	if accel != "" {
+		ann[AcceleratorRequirementsAnnotation] = accel
+	}
+	if selector != "" {
+		ann[ClusterSelectorAnnotation] = selector
+	}
+	return &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod", Annotations: ann}}
+}
+
+func TestMatchCandidates(t *testing.T) {
+	clusters := []v1beta1.WorkloadCluster{
+		wc("cluster-a", true, map[string]string{"gpu": "gb300", "provider": "prov-a"}),
+		wc("cluster-b", true, map[string]string{"gpu": "gb300", "provider": "prov-b"}),
+		wc("cluster-a-h100", true, map[string]string{"gpu": "h100", "provider": "prov-a"}),
+		wc("cluster-a-down", false, map[string]string{"gpu": "gb300", "provider": "prov-a"}),
+	}
+
+	// accelerator requirement "gpu=gb300" -> the two Ready gb300 clusters, sorted.
+	got, reason, err := MatchCandidates(isvcReq("gpu=gb300", ""), clusters)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"cluster-a", "cluster-b"}, got)
+	assert.Equal(t, MatchReason(""), reason)
+
+	// accelerator requirement AND-ed with cluster-selector.
+	got, _, err = MatchCandidates(isvcReq("gpu=gb300", "provider=prov-a"), clusters)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"cluster-a"}, got)
+
+	// cluster-selector alone is a sufficient requirement (counts as a requirement).
+	got, _, err = MatchCandidates(isvcReq("", "gpu=gb300,provider=prov-b"), clusters)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"cluster-b"}, got)
+
+	// Guard: an ISVC with NO requirement must NOT fan out to every
+	// Ready cluster — it matches NOTHING with reason NoRequirements.
+	got, reason, err = MatchCandidates(isvcReq("", ""), clusters)
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, MatchReasonNoRequirements, reason)
+
+	// requirements declared but nothing satisfies them.
+	got, reason, err = MatchCandidates(isvcReq("gpu=mi300x", ""), clusters)
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, MatchReasonNoMatch, reason)
+
+	// requirements declared but no Ready clusters at all.
+	got, reason, err = MatchCandidates(isvcReq("gpu=gb300", ""), []v1beta1.WorkloadCluster{
+		wc("cluster-a-down", false, map[string]string{"gpu": "gb300"}),
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, MatchReasonNoReadyClusters, reason)
+
+	// malformed selector -> error + MalformedSelector reason.
+	_, reason, err = MatchCandidates(isvcReq("!!!", ""), clusters)
+	assert.Error(t, err)
+	assert.Equal(t, MatchReasonMalformedSelector, reason)
+}
+
+// isvcPlacement builds a source ISVC whose candidate matching is driven by the
+// structured spec.placement field rather than annotations.
+func isvcPlacement(p *v1beta1.PlacementSpec) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "prod"},
+		Spec:       v1beta1.InferenceServiceSpec{Placement: p},
+	}
+}
+
+// TestMatchCandidates_PlacementSpec covers the structured-field path and its
+// precedence over the legacy annotations.
+func TestMatchCandidates_PlacementSpec(t *testing.T) {
+	clusters := []v1beta1.WorkloadCluster{
+		wc("cluster-a", true, map[string]string{"gpu": "gb300", "provider": "prov-a"}),
+		wc("cluster-b", true, map[string]string{"gpu": "gb300", "provider": "prov-b"}),
+	}
+
+	// spec.placement.requirements drives matching.
+	got, reason, err := MatchCandidates(isvcPlacement(&v1beta1.PlacementSpec{Requirements: "gpu=gb300"}), clusters)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"cluster-a", "cluster-b"}, got)
+	assert.Equal(t, MatchReason(""), reason)
+
+	// requirements AND clusterSelector, both from the struct.
+	got, _, err = MatchCandidates(isvcPlacement(&v1beta1.PlacementSpec{
+		Requirements: "gpu=gb300", ClusterSelector: "provider=prov-b",
+	}), clusters)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"cluster-b"}, got)
+
+	// clusterSelector alone in the struct is a sufficient requirement.
+	got, _, err = MatchCandidates(isvcPlacement(&v1beta1.PlacementSpec{ClusterSelector: "provider=prov-a"}), clusters)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"cluster-a"}, got)
+
+	// empty spec.placement (mode only) declares no requirement -> no fan-out.
+	_, reason, err = MatchCandidates(isvcPlacement(&v1beta1.PlacementSpec{Mode: v1beta1.PlacementModeSingle}), clusters)
+	assert.NoError(t, err)
+	assert.Equal(t, MatchReasonNoRequirements, reason)
+
+	// malformed selector in the struct surfaces as MalformedSelector.
+	_, reason, err = MatchCandidates(isvcPlacement(&v1beta1.PlacementSpec{Requirements: "!!!"}), clusters)
+	assert.Error(t, err)
+	assert.Equal(t, MatchReasonMalformedSelector, reason)
+}
+
+// TestPlacementInputs_StructWinsOverAnnotations verifies the struct is used
+// WHOLESALE when present: annotations are ignored entirely, not merged.
+func TestPlacementInputs_StructWinsOverAnnotations(t *testing.T) {
+	isvc := isvcPlacement(&v1beta1.PlacementSpec{Requirements: "gpu=gb300"})
+	isvc.Annotations = map[string]string{
+		AcceleratorRequirementsAnnotation: "gpu=h100",
+		ClusterSelectorAnnotation:         "provider=prov-a",
+	}
+	req, sel := placementInputs(isvc)
+	assert.Equal(t, "gpu=gb300", req, "struct requirements win over annotation")
+	assert.Equal(t, "", sel, "struct clusterSelector (empty) wins; annotation ignored")
+
+	// nil placement falls back to annotations.
+	isvc.Spec.Placement = nil
+	req, sel = placementInputs(isvc)
+	assert.Equal(t, "gpu=h100", req)
+	assert.Equal(t, "provider=prov-a", sel)
+}
+
+// TestDeclaresPlacementRequirement_StructAndAnnotations covers the field-index
+// eligibility predicate over both input sources.
+func TestDeclaresPlacementRequirement_StructAndAnnotations(t *testing.T) {
+	assert.True(t, declaresPlacementRequirement(isvcPlacement(&v1beta1.PlacementSpec{Requirements: "gpu=gb300"})))
+	assert.True(t, declaresPlacementRequirement(isvcPlacement(&v1beta1.PlacementSpec{ClusterSelector: "provider=prov-a"})))
+	assert.False(t, declaresPlacementRequirement(isvcPlacement(&v1beta1.PlacementSpec{Mode: v1beta1.PlacementModeAll})))
+	assert.False(t, declaresPlacementRequirement(isvcPlacement(nil)))
+	assert.True(t, declaresPlacementRequirement(isvcReq("gpu=gb300", "")))
+}

--- a/pkg/controller/v1beta1/placement/predicate_test.go
+++ b/pkg/controller/v1beta1/placement/predicate_test.go
@@ -1,0 +1,52 @@
+package placement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func wcWithReady(status metav1.ConditionStatus, labels map[string]string) *v1beta1.WorkloadCluster {
+	return &v1beta1.WorkloadCluster{
+		ObjectMeta: metav1.ObjectMeta{Labels: labels},
+		Status: v1beta1.WorkloadClusterStatus{
+			Conditions: []metav1.Condition{{Type: v1beta1.WorkloadClusterReady, Status: status}},
+		},
+	}
+}
+
+// Routine status heartbeats (Ready unchanged, labels unchanged) must NOT
+// re-enqueue ISVCs — this is the fan-out the predicate exists to suppress.
+func TestPlacementRelevantClusterChange_DropsHeartbeat(t *testing.T) {
+	wc := wcWithReady(metav1.ConditionTrue, map[string]string{"region": "region-a"})
+	// Same readiness + labels, a fresh re-stamp of the Ready condition (new
+	// LastTransitionTime / resourceVersion the heartbeat would carry).
+	updated := wcWithReady(metav1.ConditionTrue, map[string]string{"region": "region-a"})
+	assert.False(t, placementRelevantClusterChange.Update(event.UpdateEvent{ObjectOld: wc, ObjectNew: updated}))
+}
+
+// A readiness flip changes placement candidacy and MUST re-enqueue.
+func TestPlacementRelevantClusterChange_ReadyFlip(t *testing.T) {
+	old := wcWithReady(metav1.ConditionTrue, nil)
+	updated := wcWithReady(metav1.ConditionFalse, nil)
+	assert.True(t, placementRelevantClusterChange.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}))
+	assert.True(t, placementRelevantClusterChange.Update(event.UpdateEvent{ObjectOld: updated, ObjectNew: old}))
+}
+
+// A label change can change which clusters a selector matches and MUST re-enqueue.
+func TestPlacementRelevantClusterChange_LabelChange(t *testing.T) {
+	old := wcWithReady(metav1.ConditionTrue, map[string]string{"region": "region-a"})
+	updated := wcWithReady(metav1.ConditionTrue, map[string]string{"region": "region-b"})
+	assert.True(t, placementRelevantClusterChange.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}))
+}
+
+// Create/Delete (capacity appears/disappears) always re-enqueue.
+func TestPlacementRelevantClusterChange_CreateDelete(t *testing.T) {
+	wc := wcWithReady(metav1.ConditionTrue, nil)
+	assert.True(t, placementRelevantClusterChange.Create(event.CreateEvent{Object: wc}))
+	assert.True(t, placementRelevantClusterChange.Delete(event.DeleteEvent{Object: wc}))
+}

--- a/pkg/controller/v1beta1/placement/statusconverge.go
+++ b/pkg/controller/v1beta1/placement/statusconverge.go
@@ -1,0 +1,168 @@
+package placement
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/workloadcluster"
+)
+
+// DefaultStatusSafetyRequeue is the fallback steady-state re-read backstop. It
+// is NOT the convergence latency (the funnel re-reconciles on events) — only the
+// backstop for a missed event (dropped under a full channel, a watch gap).
+// Config-driven; this is the graceful-degradation default.
+const DefaultStatusSafetyRequeue = 10 * time.Minute
+
+// DefaultStatusBatchPeriod is the fallback debounce folding a burst of funnel
+// events for one ISVC into a single reconcile. Config-driven; graceful default.
+const DefaultStatusBatchPeriod = 1 * time.Second
+
+// convergeConfig is the resolved status-convergence configuration assembled from
+// functional Options at SetupWithManager. Every field has a
+// graceful-degradation default applied by resolveConvergeConfig so an unset
+// option never injects a magic literal mid-package.
+type convergeConfig struct {
+	// statusEvents is the remote watch-funnel channel feeding event-driven
+	// convergence. Nil leaves the controller poll-only (it still re-reconciles on
+	// the safety requeue), so the funnel is an optimization, not a dependency.
+	statusEvents <-chan event.GenericEvent
+	// batchPeriod debounces funnel events before they enqueue a reconcile.
+	batchPeriod time.Duration
+	// safetyRequeue is the long steady-state re-read backstop for the
+	// status-convergence path.
+	safetyRequeue time.Duration
+}
+
+// ConvergeOption mutates the status-convergence configuration at
+// SetupWithManager. Functional options keep the funnel channel and the timing
+// knobs injectable so tests can wire a fake channel and shrink the batch/safety
+// windows from minutes to milliseconds without touching package state.
+type ConvergeOption func(*convergeConfig)
+
+// WithStatusEvents wires the remote watch-funnel channel the controller consumes
+// via source.Channel. Without it the controller is poll-only (safety requeue).
+func WithStatusEvents(ch <-chan event.GenericEvent) ConvergeOption {
+	return func(c *convergeConfig) { c.statusEvents = ch }
+}
+
+// WithStatusBatchPeriod overrides the funnel-event debounce window. A
+// non-positive value falls back to DefaultStatusBatchPeriod.
+func WithStatusBatchPeriod(d time.Duration) ConvergeOption {
+	return func(c *convergeConfig) { c.batchPeriod = d }
+}
+
+// WithStatusSafetyRequeue overrides the long steady-state re-read backstop. A
+// non-positive value falls back to DefaultStatusSafetyRequeue.
+func WithStatusSafetyRequeue(d time.Duration) ConvergeOption {
+	return func(c *convergeConfig) { c.safetyRequeue = d }
+}
+
+// resolveConvergeConfig builds the convergeConfig from options, then fills any
+// still-unset timing field with its graceful-degradation default.
+func resolveConvergeConfig(opts ...ConvergeOption) convergeConfig {
+	c := convergeConfig{}
+	for _, o := range opts {
+		o(&c)
+	}
+	if c.batchPeriod <= 0 {
+		c.batchPeriod = DefaultStatusBatchPeriod
+	}
+	if c.safetyRequeue <= 0 {
+		c.safetyRequeue = DefaultStatusSafetyRequeue
+	}
+	return c
+}
+
+// safetyRequeue returns the long steady-state re-read backstop for the
+// status-convergence path. Falls back to the seeded Reconciler.Requeue (legacy
+// poll cadence) when SetupWithManager has not resolved a convergeConfig (e.g.
+// unit tests building the Reconciler directly), so the existing struct-field API
+// keeps working; absent both, the package default applies.
+func (r *Reconciler) safetyRequeue() time.Duration {
+	if r.converge != nil && r.converge.safetyRequeue > 0 {
+		return r.converge.safetyRequeue
+	}
+	if r.Requeue > 0 {
+		return r.Requeue
+	}
+	return DefaultStatusSafetyRequeue
+}
+
+// localKeyForDerived resolves a remote derived InferenceService delivered by a
+// workload-cluster informer to the LOCAL (control-plane) source ISVC key, and
+// reports whether it is a derived this control plane owns. A derived shares its
+// source's namespace/name (placeOn preserves identity) and carries the
+// placement-origin marker; when a control-plane identity is configured the
+// control-plane label must also match, so one control plane never re-reconciles
+// off another's deriveds on a shared workload cluster. An object lacking the
+// origin marker (a user's same-named ISVC) is rejected (ok=false).
+//
+// controlPlaneID is the operative control-plane identity (config-driven). The
+// empty value disables the control-plane-label check (single-control-plane
+// behavior) but still requires the origin marker — a blank marker never matches.
+func localKeyForDerived(remote client.Object, controlPlaneID string) (types.NamespacedName, bool) {
+	if remote == nil {
+		return types.NamespacedName{}, false
+	}
+	lbls := remote.GetLabels()
+	anns := remote.GetAnnotations()
+	// Require the origin marker (label or annotation), non-empty: this is what
+	// distinguishes a copy WE derived from a same-named user ISVC.
+	if lbls[PlacementOriginLabel] == "" && anns[PlacementOriginUIDAnnotation] == "" {
+		return types.NamespacedName{}, false
+	}
+	// Ownership scoping: when this control plane has an identity, only react to
+	// deriveds it stamped. An unstamped derived under a configured identity is
+	// another control plane's (or pre-dates the stamp) — not ours to converge.
+	if controlPlaneID != "" && lbls[PlacementControlPlaneLabel] != controlPlaneID {
+		return types.NamespacedName{}, false
+	}
+	return types.NamespacedName{Namespace: remote.GetNamespace(), Name: remote.GetName()}, true
+}
+
+// originWatchSelector builds the label selector that scopes the funnel's
+// establish-watch to this control plane's derived ISVCs: the origin label must
+// exist, and (when an identity is configured) the control-plane label must equal
+// it. It keeps the remote apiserver from streaming derived objects this control
+// plane does not own. Returns labels.Everything() only if the requirements
+// cannot be constructed (never expected) so the watch still functions.
+func originWatchSelector(controlPlaneID string) labels.Selector {
+	sel := labels.NewSelector()
+	originExists, err := labels.NewRequirement(PlacementOriginLabel, selection.Exists, nil)
+	if err != nil {
+		return labels.Everything()
+	}
+	sel = sel.Add(*originExists)
+	if controlPlaneID != "" {
+		cp, err := labels.NewRequirement(PlacementControlPlaneLabel, selection.Equals, []string{controlPlaneID})
+		if err != nil {
+			return sel
+		}
+		sel = sel.Add(*cp)
+	}
+	return sel
+}
+
+// FunnelConfigFor builds the workloadcluster.FunnelConfig for the cross-cluster
+// status watch funnel: the watched kind is the derived InferenceService, the
+// watch is scoped to this control plane's deriveds, and each remote event is
+// resolved to the local source key. cmd wiring passes the result to
+// workloadcluster.NewStatusFunnel; the funnel never imports placement, so the
+// origin/control-plane label semantics live here. batchPeriod/safetyRequeue
+// timing stays on the controller side — this configures only the funnel.
+func FunnelConfigFor(controlPlaneID string) workloadcluster.FunnelConfig {
+	return workloadcluster.FunnelConfig{
+		NewList:   func() client.ObjectList { return &v1beta1.InferenceServiceList{} },
+		NewObject: func() client.Object { return &v1beta1.InferenceService{} },
+		Resolve: func(remote client.Object) (types.NamespacedName, bool) {
+			return localKeyForDerived(remote, controlPlaneID)
+		},
+		WatchSelector: originWatchSelector(controlPlaneID),
+	}
+}

--- a/pkg/controller/v1beta1/placement/statusconverge_test.go
+++ b/pkg/controller/v1beta1/placement/statusconverge_test.go
@@ -1,0 +1,310 @@
+package placement
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+const testControlPlaneID = "cp-alpha"
+
+// derivedISVC builds a remote derived InferenceService carrying the given origin
+// and control-plane markers, for the resolver tests.
+func derivedISVC(ns, name, originUID, controlPlane string, originViaAnnotation bool) *v1beta1.InferenceService {
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   ns,
+			Name:        name,
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+	}
+	if originUID != "" {
+		if originViaAnnotation {
+			isvc.Annotations[PlacementOriginUIDAnnotation] = originUID
+		} else {
+			isvc.Labels[PlacementOriginLabel] = originUID
+		}
+	}
+	if controlPlane != "" {
+		isvc.Labels[PlacementControlPlaneLabel] = controlPlane
+	}
+	return isvc
+}
+
+func TestLocalKeyForDerived(t *testing.T) {
+	cases := []struct {
+		name           string
+		obj            *v1beta1.InferenceService
+		controlPlaneID string
+		wantOK         bool
+		wantNS         string
+		wantName       string
+	}{
+		{
+			name:           "origin label, no control-plane filter",
+			obj:            derivedISVC("team-a", "llama", "uid-1", "", false),
+			controlPlaneID: "",
+			wantOK:         true, wantNS: "team-a", wantName: "llama",
+		},
+		{
+			name:           "origin via annotation only",
+			obj:            derivedISVC("team-a", "llama", "uid-1", "", true),
+			controlPlaneID: "",
+			wantOK:         true, wantNS: "team-a", wantName: "llama",
+		},
+		{
+			name:           "origin label + matching control plane",
+			obj:            derivedISVC("team-b", "qwen", "uid-2", testControlPlaneID, false),
+			controlPlaneID: testControlPlaneID,
+			wantOK:         true, wantNS: "team-b", wantName: "qwen",
+		},
+		{
+			name:           "no origin marker is rejected (user's same-named ISVC)",
+			obj:            derivedISVC("team-a", "llama", "", "", false),
+			controlPlaneID: "",
+			wantOK:         false,
+		},
+		{
+			name:           "control-plane mismatch is rejected (another CP's derived)",
+			obj:            derivedISVC("team-b", "qwen", "uid-2", "cp-beta", false),
+			controlPlaneID: testControlPlaneID,
+			wantOK:         false,
+		},
+		{
+			name:           "origin present but control-plane label missing under configured id is rejected",
+			obj:            derivedISVC("team-b", "qwen", "uid-2", "", false),
+			controlPlaneID: testControlPlaneID,
+			wantOK:         false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, ok := localKeyForDerived(tc.obj, tc.controlPlaneID)
+			if ok != tc.wantOK {
+				t.Fatalf("localKeyForDerived ok=%v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if key.Namespace != tc.wantNS || key.Name != tc.wantName {
+				t.Errorf("localKeyForDerived key=%v, want %s/%s", key, tc.wantNS, tc.wantName)
+			}
+		})
+	}
+}
+
+// TestLocalKeyForDerived_NilObject: a nil object must be rejected, never panic.
+func TestLocalKeyForDerived_NilObject(t *testing.T) {
+	if _, ok := localKeyForDerived(nil, ""); ok {
+		t.Errorf("localKeyForDerived(nil) ok=true, want false")
+	}
+}
+
+// TestOriginWatchSelector_Matches: the watch selector must match a derived this
+// control plane owns and reject one it does not, so the remote apiserver streams
+// only our objects.
+func TestOriginWatchSelector_Matches(t *testing.T) {
+	cases := []struct {
+		name           string
+		controlPlaneID string
+		objLabels      map[string]string
+		want           bool
+	}{
+		{
+			name:           "no id: origin label present matches",
+			controlPlaneID: "",
+			objLabels:      map[string]string{PlacementOriginLabel: "uid-1"},
+			want:           true,
+		},
+		{
+			name:           "no id: missing origin label does not match",
+			controlPlaneID: "",
+			objLabels:      map[string]string{},
+			want:           false,
+		},
+		{
+			name:           "with id: origin + matching control plane matches",
+			controlPlaneID: testControlPlaneID,
+			objLabels:      map[string]string{PlacementOriginLabel: "uid-1", PlacementControlPlaneLabel: testControlPlaneID},
+			want:           true,
+		},
+		{
+			name:           "with id: origin but wrong control plane does not match",
+			controlPlaneID: testControlPlaneID,
+			objLabels:      map[string]string{PlacementOriginLabel: "uid-1", PlacementControlPlaneLabel: "cp-beta"},
+			want:           false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sel := originWatchSelector(tc.controlPlaneID)
+			if got := sel.Matches(labels.Set(tc.objLabels)); got != tc.want {
+				t.Errorf("originWatchSelector(%q).Matches(%v) = %v, want %v", tc.controlPlaneID, tc.objLabels, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFunnelConfigFor(t *testing.T) {
+	cfg := FunnelConfigFor(testControlPlaneID)
+	if cfg.NewList == nil || cfg.NewObject == nil || cfg.Resolve == nil || cfg.WatchSelector == nil {
+		t.Fatalf("FunnelConfigFor returned an incomplete config: %+v", cfg)
+	}
+	if _, isList := cfg.NewList().(*v1beta1.InferenceServiceList); !isList {
+		t.Errorf("NewList did not return an InferenceServiceList")
+	}
+	if _, isObj := cfg.NewObject().(*v1beta1.InferenceService); !isObj {
+		t.Errorf("NewObject did not return an InferenceService")
+	}
+	// Resolve must honor the bound control-plane id.
+	owned := derivedISVC("t", "m", "uid-9", testControlPlaneID, false)
+	if key, ok := cfg.Resolve(owned); !ok || key.Name != "m" {
+		t.Errorf("Resolve(owned) = %v,%v; want t/m,true", key, ok)
+	}
+	foreign := derivedISVC("t", "m", "uid-9", "cp-other", false)
+	if _, ok := cfg.Resolve(foreign); ok {
+		t.Errorf("Resolve(foreign derived) ok=true, want false")
+	}
+}
+
+// TestResolveConvergeConfig_Defaults: unset timing options fall back to the
+// package defaults; supplied options win.
+func TestResolveConvergeConfig_Defaults(t *testing.T) {
+	def := resolveConvergeConfig()
+	if def.batchPeriod != DefaultStatusBatchPeriod {
+		t.Errorf("default batchPeriod = %v, want %v", def.batchPeriod, DefaultStatusBatchPeriod)
+	}
+	if def.safetyRequeue != DefaultStatusSafetyRequeue {
+		t.Errorf("default safetyRequeue = %v, want %v", def.safetyRequeue, DefaultStatusSafetyRequeue)
+	}
+	if def.statusEvents != nil {
+		t.Errorf("default statusEvents = non-nil, want nil")
+	}
+
+	ch := make(chan event.GenericEvent)
+	got := resolveConvergeConfig(
+		WithStatusEvents(ch),
+		WithStatusBatchPeriod(7*time.Millisecond),
+		WithStatusSafetyRequeue(42*time.Second),
+	)
+	if got.batchPeriod != 7*time.Millisecond {
+		t.Errorf("batchPeriod = %v, want 7ms", got.batchPeriod)
+	}
+	if got.safetyRequeue != 42*time.Second {
+		t.Errorf("safetyRequeue = %v, want 42s", got.safetyRequeue)
+	}
+	if got.statusEvents == nil {
+		t.Errorf("statusEvents = nil, want the wired channel")
+	}
+}
+
+// TestSafetyRequeue_FallbackChain: with no convergeConfig, the safety requeue
+// honors the seeded Requeue struct field, then the package default.
+func TestSafetyRequeue_FallbackChain(t *testing.T) {
+	// No config, no struct field: package default.
+	r := &Reconciler{}
+	if got := r.safetyRequeue(); got != DefaultStatusSafetyRequeue {
+		t.Errorf("safetyRequeue() with nothing set = %v, want %v", got, DefaultStatusSafetyRequeue)
+	}
+	// No config, struct field set: struct field wins (legacy API compatibility).
+	r2 := &Reconciler{Requeue: 17 * time.Second}
+	if got := r2.safetyRequeue(); got != 17*time.Second {
+		t.Errorf("safetyRequeue() with Requeue set = %v, want 17s", got)
+	}
+	// Resolved config wins over the struct field.
+	cfg := resolveConvergeConfig(WithStatusSafetyRequeue(99 * time.Second))
+	r3 := &Reconciler{Requeue: 17 * time.Second, converge: &cfg}
+	if got := r3.safetyRequeue(); got != 99*time.Second {
+		t.Errorf("safetyRequeue() with config = %v, want 99s", got)
+	}
+}
+
+// recordingQueue captures Add / AddAfter calls. Only those two methods are
+// exercised by statusEventHandler, so the embedded (nil) interface is never
+// dereferenced — same idiom as the stub clients elsewhere in this tree.
+type recordingQueue struct {
+	workqueue.TypedRateLimitingInterface[ctrl.Request]
+	added      []ctrl.Request
+	addedAfter map[ctrl.Request]time.Duration
+}
+
+func newRecordingQueue() *recordingQueue {
+	return &recordingQueue{addedAfter: map[ctrl.Request]time.Duration{}}
+}
+
+func (q *recordingQueue) Add(item ctrl.Request) {
+	q.added = append(q.added, item)
+}
+
+func (q *recordingQueue) AddAfter(item ctrl.Request, d time.Duration) {
+	q.addedAfter[item] = d
+}
+
+// TestStatusEventHandler_BatchesWithAddAfter: a funnel event enqueues the local
+// key via AddAfter with the configured batch period (debounce), NOT an immediate
+// Add, so a burst of derived-status updates folds into one reconcile.
+func TestStatusEventHandler_BatchesWithAddAfter(t *testing.T) {
+	r := &Reconciler{}
+	const batch = 250 * time.Millisecond
+	h := r.statusEventHandler(batch)
+
+	q := newRecordingQueue()
+	ev := event.GenericEvent{Object: &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "llama"},
+	}}
+	h.Generic(context.Background(), ev, q)
+
+	if len(q.added) != 0 {
+		t.Errorf("expected no immediate Add when batching, got %v", q.added)
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "team-a", Name: "llama"}}
+	got, ok := q.addedAfter[req]
+	if !ok {
+		t.Fatalf("expected AddAfter for %v, got %v", req, q.addedAfter)
+	}
+	if got != batch {
+		t.Errorf("AddAfter delay = %v, want %v", got, batch)
+	}
+}
+
+// TestStatusEventHandler_ImmediateWhenNoBatch: a zero batch period enqueues
+// immediately via Add (no debounce).
+func TestStatusEventHandler_ImmediateWhenNoBatch(t *testing.T) {
+	r := &Reconciler{}
+	h := r.statusEventHandler(0)
+
+	q := newRecordingQueue()
+	ev := event.GenericEvent{Object: &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "llama"},
+	}}
+	h.Generic(context.Background(), ev, q)
+
+	if len(q.addedAfter) != 0 {
+		t.Errorf("expected no AddAfter when batch=0, got %v", q.addedAfter)
+	}
+	if len(q.added) != 1 || q.added[0].Namespace != "team-a" || q.added[0].Name != "llama" {
+		t.Errorf("expected immediate Add of team-a/llama, got %v", q.added)
+	}
+}
+
+// TestStatusEventHandler_NilObject: a malformed event with no object must be
+// dropped, never panic or enqueue an empty key.
+func TestStatusEventHandler_NilObject(t *testing.T) {
+	r := &Reconciler{}
+	h := r.statusEventHandler(time.Second)
+	q := newRecordingQueue()
+	h.Generic(context.Background(), event.GenericEvent{}, q)
+	if len(q.added) != 0 || len(q.addedAfter) != 0 {
+		t.Errorf("nil-object event must not enqueue; added=%v addedAfter=%v", q.added, q.addedAfter)
+	}
+}

--- a/pkg/controller/v1beta1/placement/wiring_test.go
+++ b/pkg/controller/v1beta1/placement/wiring_test.go
@@ -1,0 +1,22 @@
+package placement
+
+// validateWiring is the composition-root guard: production setup must
+// fail fast when the live reader is missing instead of silently
+// degrading every conflict-retry read to the lagging cache.
+
+import (
+	"testing"
+
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestValidateWiring(t *testing.T) {
+	r := &Reconciler{}
+	if err := r.validateWiring(); err == nil {
+		t.Fatal("nil APIReader must be rejected at setup")
+	}
+	r.APIReader = fakeclient.NewClientBuilder().Build()
+	if err := r.validateWiring(); err != nil {
+		t.Fatalf("wired APIReader must pass: %v", err)
+	}
+}


### PR DESCRIPTION
**Part 3 of 5** — depends on #726 and Part 2 (WorkloadCluster).

Adds the control-plane placement controller: fans a source ISVC out to member clusters as derived ISVCs (Single/All/Split modes), treats Kueue admission as the capacity signal, races winners, re-homes and sweeps losers, and converges derived status back to the source. Includes the endpoint publisher that programs a global HTTPRoute to the placement winner via the Gateway API.

> Squash-only repo: diff includes Parts 1–2 until they merge; rebased after each.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added multi-cluster InferenceService placement across Single, All, and Split modes.
  - Added accelerator and cluster-selector matching, replica distribution, admission tracking, and failover handling.
  - Added incremental placement dispatch with sticky winners and graceful transitions.
  - Added optional global endpoint publishing through Gateway API, including weighted multi-cluster routing.
  - Added automatic cleanup of outdated or orphaned workload services.
- **Reliability**
  - Improved status convergence, endpoint preservation, ownership safeguards, and handling of disconnected clusters or transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->