### PR TITLE
[Core] Multi-cluster: controller config

### DIFF
--- a/pkg/controller/v1beta1/controllerconfig/configmap.go
+++ b/pkg/controller/v1beta1/controllerconfig/configmap.go
@@ -355,6 +355,12 @@ func NewBenchmarkJobConfig(clientset kubernetes.Interface) (*BenchmarkJobConfig,
 	return benchmarkJobConfig, nil
 }
 
+// getInferenceServiceConfigMap fetches the inferenceservice-config ConfigMap
+// from the OME namespace.
+func getInferenceServiceConfigMap(clientset kubernetes.Interface) (*v1.ConfigMap, error) {
+	return clientset.CoreV1().ConfigMaps(constants.OMENamespace).Get(context.TODO(), constants.InferenceServiceConfigMapName, metav1.GetOptions{})
+}
+
 // NewOmeAgentConfig loads the omeAgent block from the inferenceservice-config
 // ConfigMap in the OME namespace. A missing block yields a zero-value config
 // (not an error) so the PVC path can surface PVCConfigMissing via status

--- a/pkg/controller/v1beta1/controllerconfig/multicluster.go
+++ b/pkg/controller/v1beta1/controllerconfig/multicluster.go
@@ -1,7 +1,9 @@
 package controllerconfig
 
 import (
+	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -108,6 +110,11 @@ type PlacementConfig struct {
 	// DispatcherRoundTimeout is how long an Incremental round waits for a nominated
 	// cluster to win before adding the next batch. Non-positive enforces no dwell.
 	DispatcherRoundTimeout string `json:"dispatcherRoundTimeout,omitempty"`
+	// LocalQueue is the Kueue LocalQueue that a derived workload's pods join on
+	// the target cluster when the InferenceService carries no per-ISVC queue
+	// annotation. It names a resource the operator created, so it has no in-code
+	// default: empty leaves the placement package's own fallback in place.
+	LocalQueue string `json:"localQueue,omitempty"`
 }
 
 // +kubebuilder:object:generate=false
@@ -150,6 +157,56 @@ func parseMultiClusterConfig(configMap *v1.ConfigMap) (*MultiClusterConfig, erro
 		return nil, fmt.Errorf("unable to parse multicluster config json: %w", err)
 	}
 	return cfg, nil
+}
+
+// Validate reports knob values that are stated but unusable, for the manager to
+// refuse at startup. Loading stays forgiving on purpose — an unparsable duration
+// reads as zero so the consuming package applies its own default — but that
+// makes a typo like "30" or "1 m" indistinguishable from "not set", silently
+// discarding the operator's intended value for the life of the process. The
+// composition root calls this so the deploy fails loudly instead.
+func (c MultiClusterConfig) Validate() error {
+	durations := map[string]string{
+		"workloadCluster.perCallTimeout":       c.WorkloadCluster.PerCallTimeout,
+		"workloadCluster.healthInterval":       c.WorkloadCluster.HealthInterval,
+		"workloadCluster.connectionGrace":      c.WorkloadCluster.ConnectionGrace,
+		"workloadCluster.eventsBatchPeriod":    c.WorkloadCluster.EventsBatchPeriod,
+		"workloadCluster.establishInitial":     c.WorkloadCluster.EstablishInitial,
+		"workloadCluster.establishMax":         c.WorkloadCluster.EstablishMax,
+		"workloadCluster.reconnectRetryMax":    c.WorkloadCluster.ReconnectRetryMax,
+		"workloadCluster.funnelResyncInterval": c.WorkloadCluster.FunnelResyncInterval,
+		"placement.requeueInterval":            c.Placement.RequeueInterval,
+		"placement.gcInterval":                 c.Placement.GCInterval,
+		"placement.fanoutTimeout":              c.Placement.FanoutTimeout,
+		"placement.winnerLostGrace":            c.Placement.WinnerLostGrace,
+		"placement.statusBatchPeriod":          c.Placement.StatusBatchPeriod,
+		"placement.statusSafetyRequeue":        c.Placement.StatusSafetyRequeue,
+		"placement.dispatcherRoundTimeout":     c.Placement.DispatcherRoundTimeout,
+	}
+	keys := make([]string, 0, len(durations))
+	for k := range durations {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var errs []error
+	for _, k := range keys {
+		raw := durations[k]
+		if raw == "" {
+			continue
+		}
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %q is not a duration (use forms like \"30s\", \"5m\")", k, raw))
+			continue
+		}
+		if d <= 0 {
+			errs = append(errs, fmt.Errorf("%s: %q must be positive", k, raw))
+		}
+	}
+	if p := c.Endpoint.BackendPort; p < 0 || p > 65535 {
+		errs = append(errs, fmt.Errorf("endpoint.backendPort: %d is not a valid port", p))
+	}
+	return errors.Join(errs...)
 }
 
 // PerCallTimeoutDuration returns the parsed PerCallTimeout (0 if absent/unparsable).

--- a/pkg/controller/v1beta1/controllerconfig/multicluster.go
+++ b/pkg/controller/v1beta1/controllerconfig/multicluster.go
@@ -206,6 +206,13 @@ func (c MultiClusterConfig) Validate() error {
 	if p := c.Endpoint.BackendPort; p < 0 || p > 65535 {
 		errs = append(errs, fmt.Errorf("endpoint.backendPort: %d is not a valid port", p))
 	}
+	// Naming a gateway states the intent to publish, but the publisher stays off
+	// without a routable backend port. Zero stays valid for the fully-disabled
+	// endpoint config; paired with a gateway it is a half-finished one that would
+	// otherwise publish nothing and report nothing.
+	if c.Endpoint.GlobalGateway != "" && c.Endpoint.BackendPort <= 0 {
+		errs = append(errs, fmt.Errorf("endpoint.backendPort: must be set when endpoint.globalGateway is configured (%q)", c.Endpoint.GlobalGateway))
+	}
 	return errors.Join(errs...)
 }
 

--- a/pkg/controller/v1beta1/controllerconfig/multicluster.go
+++ b/pkg/controller/v1beta1/controllerconfig/multicluster.go
@@ -1,0 +1,239 @@
+package controllerconfig
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// MultiClusterConfigName is the inferenceservice-config ConfigMap key holding
+// the multi-cluster tuning block.
+const MultiClusterConfigName = "multicluster"
+
+// +kubebuilder:object:generate=false
+// MultiClusterConfig holds operator-level tuning for the multi-cluster fan-out
+// layer (the WorkloadCluster connection/transport, the placement controller,
+// and the global endpoint publisher). It is loaded once at manager startup, from
+// the inferenceservice-config ConfigMap, only when multi-cluster is enabled.
+//
+// Topology, role, identity, and security stay manager flags, not config: they
+// decide which controllers run and the manager's identity, so they are
+// deploy-time decisions (a restart), not hot-tunable config.
+//
+// Every field degrades gracefully when omitted. Durations are stored as strings
+// and parsed by the *Duration() accessors, which yield 0 on an empty or
+// unparsable value; a zero handed to the workloadcluster/placement options
+// makes those packages apply their OWN in-package default. So the default for
+// each knob stays single-sourced in the package that owns it — never duplicated
+// as a literal here — and an absent "multicluster" block reproduces the
+// built-in behavior exactly.
+type MultiClusterConfig struct {
+	WorkloadCluster WorkloadClusterConfig `json:"workloadCluster,omitempty"`
+	Placement       PlacementConfig       `json:"placement,omitempty"`
+	Endpoint        EndpointConfig        `json:"endpoint,omitempty"`
+}
+
+// +kubebuilder:object:generate=false
+// WorkloadClusterConfig tunes the remote-cluster connection and transport layer
+// and the cross-cluster status watch funnel.
+type WorkloadClusterConfig struct {
+	// ClientQPS / ClientBurst are the steady-state request rate and burst to each
+	// remote workload-cluster apiserver. Zero leaves the client-go default.
+	ClientQPS   float64 `json:"clientQPS,omitempty"`
+	ClientBurst int     `json:"clientBurst,omitempty"`
+	// PerCallTimeout bounds one remote request. Empty leaves no client-level timeout.
+	PerCallTimeout string `json:"perCallTimeout,omitempty"`
+	// CacheEnabled serves cross-cluster derived-InferenceService reads from a
+	// per-cluster informer cache instead of live apiserver reads, and is the
+	// prerequisite event source for the status watch funnel. False (the default)
+	// keeps reads live and the funnel off.
+	CacheEnabled bool `json:"cacheEnabled,omitempty"`
+	// HealthInterval is the re-probe cadence for an otherwise-idle WorkloadCluster.
+	HealthInterval string `json:"healthInterval,omitempty"`
+	// ConnectionGrace is how long a previously reachable cluster tolerates transient
+	// probe failures before it is flipped to Ready=False and disconnected.
+	ConnectionGrace string `json:"connectionGrace,omitempty"`
+	// EventsBatchPeriod debounces a rotated-kubeconfig Secret's burst of key updates
+	// into one reconcile.
+	EventsBatchPeriod string `json:"eventsBatchPeriod,omitempty"`
+	// EstablishInitial / EstablishMax bound a single remote watch-establish attempt
+	// (the timeout grows from initial to max). ReconnectRetryMax caps the
+	// inter-attempt backoff for an unreachable cluster.
+	EstablishInitial  string `json:"establishInitial,omitempty"`
+	EstablishMax      string `json:"establishMax,omitempty"`
+	ReconnectRetryMax string `json:"reconnectRetryMax,omitempty"`
+	// FunnelResyncInterval is how often the status funnel reconciles its per-cluster
+	// watch set against the connected clusters (how fast a newly-connected cluster
+	// is noticed, not the status latency). FunnelBufferSize is the depth of its
+	// buffered event channel; a full channel drops events (the safety requeue
+	// recovers).
+	FunnelResyncInterval string `json:"funnelResyncInterval,omitempty"`
+	FunnelBufferSize     int    `json:"funnelBufferSize,omitempty"`
+}
+
+// +kubebuilder:object:generate=false
+// PlacementConfig tunes the fan-out placement controller, its status
+// convergence, and its orphan GC.
+type PlacementConfig struct {
+	// RequeueInterval is the status-refresh poll cadence. With the cache/funnel off
+	// it also paces the cross-cluster status re-read.
+	RequeueInterval string `json:"requeueInterval,omitempty"`
+	// GCInterval is the orphan-sweep cadence for the placement GC runnable.
+	GCInterval string `json:"gcInterval,omitempty"`
+	// MaxConcurrentReconciles caps placement reconciles in parallel (distinct
+	// ISVCs). Zero falls back to controller-runtime's single worker.
+	MaxConcurrentReconciles int `json:"maxConcurrentReconciles,omitempty"`
+	// FanoutTimeout is the per-cluster deadline bounding a single fan-out apply, so
+	// one slow remote cannot block placement to healthy peers.
+	FanoutTimeout string `json:"fanoutTimeout,omitempty"`
+	// WinnerLostGrace is the grace window held before re-placing when the sticky
+	// winner's derived is absent on a still-connected winner. Empty re-places
+	// immediately.
+	WinnerLostGrace string `json:"winnerLostGrace,omitempty"`
+	// StatusBatchPeriod debounces a burst of cross-cluster derived-status events for
+	// one ISVC into a single placement reconcile.
+	StatusBatchPeriod string `json:"statusBatchPeriod,omitempty"`
+	// StatusSafetyRequeue is the steady-state re-read backstop when the funnel is on
+	// (events drive freshness; this only recovers a missed event).
+	StatusSafetyRequeue string `json:"statusSafetyRequeue,omitempty"`
+	// DispatcherMode is the fan-out breadth policy: "AllAtOnce" clones onto every
+	// matched candidate at once; "Incremental" probes candidates in batches. Empty
+	// or unrecognized means AllAtOnce.
+	DispatcherMode string `json:"dispatcherMode,omitempty"`
+	// DispatcherStepSize is the candidates the Incremental dispatcher adds per round.
+	// Non-positive advances by one.
+	DispatcherStepSize int `json:"dispatcherStepSize,omitempty"`
+	// DispatcherRoundTimeout is how long an Incremental round waits for a nominated
+	// cluster to win before adding the next batch. Non-positive enforces no dwell.
+	DispatcherRoundTimeout string `json:"dispatcherRoundTimeout,omitempty"`
+}
+
+// +kubebuilder:object:generate=false
+// EndpointConfig tunes the global endpoint publisher (a Gateway API HTTPRoute to
+// the placement winner). The host template, gateway, and namespace are
+// deployment-identity values with no in-code default: empty disables publishing
+// (a no-op), never a baked-in gateway or host.
+type EndpointConfig struct {
+	// GlobalHostTemplate is the text/template for the global host an ISVC publishes
+	// to the winner. Empty means only ISVCs carrying the global-host annotation
+	// publish.
+	GlobalHostTemplate string `json:"globalHostTemplate,omitempty"`
+	// GlobalGateway is the "namespace/name" of the global-traffic Gateway the
+	// published HTTPRoute attaches to. Empty makes the publisher a no-op.
+	GlobalGateway string `json:"globalGateway,omitempty"`
+	// RouteNamespace is the namespace for the published HTTPRoute and backing
+	// Service. Empty uses the ISVC's own namespace.
+	RouteNamespace string `json:"routeNamespace,omitempty"`
+	// BackendPort is the port on the winner cluster's ingress the global host
+	// forwards to.
+	BackendPort int `json:"backendPort,omitempty"`
+}
+
+// NewMultiClusterConfig loads the "multicluster" block from the
+// inferenceservice-config ConfigMap. It is read once at manager startup (the
+// multi-cluster wiring is built before any reconcile), so there is no
+// ConfigCache-backed variant. An absent block yields a zero-valued config and
+// every consumer applies its own in-package default.
+func NewMultiClusterConfig(clientset kubernetes.Interface) (*MultiClusterConfig, error) {
+	configMap, err := getInferenceServiceConfigMap(clientset)
+	if err != nil {
+		return nil, err
+	}
+	return parseMultiClusterConfig(configMap)
+}
+
+func parseMultiClusterConfig(configMap *v1.ConfigMap) (*MultiClusterConfig, error) {
+	cfg := &MultiClusterConfig{}
+	if err := getComponentConfig(MultiClusterConfigName, configMap, cfg); err != nil {
+		return nil, fmt.Errorf("unable to parse multicluster config json: %w", err)
+	}
+	return cfg, nil
+}
+
+// PerCallTimeoutDuration returns the parsed PerCallTimeout (0 if absent/unparsable).
+func (c WorkloadClusterConfig) PerCallTimeoutDuration() time.Duration {
+	return parseDurationOrZero(c.PerCallTimeout)
+}
+
+// HealthIntervalDuration returns the parsed HealthInterval (0 if absent/unparsable).
+func (c WorkloadClusterConfig) HealthIntervalDuration() time.Duration {
+	return parseDurationOrZero(c.HealthInterval)
+}
+
+// ConnectionGraceDuration returns the parsed ConnectionGrace (0 if absent/unparsable).
+func (c WorkloadClusterConfig) ConnectionGraceDuration() time.Duration {
+	return parseDurationOrZero(c.ConnectionGrace)
+}
+
+// EventsBatchPeriodDuration returns the parsed EventsBatchPeriod (0 if absent/unparsable).
+func (c WorkloadClusterConfig) EventsBatchPeriodDuration() time.Duration {
+	return parseDurationOrZero(c.EventsBatchPeriod)
+}
+
+// EstablishInitialDuration returns the parsed EstablishInitial (0 if absent/unparsable).
+func (c WorkloadClusterConfig) EstablishInitialDuration() time.Duration {
+	return parseDurationOrZero(c.EstablishInitial)
+}
+
+// EstablishMaxDuration returns the parsed EstablishMax (0 if absent/unparsable).
+func (c WorkloadClusterConfig) EstablishMaxDuration() time.Duration {
+	return parseDurationOrZero(c.EstablishMax)
+}
+
+// ReconnectRetryMaxDuration returns the parsed ReconnectRetryMax (0 if absent/unparsable).
+func (c WorkloadClusterConfig) ReconnectRetryMaxDuration() time.Duration {
+	return parseDurationOrZero(c.ReconnectRetryMax)
+}
+
+// FunnelResyncIntervalDuration returns the parsed FunnelResyncInterval (0 if absent/unparsable).
+func (c WorkloadClusterConfig) FunnelResyncIntervalDuration() time.Duration {
+	return parseDurationOrZero(c.FunnelResyncInterval)
+}
+
+// RequeueIntervalDuration returns the parsed RequeueInterval (0 if absent/unparsable).
+func (c PlacementConfig) RequeueIntervalDuration() time.Duration {
+	return parseDurationOrZero(c.RequeueInterval)
+}
+
+// GCIntervalDuration returns the parsed GCInterval (0 if absent/unparsable).
+func (c PlacementConfig) GCIntervalDuration() time.Duration {
+	return parseDurationOrZero(c.GCInterval)
+}
+
+// FanoutTimeoutDuration returns the parsed FanoutTimeout (0 if absent/unparsable).
+func (c PlacementConfig) FanoutTimeoutDuration() time.Duration {
+	return parseDurationOrZero(c.FanoutTimeout)
+}
+
+// WinnerLostGraceDuration returns the parsed WinnerLostGrace (0 if absent/unparsable).
+func (c PlacementConfig) WinnerLostGraceDuration() time.Duration {
+	return parseDurationOrZero(c.WinnerLostGrace)
+}
+
+// StatusBatchPeriodDuration returns the parsed StatusBatchPeriod (0 if absent/unparsable).
+func (c PlacementConfig) StatusBatchPeriodDuration() time.Duration {
+	return parseDurationOrZero(c.StatusBatchPeriod)
+}
+
+// StatusSafetyRequeueDuration returns the parsed StatusSafetyRequeue (0 if absent/unparsable).
+func (c PlacementConfig) StatusSafetyRequeueDuration() time.Duration {
+	return parseDurationOrZero(c.StatusSafetyRequeue)
+}
+
+// DispatcherRoundTimeoutDuration returns the parsed DispatcherRoundTimeout (0 if absent/unparsable).
+func (c PlacementConfig) DispatcherRoundTimeoutDuration() time.Duration {
+	return parseDurationOrZero(c.DispatcherRoundTimeout)
+}
+
+// parseDurationOrZero parses s, returning 0 when it is empty, malformed, or
+// non-positive. Callers hand the zero to a workloadcluster/placement option,
+// which then applies its own in-package default — so the fallback stays
+// single-sourced in the consuming package, not duplicated here.
+func parseDurationOrZero(s string) time.Duration {
+	if d, err := time.ParseDuration(s); err == nil && d > 0 {
+		return d
+	}
+	return 0
+}

--- a/pkg/controller/v1beta1/controllerconfig/multicluster_test.go
+++ b/pkg/controller/v1beta1/controllerconfig/multicluster_test.go
@@ -1,0 +1,164 @@
+package controllerconfig
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestNewMultiClusterConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		configMapData map[string]string
+		expectedError bool
+		validate      func(*testing.T, *MultiClusterConfig)
+	}{
+		{
+			name:          "missing configmap",
+			configMapData: nil,
+			expectedError: true,
+		},
+		{
+			name:          "absent multicluster block yields zero config",
+			configMapData: map[string]string{},
+			validate: func(t *testing.T, cfg *MultiClusterConfig) {
+				// Every knob zero/empty: each consumer applies its own default.
+				assert.False(t, cfg.WorkloadCluster.CacheEnabled)
+				assert.Equal(t, time.Duration(0), cfg.WorkloadCluster.HealthIntervalDuration())
+				assert.Equal(t, time.Duration(0), cfg.Placement.RequeueIntervalDuration())
+				assert.Equal(t, 0, cfg.Placement.MaxConcurrentReconciles)
+				assert.Equal(t, "", cfg.Placement.DispatcherMode)
+				assert.Equal(t, "", cfg.Endpoint.GlobalGateway)
+			},
+		},
+		{
+			name: "full block parses every field",
+			configMapData: map[string]string{
+				MultiClusterConfigName: `{
+					"workloadCluster": {
+						"clientQPS": 50,
+						"clientBurst": 100,
+						"perCallTimeout": "15s",
+						"cacheEnabled": true,
+						"healthInterval": "30s",
+						"connectionGrace": "90s",
+						"eventsBatchPeriod": "200ms",
+						"establishInitial": "2m",
+						"establishMax": "20m",
+						"reconnectRetryMax": "5m",
+						"funnelResyncInterval": "250ms",
+						"funnelBufferSize": 64
+					},
+					"placement": {
+						"requeueInterval": "45s",
+						"gcInterval": "10m",
+						"maxConcurrentReconciles": 8,
+						"fanoutTimeout": "20s",
+						"winnerLostGrace": "2m",
+						"statusBatchPeriod": "500ms",
+						"statusSafetyRequeue": "5m",
+						"dispatcherMode": "Incremental",
+						"dispatcherStepSize": 4,
+						"dispatcherRoundTimeout": "30s"
+					},
+					"endpoint": {
+						"globalHostTemplate": "{{.Name}}.{{.Namespace}}.global.example",
+						"globalGateway": "ome/global-gateway",
+						"routeNamespace": "ome-routes",
+						"backendPort": 8080
+					}
+				}`,
+			},
+			validate: func(t *testing.T, cfg *MultiClusterConfig) {
+				wc := cfg.WorkloadCluster
+				assert.Equal(t, 50.0, wc.ClientQPS)
+				assert.Equal(t, 100, wc.ClientBurst)
+				assert.Equal(t, 15*time.Second, wc.PerCallTimeoutDuration())
+				assert.True(t, wc.CacheEnabled)
+				assert.Equal(t, 30*time.Second, wc.HealthIntervalDuration())
+				assert.Equal(t, 90*time.Second, wc.ConnectionGraceDuration())
+				assert.Equal(t, 200*time.Millisecond, wc.EventsBatchPeriodDuration())
+				assert.Equal(t, 2*time.Minute, wc.EstablishInitialDuration())
+				assert.Equal(t, 20*time.Minute, wc.EstablishMaxDuration())
+				assert.Equal(t, 5*time.Minute, wc.ReconnectRetryMaxDuration())
+				assert.Equal(t, 250*time.Millisecond, wc.FunnelResyncIntervalDuration())
+				assert.Equal(t, 64, wc.FunnelBufferSize)
+
+				pl := cfg.Placement
+				assert.Equal(t, 45*time.Second, pl.RequeueIntervalDuration())
+				assert.Equal(t, 10*time.Minute, pl.GCIntervalDuration())
+				assert.Equal(t, 8, pl.MaxConcurrentReconciles)
+				assert.Equal(t, 20*time.Second, pl.FanoutTimeoutDuration())
+				assert.Equal(t, 2*time.Minute, pl.WinnerLostGraceDuration())
+				assert.Equal(t, 500*time.Millisecond, pl.StatusBatchPeriodDuration())
+				assert.Equal(t, 5*time.Minute, pl.StatusSafetyRequeueDuration())
+				assert.Equal(t, "Incremental", pl.DispatcherMode)
+				assert.Equal(t, 4, pl.DispatcherStepSize)
+				assert.Equal(t, 30*time.Second, pl.DispatcherRoundTimeoutDuration())
+
+				ep := cfg.Endpoint
+				assert.Equal(t, "{{.Name}}.{{.Namespace}}.global.example", ep.GlobalHostTemplate)
+				assert.Equal(t, "ome/global-gateway", ep.GlobalGateway)
+				assert.Equal(t, "ome-routes", ep.RouteNamespace)
+				assert.Equal(t, 8080, ep.BackendPort)
+			},
+		},
+		{
+			name: "empty and malformed durations resolve to zero",
+			configMapData: map[string]string{
+				MultiClusterConfigName: `{
+					"workloadCluster": {"healthInterval": "", "connectionGrace": "not-a-duration"},
+					"placement": {"requeueInterval": "0s"}
+				}`,
+			},
+			validate: func(t *testing.T, cfg *MultiClusterConfig) {
+				assert.Equal(t, time.Duration(0), cfg.WorkloadCluster.HealthIntervalDuration())
+				assert.Equal(t, time.Duration(0), cfg.WorkloadCluster.ConnectionGraceDuration())
+				// non-positive parses but is treated as "use the package default".
+				assert.Equal(t, time.Duration(0), cfg.Placement.RequeueIntervalDuration())
+			},
+		},
+		{
+			name: "invalid json errors",
+			configMapData: map[string]string{
+				MultiClusterConfigName: `{"workloadCluster": {`,
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			if tt.configMapData != nil {
+				_, err := clientset.CoreV1().ConfigMaps(constants.OMENamespace).Create(context.TODO(), &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      constants.InferenceServiceConfigMapName,
+						Namespace: constants.OMENamespace,
+					},
+					Data: tt.configMapData,
+				}, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			cfg, err := NewMultiClusterConfig(clientset)
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			if tt.validate != nil {
+				tt.validate(t, cfg)
+			}
+		})
+	}
+}

--- a/pkg/controller/v1beta1/controllerconfig/multicluster_test.go
+++ b/pkg/controller/v1beta1/controllerconfig/multicluster_test.go
@@ -184,6 +184,11 @@ func TestMultiClusterConfig_ValidateRejectsMalformedKnobs(t *testing.T) {
 			want: "placement.gcInterval",
 		},
 		{
+			name: "gateway configured without a backend port",
+			cfg:  MultiClusterConfig{Endpoint: EndpointConfig{GlobalGateway: "infra/global-gw"}},
+			want: "endpoint.backendPort",
+		},
+		{
 			name: "port out of range",
 			cfg:  MultiClusterConfig{Endpoint: EndpointConfig{BackendPort: 99999}},
 			want: "endpoint.backendPort",
@@ -202,6 +207,9 @@ func TestMultiClusterConfig_ValidateRejectsMalformedKnobs(t *testing.T) {
 // blocks a legitimate config (or the graceful-degradation path).
 func TestMultiClusterConfig_ValidateAcceptsEmptyAndWellFormed(t *testing.T) {
 	require.NoError(t, MultiClusterConfig{}.Validate())
+	// Endpoint publishing fully off (no gateway, no port) stays valid: that is
+	// the graceful-degradation default, not a half-finished config.
+	require.NoError(t, MultiClusterConfig{Endpoint: EndpointConfig{}}.Validate())
 	require.NoError(t, MultiClusterConfig{
 		WorkloadCluster: WorkloadClusterConfig{HealthInterval: "30s", EstablishMax: "10m"},
 		Placement:       PlacementConfig{GCInterval: "5m", LocalQueue: "gpu-queue"},

--- a/pkg/controller/v1beta1/controllerconfig/multicluster_test.go
+++ b/pkg/controller/v1beta1/controllerconfig/multicluster_test.go
@@ -162,3 +162,66 @@ func TestNewMultiClusterConfig(t *testing.T) {
 		})
 	}
 }
+
+// A stated-but-unparsable duration must fail at startup rather than read as
+// "not set": the forgiving accessors would discard the operator's intended
+// value for the life of the process, with the built-in default silently
+// standing in.
+func TestMultiClusterConfig_ValidateRejectsMalformedKnobs(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  MultiClusterConfig
+		want string
+	}{
+		{
+			name: "duration missing a unit",
+			cfg:  MultiClusterConfig{WorkloadCluster: WorkloadClusterConfig{HealthInterval: "30"}},
+			want: "workloadCluster.healthInterval",
+		},
+		{
+			name: "non-positive duration",
+			cfg:  MultiClusterConfig{Placement: PlacementConfig{GCInterval: "0s"}},
+			want: "placement.gcInterval",
+		},
+		{
+			name: "port out of range",
+			cfg:  MultiClusterConfig{Endpoint: EndpointConfig{BackendPort: 99999}},
+			want: "endpoint.backendPort",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// An absent block and every well-formed knob must pass, so validation never
+// blocks a legitimate config (or the graceful-degradation path).
+func TestMultiClusterConfig_ValidateAcceptsEmptyAndWellFormed(t *testing.T) {
+	require.NoError(t, MultiClusterConfig{}.Validate())
+	require.NoError(t, MultiClusterConfig{
+		WorkloadCluster: WorkloadClusterConfig{HealthInterval: "30s", EstablishMax: "10m"},
+		Placement:       PlacementConfig{GCInterval: "5m", LocalQueue: "gpu-queue"},
+		Endpoint:        EndpointConfig{BackendPort: 8080},
+	}.Validate())
+}
+
+// Loading stays forgiving by contract: a malformed knob must NOT fail the load
+// (the accessor reads it as zero). Validate is the separate, explicit gate the
+// composition root applies.
+func TestNewMultiClusterConfig_LoadStaysForgiving_ValidateGates(t *testing.T) {
+	cs := fake.NewSimpleClientset(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.OMENamespace},
+		Data:       map[string]string{MultiClusterConfigName: `{"workloadCluster":{"healthInterval":"1 m"}}`},
+	})
+	cfg, err := NewMultiClusterConfig(cs)
+	require.NoError(t, err, "load must not reject knob values")
+	assert.Equal(t, time.Duration(0), cfg.WorkloadCluster.HealthIntervalDuration())
+
+	err = cfg.Validate()
+	require.Error(t, err, "validation must catch what loading tolerates")
+	assert.Contains(t, err.Error(), "workloadCluster.healthInterval")
+}


### PR DESCRIPTION
**Part 4 of 5** — depends on Parts 1–3.

Loads `MultiClusterConfig` (workload-cluster transport tunables, placement timing/GC, and endpoint routing) from the `inferenceservice-config` ConfigMap, with per-key duration accessors that degrade gracefully when a key is omitted so each consumer applies its own in-package default.

> Squash-only repo: diff includes Parts 1–3 until they merge; rebased after each.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multi-cluster configuration support through the controller configuration settings.
  - Added options for workload-cluster communication, resource placement, local queues, watch behavior, and endpoint publishing.
  - Added startup validation for configuration values, including durations and endpoint ports.

- **Bug Fixes**
  - Improved handling of missing or incomplete configuration, with safe defaults for invalid duration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->