### PR TITLE
[Core] Multi-cluster: manager wiring

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -193,7 +193,9 @@ func GetOptions() Options {
 			"--exec-credential-allowed-commands, and its binary must be present in the manager image. "+
 			"SECURITY: an exec block runs a command in the controller pod; keep WorkloadCluster kubeconfig Secrets admin-only.")
 	flag.StringVar(&opts.execCredentialAllowedCmds, "exec-credential-allowed-commands", opts.execCredentialAllowedCmds,
-		"Comma-separated allowlist of exec credential plugin command basenames permitted when --allow-exec-credentials is set.")
+		"Comma-separated allowlist of exec credential plugin commands permitted when --allow-exec-credentials is set. "+
+			"Each entry is matched exactly against the command the kubeconfig names: a bare command (\"aws\") permits PATH "+
+			"resolution and an absolute path pins one binary, but a bare entry does NOT permit a path that merely ends in that name.")
 	flag.StringVar(&opts.placementControlPlaneID, "placement-control-plane-id", opts.placementControlPlaneID,
 		"identity stamped on every derived InferenceService this control plane creates. "+
 			"Required when multiple control planes share a workload cluster so each control plane's GC "+

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	kedav1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -61,6 +62,11 @@ import (
 const (
 	LeaderLockName          = "ome-controller-manager-leader-lock"
 	LeaderElectionNamespace = "ome"
+
+	// multiClusterRoleControlPlane is the --multicluster-role value that makes
+	// this manager the multi-cluster fan-out control plane: it runs the placement
+	// controller and disables the local InferenceService reconcilers.
+	multiClusterRoleControlPlane = "control-plane"
 )
 
 var (
@@ -68,6 +74,17 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 	tlsOpts  []func(*tls.Config)
 )
+
+// splitAndTrim splits a comma-separated list, trims spaces, and drops empties.
+func splitAndTrim(csv string) []string {
+	var out []string
+	for _, p := range strings.Split(csv, ",") {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
 
 // registerOptionalScheme attempts to register a scheme if its CRD is available
 func registerOptionalScheme(cfg *rest.Config, s *runtime.Scheme, groupVersion schema.GroupVersion, kind string, addToScheme func(*runtime.Scheme) error) error {
@@ -107,7 +124,16 @@ type Options struct {
 	leaderElectionNamespace    string
 	runtimeRevisionRetention   int
 	runtimeRevisionGracePeriod time.Duration
-	zapOpts                    zap.Options
+	// Multi-cluster topology, identity, and security: these decide which
+	// controllers run and the manager's identity, so they are deploy-time flags.
+	// The tunables live in the inferenceservice-config ConfigMap
+	// (controllerconfig.MultiClusterConfig), loaded at startup.
+	enableMultiCluster        bool
+	multiClusterRole          string
+	allowExecCredentials      bool
+	execCredentialAllowedCmds string
+	placementControlPlaneID   string
+	zapOpts                   zap.Options
 }
 
 // DefaultOptions returns the default values for the program options.
@@ -123,6 +149,10 @@ func DefaultOptions() Options {
 		leaderElectionNamespace:    LeaderElectionNamespace,
 		runtimeRevisionRetention:   10,
 		runtimeRevisionGracePeriod: 24 * time.Hour,
+		enableMultiCluster:         false,
+		multiClusterRole:           "",
+		allowExecCredentials:       false,
+		execCredentialAllowedCmds:  "aws,gke-gcloud-auth-plugin,kubelogin",
 		zapOpts: zap.Options{
 			TimeEncoder: zapcore.RFC3339TimeEncoder,
 			ZapOpts:     []zaplog.Option{zaplog.AddCaller()},
@@ -150,6 +180,25 @@ func GetOptions() Options {
 		"Number of ControllerRevision snapshots to retain per source runtime before garbage collection.")
 	flag.DurationVar(&opts.runtimeRevisionGracePeriod, "runtime-revision-grace-period", opts.runtimeRevisionGracePeriod,
 		"How long a runtime-revision snapshot must stay unreferenced and over-retention before GC deletes it.")
+	flag.BoolVar(&opts.enableMultiCluster, "enable-multicluster", opts.enableMultiCluster,
+		"Enable the multi-cluster controllers (WorkloadCluster registry). Alpha; default off.")
+	flag.StringVar(&opts.multiClusterRole, "multicluster-role", opts.multiClusterRole,
+		"Multi-cluster role. \"control-plane\" makes this the fan-out placer: it runs "+
+			"the placement controller (which clones InferenceServices onto workload clusters) and "+
+			"DISABLES the local InferenceService reconcilers. Empty (default) is a normal "+
+			"single-cluster / workload-cluster manager. \"control-plane\" implies --enable-multicluster.")
+	flag.BoolVar(&opts.allowExecCredentials, "allow-exec-credentials", opts.allowExecCredentials,
+		"Allow WorkloadCluster kubeconfigs to use an exec credential plugin (e.g. aws, gke-gcloud-auth-plugin) "+
+			"for short-lived cloud tokens. Default false. The plugin command must also appear in "+
+			"--exec-credential-allowed-commands, and its binary must be present in the manager image. "+
+			"SECURITY: an exec block runs a command in the controller pod; keep WorkloadCluster kubeconfig Secrets admin-only.")
+	flag.StringVar(&opts.execCredentialAllowedCmds, "exec-credential-allowed-commands", opts.execCredentialAllowedCmds,
+		"Comma-separated allowlist of exec credential plugin command basenames permitted when --allow-exec-credentials is set.")
+	flag.StringVar(&opts.placementControlPlaneID, "placement-control-plane-id", opts.placementControlPlaneID,
+		"identity stamped on every derived InferenceService this control plane creates. "+
+			"Required when multiple control planes share a workload cluster so each control plane's GC "+
+			"only reaps its OWN deriveds; the chart supplies a per-control-plane value. Empty (default) "+
+			"keeps single-control-plane behavior (no identity stamping or GC scoping).")
 	opts.zapOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 	return opts
@@ -257,6 +306,15 @@ func main() {
 		}
 	}
 
+	// Multi-cluster role resolution. On the control plane the placement (fan-out)
+	// controller owns InferenceServices — it clones them onto workload clusters —
+	// so the local ISVC and model/runtime reconcilers must NOT run here.
+	isControlPlane := options.multiClusterRole == multiClusterRoleControlPlane
+	if options.multiClusterRole != "" && !isControlPlane {
+		setupLog.Error(fmt.Errorf("invalid --multicluster-role %q (want %q or empty)", options.multiClusterRole, multiClusterRoleControlPlane), "bad flag")
+		os.Exit(1)
+	}
+
 	// Setup Event Broadcaster
 	// Select the active traffic translator based on
 	// installed backend-policy CRDs (Envoy Gateway BackendTrafficPolicy,
@@ -274,84 +332,107 @@ func main() {
 
 	setupLog.Info("Configuring event broadcaster")
 	eventBroadcaster := record.NewBroadcaster()
-	setupLog.Info("Setting up InferenceService controller")
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
-	if err = (&v1beta1isvccontroller.InferenceServiceReconciler{
-		Client:            mgr.GetClient(),
-		Clientset:         clientSet,
-		Log:               ctrl.Log.WithName("InferenceService"),
-		Scheme:            mgr.GetScheme(),
-		Recorder:          eventBroadcaster.NewRecorder(mgr.GetScheme(), v1.EventSource{Component: "v1beta1Controllers"}),
-		TrafficReconciler: trafficReconciler,
-	}).SetupWithManager(mgr, deployConfig, ingressConfig); err != nil {
-		setupLog.Error(err, "Failed to create InferenceService controller")
-		os.Exit(1)
+	if isControlPlane {
+		setupLog.Info("control-plane role: local InferenceService reconciler disabled; placement controller owns ISVCs")
+	} else {
+		setupLog.Info("Setting up InferenceService controller")
+		if err = (&v1beta1isvccontroller.InferenceServiceReconciler{
+			Client:            mgr.GetClient(),
+			Clientset:         clientSet,
+			Log:               ctrl.Log.WithName("InferenceService"),
+			Scheme:            mgr.GetScheme(),
+			Recorder:          eventBroadcaster.NewRecorder(mgr.GetScheme(), v1.EventSource{Component: "v1beta1Controllers"}),
+			TrafficReconciler: trafficReconciler,
+		}).SetupWithManager(mgr, deployConfig, ingressConfig); err != nil {
+			setupLog.Error(err, "Failed to create InferenceService controller")
+			os.Exit(1)
+		}
 	}
 
-	// Setup BaseModel and ClusterBaseModel controllers with the manager
-	setupLog.Info("Setting up BaseModel controller")
-	if err = (&v1beta1basemodelcontroller.BaseModelReconciler{
-		Client:         mgr.GetClient(),
-		Log:            ctrl.Log.WithName("BaseModel"),
-		Scheme:         mgr.GetScheme(),
-		OmeAgentConfig: omeAgentConfig,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create BaseModel controller")
-		os.Exit(1)
+	// The control plane owns no workloads, models, or runtimes — those live on the
+	// workload clusters. Running the model/runtime lifecycle controllers here would
+	// reconcile against an empty local catalog (no-op at best, churn at worst), so
+	// gate them off under the control-plane role.
+	if isControlPlane {
+		setupLog.Info("control-plane role: BaseModel/ClusterBaseModel/BenchmarkJob/AcceleratorClass/RuntimeRevisionGC controllers disabled")
+	} else {
+		// Setup BaseModel and ClusterBaseModel controllers with the manager
+		setupLog.Info("Setting up BaseModel controller")
+		if err = (&v1beta1basemodelcontroller.BaseModelReconciler{
+			Client:         mgr.GetClient(),
+			Log:            ctrl.Log.WithName("BaseModel"),
+			Scheme:         mgr.GetScheme(),
+			OmeAgentConfig: omeAgentConfig,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "Failed to create BaseModel controller")
+			os.Exit(1)
+		}
+
+		setupLog.Info("Setting up ClusterBaseModel controller")
+		if err = (&v1beta1basemodelcontroller.ClusterBaseModelReconciler{
+			Client:         mgr.GetClient(),
+			Log:            ctrl.Log.WithName("ClusterBaseModel"),
+			Scheme:         mgr.GetScheme(),
+			OmeAgentConfig: omeAgentConfig,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "Failed to create ClusterBaseModel controller")
+			os.Exit(1)
+		}
+
+		benchmarkJobEventBroadcaster := record.NewBroadcaster()
+		setupLog.Info("Setting up BenchmarkJob controller")
+		benchmarkJobEventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
+		if err = (&v1beta1benchmarkjobcontroller.BenchmarkJobReconciler{
+			Client:    mgr.GetClient(),
+			Clientset: clientSet,
+			Log:       ctrl.Log.WithName("BenchmarkJob"),
+			Scheme:    mgr.GetScheme(),
+			Recorder:  benchmarkJobEventBroadcaster.NewRecorder(mgr.GetScheme(), v1.EventSource{Component: "v1beta1Controllers"}),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "Failed to create Benchmark Job controller")
+			os.Exit(1)
+		}
+
+		// Setup AcceleratorClass controller
+		acceleratorClassEventBroadcaster := record.NewBroadcaster()
+		setupLog.Info("Setting up AcceleratorClass controller")
+		acceleratorClassEventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
+		if err = (&v1beta1acceleratorclasscontroller.AcceleratorClassReconciler{
+			Client:   mgr.GetClient(),
+			Log:      ctrl.Log.WithName("AcceleratorClass"),
+			Scheme:   mgr.GetScheme(),
+			Recorder: acceleratorClassEventBroadcaster.NewRecorder(mgr.GetScheme(), v1.EventSource{Component: "v1beta1Controllers"}),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "Failed to create AcceleratorClass controller")
+			os.Exit(1)
+		}
+
+		setupLog.Info("Setting up runtime-revision GC controller",
+			"retention", options.runtimeRevisionRetention,
+			"gracePeriod", options.runtimeRevisionGracePeriod)
+		if err = (&v1beta1runtimerevisioncontroller.GCReconciler{
+			Client:              mgr.GetClient(),
+			Log:                 ctrl.Log.WithName("RuntimeRevisionGC"),
+			Scheme:              mgr.GetScheme(),
+			OMENamespace:        constants.OMENamespace,
+			RetentionPerRuntime: options.runtimeRevisionRetention,
+			GracePeriod:         options.runtimeRevisionGracePeriod,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "Failed to create runtime-revision GC controller")
+			os.Exit(1)
+		}
 	}
 
-	setupLog.Info("Setting up ClusterBaseModel controller")
-	if err = (&v1beta1basemodelcontroller.ClusterBaseModelReconciler{
-		Client:         mgr.GetClient(),
-		Log:            ctrl.Log.WithName("ClusterBaseModel"),
-		Scheme:         mgr.GetScheme(),
-		OmeAgentConfig: omeAgentConfig,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create ClusterBaseModel controller")
-		os.Exit(1)
-	}
-
-	benchmarkJobEventBroadcaster := record.NewBroadcaster()
-	setupLog.Info("Setting up BenchmarkJob controller")
-	benchmarkJobEventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
-	if err = (&v1beta1benchmarkjobcontroller.BenchmarkJobReconciler{
-		Client:    mgr.GetClient(),
-		Clientset: clientSet,
-		Log:       ctrl.Log.WithName("BenchmarkJob"),
-		Scheme:    mgr.GetScheme(),
-		Recorder:  benchmarkJobEventBroadcaster.NewRecorder(mgr.GetScheme(), v1.EventSource{Component: "v1beta1Controllers"}),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create Benchmark Job controller")
-		os.Exit(1)
-	}
-
-	// Setup AcceleratorClass controller
-	acceleratorClassEventBroadcaster := record.NewBroadcaster()
-	setupLog.Info("Setting up AcceleratorClass controller")
-	acceleratorClassEventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
-	if err = (&v1beta1acceleratorclasscontroller.AcceleratorClassReconciler{
-		Client:   mgr.GetClient(),
-		Log:      ctrl.Log.WithName("AcceleratorClass"),
-		Scheme:   mgr.GetScheme(),
-		Recorder: acceleratorClassEventBroadcaster.NewRecorder(mgr.GetScheme(), v1.EventSource{Component: "v1beta1Controllers"}),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create AcceleratorClass controller")
-		os.Exit(1)
-	}
-
-	setupLog.Info("Setting up runtime-revision GC controller",
-		"retention", options.runtimeRevisionRetention,
-		"gracePeriod", options.runtimeRevisionGracePeriod)
-	if err = (&v1beta1runtimerevisioncontroller.GCReconciler{
-		Client:              mgr.GetClient(),
-		Log:                 ctrl.Log.WithName("RuntimeRevisionGC"),
-		Scheme:              mgr.GetScheme(),
-		OMENamespace:        constants.OMENamespace,
-		RetentionPerRuntime: options.runtimeRevisionRetention,
-		GracePeriod:         options.runtimeRevisionGracePeriod,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create runtime-revision GC controller")
-		os.Exit(1)
+	// Multi-cluster: the WorkloadCluster registry/transport runs when multi-cluster
+	// is enabled OR this is the control plane (which requires it). The control plane
+	// additionally runs the placement (fan-out) controller, its GC, and the endpoint
+	// publisher — see setupMultiCluster.
+	if options.enableMultiCluster || isControlPlane {
+		if err = setupMultiCluster(mgr, clientSet, options, isControlPlane); err != nil {
+			setupLog.Error(err, "Failed to set up multi-cluster")
+			os.Exit(1)
+		}
 	}
 
 	if options.enableWebhook {

--- a/cmd/manager/multicluster.go
+++ b/cmd/manager/multicluster.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/placement"
+	placementendpoint "sigs.k8s.io/ome/pkg/controller/v1beta1/placement/endpoint"
+	workloadcluster "sigs.k8s.io/ome/pkg/controller/v1beta1/workloadcluster"
+)
+
+// mcWiring is the multi-cluster wiring resolved from a MultiClusterConfig: the
+// plain values that flow into the WorkloadCluster transport, the placement
+// controller, and the endpoint publisher. It is split out of setupMultiCluster
+// so the config->values mapping — the part where a mis-wired field would
+// silently mis-tune the control plane — is unit-testable without a manager.
+//
+// Durations are already resolved (the accessors yield 0 on an omitted key, and
+// each consuming option then applies its own in-package default).
+type mcWiring struct {
+	clientTuning      workloadcluster.ClientTuning
+	cacheEnabled      bool
+	healthInterval    time.Duration
+	connectionGrace   time.Duration
+	eventsBatchPeriod time.Duration
+	reconnectBackoff  workloadcluster.ReconnectBackoffConfig
+
+	// Placement + its status convergence and GC (control plane only).
+	requeue                time.Duration
+	gcInterval             time.Duration
+	maxConcurrent          int
+	placeTimeout           time.Duration
+	winnerLostGrace        time.Duration
+	statusBatchPeriod      time.Duration
+	statusSafetyRequeue    time.Duration
+	dispatcherMode         placement.DispatcherMode
+	dispatcherStepSize     int
+	dispatcherRoundTimeout time.Duration
+	funnelResyncInterval   time.Duration
+	funnelBufferSize       int
+
+	endpoint placementendpoint.Config
+}
+
+// resolveMCWiring maps a loaded MultiClusterConfig to the wiring values used to
+// build the multi-cluster controllers.
+func resolveMCWiring(mc *controllerconfig.MultiClusterConfig) mcWiring {
+	wc, pl, ep := mc.WorkloadCluster, mc.Placement, mc.Endpoint
+
+	// Status-convergence backstop: with the cache (and thus the watch funnel) on,
+	// events drive freshness and the safety requeue only recovers a missed event;
+	// with it off there is no event source, so the poll cadence (requeueInterval)
+	// is the backstop.
+	safetyRequeue := pl.StatusSafetyRequeueDuration()
+	if !wc.CacheEnabled {
+		safetyRequeue = pl.RequeueIntervalDuration()
+	}
+
+	return mcWiring{
+		clientTuning: workloadcluster.ClientTuning{
+			QPS:            float32(wc.ClientQPS),
+			Burst:          wc.ClientBurst,
+			PerCallTimeout: wc.PerCallTimeoutDuration(),
+		},
+		cacheEnabled:      wc.CacheEnabled,
+		healthInterval:    wc.HealthIntervalDuration(),
+		connectionGrace:   wc.ConnectionGraceDuration(),
+		eventsBatchPeriod: wc.EventsBatchPeriodDuration(),
+		reconnectBackoff: workloadcluster.ReconnectBackoffConfig{
+			EstablishInitial: wc.EstablishInitialDuration(),
+			EstablishMax:     wc.EstablishMaxDuration(),
+			RetryMax:         wc.ReconnectRetryMaxDuration(),
+		},
+		requeue:                pl.RequeueIntervalDuration(),
+		gcInterval:             pl.GCIntervalDuration(),
+		maxConcurrent:          pl.MaxConcurrentReconciles,
+		placeTimeout:           pl.FanoutTimeoutDuration(),
+		winnerLostGrace:        pl.WinnerLostGraceDuration(),
+		statusBatchPeriod:      pl.StatusBatchPeriodDuration(),
+		statusSafetyRequeue:    safetyRequeue,
+		dispatcherMode:         placement.DispatcherMode(pl.DispatcherMode),
+		dispatcherStepSize:     pl.DispatcherStepSize,
+		dispatcherRoundTimeout: pl.DispatcherRoundTimeoutDuration(),
+		funnelResyncInterval:   wc.FunnelResyncIntervalDuration(),
+		funnelBufferSize:       wc.FunnelBufferSize,
+		endpoint: placementendpoint.Config{
+			GlobalHostTemplate: ep.GlobalHostTemplate,
+			GlobalGateway:      ep.GlobalGateway,
+			RouteNamespace:     ep.RouteNamespace,
+			BackendPort:        int32(ep.BackendPort),
+		},
+	}
+}
+
+// setupMultiCluster wires the multi-cluster control/transport layer onto mgr:
+// the WorkloadCluster registry/transport always, plus — on the control plane —
+// the placement (fan-out) controller, its orphan GC, and the global endpoint
+// publisher, all sharing the one WorkloadCluster Manager so the placement
+// controllers read the live per-cluster clients it connects. Tunables load from
+// the inferenceservice-config ConfigMap; topology, identity, and security come
+// from options (flags).
+func setupMultiCluster(mgr manager.Manager, clientSet kubernetes.Interface, options Options, isControlPlane bool) error {
+	mcConfig, err := controllerconfig.NewMultiClusterConfig(clientSet)
+	if err != nil {
+		return fmt.Errorf("load multi-cluster configuration: %w", err)
+	}
+	w := resolveMCWiring(mcConfig)
+
+	clusterManager := workloadcluster.NewManager(mgr.GetScheme())
+	execPolicy := workloadcluster.ExecCredentialPolicy{
+		Allowed:         options.allowExecCredentials,
+		AllowedCommands: splitAndTrim(options.execCredentialAllowedCmds),
+	}
+	clusterManager.SetExecCredentialPolicy(execPolicy)
+	clusterManager.SetClientTuning(w.clientTuning)
+	if w.cacheEnabled {
+		// Scope the cached derived-InferenceService informer to exactly the set the
+		// watch funnel watches and resolves: this control plane's deriveds (origin
+		// marker, control-plane-scoped when an identity is configured). Sharing one
+		// selector keeps the cache from holding another control plane's deriveds on
+		// a shared workload cluster and guarantees every object the funnel's cache
+		// handler resolves is actually cached.
+		clusterManager.SetCacheOptions(workloadcluster.CacheOptions{
+			CachedKinds:     sets.New(v1beta1.SchemeGroupVersion.WithKind("InferenceService").GroupKind()),
+			DefaultSelector: placement.FunnelConfigFor(options.placementControlPlaneID).WatchSelector,
+		})
+	}
+	// Run the cluster Manager as a Runnable so it captures the controller-manager's
+	// long-lived context as the base for remote-client (and cache-informer)
+	// contexts, and disconnects everything on shutdown (no leaked watches).
+	if err := mgr.Add(clusterManager); err != nil {
+		return fmt.Errorf("add WorkloadCluster manager runnable: %w", err)
+	}
+	setupLog.Info("Setting up WorkloadCluster controller")
+	if err := (&workloadcluster.Reconciler{
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		Log:                   ctrl.Log.WithName("controllers").WithName("WorkloadCluster"),
+		Manager:               clusterManager,
+		ExecPolicy:            execPolicy,
+		HealthInterval:        w.healthInterval,
+		ConnectionGracePeriod: w.connectionGrace,
+	}).SetupWithManager(mgr,
+		workloadcluster.WithEventsBatchPeriod(w.eventsBatchPeriod),
+		workloadcluster.WithReconnectBackoff(w.reconnectBackoff),
+	); err != nil {
+		return fmt.Errorf("create WorkloadCluster controller: %w", err)
+	}
+
+	if !isControlPlane {
+		return nil
+	}
+
+	setupLog.Info("Setting up multi-cluster placement (fan-out) controller")
+	// Cross-cluster status convergence. The status batch period and safety requeue
+	// always apply; when the cache is enabled the watch funnel additionally feeds
+	// events so a derived's status change re-reconciles its source on an event
+	// rather than waiting for the safety requeue (which is then only the
+	// missed-event backstop). Without the cache there is no event source, so
+	// convergence stays on the poll cadence (already folded into statusSafetyRequeue).
+	convergeOpts := []placement.ConvergeOption{
+		placement.WithStatusBatchPeriod(w.statusBatchPeriod),
+		placement.WithStatusSafetyRequeue(w.statusSafetyRequeue),
+	}
+	if w.cacheEnabled {
+		funnelCfg := placement.FunnelConfigFor(options.placementControlPlaneID)
+		funnelCfg.ResyncInterval = w.funnelResyncInterval
+		funnelCfg.BufferSize = w.funnelBufferSize
+		funnel := workloadcluster.NewStatusFunnel(clusterManager, funnelCfg)
+		if err := mgr.Add(funnel); err != nil {
+			return fmt.Errorf("add multi-cluster status funnel runnable: %w", err)
+		}
+		convergeOpts = append(convergeOpts, placement.WithStatusEvents(funnel.Events()))
+	}
+
+	if err := (&placement.Reconciler{
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Log:                     ctrl.Log.WithName("controllers").WithName("Placement"),
+		Clusters:                clusterManager,
+		Requeue:                 w.requeue,
+		ControlPlaneID:          options.placementControlPlaneID,
+		MaxConcurrentReconciles: w.maxConcurrent,
+		PlaceTimeout:            w.placeTimeout,
+		WinnerLostGracePeriod:   w.winnerLostGrace,
+		DispatcherMode:          w.dispatcherMode,
+		DispatcherStepSize:      w.dispatcherStepSize,
+		DispatcherRoundTimeout:  w.dispatcherRoundTimeout,
+	}).SetupWithManager(mgr, convergeOpts...); err != nil {
+		return fmt.Errorf("create Placement controller: %w", err)
+	}
+	if err := mgr.Add(&placement.GCReconciler{
+		APIReader:      mgr.GetAPIReader(),
+		Log:            ctrl.Log.WithName("controllers").WithName("PlacementGC"),
+		Clusters:       clusterManager,
+		Interval:       w.gcInterval,
+		ControlPlaneID: options.placementControlPlaneID,
+	}); err != nil {
+		return fmt.Errorf("add placement GC runnable: %w", err)
+	}
+
+	// Program the global endpoint to the placement winner. The Gateway API scheme
+	// is required for the HTTPRoute the publisher writes; register it here
+	// (idempotent) since the control plane may not have EnableGatewayAPI set for
+	// its own (empty) ingress config.
+	utilruntime.Must(gatewayapiv1.Install(mgr.GetScheme()))
+	setupLog.Info("Setting up multi-cluster endpoint publisher")
+	if err := (&placementendpoint.Reconciler{
+		Client:    mgr.GetClient(),
+		Log:       ctrl.Log.WithName("controllers").WithName("PlacementEndpoint"),
+		Publisher: placementendpoint.NewGatewayAPIPublisher(mgr.GetClient(), w.endpoint),
+		Config:    w.endpoint,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("create PlacementEndpoint controller: %w", err)
+	}
+	return nil
+}

--- a/cmd/manager/multicluster.go
+++ b/cmd/manager/multicluster.go
@@ -45,6 +45,7 @@ type mcWiring struct {
 	dispatcherMode         placement.DispatcherMode
 	dispatcherStepSize     int
 	dispatcherRoundTimeout time.Duration
+	localQueue             string
 	funnelResyncInterval   time.Duration
 	funnelBufferSize       int
 
@@ -90,6 +91,7 @@ func resolveMCWiring(mc *controllerconfig.MultiClusterConfig) mcWiring {
 		dispatcherMode:         placement.DispatcherMode(pl.DispatcherMode),
 		dispatcherStepSize:     pl.DispatcherStepSize,
 		dispatcherRoundTimeout: pl.DispatcherRoundTimeoutDuration(),
+		localQueue:             pl.LocalQueue,
 		funnelResyncInterval:   wc.FunnelResyncIntervalDuration(),
 		funnelBufferSize:       wc.FunnelBufferSize,
 		endpoint: placementendpoint.Config{
@@ -98,6 +100,20 @@ func resolveMCWiring(mc *controllerconfig.MultiClusterConfig) mcWiring {
 			RouteNamespace:     ep.RouteNamespace,
 			BackendPort:        int32(ep.BackendPort),
 		},
+	}
+}
+
+// validateDispatcherMode rejects an unrecognized fan-out policy. The dispatcher
+// itself falls back to AllAtOnce for anything it does not recognize, so a typo
+// ("incremental" for "Incremental") would otherwise silently select a different
+// breadth policy than the operator asked for.
+func validateDispatcherMode(mode placement.DispatcherMode) error {
+	switch mode {
+	case "", placement.DispatcherModeAllAtOnce, placement.DispatcherModeIncremental:
+		return nil
+	default:
+		return fmt.Errorf("invalid multi-cluster configuration: placement.dispatcherMode %q must be %q or %q",
+			mode, placement.DispatcherModeAllAtOnce, placement.DispatcherModeIncremental)
 	}
 }
 
@@ -113,7 +129,17 @@ func setupMultiCluster(mgr manager.Manager, clientSet kubernetes.Interface, opti
 	if err != nil {
 		return fmt.Errorf("load multi-cluster configuration: %w", err)
 	}
+	// Loading is forgiving by contract (an unusable knob reads as "unset" and the
+	// owning package applies its default). Refuse to start on one instead: a
+	// silently-ignored knob means the control plane runs with timings the operator
+	// did not choose.
+	if err := mcConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid multi-cluster configuration: %w", err)
+	}
 	w := resolveMCWiring(mcConfig)
+	if err := validateDispatcherMode(w.dispatcherMode); err != nil {
+		return err
+	}
 
 	clusterManager := workloadcluster.NewManager(mgr.GetScheme())
 	execPolicy := workloadcluster.ExecCredentialPolicy{
@@ -149,6 +175,7 @@ func setupMultiCluster(mgr manager.Manager, clientSet kubernetes.Interface, opti
 		ExecPolicy:            execPolicy,
 		HealthInterval:        w.healthInterval,
 		ConnectionGracePeriod: w.connectionGrace,
+		ProbeTimeout:          w.clientTuning.PerCallTimeout,
 	}).SetupWithManager(mgr,
 		workloadcluster.WithEventsBatchPeriod(w.eventsBatchPeriod),
 		workloadcluster.WithReconnectBackoff(w.reconnectBackoff),
@@ -184,6 +211,7 @@ func setupMultiCluster(mgr manager.Manager, clientSet kubernetes.Interface, opti
 
 	if err := (&placement.Reconciler{
 		Client:                  mgr.GetClient(),
+		APIReader:               mgr.GetAPIReader(),
 		Scheme:                  mgr.GetScheme(),
 		Log:                     ctrl.Log.WithName("controllers").WithName("Placement"),
 		Clusters:                clusterManager,
@@ -195,6 +223,7 @@ func setupMultiCluster(mgr manager.Manager, clientSet kubernetes.Interface, opti
 		DispatcherMode:          w.dispatcherMode,
 		DispatcherStepSize:      w.dispatcherStepSize,
 		DispatcherRoundTimeout:  w.dispatcherRoundTimeout,
+		LocalQueue:              w.localQueue,
 	}).SetupWithManager(mgr, convergeOpts...); err != nil {
 		return fmt.Errorf("create Placement controller: %w", err)
 	}

--- a/cmd/manager/multicluster_test.go
+++ b/cmd/manager/multicluster_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/placement"
+	placementendpoint "sigs.k8s.io/ome/pkg/controller/v1beta1/placement/endpoint"
+	workloadcluster "sigs.k8s.io/ome/pkg/controller/v1beta1/workloadcluster"
+)
+
+// mcWiringFromJSON exercises the production config path: it seeds the
+// inferenceservice-config ConfigMap with the given "multicluster" block, loads
+// it via controllerconfig.NewMultiClusterConfig (as cmd/manager does), and
+// resolves the wiring. An empty mcJSON omits the block entirely.
+func mcWiringFromJSON(t *testing.T, mcJSON string) mcWiring {
+	t.Helper()
+	data := map[string]string{}
+	if mcJSON != "" {
+		data[controllerconfig.MultiClusterConfigName] = mcJSON
+	}
+	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.InferenceServiceConfigMapName,
+			Namespace: constants.OMENamespace,
+		},
+		Data: data,
+	})
+	mc, err := controllerconfig.NewMultiClusterConfig(clientset)
+	require.NoError(t, err)
+	return resolveMCWiring(mc)
+}
+
+// TestResolveMCWiringFullConfig asserts every ConfigMap field lands on the right
+// wiring field — the mapping that would otherwise only exist (untested) in the
+// cmd/manager wiring block, where a cross-wire would silently mis-tune the
+// control plane.
+func TestResolveMCWiringFullConfig(t *testing.T) {
+	w := mcWiringFromJSON(t, `{
+		"workloadCluster": {
+			"clientQPS": 50, "clientBurst": 100, "perCallTimeout": "15s", "cacheEnabled": true,
+			"healthInterval": "30s", "connectionGrace": "90s", "eventsBatchPeriod": "200ms",
+			"establishInitial": "2m", "establishMax": "20m", "reconnectRetryMax": "5m",
+			"funnelResyncInterval": "250ms", "funnelBufferSize": 64
+		},
+		"placement": {
+			"requeueInterval": "45s", "gcInterval": "10m", "maxConcurrentReconciles": 8,
+			"fanoutTimeout": "20s", "winnerLostGrace": "2m", "statusBatchPeriod": "500ms",
+			"statusSafetyRequeue": "7m", "dispatcherMode": "Incremental", "dispatcherStepSize": 4,
+			"dispatcherRoundTimeout": "30s"
+		},
+		"endpoint": {
+			"globalHostTemplate": "{{.Name}}.global", "globalGateway": "ome/gw",
+			"routeNamespace": "ome-routes", "backendPort": 8080
+		}
+	}`)
+
+	// WorkloadCluster transport.
+	assert.Equal(t, float32(50), w.clientTuning.QPS)
+	assert.Equal(t, 100, w.clientTuning.Burst)
+	assert.Equal(t, 15*time.Second, w.clientTuning.PerCallTimeout)
+	assert.True(t, w.cacheEnabled)
+	assert.Equal(t, 30*time.Second, w.healthInterval)
+	assert.Equal(t, 90*time.Second, w.connectionGrace)
+	assert.Equal(t, 200*time.Millisecond, w.eventsBatchPeriod)
+	assert.Equal(t, 2*time.Minute, w.reconnectBackoff.EstablishInitial)
+	assert.Equal(t, 20*time.Minute, w.reconnectBackoff.EstablishMax)
+	assert.Equal(t, 5*time.Minute, w.reconnectBackoff.RetryMax)
+	assert.Equal(t, 250*time.Millisecond, w.funnelResyncInterval)
+	assert.Equal(t, 64, w.funnelBufferSize)
+
+	// Placement.
+	assert.Equal(t, 45*time.Second, w.requeue)
+	assert.Equal(t, 10*time.Minute, w.gcInterval)
+	assert.Equal(t, 8, w.maxConcurrent)
+	assert.Equal(t, 20*time.Second, w.placeTimeout)
+	assert.Equal(t, 2*time.Minute, w.winnerLostGrace)
+	assert.Equal(t, 500*time.Millisecond, w.statusBatchPeriod)
+	assert.Equal(t, 7*time.Minute, w.statusSafetyRequeue) // cache on => configured backstop
+	assert.Equal(t, placement.DispatcherMode("Incremental"), w.dispatcherMode)
+	assert.Equal(t, 4, w.dispatcherStepSize)
+	assert.Equal(t, 30*time.Second, w.dispatcherRoundTimeout)
+
+	// Endpoint.
+	assert.Equal(t, "{{.Name}}.global", w.endpoint.GlobalHostTemplate)
+	assert.Equal(t, "ome/gw", w.endpoint.GlobalGateway)
+	assert.Equal(t, "ome-routes", w.endpoint.RouteNamespace)
+	assert.Equal(t, int32(8080), w.endpoint.BackendPort)
+}
+
+// TestResolveMCWiringSafetyRequeueDependsOnCache pins the one non-trivial bit of
+// logic in the mapping: the status-convergence backstop is the configured
+// statusSafetyRequeue when the cache/funnel is on (events drive freshness), but
+// folds to the poll cadence (requeueInterval) when it's off (no event source).
+func TestResolveMCWiringSafetyRequeueDependsOnCache(t *testing.T) {
+	off := mcWiringFromJSON(t, `{"placement": {"requeueInterval": "30s", "statusSafetyRequeue": "10m"}}`)
+	assert.False(t, off.cacheEnabled)
+	assert.Equal(t, 30*time.Second, off.statusSafetyRequeue, "cache off => backstop is the poll cadence")
+
+	on := mcWiringFromJSON(t, `{
+		"workloadCluster": {"cacheEnabled": true},
+		"placement": {"requeueInterval": "30s", "statusSafetyRequeue": "10m"}
+	}`)
+	assert.True(t, on.cacheEnabled)
+	assert.Equal(t, 10*time.Minute, on.statusSafetyRequeue, "cache on => backstop is the configured statusSafetyRequeue")
+}
+
+// TestResolveMCWiringAbsentBlockIsZero confirms an omitted "multicluster" block
+// yields an all-zero wiring, so every consuming option applies its own
+// in-package default (no magic literals in cmd/manager).
+func TestResolveMCWiringAbsentBlockIsZero(t *testing.T) {
+	w := mcWiringFromJSON(t, "")
+
+	assert.Equal(t, float32(0), w.clientTuning.QPS)
+	assert.Equal(t, 0, w.clientTuning.Burst)
+	assert.Equal(t, time.Duration(0), w.clientTuning.PerCallTimeout)
+	assert.False(t, w.cacheEnabled)
+	assert.Equal(t, time.Duration(0), w.healthInterval)
+	assert.Equal(t, time.Duration(0), w.connectionGrace)
+	assert.Equal(t, workloadcluster.ReconnectBackoffConfig{}, w.reconnectBackoff)
+	assert.Equal(t, time.Duration(0), w.requeue)
+	assert.Equal(t, time.Duration(0), w.gcInterval)
+	assert.Equal(t, time.Duration(0), w.statusSafetyRequeue)
+	assert.Equal(t, 0, w.maxConcurrent)
+	assert.Equal(t, 0, w.funnelBufferSize)
+	assert.Equal(t, placement.DispatcherMode(""), w.dispatcherMode)
+	assert.Equal(t, placementendpoint.Config{}, w.endpoint)
+}
+
+// TestResolveMCWiringMissingConfigMapErrors confirms the loader (and thus
+// cmd/manager startup) fails fast when the ConfigMap is absent, rather than
+// silently running with an empty config.
+func TestResolveMCWiringMissingConfigMapErrors(t *testing.T) {
+	_, err := controllerconfig.NewMultiClusterConfig(fake.NewSimpleClientset())
+	assert.Error(t, err)
+}

--- a/cmd/manager/multicluster_test.go
+++ b/cmd/manager/multicluster_test.go
@@ -142,3 +142,28 @@ func TestResolveMCWiringMissingConfigMapErrors(t *testing.T) {
 	_, err := controllerconfig.NewMultiClusterConfig(fake.NewSimpleClientset())
 	assert.Error(t, err)
 }
+
+// The operator-configured LocalQueue must reach the placement reconciler; if it
+// stops being mapped, deriveds silently fall back to the in-package default and
+// Kueue never admits them on a fleet that names its queue anything else.
+func TestResolveMCWiringCarriesLocalQueue(t *testing.T) {
+	w := mcWiringFromJSON(t, `{"placement":{"localQueue":"gpu-queue"}}`)
+	assert.Equal(t, "gpu-queue", w.localQueue)
+
+	assert.Empty(t, mcWiringFromJSON(t, `{"placement":{}}`).localQueue,
+		"absent knob stays empty so placement applies its own fallback")
+}
+
+// The dispatcher falls back to AllAtOnce for anything it does not recognize, so
+// a mis-cased mode would silently select a different fan-out breadth than the
+// operator asked for. Startup must reject it instead.
+func TestValidateDispatcherMode(t *testing.T) {
+	for _, ok := range []placement.DispatcherMode{"", placement.DispatcherModeAllAtOnce, placement.DispatcherModeIncremental} {
+		assert.NoError(t, validateDispatcherMode(ok), "mode %q must be accepted", ok)
+	}
+	for _, bad := range []placement.DispatcherMode{"incremental", "allatonce", "Bogus"} {
+		err := validateDispatcherMode(bad)
+		require.Error(t, err, "mode %q must be rejected", bad)
+		assert.Contains(t, err.Error(), "dispatcherMode")
+	}
+}

--- a/pkg/controller/v1beta1/placement/controller.go
+++ b/pkg/controller/v1beta1/placement/controller.go
@@ -90,6 +90,10 @@ type Reconciler struct {
 	APIReader client.Reader
 	// Requeue is the status-refresh poll cadence; defaults to DefaultPlacementRequeue.
 	Requeue time.Duration
+	// LocalQueue is the Kueue LocalQueue a derived workload's pods join when the
+	// source ISVC carries no per-ISVC queue annotation. It names a resource the
+	// operator created, so it is config-driven; empty leaves DefaultLocalQueue.
+	LocalQueue string
 	// ControlPlaneID is this control plane's identity, stamped onto every derived
 	// ISVC (PlacementControlPlaneLabel) so the GC sweep only reaps deriveds THIS
 	// control plane created. Config-driven (manager flag / chart); empty leaves
@@ -943,14 +947,14 @@ func (r *Reconciler) getWinnerDerived(ctx context.Context, cluster string, isvc 
 // replacing them wholesale — preserving worker-side reconciler state across the
 // poll-driven re-apply.
 func (r *Reconciler) placeOn(ctx context.Context, cl client.Client, src *v1beta1.InferenceService) error {
-	return r.applyDerived(ctx, cl, src, DeriveISVC(src, r.ControlPlaneID))
+	return r.applyDerived(ctx, cl, src, DeriveISVC(src, r.ControlPlaneID, r.LocalQueue))
 }
 
 // placeOnReplicas is placeOn with a Split per-cluster apportioned replica band
 // pinned onto the derived's scalable components before the apply: replicas is
 // this home's share (the floor), maxPer the per-cluster ceiling (0 = uncapped).
 func (r *Reconciler) placeOnReplicas(ctx context.Context, cl client.Client, src *v1beta1.InferenceService, replicas, maxPer int32) error {
-	d := DeriveISVC(src, r.ControlPlaneID)
+	d := DeriveISVC(src, r.ControlPlaneID, r.LocalQueue)
 	setDerivedReplicas(d, replicas, maxPer)
 	return r.applyDerived(ctx, cl, src, d)
 }

--- a/pkg/controller/v1beta1/placement/derive.go
+++ b/pkg/controller/v1beta1/placement/derive.go
@@ -18,7 +18,10 @@ import (
 //   - Kueue gating stamped on component pod metadata (the queue-name label).
 //   - Control-plane-only directives removed (placement selectors + rollout verbs)
 //     so the worker reconciler does not (re)act on the control plane's decisions.
-func DeriveISVC(src *v1beta1.InferenceService, controlPlaneID string) *v1beta1.InferenceService {
+//
+// localQueue is the operator-configured LocalQueue used when the source carries
+// no LocalQueueAnnotation; empty falls back to DefaultLocalQueue.
+func DeriveISVC(src *v1beta1.InferenceService, controlPlaneID, localQueue string) *v1beta1.InferenceService {
 	d := src.DeepCopy()
 
 	// Clear server-side / control-plane state.
@@ -32,8 +35,12 @@ func DeriveISVC(src *v1beta1.InferenceService, controlPlaneID string) *v1beta1.I
 	d.ManagedFields = nil
 	d.Status = v1beta1.InferenceServiceStatus{}
 
-	// Resolve queue name: from LocalQueueAnnotation or default.
+	// Resolve queue name: per-ISVC annotation, then the operator-configured
+	// queue, then the in-package fallback.
 	queue := src.Annotations[LocalQueueAnnotation]
+	if queue == "" {
+		queue = localQueue
+	}
 	if queue == "" {
 		queue = DefaultLocalQueue
 	}

--- a/pkg/controller/v1beta1/placement/derive_test.go
+++ b/pkg/controller/v1beta1/placement/derive_test.go
@@ -36,7 +36,7 @@ func TestDeriveISVC(t *testing.T) {
 		},
 	}
 
-	d := DeriveISVC(src, "cp-east")
+	d := DeriveISVC(src, "cp-east", "")
 
 	// identity preserved (worker addresses it by the same name/ns).
 	assert.Equal(t, "svc", d.Name)
@@ -70,10 +70,11 @@ func TestDeriveISVC(t *testing.T) {
 	// rides along untouched.
 	assert.Equal(t, "cluster-local", d.Annotations[constants.NetworkVisibility])
 
-	// queue defaulting: no LocalQueueAnnotation -> DefaultLocalQueue.
+	// queue defaulting: no LocalQueueAnnotation and no configured queue ->
+	// DefaultLocalQueue.
 	src2 := src.DeepCopy()
 	delete(src2.Annotations, LocalQueueAnnotation)
-	d2 := DeriveISVC(src2, "")
+	d2 := DeriveISVC(src2, "", "")
 	assert.Equal(t, DefaultLocalQueue, d2.Spec.Engine.ComponentExtensionSpec.Labels[constants.KueueQueueLabelKey])
 	// empty control-plane id leaves the identity label unset (single-CP behavior).
 	_, hasCP := d2.Labels[PlacementControlPlaneLabel]
@@ -118,4 +119,30 @@ func TestSetDerivedReplicas(t *testing.T) {
 	setDerivedReplicas(d, 3, 0)
 	assert.Equal(t, 3, *d.Spec.Engine.MinReplicas)
 	assert.Equal(t, 3, d.Spec.Engine.MaxReplicas, "uncapped -> Max raised to keep Max >= Min")
+}
+
+// The queue a derived workload joins is operator-configurable: a per-ISVC
+// annotation wins, then the configured queue, and only then the in-package
+// fallback. Without the middle rung a fleet whose LocalQueue is not named
+// "default" gets deriveds Kueue never admits.
+func TestDeriveISVC_LocalQueuePrecedence(t *testing.T) {
+	base := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "svc", UID: "uid-1"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Engine: &v1beta1.EngineSpec{},
+		},
+	}
+	queueOf := func(d *v1beta1.InferenceService) string {
+		return d.Spec.Engine.ComponentExtensionSpec.Labels[constants.KueueQueueLabelKey]
+	}
+
+	assert.Equal(t, DefaultLocalQueue, queueOf(DeriveISVC(base, "", "")),
+		"nothing configured -> in-package fallback")
+	assert.Equal(t, "gpu-queue", queueOf(DeriveISVC(base, "", "gpu-queue")),
+		"configured queue must beat the in-package fallback")
+
+	annotated := base.DeepCopy()
+	annotated.Annotations = map[string]string{LocalQueueAnnotation: "per-isvc"}
+	assert.Equal(t, "per-isvc", queueOf(DeriveISVC(annotated, "", "gpu-queue")),
+		"per-ISVC annotation must beat the configured queue")
 }

--- a/pkg/controller/v1beta1/workloadcluster/controller.go
+++ b/pkg/controller/v1beta1/workloadcluster/controller.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -63,6 +64,12 @@ type Reconciler struct {
 	Manager *Manager
 	// ExecPolicy is the exec credential policy applied during validation.
 	ExecPolicy ExecCredentialPolicy
+	// SecretReader reads kubeconfig Secrets WITHOUT caching them. The Secret watch
+	// is metadata-only, so payloads never enter the informer cache; reading the
+	// bytes through the cached client would defeat that by starting a second,
+	// full-payload Secret informer over every namespace. SetupWithManager defaults
+	// it to mgr.GetAPIReader(); nil falls back to the reconciler's own client.
+	SecretReader client.Reader
 	// ConnectionGracePeriod is how long a previously reachable cluster tolerates
 	// transient probe failures before it is flipped to Ready=False and
 	// disconnected; zero defaults to DefaultConnectionGracePeriod. A negative
@@ -313,7 +320,7 @@ func (r *Reconciler) assess(ctx context.Context, wc *v1beta1.WorkloadCluster) (s
 	}
 	secret := &corev1.Secret{}
 	nn := types.NamespacedName{Name: src.KubeConfig.SecretRef.Name, Namespace: src.KubeConfig.SecretRef.Namespace}
-	if err := r.Get(ctx, nn, secret); err != nil {
+	if err := r.secretReader().Get(ctx, nn, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			return metav1.ConditionFalse, "SecretNotFound",
 				fmt.Sprintf("kubeconfig Secret %s/%s not found", nn.Namespace, nn.Name), nil
@@ -352,6 +359,15 @@ func (r *Reconciler) healthInterval() time.Duration {
 	return DefaultHealthInterval
 }
 
+// secretReader returns the uncached reader for kubeconfig Secrets, falling back
+// to the reconciler's client when none was wired (unit tests build it directly).
+func (r *Reconciler) secretReader() client.Reader {
+	if r.SecretReader != nil {
+		return r.SecretReader
+	}
+	return r.Client
+}
+
 func (r *Reconciler) probeTimeout() time.Duration {
 	if r.cfg != nil {
 		return r.cfg.probeTimeout
@@ -372,6 +388,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts ...Option) error {
 			return probeViaServerVersion(ctx, raw, r.ExecPolicy, r.probeTimeout())
 		}
 	}
+	if r.SecretReader == nil {
+		r.SecretReader = mgr.GetAPIReader()
+	}
 	if r.firstFailure == nil {
 		r.firstFailure = map[string]time.Time{}
 	}
@@ -387,7 +406,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts ...Option) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.WorkloadCluster{}).
-		Watches(&corev1.Secret{}, r.secretEventHandler(cfg.eventsBatchPeriod)).
+		// Metadata-only: this controller needs Secret CHANGE events, never cached
+		// Secret payloads. A full informer would hold every Secret in the cluster
+		// in memory and widen the blast radius of a compromised manager pod.
+		Watches(&corev1.Secret{}, r.secretEventHandler(cfg.eventsBatchPeriod), builder.OnlyMetadata).
 		Complete(r)
 }
 


### PR DESCRIPTION
**Part 5 of 5** — depends on Parts 1–4.

Wires the multi-cluster layer into the manager: a `--multicluster-role` gate (control-plane vs member), flags for exec-credential policy and the placement control-plane identity, and `setupMultiCluster` which builds the WorkloadCluster transport always and the placement controller + GC + endpoint publisher on the control plane. On the control plane the local ISVC and model/runtime reconcilers stand down (placement owns ISVCs). Regenerates the manager ClusterRole for `workloadclusters` and `httproutes`.

> Squash-only repo: diff includes Parts 1–4 until they merge; rebased after each.