### PR TITLE
[Helm] Bump image references to v1.2.2

### DIFF
--- a/charts/ome-resources/values.yaml
+++ b/charts/ome-resources/values.yaml
@@ -8,7 +8,7 @@ global:
   imagePullSecrets: []
 
 ome:
-  version: &defaultVersion v1.2.1
+  version: &defaultVersion v1.2.2
   benchmarkJob:
     image: genai-bench
     tag: 0.1.113

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -27,7 +27,7 @@ data:
 
   modelInit: |-
     {
-        "image" : "ghcr.io/moirai-internal/ome-agent:v1.2.1",
+        "image" : "ghcr.io/moirai-internal/ome-agent:v1.2.2",
         "memoryRequest": "320Gi",
         "memoryLimit": "320Gi",
         "cpuRequest": "15",

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: manager
-          image: ghcr.io/moirai-internal/ome-manager:v1.2.1
+          image: ghcr.io/moirai-internal/ome-manager:v1.2.2

--- a/config/default/model_agent_image_patch.yaml
+++ b/config/default/model_agent_image_patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: model-agent
-          image: ghcr.io/moirai-internal/model-agent:v1.2.1
+          image: ghcr.io/moirai-internal/model-agent:v1.2.2

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
           - "--leader-elect"
           - "webhook"
           - "--zap-encoder=console"
-        image: ghcr.io/moirai-internal/ome-manager:v1.2.1
+        image: ghcr.io/moirai-internal/ome-manager:v1.2.2
         imagePullPolicy: Always
         name: manager
         securityContext:

--- a/config/model-agent/daemonset.yaml
+++ b/config/model-agent/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
           type: DirectoryOrCreate
       containers:
       - name: model-agent
-        image: ghcr.io/moirai-internal/model-agent:v1.2.1
+        image: ghcr.io/moirai-internal/model-agent:v1.2.2
         imagePullPolicy: Always
         ports:
         - name: metrics


### PR DESCRIPTION
## Summary

Bump OME image references from `v1.2.1` to `v1.2.2` across **both** deploy paths — the Helm chart and the raw kustomize manifests — so they stay consistent for the release.

## Changes

**Helm chart**
- `charts/ome-resources/values.yaml` — `ome.version` (`&defaultVersion`) `v1.2.1` → `v1.2.2`, which propagates through the `*defaultVersion` anchor to all three image tags that reference it.

**Raw manifests (`config/`)**
- `config/manager/manager.yaml` — `ome-manager:v1.2.2`
- `config/default/manager_image_patch.yaml` — `ome-manager:v1.2.2`
- `config/model-agent/daemonset.yaml` — `model-agent:v1.2.2`
- `config/default/model_agent_image_patch.yaml` — `model-agent:v1.2.2`
- `config/configmap/inferenceservice.yaml` — `ome-agent:v1.2.2`

6 files changed, 6 insertions(+), 6 deletions(-). No `v1.2.1` references remain in `charts/` or `config/`.
