### PR TITLE
Bump rand from 0.9.2 to 0.9.3 in pkg/xet

### DIFF
--- a/pkg/xet/Cargo.lock
+++ b/pkg/xet/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
  "mdb_shard",
  "merklehash",
  "more-asserts",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "thiserror 2.0.16",
  "tokio",
@@ -396,7 +396,7 @@ dependencies = [
  "merklehash",
  "mockall",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -643,7 +643,7 @@ dependencies = [
  "more-asserts",
  "progress_tracking",
  "prometheus",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "regex",
  "serde",
@@ -828,7 +828,7 @@ dependencies = [
  "colored",
  "lazy_static",
  "libc",
- "rand 0.9.2",
+ "rand 0.9.3",
  "tracing",
  "whoami",
  "winapi",
@@ -1661,7 +1661,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "merklehash",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "serde",
  "static_assertions",
@@ -1688,7 +1688,7 @@ dependencies = [
  "blake3",
  "getrandom 0.3.3",
  "heed",
- "rand 0.9.2",
+ "rand 0.9.3",
  "safe-transmute",
  "serde",
 ]
@@ -2228,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3317,7 +3317,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.3",
  "web-time",
 ]
 


### PR DESCRIPTION
## What this PR does

Lockfile-only patch bump of `rand` 0.9.2 → 0.9.3 in
`pkg/xet/Cargo.lock`. No other crate versions move (the diff beyond
the version/checksum flip is just per-crate dependency references).

## Why we need it

Resolves Dependabot alert #90 —
[GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc)
(low): rand 0.9.0–0.9.2 unsoundness when a custom logger calls
`rand::rng()`. The `rand 0.8.7` copy also in the lockfile is outside
the advisory's affected range.

## How to test

`cargo build --release` in `pkg/xet` succeeds; `go test ./pkg/xet`
passes except `TestConfig_Validate/valid_config`, which fails
identically on unmodified `main` ("cache directory is required",
`config_test.go:266`) — pre-existing and unrelated to this bump.

## Checklist

- [ ] Tests added/updated (N/A — lockfile patch bump)
- [ ] Docs updated (N/A)
- [x] Rust build and Go binding tests verified locally