### PR TITLE
Bump xet-core to drop vulnerable jsonwebtoken

### DIFF
--- a/pkg/xet/Cargo.lock
+++ b/pkg/xet/Cargo.lock
@@ -92,6 +92,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +134,58 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -223,48 +284,56 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cas_client"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
+ "base64 0.22.1",
  "bytes",
  "cas_object",
  "cas_types",
- "chunk_cache",
+ "chrono",
+ "clap",
  "deduplication",
- "derivative",
  "error_printer",
  "file_utils",
  "futures",
+ "futures-util",
  "heed",
  "http 1.3.1",
  "hyper 1.7.0",
- "hyper-util",
  "lazy_static",
  "mdb_shard",
  "merklehash",
  "more-asserts",
  "progress_tracking",
+ "rand 0.9.3",
  "reqwest 0.12.23",
  "reqwest-middleware",
  "reqwest-retry",
  "serde",
  "serde_json",
+ "statrs",
  "tempfile",
  "thiserror 2.0.16",
  "tokio",
  "tokio-retry",
- "tower-service",
+ "tower-http",
  "tracing",
+ "tracing-log",
+ "tracing-subscriber",
  "url",
  "utils",
+ "warp",
+ "web-time",
  "xet_runtime",
 ]
 
 [[package]]
 name = "cas_object"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -273,7 +342,6 @@ dependencies = [
  "countio",
  "csv",
  "deduplication",
- "error_printer",
  "futures",
  "half",
  "lz4_flex",
@@ -284,15 +352,15 @@ dependencies = [
  "serde",
  "thiserror 2.0.16",
  "tokio",
- "tokio-util",
  "tracing",
  "utils",
+ "xet_runtime",
 ]
 
 [[package]]
 name = "cas_types"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "merklehash",
  "serde",
@@ -353,27 +421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chunk_cache"
-version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "cas_types",
- "crc32fast",
- "error_printer",
- "file_utils",
- "merklehash",
- "mockall",
- "once_cell",
- "rand 0.9.3",
- "thiserror 2.0.16",
- "tokio",
- "tracing",
- "utils",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +474,35 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "const-str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21077772762a1002bb421c3af42ac1725fa56066bfc53d9a55bb79905df2aaf3"
+dependencies = [
+ "const-str-proc-macro",
+]
+
+[[package]]
+name = "const-str-proc-macro"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1e0fdd2e5d3041e530e1b21158aeeef8b5d0e306bc5c1e3d6cf0930d10e25a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -486,15 +562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if 1.0.3",
 ]
 
 [[package]]
@@ -568,7 +635,7 @@ checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 [[package]]
 name = "data"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -579,10 +646,9 @@ dependencies = [
  "chrono",
  "clap",
  "deduplication",
- "dirs 5.0.1",
  "error_printer",
+ "file_reconstruction",
  "hub_client",
- "jsonwebtoken",
  "lazy_static",
  "mdb_shard",
  "merklehash",
@@ -590,7 +656,6 @@ dependencies = [
  "progress_tracking",
  "prometheus",
  "rand 0.9.3",
- "rand_chacha 0.9.0",
  "regex",
  "serde",
  "serde_json",
@@ -606,18 +671,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "deduplication"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "async-trait",
  "bytes",
  "gearhash",
+ "lazy_static",
  "mdb_shard",
  "merklehash",
  "more-asserts",
  "progress_tracking",
  "utils",
+ "xet_runtime",
 ]
 
 [[package]]
@@ -701,12 +774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "dtor"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +787,20 @@ name = "dtor-proc-macro"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+
+[[package]]
+name = "duration-str"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9add086174f60bcbcfde7175e71dcfd99da24dfd12f611d0faf74f4f26e15a06"
+dependencies = [
+ "chrono",
+ "rust_decimal",
+ "serde",
+ "thiserror 2.0.16",
+ "time",
+ "winnow",
+]
 
 [[package]]
 name = "either"
@@ -755,7 +836,7 @@ dependencies = [
 [[package]]
 name = "error_printer"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "tracing",
 ]
@@ -767,9 +848,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "file_reconstruction"
+version = "0.14.5"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cas_client",
+ "cas_types",
+ "lazy_static",
+ "merklehash",
+ "more-asserts",
+ "progress_tracking",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "utils",
+ "xet_config",
+ "xet_runtime",
+]
+
+[[package]]
 name = "file_utils"
 version = "0.14.2"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "colored",
  "lazy_static",
@@ -815,12 +917,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -1013,6 +1109,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.12",
+]
+
+[[package]]
 name = "heapify"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,16 +1254,16 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub_client"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "anyhow",
  "async-trait",
  "cas_client",
- "http 1.3.1",
  "reqwest 0.12.23",
  "reqwest-middleware",
  "serde",
  "thiserror 2.0.16",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1183,6 +1303,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1240,7 +1361,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -1460,19 +1581,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "9.3.1"
+name = "konst"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "97feab15b395d1860944abe6a8dd8ed9f8eadfae01750fada8427abda531d887"
 dependencies = [
- "base64 0.22.1",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
+ "const_panic",
+ "konst_kernel",
+ "konst_proc_macros",
+ "typewit",
 ]
+
+[[package]]
+name = "konst_kernel"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b1eb7788f3824c629b1116a7a9060d6e898c358ebff59070093d51103dcc3c"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00af7901ba50898c9e545c24d5c580c96a982298134e8037d8978b6594782c07"
 
 [[package]]
 name = "lazy_static"
@@ -1485,6 +1618,12 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1561,9 +1700,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "mdb_shard"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1576,6 +1731,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "merklehash",
+ "more-asserts",
  "rand 0.9.3",
  "regex",
  "serde",
@@ -1586,6 +1742,7 @@ dependencies = [
  "tracing",
  "utils",
  "uuid",
+ "xet_runtime",
 ]
 
 [[package]]
@@ -1597,7 +1754,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 [[package]]
 name = "merklehash"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -1613,6 +1770,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1635,36 +1802,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
-dependencies = [
- "cfg-if 1.0.3",
- "downcast",
- "fragile",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
-dependencies = [
- "cfg-if 1.0.3",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "more-asserts"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
+
+[[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.8.7",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "native-tls"
@@ -1693,12 +1881,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
+name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "num-integer",
  "num-traits",
 ]
 
@@ -1718,12 +1905,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1745,6 +1943,7 @@ dependencies = [
  "cas_object",
  "data",
  "dirs 5.0.1",
+ "file_reconstruction",
  "futures",
  "libc",
  "merklehash",
@@ -1887,14 +2086,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "3.0.5"
+name = "paste"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
-dependencies = [
- "base64 0.22.1",
- "serde",
-]
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1965,32 +2160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "predicates"
-version = "3.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
-dependencies = [
- "anstyle",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,13 +2171,12 @@ dependencies = [
 [[package]]
 name = "progress_tracking"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "async-trait",
  "merklehash",
  "more-asserts",
  "tokio",
- "utils",
 ]
 
 [[package]]
@@ -2059,7 +2227,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -2097,7 +2265,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2200,6 +2368,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2385,12 @@ checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -2422,6 +2606,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,6 +2715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +2740,12 @@ checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.0",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2624,6 +2833,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +2864,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if 1.0.3",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -2701,15 +2932,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple_asn1"
-version = "0.6.3"
+name = "simba"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
 dependencies = [
- "num-bigint",
+ "approx",
+ "num-complex",
  "num-traits",
- "thiserror 2.0.16",
- "time",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -2745,6 +2977,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,6 +2993,19 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35a062dbadac17a42e0fc64c27f419b25d6fae98572eb43c8814c9e873d7721"
+dependencies = [
+ "approx",
+ "lazy_static",
+ "nalgebra",
+ "num-traits",
+ "rand 0.8.7",
+]
 
 [[package]]
 name = "strsim"
@@ -2881,12 +3132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,9 +3189,7 @@ dependencies = [
  "deranged",
  "num-conv",
  "powerfmt",
- "serde_core",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -2954,16 +3197,6 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
-
-[[package]]
-name = "time-macros"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
-dependencies = [
- "num-conv",
- "time-core",
-]
 
 [[package]]
 name = "tinystr"
@@ -3053,6 +3286,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,6 +3323,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3116,6 +3362,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3154,6 +3401,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,12 +3420,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3176,6 +3436,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.8.7",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "twox-hash"
@@ -3190,6 +3469,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
+dependencies = [
+ "typewit_proc_macros",
+]
+
+[[package]]
+name = "typewit_proc_macros"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
+
+[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3492,12 @@ dependencies = [
  "rand 0.9.3",
  "web-time",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -3224,6 +3524,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,12 +3550,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
  "async-trait",
  "bytes",
  "ctor",
  "derivative",
+ "duration-str",
  "error_printer",
  "futures",
  "lazy_static",
@@ -3252,6 +3565,7 @@ dependencies = [
  "shellexpand",
  "thiserror 2.0.16",
  "tokio",
+ "tokio-util",
  "tracing",
  "web-time",
 ]
@@ -3302,6 +3616,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3472,6 +3815,16 @@ dependencies = [
  "libredox",
  "wasite",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -3831,6 +4184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3853,10 +4215,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
+name = "xet_config"
+version = "0.14.5"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
+dependencies = [
+ "const-str",
+ "konst",
+ "utils",
+]
+
+[[package]]
 name = "xet_runtime"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core#fa030edcd5edc7b18af1c7073bcc3dcf2f9cfc48"
+source = "git+https://github.com/huggingface/xet-core#db2a0e722bcd80ea7f5cf339a0b550d01e6321b2"
 dependencies = [
+ "dirs 6.0.0",
  "error_printer",
  "libc",
  "oneshot",
@@ -3865,6 +4238,7 @@ dependencies = [
  "tokio",
  "tracing",
  "utils",
+ "xet_config",
 ]
 
 [[package]]

--- a/pkg/xet/Cargo.toml
+++ b/pkg/xet/Cargo.toml
@@ -16,6 +16,7 @@ utils = { git = "https://github.com/huggingface/xet-core", package = "utils" }
 xet-runtime = { git = "https://github.com/huggingface/xet-core", package = "xet_runtime" }
 progress-tracking = { git = "https://github.com/huggingface/xet-core", package = "progress_tracking" }
 merklehash = { git = "https://github.com/huggingface/xet-core", package = "merklehash" }
+file_reconstruction = { git = "https://github.com/huggingface/xet-core", package = "file_reconstruction" }
 
 # Standard dependencies
 ulid = "1.1"

--- a/pkg/xet/src/xet_downloader.rs
+++ b/pkg/xet/src/xet_downloader.rs
@@ -2,7 +2,7 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use cas_client::remote_client::PREFIX_DEFAULT;
-use cas_client::{CacheConfig, FileProvider, OutputProvider, CHUNK_CACHE_SIZE_BYTES};
+use file_reconstruction::DataOutput;
 use dirs::home_dir;
 use merklehash::MerkleHash;
 use progress_tracking::{
@@ -129,7 +129,7 @@ impl XetDownloader {
             std::fs::create_dir_all(parent)?;
         }
 
-        let output = OutputProvider::File(FileProvider::new(destination_path.to_path_buf()));
+        let output = DataOutput::write_in_file(destination_path);
         let file_name_arc: Arc<str> = Arc::from(file_name.to_owned());
 
         let progress_updater = progress.as_ref().map(|tracker| {
@@ -143,7 +143,7 @@ impl XetDownloader {
 
         let bytes_downloaded = self
             .downloader
-            .smudge_file_from_hash(&hash, file_name_arc, &output, None, progress_updater)
+            .smudge_file_from_hash(&hash, file_name_arc, output, None, progress_updater)
             .await?;
 
         info!(
@@ -230,11 +230,8 @@ fn create_xet_config(
             compression: None,
             auth: auth_cfg,
             prefix: PREFIX_DEFAULT.into(),
-            cache_config: CacheConfig {
-                cache_directory: cache_path.join("chunk-cache"),
-                cache_size: *CHUNK_CACHE_SIZE_BYTES,
-            },
             staging_directory: None,
+            user_agent: format!("ome-xet-binding/{}", env!("CARGO_PKG_VERSION")),
         },
         shard_config: ShardConfig {
             prefix: PREFIX_DEFAULT.into(),


### PR DESCRIPTION
## What this PR does

Advances the `xet-core` git pin from `fa030edc` (2025-09-17) to
`db2a0e72` (2026-01-21) and migrates `pkg/xet` to the small API
changes that come with it:

- `cas_client::{OutputProvider, FileProvider}` →
  `file_reconstruction::DataOutput` (new direct git dependency),
  passed by value to `smudge_file_from_hash`
- `DataConfig.cache_config` removed upstream — chunk-cache placement
  and sizing are now managed by xet-core's global config, which
  resolves the **same** `HF_XET_CACHE`/`HF_HOME`/`XDG_CACHE_HOME`
  chain the binding already uses, so the cache root is unchanged
- `DataConfig.user_agent` is now required (set to
  `ome-xet-binding/<version>`)

`db2a0e72` is deliberately the last rev before upstream's March 2026
crate reorganization; anything newer renames the crates this binding
depends on and becomes a full migration (tracked as future work —
upstream also fixed 21 of its own Dependabot alerts in July 2026).

## Why we need it

Resolves Dependabot alert #33 —
[GHSA-h395-gr6q-cpjc](https://github.com/advisories/GHSA-h395-gr6q-cpjc)
(moderate): jsonwebtoken < 10.3.0 type confusion, potential
authorization bypass. Upstream removed the jsonwebtoken dependency
entirely in this range: `cargo update` explicitly logs
`Removing jsonwebtoken v9.3.1`, and the lockfile now has zero
entries for it.

## How to test

- `cargo build --release` clean, no warnings
- `cargo test --release`: 6/6 Rust unit tests pass
- `go test ./pkg/xet`: passes except
  `TestConfig_Validate/valid_config`, which fails identically on
  unmodified `main` (pre-existing, unrelated)

**Review note:** the on-disk chunk-cache subpath layout under the
cache root is now upstream-managed (was `<root>/<endpoint-tag>/
chunk-cache`), and cache sizing moved to the
`HF_XET_CHUNK_CACHE_SIZE_BYTES` env var. Worth a real model-download
smoke test in a dev cluster before this ships in a release.

## Checklist

- [ ] Tests added/updated (existing Rust + Go binding tests cover
  the migration surface)
- [ ] Docs updated (N/A)
- [x] Build, Rust tests, and Go binding tests verified locally