### PR TITLE
[CI/Tests] stop per-commit docker image builds

### DIFF
--- a/.github/workflows/dev-images.yaml
+++ b/.github/workflows/dev-images.yaml
@@ -1,9 +1,9 @@
 name: Dev Images
 
+# Dev images are built and pushed on demand only; every merge to main was
+# rebuilding and pushing all images, which ate runner capacity. Release
+# images are unaffected (release.yaml builds on tags).
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -139,11 +139,37 @@ jobs:
           make ome-manager
           make model-agent
 
+  # Docker builds only validate Dockerfile/build-context breakage —
+  # test-and-build already compiles and tests the same code natively —
+  # so they run only when a docker-relevant path actually changed.
+  docker-changes:
+    name: Detect Docker-Relevant Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check changed paths
+        id: filter
+        run: |
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | \
+             grep -qE '^(dockerfiles/|Makefile|pkg/xet/|go\.(mod|sum)|\.github/workflows/pr-validation\.yml)'; then
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docker=false" >> "$GITHUB_OUTPUT"
+          fi
+
   docker-validation:
     name: Docker Build Validation
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: pre-commit-checks
+    needs: [pre-commit-checks, docker-changes]
+    if: needs.docker-changes.outputs.docker == 'true'
     strategy:
       matrix:
         image: [ome-image, model-agent-image, ome-agent-image]


### PR DESCRIPTION
## What this PR does

- **dev-images.yaml**: removes the `push: main` trigger — every merge
  to main was building and pushing all three dev images to ghcr.
  `workflow_dispatch` remains for on-demand dev images; release
  images are unaffected (`release.yaml` builds on tags).
- **pr-validation.yml**: adds a `docker-changes` detection job and
  runs the 3-image `docker-validation` matrix only when the PR
  touches a docker-relevant path (`dockerfiles/`, `Makefile`,
  `pkg/xet/`, root `go.mod`/`go.sum`, or the workflow itself).
  `test-and-build` already compiles and tests the same code natively
  on every commit — the docker builds only catch Dockerfile and
  build-context breakage. The QEMU multi-arch job was already
  opt-in via the `test-multiarch` label; that stays as is.

## Why we need it

CI is queueing badly. All runners are GitHub-hosted
(`ubuntu-latest` across every workflow), so concurrent-job limits
apply, and each PR commit was spawning 3 docker image builds (up to
15 min each) plus each merge to main another 3 build-and-push jobs.
For a docs or dependency PR, none of that validates anything the
native build didn't already cover.

## How to test

YAML validated locally. A follow-up PR touching only docs should
show `docker-validation` as skipped in the PR summary (the summary
job already treats skipped as non-failing); a PR touching
`dockerfiles/` should run it.

## Checklist

- [ ] Tests added/updated (N/A — CI configuration)
- [ ] Docs updated (N/A)
- [x] Workflow YAML validated locally