### PR TITLE
Allow model agent to run on non-GPU nodes

### DIFF
--- a/pkg/modelagent/scout.go
+++ b/pkg/modelagent/scout.go
@@ -81,7 +81,11 @@ func NewScout(ctx context.Context, nodeName string,
 	}
 	nodeShapeAlias, err := utils.GetInstanceTypeShortName(instanceType)
 	if err != nil {
-		return nil, err
+		// A shape alias is only needed for shape-specific TensorRT-LLM artifacts.
+		// CPU nodes do not have an entry in the GPU shape map, but can still
+		// download normal models.
+		logger.Infof("Node %s has no GPU shape alias; continuing without TensorRT-LLM shape filtering: %s", nodeName, err)
+		nodeShapeAlias = ""
 	}
 
 	scout := &Scout{


### PR DESCRIPTION
## What this PR does

Allow the model agent to start on CPU nodes whose instance type does not have a GPU shape alias.

## Why we need it

Shape aliases are only needed to select shape-specific TensorRT-LLM artifacts. Returning an error when a CPU node has no GPU shape alias prevents the model agent from downloading normal CPU-served models.

## How to test

- Run a model agent on a node whose instance type is not in the GPU shape map.
- Verify that the agent starts successfully and can download a normal model.
- TensorRT-LLM artifact selection remains shape-specific.