### PR TITLE
[Misc] replace committed token in benchmark sample

### DIFF
--- a/config/samples/benchmark/huggingface-secret.yaml
+++ b/config/samples/benchmark/huggingface-secret.yaml
@@ -4,5 +4,10 @@ metadata:
   name: huggingface-secret
   namespace: llama-3-1-70b
 type: Opaque
-data:
-  HUGGINGFACE_API_KEY: aGZfbXB5cnpsakhKRVhGcElrVkxOcGJ6cEJNY1F0Qk1CbVZNUw==
+stringData:
+  # Replace with your own Hugging Face access token
+  # (https://huggingface.co/settings/tokens), or create the secret
+  # directly without editing this file:
+  #   kubectl create secret generic huggingface-secret -n llama-3-1-70b \
+  #     --from-literal=HUGGINGFACE_API_KEY=<your-token>
+  HUGGINGFACE_API_KEY: REPLACE_WITH_YOUR_HUGGING_FACE_TOKEN


### PR DESCRIPTION
## What this PR does

Replaces the real-format Hugging Face user access token in
`config/samples/benchmark/huggingface-secret.yaml` (secret-scanning
alert #4, open since 2025-11) with a `stringData` placeholder plus
instructions for creating the secret via `kubectl create secret`
without editing the file.

## Why we need it

A working-format credential in a public sample is a leak regardless
of intent. **Merging this does not remediate the exposure by
itself:** the token has been in public git history since November
2025 and must be revoked/rotated on huggingface.co by whoever owns
it. Once revoked, the secret-scanning alert can be closed as
"revoked".

## How to test

`kubectl apply` of the sample still produces a valid Secret object
(placeholder value); the benchmark sample references the secret by
name, unchanged.

## Checklist

- [ ] Tests added/updated (N/A — sample manifest)
- [x] Docs updated (instructions embedded in the sample)
- [ ] `make test` passes locally (N/A — no code change)