### PR TITLE
[Bugfix] reject path traversal in zip extraction

### DIFF
--- a/pkg/zipper/unzip.go
+++ b/pkg/zipper/unzip.go
@@ -2,9 +2,11 @@ package zipper
 
 import (
 	"archive/zip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func Unzip(zippedFile string, extractingDir string) error {
@@ -36,6 +38,11 @@ func Unzip(zippedFile string, extractingDir string) error {
 		}()
 
 		path := filepath.Join(extractingDir, f.Name)
+
+		// Reject entries that resolve outside the extraction directory (zip-slip).
+		if path != filepath.Clean(extractingDir) && !strings.HasPrefix(path, filepath.Clean(extractingDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("archive entry %q escapes the extraction directory", f.Name)
+		}
 
 		if f.FileInfo().IsDir() {
 			if err := os.MkdirAll(path, 0777); err != nil {

--- a/pkg/zipper/unzip_test.go
+++ b/pkg/zipper/unzip_test.go
@@ -280,3 +280,24 @@ func TestUnzipWithInvalidExtractionPath(t *testing.T) {
 		}
 	}
 }
+
+func TestUnzipRejectsPathTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+	zipFile := filepath.Join(tmpDir, "evil.zip")
+	createTestZip(t, zipFile, map[string]string{
+		"../escaped.txt": "outside",
+	})
+
+	extractDir := filepath.Join(tmpDir, "extract")
+	if err := os.MkdirAll(extractDir, 0o755); err != nil {
+		t.Fatalf("Failed to create extraction dir: %v", err)
+	}
+
+	if err := Unzip(zipFile, extractDir); err == nil {
+		t.Fatal("Unzip accepted an archive entry that escapes the extraction directory")
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "escaped.txt")); err == nil {
+		t.Fatal("Unzip wrote a file outside the extraction directory")
+	}
+}


### PR DESCRIPTION
## What this PR does

`pkg/zipper.Unzip` joined archive entry names onto the extraction
directory without verifying the result stays inside it, so a
crafted archive entry (`../escaped.txt`) could write files outside
the target directory. Adds a containment check that rejects such
entries, plus a regression test that fails against the old code.

## Why we need it

Resolves CodeQL alert #15 (go/zipslip, high). The affected code
extracts downloaded artifacts in `internal/ome-agent/serving-agent`
and `internal/ome-agent/fine-tuned-adapter`, so archive contents are
not always locally authored.

## How to test

`go test ./pkg/zipper` — the new `TestUnzipRejectsPathTraversal`
fails without the fix (entry accepted, file written outside) and
passes with it; the existing zipper tests still pass.

## Checklist

- [x] Tests added/updated (regression test included)
- [ ] Docs updated (N/A)
- [x] Package tests pass locally