### PR TITLE
[Bugfix] drop secret key names from gopher logs

### DIFF
--- a/pkg/modelagent/gopher.go
+++ b/pkg/modelagent/gopher.go
@@ -916,16 +916,16 @@ func (s *Gopher) getHuggingFaceToken(task *GopherTask, baseModelSpec v1beta1.Bas
 				if baseModelSpec.Storage.Parameters != nil {
 					if customKey, exists := (*baseModelSpec.Storage.Parameters)["secretKey"]; exists && customKey != "" {
 						secretKeyName = customKey
-						s.logger.Infof("Using custom secret key name '%s' for model %s", secretKeyName, modelInfo)
+						s.logger.Infof("Using custom secret key from storage parameters for model %s", modelInfo)
 					}
 				}
 
 				// Try to get the token using the determined key name
 				if tokenBytes, exists := secret.Data[secretKeyName]; exists {
 					hfToken = string(tokenBytes)
-					s.logger.Infof("Successfully retrieved Hugging Face token from secret %s in namespace %s using key '%s'", *baseModelSpec.Storage.StorageKey, namespace, secretKeyName)
+					s.logger.Infof("Successfully retrieved Hugging Face token from secret %s in namespace %s", *baseModelSpec.Storage.StorageKey, namespace)
 				} else {
-					s.logger.Warnf("Secret %s in namespace %s does not contain key '%s'", *baseModelSpec.Storage.StorageKey, namespace, secretKeyName)
+					s.logger.Warnf("Secret %s in namespace %s does not contain the configured token key", *baseModelSpec.Storage.StorageKey, namespace)
 				}
 			}
 		} else {


### PR DESCRIPTION
## What this PR does

Rewords three model-agent log lines so the Hugging Face token
secret's key name (sourced from user-supplied storage `Parameters`)
is no longer interpolated into log output. The secret's name and
namespace — the operationally useful, non-sensitive parts — are
still logged.

## Why we need it

Resolves CodeQL alerts #12, #13, #14 (go/clear-text-logging, high)
on `pkg/modelagent/gopher.go`.

## How to test

`go build ./pkg/modelagent` and `go test ./pkg/modelagent` pass;
message content change only, no control-flow changes.

## Checklist

- [ ] Tests added/updated (N/A — log message wording)
- [ ] Docs updated (N/A)
- [x] Package build and tests pass locally