### PR TITLE
[Bugfix] bound integer parses in reconcilers

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -102,8 +102,9 @@ func getHPAMetrics(metadata metav1.ObjectMeta, componentExt *v1beta1.ComponentEx
 
 func getTargetUtilization(metadata metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec) int32 {
 	if value, ok := metadata.Annotations[constants.TargetUtilizationPercentage]; ok {
-		utilization, _ := strconv.Atoi(value)
-		return int32(utilization) // #nosec G109
+		if utilization, err := strconv.ParseInt(value, 10, 32); err == nil {
+			return int32(utilization)
+		}
 	}
 	if componentExt.ScaleTarget != nil {
 		return int32(*componentExt.ScaleTarget)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/istiosidecar/istiosidecar_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/istiosidecar/istiosidecar_reconciler.go
@@ -35,7 +35,7 @@ func NewIstioSidecarReconciler(client kclient.Client, scheme *runtime.Scheme, co
 }
 
 func createSidecar(componentMeta metav1.ObjectMeta) *istioclientv1beta1.Sidecar {
-	portInt, _ := strconv.Atoi(constants.InferenceServiceDefaultHttpPort)
+	portInt, _ := strconv.ParseUint(constants.InferenceServiceDefaultHttpPort, 10, 32)
 	return &istioclientv1beta1.Sidecar{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      componentMeta.Name,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -162,7 +162,7 @@ func buildServicePort(containerPort corev1.ContainerPort, appProtocol string) co
 
 // buildDefaultServicePort creates a default ServicePort
 func buildDefaultServicePort(name, appProtocol string) corev1.ServicePort {
-	port, _ := strconv.Atoi(constants.InferenceServiceDefaultHttpPort)
+	port, _ := strconv.ParseInt(constants.InferenceServiceDefaultHttpPort, 10, 32)
 	servicePort := corev1.ServicePort{
 		Name: name,
 		Port: constants.CommonISVCPort,


### PR DESCRIPTION
## What this PR does

Replaces `strconv.Atoi` + unchecked `int32`/`uint32` conversions
with size-bounded `strconv.ParseInt`/`ParseUint` at the four sites
CodeQL flags (go/incorrect-integer-conversion — alerts #16, #17,
#18, #340).

## Why we need it

- `hpa_reconciler.getTargetUtilization` converts a **user-supplied
  annotation**; a non-numeric or >int32 value previously became a
  garbage utilization target (0 on parse error). It now falls
  through to the `ScaleTarget`/default path.
- The `istiosidecar` and `service` sites parse a package constant —
  no behavior change, the bounded parse just makes the conversion
  provably safe and clears the alerts.

## How to test

`go build ./pkg/controller/...` clean;
`go test` passes for the hpa and service reconciler packages.

## Checklist

- [ ] Tests added/updated (existing reconciler tests cover the
  paths; hpa fallback behavior is exercised by defaults tests)
- [ ] Docs updated (N/A)
- [x] Build and affected-package tests pass locally