### PR TITLE
[Core] kubectl ome get: model-centric listings for all OME resources

### DIFF
--- a/pkg/cli/cmd/get/columns_test.go
+++ b/pkg/cli/cmd/get/columns_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
@@ -117,6 +118,80 @@ func TestModelAndRuntimeColumnsWrongType(t *testing.T) {
 			case domainTypedColumn[c.Name]:
 				assert.Equal(t, "?", got, "%s/%s", resource, c.Name)
 			}
+		}
+	}
+}
+
+func TestLongTailColumns(t *testing.T) {
+	mt := "LoRA"
+	base := "llama-3-3-70b"
+	cases := []struct {
+		resource string
+		obj      runtime.Object
+		want     map[string]string
+	}{
+		{"acceleratorclasses", &v1beta1.AcceleratorClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "h100"},
+			Spec:       v1beta1.AcceleratorClassSpec{Vendor: "nvidia", Family: "hopper"},
+		}, map[string]string{"NAME": "h100", "VENDOR": "nvidia", "FAMILY": "hopper"}},
+		{"benchmarkjobs", &v1beta1.BenchmarkJob{
+			ObjectMeta: metav1.ObjectMeta{Name: "bj"},
+			Status:     v1beta1.BenchmarkJobStatus{State: "Running"},
+		}, map[string]string{"NAME": "bj", "STATE": "Running"}},
+		{"finetunedweights", &v1beta1.FineTunedWeight{
+			ObjectMeta: metav1.ObjectMeta{Name: "ftw"},
+			Spec: v1beta1.FineTunedWeightSpec{
+				ModelType:    &mt,
+				BaseModelRef: v1beta1.ObjectReference{Name: &base},
+			},
+		}, map[string]string{"NAME": "ftw", "TYPE": "LoRA", "BASEMODEL": "llama-3-3-70b"}},
+		{"inferencereplicas", &v1beta1.InferenceReplica{
+			ObjectMeta: metav1.ObjectMeta{Name: "rep"},
+			Spec: v1beta1.InferenceReplicaSpec{
+				Component: v1beta1.EngineComponent,
+				ParentRef: v1beta1.ParentReference{Name: "llama-70b"},
+			},
+			Status: v1beta1.InferenceReplicaStatus{Replicas: 3},
+		}, map[string]string{"NAME": "rep", "COMPONENT": "engine", "PARENT": "llama-70b", "REPLICAS": "3"}},
+		{"workloadclusters", &v1beta1.WorkloadCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "wc"},
+			Status: v1beta1.WorkloadClusterStatus{Conditions: []metav1.Condition{{
+				Type: "Ready", Status: metav1.ConditionTrue,
+			}}},
+		}, map[string]string{"NAME": "wc", "READY": "True"}},
+	}
+	for _, tc := range cases {
+		e, err := resolve(tc.resource)
+		require.NoError(t, err, tc.resource)
+		got := map[string]string{}
+		for _, c := range e.Columns {
+			got[c.Name] = c.Extract(tc.obj)
+		}
+		for k, v := range tc.want {
+			assert.Equal(t, v, got[k], "%s/%s", tc.resource, k)
+		}
+	}
+}
+
+// TestLongTailColumnsWrongType extends the nil-safety guarantee pinned by
+// TestModelAndRuntimeColumnsWrongType (see its doc comment) to the five Task
+// 2.3 entries. Unlike models/runtimes, none of these entries merge multiple
+// concrete kinds behind one column set -- each is a single domain type -- so
+// every column here (including NAME/AGE) guards on that entry's own type and
+// reports "?" for any other kind; no metav1.Object broad-guard exception
+// applies.
+func TestLongTailColumnsWrongType(t *testing.T) {
+	wrong := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "not-a-long-tail-resource"}}
+	for _, resource := range []string{
+		"acceleratorclasses", "benchmarkjobs", "finetunedweights",
+		"inferencereplicas", "workloadclusters",
+	} {
+		e, err := resolve(resource)
+		require.NoError(t, err, resource)
+		for _, c := range e.Columns {
+			var got string
+			assert.NotPanics(t, func() { got = c.Extract(wrong) }, "%s/%s", resource, c.Name)
+			assert.Equal(t, "?", got, "%s/%s", resource, c.Name)
 		}
 	}
 }

--- a/pkg/cli/cmd/get/columns_test.go
+++ b/pkg/cli/cmd/get/columns_test.go
@@ -78,3 +78,45 @@ func TestModelColumnsMergedScope(t *testing.T) {
 		}
 	}
 }
+
+// TestModelAndRuntimeColumnsWrongType pins a fix for a nil-pointer-deref
+// panic: baseModelColumns'/runtimeColumns' internal spec()/status()
+// type-switch helpers used to return a nil pointer for any concrete type
+// outside {BaseModel,ClusterBaseModel} / {ServingRuntime,ClusterServingRuntime},
+// and several extractors dereferenced that nil unconditionally. Every
+// extractor must be nil-safe -- including against an object of the wrong
+// resource kind entirely, which should never reach these columns in
+// practice but must never crash the CLI if it does.
+//
+// Every column must survive (NotPanics). Columns that guard on the object's
+// *domain* type (a BaseModel/ClusterBaseModel or ServingRuntime/
+// ClusterServingRuntime type-switch, directly or via spec()/status()) report
+// "?" for a foreign type. AGE and runtimes' NAME instead guard on the
+// broader `metav1.Object` interface, which any real Kubernetes object
+// satisfies -- including the InferenceService used here, since it embeds
+// ObjectMeta -- so that guard defends against non-Kubernetes runtime.Objects
+// rather than a wrong domain kind, and legitimately renders the object's
+// real (harmless) name / a zero-value age instead of "?".
+func TestModelAndRuntimeColumnsWrongType(t *testing.T) {
+	wrong := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "not-a-model-or-runtime"}}
+	domainTypedColumn := map[string]bool{
+		"NAME": true, "SCOPE": true, "ARCH": true, "PARAMS": true,
+		"FORMAT": true, "STATE": true, "DISABLED": true, "FORMATS": true,
+	}
+	for _, resource := range []string{"models", "runtimes"} {
+		e, err := resolve(resource)
+		require.NoError(t, err, resource)
+		for _, c := range e.Columns {
+			var got string
+			assert.NotPanics(t, func() { got = c.Extract(wrong) }, "%s/%s", resource, c.Name)
+			switch {
+			case c.Name == "AGE":
+				assert.Equal(t, "-", got, "%s/%s", resource, c.Name)
+			case resource == "runtimes" && c.Name == "NAME":
+				assert.Equal(t, "not-a-model-or-runtime", got, "%s/%s", resource, c.Name)
+			case domainTypedColumn[c.Name]:
+				assert.Equal(t, "?", got, "%s/%s", resource, c.Name)
+			}
+		}
+	}
+}

--- a/pkg/cli/cmd/get/columns_test.go
+++ b/pkg/cli/cmd/get/columns_test.go
@@ -1,0 +1,80 @@
+package get
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+func TestISVCColumns(t *testing.T) {
+	e, err := resolve("isvc")
+	require.NoError(t, err)
+	u, _ := apis.ParseURL("https://llama.team-a.example.com")
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-70b"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Model:   &v1beta1.ModelRef{Name: "llama-3-3-70b"},
+			Runtime: &v1beta1.ServingRuntimeRef{Name: "srt-llama"},
+		},
+		Status: v1beta1.InferenceServiceStatus{
+			URL: u,
+			Status: duckv1.Status{Conditions: duckv1.Conditions{{
+				Type: apis.ConditionReady, Status: "True",
+			}}},
+		},
+	}
+	got := map[string]string{}
+	for _, c := range e.Columns {
+		got[c.Name] = c.Extract(isvc)
+	}
+	assert.Equal(t, "llama-70b", got["NAME"])
+	assert.Equal(t, "llama-3-3-70b", got["MODEL"])
+	assert.Equal(t, "srt-llama", got["RUNTIME"])
+	assert.Equal(t, "True", got["READY"])
+	assert.Equal(t, "https://llama.team-a.example.com", got["URL"])
+}
+
+func TestISVCColumnsNilRefs(t *testing.T) {
+	e, _ := resolve("isvc")
+	isvc := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "bare"}}
+	for _, c := range e.Columns {
+		assert.NotPanics(t, func() { c.Extract(isvc) }, c.Name)
+	}
+}
+
+func TestModelColumnsMergedScope(t *testing.T) {
+	e, err := resolve("models")
+	require.NoError(t, err)
+	arch, params := "LlamaForCausalLM", "70B"
+	bm := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "team-a"},
+		Spec: v1beta1.BaseModelSpec{
+			ModelFormat:        v1beta1.ModelFormat{Name: "safetensors"},
+			ModelArchitecture:  &arch,
+			ModelParameterSize: &params,
+		},
+		Status: v1beta1.ModelStatusSpec{State: v1beta1.LifeCycleStateReady},
+	}
+	got := map[string]string{}
+	for _, c := range e.Columns {
+		got[c.Name] = c.Extract(bm)
+	}
+	assert.Equal(t, "Namespaced", got["SCOPE"])
+	assert.Equal(t, "LlamaForCausalLM", got["ARCH"])
+	assert.Equal(t, "70B", got["PARAMS"])
+	assert.Equal(t, "safetensors", got["FORMAT"])
+	assert.Equal(t, "Ready", got["STATE"])
+
+	cbm := &v1beta1.ClusterBaseModel{ObjectMeta: metav1.ObjectMeta{Name: "m2"}}
+	for _, c := range e.Columns {
+		if c.Name == "SCOPE" {
+			assert.Equal(t, "Cluster", c.Extract(cbm))
+		}
+	}
+}

--- a/pkg/cli/cmd/get/get.go
+++ b/pkg/cli/cmd/get/get.go
@@ -1,0 +1,138 @@
+package get
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/apierror"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/printers"
+)
+
+type Options struct {
+	genericiooptions.IOStreams
+	Resource      string
+	Name          string
+	Output        string // "", "wide", "json", "yaml"
+	AllNamespaces bool
+	Selector      string
+
+	entry     *entry
+	namespace string
+}
+
+func NewCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	o := &Options{IOStreams: streams}
+	cmd := &cobra.Command{
+		Use:   "get RESOURCE [NAME]",
+		Short: "List OME resources with model-centric columns",
+		Long: `List OME resources. RESOURCE is one of the OME CRDs (e.g. isvc,
+basemodels, servingruntimes) or a merged view: "models" (BaseModels +
+ClusterBaseModels) or "runtimes" (ServingRuntimes + ClusterServingRuntimes).`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(f, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run(cmd.Context(), f)
+		},
+	}
+	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "Output format: wide, json or yaml")
+	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "List across all namespaces")
+	cmd.Flags().StringVarP(&o.Selector, "selector", "l", "", "Label selector to filter on")
+	return cmd
+}
+
+func (o *Options) Complete(f factory.Factory, args []string) error {
+	o.Resource = args[0]
+	if len(args) == 2 {
+		o.Name = args[1]
+	}
+	e, err := resolve(o.Resource)
+	if err != nil {
+		return err
+	}
+	o.entry = e
+	ns, _, err := f.Namespace()
+	if err != nil {
+		return err
+	}
+	o.namespace = ns
+	if o.AllNamespaces {
+		o.namespace = metav1.NamespaceAll
+	}
+	return nil
+}
+
+func (o *Options) Validate() error {
+	switch o.Output {
+	case "", "wide", "json", "yaml":
+	default:
+		return fmt.Errorf("unsupported output format %q (supported: wide, json, yaml)", o.Output)
+	}
+	if o.Name != "" && o.AllNamespaces {
+		return fmt.Errorf("a resource name cannot be combined with --all-namespaces")
+	}
+	if o.Name != "" && o.Selector != "" {
+		return fmt.Errorf("a resource name cannot be combined with --selector")
+	}
+	return nil
+}
+
+func (o *Options) Run(ctx context.Context, f factory.Factory) error {
+	var objs []runtime.Object
+	if o.Name != "" {
+		obj, err := o.entry.GetOne(ctx, f, o.namespace, o.Name)
+		if err != nil {
+			return apierror.Friendly(err)
+		}
+		objs = []runtime.Object{obj}
+	} else {
+		var err error
+		objs, err = o.entry.List(ctx, f, o.namespace, metav1.ListOptions{LabelSelector: o.Selector})
+		if err != nil {
+			return apierror.Friendly(err)
+		}
+	}
+	if o.Output == "json" || o.Output == "yaml" {
+		if o.Name != "" {
+			return printers.PrintObj(objs[0], o.Output, o.Out)
+		}
+		for _, obj := range objs {
+			if err := printers.PrintObj(obj, o.Output, o.Out); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if len(objs) == 0 {
+		fmt.Fprintf(o.ErrOut, "No %s found in namespace %q.\n", o.entry.Canonical, o.namespace)
+		return nil
+	}
+	table := printers.Table{}
+	for _, c := range o.entry.Columns {
+		if c.Wide && o.Output != "wide" {
+			continue
+		}
+		table.Headers = append(table.Headers, c.Name)
+	}
+	for _, obj := range objs {
+		var row []string
+		for _, c := range o.entry.Columns {
+			if c.Wide && o.Output != "wide" {
+				continue
+			}
+			row = append(row, c.Extract(obj))
+		}
+		table.Rows = append(table.Rows, row)
+	}
+	return table.Write(o.Out)
+}

--- a/pkg/cli/cmd/get/get.go
+++ b/pkg/cli/cmd/get/get.go
@@ -111,7 +111,7 @@ func (o *Options) Run(ctx context.Context, f factory.Factory) error {
 		if o.Name != "" {
 			return printers.PrintObj(objs[0], o.Output, o.Out)
 		}
-		list := &corev1.List{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "List"}}
+		list := &corev1.List{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "List"}, Items: []runtime.RawExtension{}}
 		for _, obj := range objs {
 			list.Items = append(list.Items, runtime.RawExtension{Object: obj})
 		}

--- a/pkg/cli/cmd/get/get.go
+++ b/pkg/cli/cmd/get/get.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -67,7 +68,11 @@ func (o *Options) Complete(f factory.Factory, args []string) error {
 	}
 	o.namespace = ns
 	if o.AllNamespaces {
-		o.namespace = metav1.NamespaceAll
+		if e.Namespaced {
+			o.namespace = metav1.NamespaceAll
+		} else {
+			fmt.Fprintf(o.ErrOut, "warning: --all-namespaces is ignored for the cluster-scoped resource %q\n", e.Canonical)
+		}
 	}
 	return nil
 }
@@ -106,15 +111,18 @@ func (o *Options) Run(ctx context.Context, f factory.Factory) error {
 		if o.Name != "" {
 			return printers.PrintObj(objs[0], o.Output, o.Out)
 		}
+		list := &corev1.List{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "List"}}
 		for _, obj := range objs {
-			if err := printers.PrintObj(obj, o.Output, o.Out); err != nil {
-				return err
-			}
+			list.Items = append(list.Items, runtime.RawExtension{Object: obj})
 		}
-		return nil
+		return printers.PrintObj(list, o.Output, o.Out)
 	}
 	if len(objs) == 0 {
-		fmt.Fprintf(o.ErrOut, "No %s found in namespace %q.\n", o.entry.Canonical, o.namespace)
+		if !o.entry.Namespaced || o.AllNamespaces {
+			fmt.Fprintf(o.ErrOut, "No %s found.\n", o.entry.Canonical)
+		} else {
+			fmt.Fprintf(o.ErrOut, "No %s found in namespace %q.\n", o.entry.Canonical, o.namespace)
+		}
 		return nil
 	}
 	table := printers.Table{}

--- a/pkg/cli/cmd/get/get_test.go
+++ b/pkg/cli/cmd/get/get_test.go
@@ -1,0 +1,97 @@
+package get
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+)
+
+var update = flag.Bool("update", false, "rewrite golden files")
+
+func assertGolden(t *testing.T, name string, got []byte) {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	if *update {
+		require.NoError(t, os.WriteFile(path, got, 0o644))
+	}
+	want, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(want), string(got))
+}
+
+func execute(t *testing.T, f factory.Factory, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	streams := genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &out, ErrOut: &out}
+	cmd := NewCmd(f, streams)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func fixtureISVC(name, ns string) *v1beta1.InferenceService {
+	return &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: v1beta1.InferenceServiceSpec{
+			Model:   &v1beta1.ModelRef{Name: "llama-3-3-70b"},
+			Runtime: &v1beta1.ServingRuntimeRef{Name: "srt-llama"},
+		},
+	}
+}
+
+func TestGetISVCTable(t *testing.T) {
+	f := factory.Static{
+		OME: omefake.NewSimpleClientset(fixtureISVC("a-isvc", "team-a"), fixtureISVC("b-isvc", "team-a")),
+		NS:  "team-a",
+	}
+	out, err := execute(t, f, "isvc")
+	require.NoError(t, err)
+	assertGolden(t, "isvc_list.golden", []byte(out))
+}
+
+func TestGetModelsMerged(t *testing.T) {
+	arch := "LlamaForCausalLM"
+	f := factory.Static{
+		OME: omefake.NewSimpleClientset(
+			&v1beta1.BaseModel{ObjectMeta: metav1.ObjectMeta{Name: "ns-model", Namespace: "team-a"},
+				Spec: v1beta1.BaseModelSpec{ModelArchitecture: &arch}},
+			&v1beta1.ClusterBaseModel{ObjectMeta: metav1.ObjectMeta{Name: "cluster-model"},
+				Spec: v1beta1.BaseModelSpec{ModelArchitecture: &arch}},
+		),
+		NS: "team-a",
+	}
+	out, err := execute(t, f, "models")
+	require.NoError(t, err)
+	assertGolden(t, "models_merged.golden", []byte(out))
+}
+
+func TestGetSingleNameJSON(t *testing.T) {
+	f := factory.Static{OME: omefake.NewSimpleClientset(fixtureISVC("a-isvc", "team-a")), NS: "team-a"}
+	out, err := execute(t, f, "isvc", "a-isvc", "-o", "json")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"name": "a-isvc"`)
+}
+
+func TestGetUnknownResourceErr(t *testing.T) {
+	_, err := execute(t, factory.Static{NS: "d"}, "banana")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown resource")
+}
+
+func TestGetNotFoundFriendly(t *testing.T) {
+	f := factory.Static{OME: omefake.NewSimpleClientset(), NS: "team-a"}
+	_, err := execute(t, f, "isvc", "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"missing" not found`)
+}

--- a/pkg/cli/cmd/get/get_test.go
+++ b/pkg/cli/cmd/get/get_test.go
@@ -146,6 +146,25 @@ func TestGetModelsListYAMLEnvelope(t *testing.T) {
 	assert.Len(t, doc.Items, 2)
 }
 
+// TestGetEmptyListJSONEnvelopeHasEmptyItemsArray pins the round-2 fix: an
+// empty result set's -o json output must have an empty items ARRAY, never a
+// null items field -- naive consumers like `jq '.items[]'` error on null.
+func TestGetEmptyListJSONEnvelopeHasEmptyItemsArray(t *testing.T) {
+	f := factory.Static{OME: omefake.NewSimpleClientset(), NS: "team-a"}
+	out, err := execute(t, f, "workloadclusters", "-o", "json")
+	require.NoError(t, err)
+	assert.NotContains(t, out, "null", "no field of an empty List envelope should render as null")
+
+	var list struct {
+		Kind  string            `json:"kind"`
+		Items []json.RawMessage `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &list), "must be a single valid JSON document")
+	assert.Equal(t, "List", list.Kind)
+	assert.NotNil(t, list.Items, "items must unmarshal as an empty array, not null")
+	assert.Len(t, list.Items, 0)
+}
+
 // TestGetAllNamespacesWarnsOnClusterScoped pins Finding 2a: -A on a
 // cluster-scoped resource is accepted (not an error, kubectl parity) but
 // warns instead of silently doing nothing.

--- a/pkg/cli/cmd/get/get_test.go
+++ b/pkg/cli/cmd/get/get_test.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/cli/factory"
@@ -94,4 +96,91 @@ func TestGetNotFoundFriendly(t *testing.T) {
 	_, err := execute(t, f, "isvc", "missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `"missing" not found`)
+}
+
+// TestGetISVCListJSONEnvelope pins Finding 1: a multi-object -o json listing
+// must be one valid document -- a v1 List envelope -- not several bare
+// objects printed back-to-back.
+func TestGetISVCListJSONEnvelope(t *testing.T) {
+	f := factory.Static{
+		OME: omefake.NewSimpleClientset(fixtureISVC("a-isvc", "team-a"), fixtureISVC("b-isvc", "team-a")),
+		NS:  "team-a",
+	}
+	out, err := execute(t, f, "isvc", "-o", "json")
+	require.NoError(t, err)
+	var list struct {
+		Kind  string            `json:"kind"`
+		Items []json.RawMessage `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &list), "must be a single valid JSON document")
+	assert.Equal(t, "List", list.Kind)
+	assert.Len(t, list.Items, 2)
+}
+
+// TestGetModelsListYAMLEnvelope pins Finding 1 for the YAML path: printing
+// each object separately produces a malformed multi-document stream (no ---
+// separators); the fix wraps the list in a single List envelope instead.
+func TestGetModelsListYAMLEnvelope(t *testing.T) {
+	arch := "LlamaForCausalLM"
+	f := factory.Static{
+		OME: omefake.NewSimpleClientset(
+			&v1beta1.BaseModel{ObjectMeta: metav1.ObjectMeta{Name: "ns-model", Namespace: "team-a"},
+				Spec: v1beta1.BaseModelSpec{ModelArchitecture: &arch}},
+			&v1beta1.ClusterBaseModel{ObjectMeta: metav1.ObjectMeta{Name: "cluster-model"},
+				Spec: v1beta1.BaseModelSpec{ModelArchitecture: &arch}},
+		),
+		NS: "team-a",
+	}
+	out, err := execute(t, f, "models", "-o", "yaml")
+	require.NoError(t, err)
+	assert.Contains(t, out, "kind: List")
+	assert.Contains(t, out, "name: ns-model")
+	assert.Contains(t, out, "name: cluster-model")
+
+	var doc struct {
+		Kind  string           `json:"kind"`
+		Items []map[string]any `json:"items"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(out), &doc), "must be a single valid YAML document")
+	assert.Equal(t, "List", doc.Kind)
+	assert.Len(t, doc.Items, 2)
+}
+
+// TestGetAllNamespacesWarnsOnClusterScoped pins Finding 2a: -A on a
+// cluster-scoped resource is accepted (not an error, kubectl parity) but
+// warns instead of silently doing nothing.
+func TestGetAllNamespacesWarnsOnClusterScoped(t *testing.T) {
+	f := factory.Static{OME: omefake.NewSimpleClientset(), NS: "team-a"}
+	out, err := execute(t, f, "acceleratorclasses", "-A")
+	require.NoError(t, err)
+	assert.Contains(t, out, `warning: --all-namespaces is ignored for the cluster-scoped resource "acceleratorclasses"`)
+}
+
+// TestGetEmptyClusterScopedMessageHasNoNamespaceClause pins Finding 2b: the
+// empty-list message for a cluster-scoped resource must not claim a
+// namespace scope that doesn't apply.
+func TestGetEmptyClusterScopedMessageHasNoNamespaceClause(t *testing.T) {
+	f := factory.Static{OME: omefake.NewSimpleClientset(), NS: "team-a"}
+	out, err := execute(t, f, "workloadclusters")
+	require.NoError(t, err)
+	assert.Contains(t, out, "No workloadclusters found.\n")
+	assert.NotContains(t, out, "namespace")
+}
+
+func TestGetInvalidOutputFormat(t *testing.T) {
+	_, err := execute(t, factory.Static{NS: "team-a"}, "isvc", "-o", "toml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "supported: wide, json, yaml")
+}
+
+func TestGetNameWithAllNamespacesRejected(t *testing.T) {
+	_, err := execute(t, factory.Static{NS: "team-a"}, "isvc", "a-isvc", "-A")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined with --all-namespaces")
+}
+
+func TestGetNameWithSelectorRejected(t *testing.T) {
+	_, err := execute(t, factory.Static{NS: "team-a"}, "isvc", "a-isvc", "-l", "foo=bar")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined with --selector")
 }

--- a/pkg/cli/cmd/get/registry.go
+++ b/pkg/cli/cmd/get/registry.go
@@ -1,0 +1,456 @@
+// Package get implements `kubectl ome get`: a table-driven view over every
+// OME resource. Each resource is one registry entry; adding a resource means
+// adding an entry, never a new command.
+package get
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/printers"
+)
+
+type listFunc func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error)
+
+type getFunc func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error)
+
+type column struct {
+	Name    string
+	Wide    bool // shown only with -o wide
+	Extract func(obj runtime.Object) string
+}
+
+type entry struct {
+	Canonical  string
+	Aliases    []string
+	Namespaced bool
+	Columns    []column
+	List       listFunc
+	GetOne     getFunc
+}
+
+func resolve(resource string) (*entry, error) {
+	needle := strings.ToLower(resource)
+	for _, e := range registry {
+		if e.Canonical == needle {
+			return e, nil
+		}
+		for _, a := range e.Aliases {
+			if a == needle {
+				return e, nil
+			}
+		}
+	}
+	names := make([]string, 0, len(registry))
+	for _, e := range registry {
+		names = append(names, e.Canonical)
+	}
+	sort.Strings(names)
+	return nil, fmt.Errorf("unknown resource %q (valid resources: %s)", resource, strings.Join(names, ", "))
+}
+
+// nameCol adapts a typed extractor (e.g. func(*v1beta1.InferenceService) string)
+// to the runtime.Object-keyed column.Extract signature, so each entry's
+// column table can be written against its concrete API type instead of
+// runtime.Object.
+func nameCol[T runtime.Object](extract func(T) string) func(runtime.Object) string {
+	return func(o runtime.Object) string { return extract(o.(T)) }
+}
+
+var isvcEntry = &entry{
+	Canonical:  "inferenceservices",
+	Aliases:    []string{"inferenceservice", "isvc", "isvcs"},
+	Namespaced: true,
+	Columns: []column{
+		{Name: "NAME", Extract: nameCol(func(i *v1beta1.InferenceService) string { return i.Name })},
+		{Name: "MODEL", Extract: nameCol(func(i *v1beta1.InferenceService) string {
+			if i.Spec.Model == nil {
+				return "-"
+			}
+			return i.Spec.Model.Name
+		})},
+		{Name: "RUNTIME", Extract: nameCol(func(i *v1beta1.InferenceService) string {
+			if i.Spec.Runtime == nil {
+				return "-" // auto-selected; status view shows the resolved one
+			}
+			return i.Spec.Runtime.Name
+		})},
+		{Name: "READY", Extract: nameCol(func(i *v1beta1.InferenceService) string {
+			c := i.Status.GetCondition(apis.ConditionReady)
+			if c == nil {
+				return "Unknown"
+			}
+			return string(c.Status)
+		})},
+		{Name: "URL", Extract: nameCol(func(i *v1beta1.InferenceService) string {
+			if i.Status.URL == nil {
+				return "-"
+			}
+			return i.Status.URL.String()
+		})},
+		{Name: "AGE", Extract: nameCol(func(i *v1beta1.InferenceService) string {
+			return printers.Age(i.CreationTimestamp)
+		})},
+	},
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		l, err := c.OmeV1beta1().InferenceServices(ns).List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			out = append(out, &l.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return c.OmeV1beta1().InferenceServices(ns).Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+// baseModelColumns builds the shared column set for BaseModel/ClusterBaseModel
+// objects. withScope adds a SCOPE column distinguishing namespaced vs
+// cluster-scoped entries; used only by the merged `models` view since the
+// single-kind `basemodels`/`clusterbasemodels` views have a fixed scope.
+func baseModelColumns(withScope bool) []column {
+	cols := []column{
+		{Name: "NAME", Extract: func(o runtime.Object) string {
+			switch m := o.(type) {
+			case *v1beta1.BaseModel:
+				return m.Name
+			case *v1beta1.ClusterBaseModel:
+				return m.Name
+			}
+			return "?"
+		}},
+	}
+	if withScope {
+		cols = append(cols, column{Name: "SCOPE", Extract: func(o runtime.Object) string {
+			if _, ok := o.(*v1beta1.ClusterBaseModel); ok {
+				return "Cluster"
+			}
+			return "Namespaced"
+		}})
+	}
+	spec := func(o runtime.Object) *v1beta1.BaseModelSpec {
+		switch m := o.(type) {
+		case *v1beta1.BaseModel:
+			return &m.Spec
+		case *v1beta1.ClusterBaseModel:
+			return &m.Spec
+		}
+		return nil
+	}
+	status := func(o runtime.Object) *v1beta1.ModelStatusSpec {
+		switch m := o.(type) {
+		case *v1beta1.BaseModel:
+			return &m.Status
+		case *v1beta1.ClusterBaseModel:
+			return &m.Status
+		}
+		return nil
+	}
+	deref := func(p *string) string {
+		if p == nil {
+			return "-"
+		}
+		return *p
+	}
+	cols = append(cols,
+		column{Name: "ARCH", Extract: func(o runtime.Object) string { return deref(spec(o).ModelArchitecture) }},
+		column{Name: "PARAMS", Extract: func(o runtime.Object) string { return deref(spec(o).ModelParameterSize) }},
+		column{Name: "FORMAT", Extract: func(o runtime.Object) string { return printers.OrDash(spec(o).ModelFormat.Name) }},
+		column{Name: "STATE", Extract: func(o runtime.Object) string { return printers.OrDash(string(status(o).State)) }},
+		column{Name: "AGE", Extract: func(o runtime.Object) string {
+			acc, _ := o.(metav1.Object)
+			return printers.Age(metav1.Time{Time: acc.GetCreationTimestamp().Time})
+		}},
+	)
+	return cols
+}
+
+// modelsEntry is the merged view: BaseModels from the target namespace (all
+// namespaces with -A) plus ClusterBaseModels always. A single-name lookup
+// resolves BaseModel first, falling back to ClusterBaseModel on NotFound —
+// the same precedence the operator itself applies when resolving an
+// InferenceService's model reference (see pkg/modelparser).
+var modelsEntry = &entry{
+	Canonical:  "models",
+	Aliases:    []string{"model"},
+	Namespaced: true, // namespace scopes the BaseModel half of the view
+	Columns:    baseModelColumns(true),
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		var out []runtime.Object
+		bms, err := c.OmeV1beta1().BaseModels(ns).List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		for i := range bms.Items {
+			out = append(out, &bms.Items[i])
+		}
+		cbms, err := c.OmeV1beta1().ClusterBaseModels().List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		for i := range cbms.Items {
+			out = append(out, &cbms.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		if bm, err := c.OmeV1beta1().BaseModels(ns).Get(ctx, name, metav1.GetOptions{}); err == nil {
+			return bm, nil
+		} else if !kerrors.IsNotFound(err) {
+			return nil, err
+		}
+		return c.OmeV1beta1().ClusterBaseModels().Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+var baseModelsEntry = &entry{
+	Canonical:  "basemodels",
+	Aliases:    []string{"basemodel", "bm"},
+	Namespaced: true,
+	Columns:    baseModelColumns(false),
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		l, err := c.OmeV1beta1().BaseModels(ns).List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			out = append(out, &l.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return c.OmeV1beta1().BaseModels(ns).Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+var clusterBaseModelsEntry = &entry{
+	Canonical:  "clusterbasemodels",
+	Aliases:    []string{"clusterbasemodel", "cbm"},
+	Namespaced: false,
+	Columns:    baseModelColumns(false),
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		l, err := c.OmeV1beta1().ClusterBaseModels().List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			out = append(out, &l.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return c.OmeV1beta1().ClusterBaseModels().Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+// runtimeColumns builds the shared column set for ServingRuntime/
+// ClusterServingRuntime objects. withScope adds a SCOPE column; used only by
+// the merged `runtimes` view, mirroring baseModelColumns.
+func runtimeColumns(withScope bool) []column {
+	spec := func(o runtime.Object) *v1beta1.ServingRuntimeSpec {
+		switch r := o.(type) {
+		case *v1beta1.ServingRuntime:
+			return &r.Spec
+		case *v1beta1.ClusterServingRuntime:
+			return &r.Spec
+		}
+		return nil
+	}
+	cols := []column{
+		{Name: "NAME", Extract: func(o runtime.Object) string {
+			acc, _ := o.(metav1.Object)
+			return acc.GetName()
+		}},
+	}
+	if withScope {
+		cols = append(cols, column{Name: "SCOPE", Extract: func(o runtime.Object) string {
+			if _, ok := o.(*v1beta1.ClusterServingRuntime); ok {
+				return "Cluster"
+			}
+			return "Namespaced"
+		}})
+	}
+	cols = append(cols,
+		column{Name: "DISABLED", Extract: func(o runtime.Object) string {
+			d := spec(o).Disabled
+			return fmt.Sprintf("%t", d != nil && *d)
+		}},
+		column{Name: "FORMATS", Extract: func(o runtime.Object) string {
+			fmts := spec(o).SupportedModelFormats
+			names := make([]string, 0, len(fmts))
+			for _, sf := range fmts {
+				names = append(names, sf.Name)
+			}
+			if len(names) > 3 {
+				return strings.Join(names[:3], ",") + fmt.Sprintf(",+%d", len(names)-3)
+			}
+			return printers.OrDash(strings.Join(names, ","))
+		}},
+		column{Name: "AGE", Extract: func(o runtime.Object) string {
+			acc, _ := o.(metav1.Object)
+			return printers.Age(metav1.Time{Time: acc.GetCreationTimestamp().Time})
+		}},
+	)
+	return cols
+}
+
+// runtimesEntry is the merged view: ServingRuntimes from the target
+// namespace (all namespaces with -A) plus ClusterServingRuntimes always. A
+// single-name lookup resolves ServingRuntime first, falling back to
+// ClusterServingRuntime on NotFound — mirroring modelsEntry's precedence.
+var runtimesEntry = &entry{
+	Canonical:  "runtimes",
+	Aliases:    []string{"runtime"},
+	Namespaced: true, // namespace scopes the ServingRuntime half of the view
+	Columns:    runtimeColumns(true),
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		var out []runtime.Object
+		srts, err := c.OmeV1beta1().ServingRuntimes(ns).List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		for i := range srts.Items {
+			out = append(out, &srts.Items[i])
+		}
+		csrts, err := c.OmeV1beta1().ClusterServingRuntimes().List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		for i := range csrts.Items {
+			out = append(out, &csrts.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		if srt, err := c.OmeV1beta1().ServingRuntimes(ns).Get(ctx, name, metav1.GetOptions{}); err == nil {
+			return srt, nil
+		} else if !kerrors.IsNotFound(err) {
+			return nil, err
+		}
+		return c.OmeV1beta1().ClusterServingRuntimes().Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+var servingRuntimesEntry = &entry{
+	Canonical:  "servingruntimes",
+	Aliases:    []string{"servingruntime", "srt"},
+	Namespaced: true,
+	Columns:    runtimeColumns(false),
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		l, err := c.OmeV1beta1().ServingRuntimes(ns).List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			out = append(out, &l.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return c.OmeV1beta1().ServingRuntimes(ns).Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+var clusterServingRuntimesEntry = &entry{
+	Canonical:  "clusterservingruntimes",
+	Aliases:    []string{"clusterservingruntime", "csrt"},
+	Namespaced: false,
+	Columns:    runtimeColumns(false),
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		l, err := c.OmeV1beta1().ClusterServingRuntimes().List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			out = append(out, &l.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return c.OmeV1beta1().ClusterServingRuntimes().Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+// registry lists every resource `kubectl ome get` knows how to render. Adding
+// a resource means adding an entry here, never a new command.
+var registry = []*entry{
+	isvcEntry,
+	modelsEntry,
+	baseModelsEntry, clusterBaseModelsEntry,
+	runtimesEntry, servingRuntimesEntry, clusterServingRuntimesEntry,
+	// Task 2.3 appends: acceleratorClassesEntry, benchmarkJobsEntry,
+	// fineTunedWeightsEntry, inferenceReplicasEntry, workloadClustersEntry
+}

--- a/pkg/cli/cmd/get/registry.go
+++ b/pkg/cli/cmd/get/registry.go
@@ -143,10 +143,13 @@ func baseModelColumns(withScope bool) []column {
 	}
 	if withScope {
 		cols = append(cols, column{Name: "SCOPE", Extract: func(o runtime.Object) string {
-			if _, ok := o.(*v1beta1.ClusterBaseModel); ok {
+			switch o.(type) {
+			case *v1beta1.ClusterBaseModel:
 				return "Cluster"
+			case *v1beta1.BaseModel:
+				return "Namespaced"
 			}
-			return "Namespaced"
+			return "?"
 		}})
 	}
 	spec := func(o runtime.Object) *v1beta1.BaseModelSpec {
@@ -174,12 +177,39 @@ func baseModelColumns(withScope bool) []column {
 		return *p
 	}
 	cols = append(cols,
-		column{Name: "ARCH", Extract: func(o runtime.Object) string { return deref(spec(o).ModelArchitecture) }},
-		column{Name: "PARAMS", Extract: func(o runtime.Object) string { return deref(spec(o).ModelParameterSize) }},
-		column{Name: "FORMAT", Extract: func(o runtime.Object) string { return printers.OrDash(spec(o).ModelFormat.Name) }},
-		column{Name: "STATE", Extract: func(o runtime.Object) string { return printers.OrDash(string(status(o).State)) }},
+		column{Name: "ARCH", Extract: func(o runtime.Object) string {
+			s := spec(o)
+			if s == nil {
+				return "?"
+			}
+			return deref(s.ModelArchitecture)
+		}},
+		column{Name: "PARAMS", Extract: func(o runtime.Object) string {
+			s := spec(o)
+			if s == nil {
+				return "?"
+			}
+			return deref(s.ModelParameterSize)
+		}},
+		column{Name: "FORMAT", Extract: func(o runtime.Object) string {
+			s := spec(o)
+			if s == nil {
+				return "?"
+			}
+			return printers.OrDash(s.ModelFormat.Name)
+		}},
+		column{Name: "STATE", Extract: func(o runtime.Object) string {
+			s := status(o)
+			if s == nil {
+				return "?"
+			}
+			return printers.OrDash(string(s.State))
+		}},
 		column{Name: "AGE", Extract: func(o runtime.Object) string {
-			acc, _ := o.(metav1.Object)
+			acc, ok := o.(metav1.Object)
+			if !ok {
+				return "?"
+			}
 			return printers.Age(metav1.Time{Time: acc.GetCreationTimestamp().Time})
 		}},
 	)
@@ -305,25 +335,39 @@ func runtimeColumns(withScope bool) []column {
 	}
 	cols := []column{
 		{Name: "NAME", Extract: func(o runtime.Object) string {
-			acc, _ := o.(metav1.Object)
+			acc, ok := o.(metav1.Object)
+			if !ok {
+				return "?"
+			}
 			return acc.GetName()
 		}},
 	}
 	if withScope {
 		cols = append(cols, column{Name: "SCOPE", Extract: func(o runtime.Object) string {
-			if _, ok := o.(*v1beta1.ClusterServingRuntime); ok {
+			switch o.(type) {
+			case *v1beta1.ClusterServingRuntime:
 				return "Cluster"
+			case *v1beta1.ServingRuntime:
+				return "Namespaced"
 			}
-			return "Namespaced"
+			return "?"
 		}})
 	}
 	cols = append(cols,
 		column{Name: "DISABLED", Extract: func(o runtime.Object) string {
-			d := spec(o).Disabled
+			s := spec(o)
+			if s == nil {
+				return "?"
+			}
+			d := s.Disabled
 			return fmt.Sprintf("%t", d != nil && *d)
 		}},
 		column{Name: "FORMATS", Extract: func(o runtime.Object) string {
-			fmts := spec(o).SupportedModelFormats
+			s := spec(o)
+			if s == nil {
+				return "?"
+			}
+			fmts := s.SupportedModelFormats
 			names := make([]string, 0, len(fmts))
 			for _, sf := range fmts {
 				names = append(names, sf.Name)
@@ -334,7 +378,10 @@ func runtimeColumns(withScope bool) []column {
 			return printers.OrDash(strings.Join(names, ","))
 		}},
 		column{Name: "AGE", Extract: func(o runtime.Object) string {
-			acc, _ := o.(metav1.Object)
+			acc, ok := o.(metav1.Object)
+			if !ok {
+				return "?"
+			}
 			return printers.Age(metav1.Time{Time: acc.GetCreationTimestamp().Time})
 		}},
 	)

--- a/pkg/cli/cmd/get/registry.go
+++ b/pkg/cli/cmd/get/registry.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
@@ -64,6 +65,32 @@ func resolve(resource string) (*entry, error) {
 // runtime.Object.
 func nameCol[T runtime.Object](extract func(T) string) func(runtime.Object) string {
 	return func(o runtime.Object) string { return extract(o.(T)) }
+}
+
+// safeCol is nameCol's nil-safe sibling: a wrong-typed object returns "?"
+// instead of panicking through a failed type assertion. The Task 2.3
+// long-tail entries (acceleratorclasses, benchmarkjobs, finetunedweights,
+// inferencereplicas, workloadclusters) use this instead of nameCol because
+// TestLongTailColumnsWrongType requires every one of their columns to
+// survive an object of the wrong resource kind.
+func safeCol[T runtime.Object](extract func(T) string) func(runtime.Object) string {
+	return func(o runtime.Object) string {
+		t, ok := o.(T)
+		if !ok {
+			return "?"
+		}
+		return extract(t)
+	}
+}
+
+// derefOrDash dereferences a *string for column rendering, substituting "-"
+// for a nil pointer (mirrors baseModelColumns' local deref helper, promoted
+// to package scope since finetunedweights needs it for two separate fields).
+func derefOrDash(p *string) string {
+	if p == nil {
+		return "-"
+	}
+	return printers.OrDash(*p)
 }
 
 var isvcEntry = &entry{
@@ -491,6 +518,185 @@ var clusterServingRuntimesEntry = &entry{
 	},
 }
 
+var acceleratorClassesEntry = &entry{
+	Canonical:  "acceleratorclasses",
+	Aliases:    []string{"acceleratorclass", "ac"},
+	Namespaced: false,
+	Columns: []column{
+		{Name: "NAME", Extract: safeCol(func(a *v1beta1.AcceleratorClass) string { return a.Name })},
+		{Name: "VENDOR", Extract: safeCol(func(a *v1beta1.AcceleratorClass) string { return printers.OrDash(a.Spec.Vendor) })},
+		{Name: "FAMILY", Extract: safeCol(func(a *v1beta1.AcceleratorClass) string { return printers.OrDash(a.Spec.Family) })},
+		{Name: "AGE", Extract: safeCol(func(a *v1beta1.AcceleratorClass) string { return printers.Age(a.CreationTimestamp) })},
+	},
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		l, err := c.OmeV1beta1().AcceleratorClasses().List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			out = append(out, &l.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return c.OmeV1beta1().AcceleratorClasses().Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+var benchmarkJobsEntry = &entry{
+	Canonical:  "benchmarkjobs",
+	Aliases:    []string{"benchmarkjob", "bj"},
+	Namespaced: true,
+	Columns: []column{
+		{Name: "NAME", Extract: safeCol(func(b *v1beta1.BenchmarkJob) string { return b.Name })},
+		{Name: "STATE", Extract: safeCol(func(b *v1beta1.BenchmarkJob) string { return printers.OrDash(b.Status.State) })},
+		{Name: "AGE", Extract: safeCol(func(b *v1beta1.BenchmarkJob) string { return printers.Age(b.CreationTimestamp) })},
+	},
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		l, err := c.OmeV1beta1().BenchmarkJobs(ns).List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			out = append(out, &l.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return c.OmeV1beta1().BenchmarkJobs(ns).Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+// fineTunedWeightsEntry is cluster-scoped: FineTunedWeight carries
+// +genclient:nonNamespaced and +kubebuilder:resource:scope="Cluster" (see
+// pkg/apis/ome/v1beta1/model.go), so the generated FineTunedWeights() getter
+// takes no namespace argument -- unlike BenchmarkJobs/InferenceReplicas.
+var fineTunedWeightsEntry = &entry{
+	Canonical:  "finetunedweights",
+	Aliases:    []string{"finetunedweight", "ftw"},
+	Namespaced: false,
+	Columns: []column{
+		{Name: "NAME", Extract: safeCol(func(w *v1beta1.FineTunedWeight) string { return w.Name })},
+		{Name: "TYPE", Extract: safeCol(func(w *v1beta1.FineTunedWeight) string { return derefOrDash(w.Spec.ModelType) })},
+		{Name: "BASEMODEL", Extract: safeCol(func(w *v1beta1.FineTunedWeight) string { return derefOrDash(w.Spec.BaseModelRef.Name) })},
+		{Name: "AGE", Extract: safeCol(func(w *v1beta1.FineTunedWeight) string { return printers.Age(w.CreationTimestamp) })},
+	},
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		l, err := c.OmeV1beta1().FineTunedWeights().List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			out = append(out, &l.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return c.OmeV1beta1().FineTunedWeights().Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+var inferenceReplicasEntry = &entry{
+	Canonical:  "inferencereplicas",
+	Aliases:    []string{"inferencereplica", "ir"},
+	Namespaced: true,
+	Columns: []column{
+		{Name: "NAME", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return r.Name })},
+		{Name: "COMPONENT", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return printers.OrDash(string(r.Spec.Component)) })},
+		{Name: "PARENT", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return printers.OrDash(r.Spec.ParentRef.Name) })},
+		{Name: "REPLICAS", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return fmt.Sprintf("%d", r.Status.Replicas) })},
+		{Name: "AGE", Extract: safeCol(func(r *v1beta1.InferenceReplica) string { return printers.Age(r.CreationTimestamp) })},
+	},
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		l, err := c.OmeV1beta1().InferenceReplicas(ns).List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			out = append(out, &l.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return c.OmeV1beta1().InferenceReplicas(ns).Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
+var workloadClustersEntry = &entry{
+	Canonical:  "workloadclusters",
+	Aliases:    []string{"workloadcluster", "wc"},
+	Namespaced: false,
+	Columns: []column{
+		{Name: "NAME", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string { return w.Name })},
+		{Name: "READY", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string {
+			c := meta.FindStatusCondition(w.Status.Conditions, v1beta1.WorkloadClusterReady)
+			if c == nil {
+				return "Unknown"
+			}
+			return string(c.Status)
+		})},
+		{Name: "AGE", Extract: safeCol(func(w *v1beta1.WorkloadCluster) string { return printers.Age(w.CreationTimestamp) })},
+	},
+	List: func(ctx context.Context, f factory.Factory, ns string, opts metav1.ListOptions) ([]runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		l, err := c.OmeV1beta1().WorkloadClusters().List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			out = append(out, &l.Items[i])
+		}
+		return out, nil
+	},
+	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
+		c, err := f.OMEClient()
+		if err != nil {
+			return nil, err
+		}
+		return c.OmeV1beta1().WorkloadClusters().Get(ctx, name, metav1.GetOptions{})
+	},
+}
+
 // registry lists every resource `kubectl ome get` knows how to render. Adding
 // a resource means adding an entry here, never a new command.
 var registry = []*entry{
@@ -498,6 +704,6 @@ var registry = []*entry{
 	modelsEntry,
 	baseModelsEntry, clusterBaseModelsEntry,
 	runtimesEntry, servingRuntimesEntry, clusterServingRuntimesEntry,
-	// Task 2.3 appends: acceleratorClassesEntry, benchmarkJobsEntry,
-	// fineTunedWeightsEntry, inferenceReplicasEntry, workloadClustersEntry
+	acceleratorClassesEntry, benchmarkJobsEntry,
+	fineTunedWeightsEntry, inferenceReplicasEntry, workloadClustersEntry,
 }

--- a/pkg/cli/cmd/get/registry_test.go
+++ b/pkg/cli/cmd/get/registry_test.go
@@ -1,0 +1,37 @@
+package get
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveCanonicalAndAlias(t *testing.T) {
+	for _, name := range []string{"inferenceservices", "inferenceservice", "isvc", "ISVC"} {
+		e, err := resolve(name)
+		require.NoError(t, err, name)
+		assert.Equal(t, "inferenceservices", e.Canonical, name)
+	}
+}
+
+func TestResolveUnknownListsChoices(t *testing.T) {
+	_, err := resolve("banana")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown resource \"banana\"")
+	assert.Contains(t, err.Error(), "inferenceservices") // error enumerates valid names
+}
+
+func TestRegistryHasAllResources(t *testing.T) {
+	want := []string{
+		"inferenceservices", "basemodels", "clusterbasemodels",
+		"servingruntimes", "clusterservingruntimes", "acceleratorclasses",
+		"benchmarkjobs", "finetunedweights", "inferencereplicas",
+		"workloadclusters", "models", "runtimes",
+	}
+	var got []string
+	for _, e := range registry {
+		got = append(got, e.Canonical)
+	}
+	assert.ElementsMatch(t, want, got)
+}

--- a/pkg/cli/cmd/get/testdata/isvc_list.golden
+++ b/pkg/cli/cmd/get/testdata/isvc_list.golden
@@ -1,0 +1,3 @@
+NAME     MODEL           RUNTIME     READY     URL   AGE
+a-isvc   llama-3-3-70b   srt-llama   Unknown   -     -
+b-isvc   llama-3-3-70b   srt-llama   Unknown   -     -

--- a/pkg/cli/cmd/get/testdata/models_merged.golden
+++ b/pkg/cli/cmd/get/testdata/models_merged.golden
@@ -1,0 +1,3 @@
+NAME            SCOPE        ARCH               PARAMS   FORMAT   STATE   AGE
+ns-model        Namespaced   LlamaForCausalLM   -        -        -       -
+cluster-model   Cluster      LlamaForCausalLM   -        -        -       -

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"sigs.k8s.io/ome/pkg/cli/cmd/get"
 	"sigs.k8s.io/ome/pkg/cli/cmd/version"
 	"sigs.k8s.io/ome/pkg/cli/factory"
 )
@@ -32,7 +33,8 @@ component-aware log streaming.`,
 	configFlags.AddFlags(cmd.PersistentFlags())
 
 	// Command families. Keep alphabetical.
-	// (get/status/runtime/logs are added by later PRs; version below.)
+	// (status/runtime/logs are added by later PRs; get/version below.)
+	cmd.AddCommand(get.NewCmd(f, streams))
 	cmd.AddCommand(version.NewCmd(f, streams))
 
 	return cmd


### PR DESCRIPTION
## What this PR does

Second implementation PR for OEP-0011 (oeps/0011-kubectl-ome-plugin): adds `kubectl ome get`.

- Table-driven resource registry covering all 10 OME CRDs with short aliases (isvc, bm, cbm, srt, csrt, ac, bj, ftw, ir, wc)
- Two merged convenience views kubectl cannot express: `models` (BaseModels + ClusterBaseModels, SCOPE column) and `runtimes` (ServingRuntimes + ClusterServingRuntimes)
- Model-centric columns (arch, params, format, state; runtime match; readiness; URLs)
- `-o json|yaml|wide`, `-A/--all-namespaces`, `-l/--selector`; single-name get with BaseModel→ClusterBaseModel fallback matching operator resolution order
- Friendly "OME is not installed" error when the ome.io CRDs are absent
- Every column extractor is nil-safe (wrong-type and nil-field regression tests); golden-file rendering tests against the generated fake clientset

## Why we need it

OEP-0011 (merged, #736): CRD printer columns can't join across resources or merge cluster- and namespace-scoped listings; this is the CLI's core visibility surface. Builds on the scaffold from #747.

## How to test

go test ./pkg/cli/...; make kubectl-ome && ./bin/kubectl-ome get isvc / get models -A / get runtimes -o wide

## Checklist

- [x] Tests added/updated
- [ ] Docs updated (docs page lands with the release PR per the OEP plan)
- [x] Scoped test suite passes locally (go test ./pkg/cli/... — full make test requires the Rust xet toolchain, unaffected by this PR)