### PR TITLE
[Bugfix] use CodeQL-recognized guard for zip-slip

### DIFF
--- a/pkg/zipper/unzip.go
+++ b/pkg/zipper/unzip.go
@@ -40,7 +40,13 @@ func Unzip(zippedFile string, extractingDir string) error {
 		path := filepath.Join(extractingDir, f.Name)
 
 		// Reject entries that resolve outside the extraction directory (zip-slip).
-		if path != filepath.Clean(extractingDir) && !strings.HasPrefix(path, filepath.Clean(extractingDir)+string(os.PathSeparator)) {
+		cleanDest := filepath.Clean(extractingDir)
+		if path == cleanDest {
+			// The entry resolves to the extraction directory itself
+			// (e.g. a "./" entry); there is nothing to write.
+			return nil
+		}
+		if !strings.HasPrefix(path, cleanDest+string(os.PathSeparator)) {
 			return fmt.Errorf("archive entry %q escapes the extraction directory", f.Name)
 		}
 


### PR DESCRIPTION
## What this PR does

Restructures the zip-slip containment check from #751 into the
canonical form CodeQL recognizes: a standalone
`strings.HasPrefix(path, cleanDest + separator)` guard, with the
"entry resolves to the extraction directory itself" case handled by
a separate early return instead of a `&&` conjunct.

## Why we need it

Alert #15 (go/zipslip, high) stayed open even though the CodeQL
analysis at 15:02 ran on the merged fix commit — the compound
condition isn't accepted by CodeQL's barrier-guard recognition, so
the sink remained "unsanitized" in its eyes.

Verified empirically this time: built a scoped CodeQL database
locally and ran `codeql/go-queries` — **zero results** on this
branch (versus a reproduced go/zipslip finding on current main).

Semantics change slightly for one edge case: an entry that resolves
exactly to the extraction directory (e.g. `./`) now returns early as
a no-op instead of falling through to the directory-create path.

## How to test

- `go test ./pkg/zipper` — all tests pass, including the
  `TestUnzipRejectsPathTraversal` regression test from #751
- Local CodeQL run: `go/zipslip` reports no findings

## Checklist

- [x] Tests added/updated (regression test from #751 still covers this)
- [ ] Docs updated (N/A)
- [x] Package tests and local CodeQL analysis verified