### PR TITLE
[Core] kubectl ome status: one-view InferenceService diagnosis

### DIFF
--- a/pkg/cli/cmd/status/gather.go
+++ b/pkg/cli/cmd/status/gather.go
@@ -1,0 +1,62 @@
+// Package status implements `kubectl ome status`: the full readiness story
+// of one InferenceService in a single view.
+package status
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/apierror"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+type report struct {
+	ISVC   *v1beta1.InferenceService
+	Pods   map[v1beta1.ComponentType][]corev1.Pod
+	Events []corev1.Event
+}
+
+func gather(ctx context.Context, f factory.Factory, ns, name string) (*report, error) {
+	ome, err := f.OMEClient()
+	if err != nil {
+		return nil, err
+	}
+	isvc, err := ome.OmeV1beta1().InferenceServices(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, apierror.Friendly(err)
+	}
+	kube, err := f.KubeClient()
+	if err != nil {
+		return nil, err
+	}
+	pods, err := kube.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", constants.InferenceServiceLabel, name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	r := &report{ISVC: isvc, Pods: map[v1beta1.ComponentType][]corev1.Pod{}}
+	ours := map[string]bool{name: true} // involvedObject names we care about
+	for _, p := range pods.Items {
+		component := v1beta1.ComponentType(p.Labels[constants.OMEComponentLabel])
+		r.Pods[component] = append(r.Pods[component], p)
+		ours[p.Name] = true
+	}
+	events, err := kube.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+		FieldSelector: "type=" + corev1.EventTypeWarning,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range events.Items {
+		if e.Type == corev1.EventTypeWarning && ours[e.InvolvedObject.Name] {
+			r.Events = append(r.Events, e)
+		}
+	}
+	return r, nil
+}

--- a/pkg/cli/cmd/status/gather_test.go
+++ b/pkg/cli/cmd/status/gather_test.go
@@ -1,0 +1,70 @@
+package status
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func pod(name, ns, isvc, component string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: ns,
+		Labels: map[string]string{
+			constants.InferenceServiceLabel: isvc,
+			constants.OMEComponentLabel:     component,
+		},
+	}}
+}
+
+func TestGatherGroupsPodsByComponent(t *testing.T) {
+	f := factory.Static{
+		OME: omefake.NewSimpleClientset(&v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "llama", Namespace: "team-a"},
+		}),
+		Kube: kubefake.NewSimpleClientset(
+			pod("llama-engine-1", "team-a", "llama", "engine"),
+			pod("llama-decoder-1", "team-a", "llama", "decoder"),
+			pod("other-engine-1", "team-a", "other", "engine"),
+		),
+		NS: "team-a",
+	}
+	r, err := gather(context.Background(), f, "team-a", "llama")
+	require.NoError(t, err)
+	require.Len(t, r.Pods[v1beta1.EngineComponent], 1)
+	assert.Equal(t, "llama-engine-1", r.Pods[v1beta1.EngineComponent][0].Name)
+	require.Len(t, r.Pods[v1beta1.DecoderComponent], 1)
+	assert.Empty(t, r.Pods[v1beta1.RouterComponent])
+}
+
+func TestGatherKeepsOnlyWarningEventsForOurObjects(t *testing.T) {
+	warn := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "e1", Namespace: "team-a"},
+		Type:           corev1.EventTypeWarning,
+		Reason:         "FailedScheduling",
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "llama-engine-1", Namespace: "team-a"},
+	}
+	other := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "e2", Namespace: "team-a"},
+		Type:           corev1.EventTypeWarning,
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "unrelated", Namespace: "team-a"},
+	}
+	f := factory.Static{
+		OME:  omefake.NewSimpleClientset(&v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "llama", Namespace: "team-a"}}),
+		Kube: kubefake.NewSimpleClientset(pod("llama-engine-1", "team-a", "llama", "engine"), warn, other),
+		NS:   "team-a",
+	}
+	r, err := gather(context.Background(), f, "team-a", "llama")
+	require.NoError(t, err)
+	require.Len(t, r.Events, 1)
+	assert.Equal(t, "FailedScheduling", r.Events[0].Reason)
+}

--- a/pkg/cli/cmd/status/render.go
+++ b/pkg/cli/cmd/status/render.go
@@ -1,0 +1,164 @@
+package status
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/printers"
+)
+
+// componentOrder fixes section ordering; conditions sort component-first,
+// aggregate Ready last.
+var componentOrder = []v1beta1.ComponentType{
+	v1beta1.EngineComponent, v1beta1.DecoderComponent, v1beta1.RouterComponent,
+}
+
+func render(r *report, w io.Writer) error {
+	isvc := r.ISVC
+	fmt.Fprintf(w, "Name:       %s\n", isvc.Name)
+	fmt.Fprintf(w, "Namespace:  %s\n", isvc.Namespace)
+	fmt.Fprintf(w, "Ready:      %t\n", isvc.Status.IsReady())
+	if isvc.Status.URL != nil {
+		fmt.Fprintf(w, "URL:        %s\n", isvc.Status.URL.String())
+	}
+	if isvc.Spec.Model != nil {
+		fmt.Fprintf(w, "Model:      %s\n", isvc.Spec.Model.Name)
+	}
+	if isvc.Spec.Runtime != nil {
+		fmt.Fprintf(w, "Runtime:    %s\n", isvc.Spec.Runtime.Name)
+	} else {
+		fmt.Fprintf(w, "Runtime:    (auto-selected)\n")
+	}
+
+	fmt.Fprintf(w, "\nConditions:\n")
+	conds := append([]apis.Condition{}, isvc.Status.Conditions...)
+	sort.SliceStable(conds, func(i, j int) bool { return condRank(conds[i].Type) < condRank(conds[j].Type) })
+	condTable := printers.Table{Headers: []string{"  TYPE", "STATUS", "REASON", "MESSAGE"}}
+	for _, c := range conds {
+		condTable.Rows = append(condTable.Rows, []string{
+			"  " + string(c.Type), string(c.Status), printers.OrDash(c.Reason), printers.OrDash(c.Message),
+		})
+	}
+	if err := condTable.Write(w); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "\nComponents:\n")
+	seen := make(map[v1beta1.ComponentType]bool, len(componentOrder))
+	for _, ct := range componentOrder {
+		seen[ct] = true
+		spec, inStatus := isvc.Status.Components[ct]
+		pods := r.Pods[ct]
+		if !inStatus && len(pods) == 0 {
+			continue
+		}
+		if err := writeComponent(w, componentLabel(ct), spec, pods); err != nil {
+			return err
+		}
+	}
+	// gather() buckets pods by their component label verbatim, so a pod
+	// whose label is missing (ComponentType("")) or names something other
+	// than engine/decoder/router lands here instead of in componentOrder.
+	// Surface it rather than silently dropping it from the report; sort
+	// for deterministic output.
+	var remaining []v1beta1.ComponentType
+	for ct := range r.Pods {
+		if !seen[ct] {
+			remaining = append(remaining, ct)
+		}
+	}
+	sort.Slice(remaining, func(i, j int) bool { return remaining[i] < remaining[j] })
+	for _, ct := range remaining {
+		if err := writeComponent(w, componentLabel(ct), isvc.Status.Components[ct], r.Pods[ct]); err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(w, "\nModel Status:\n  Transition: %s\n", printers.OrDash(string(isvc.Status.ModelStatus.TransitionStatus)))
+	writeOptionalSection(w, "Traffic", isvc.Status.Traffic != nil)
+	writeOptionalSection(w, "Canary", isvc.Status.Canary != nil)
+	writeOptionalSection(w, "Placement", isvc.Status.Placement != nil)
+	writeOptionalSection(w, "RolloutCoordination", isvc.Status.RolloutCoordination != nil)
+
+	if len(r.Events) > 0 {
+		fmt.Fprintf(w, "\nRecent Warning Events:\n")
+		evTable := printers.Table{Headers: []string{"  OBJECT", "REASON", "MESSAGE"}}
+		for _, e := range r.Events {
+			evTable.Rows = append(evTable.Rows, []string{
+				"  " + e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name, e.Reason, e.Message,
+			})
+		}
+		if err := evTable.Write(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// componentLabel names a Components section heading. Pods whose component
+// label was missing land under ComponentType("") (see gather.go); render
+// that as an explicit placeholder rather than a blank heading.
+func componentLabel(ct v1beta1.ComponentType) string {
+	if ct == "" {
+		return "(unlabeled)"
+	}
+	return string(ct)
+}
+
+// writeComponent renders one Components section: the revision header line
+// plus a pod table (or a "(no pods)" placeholder).
+func writeComponent(w io.Writer, label string, spec v1beta1.ComponentStatusSpec, pods []corev1.Pod) error {
+	fmt.Fprintf(w, "  %s   revision %s\n", label, printers.OrDash(spec.LatestCreatedRevision))
+	if len(pods) == 0 {
+		fmt.Fprintf(w, "    (no pods)\n")
+		return nil
+	}
+	podTable := printers.Table{Headers: []string{"    POD", "PHASE", "READY", "RESTARTS", "NODE"}}
+	for _, p := range pods {
+		ready, restarts := 0, int32(0)
+		for _, cs := range p.Status.ContainerStatuses {
+			if cs.Ready {
+				ready++
+			}
+			restarts += cs.RestartCount
+		}
+		podTable.Rows = append(podTable.Rows, []string{
+			"    " + p.Name, string(p.Status.Phase),
+			fmt.Sprintf("%d/%d", ready, len(p.Status.ContainerStatuses)),
+			fmt.Sprintf("%d", restarts), printers.OrDash(p.Spec.NodeName),
+		})
+	}
+	return podTable.Write(w)
+}
+
+// writeOptionalSection prints a one-line presence indicator for a
+// v1-deferred status section (Traffic/Canary/Placement/RolloutCoordination):
+// full rendering is follow-up work, but presence must never be silently
+// dropped from the report.
+func writeOptionalSection(w io.Writer, name string, present bool) {
+	if present {
+		fmt.Fprintf(w, "  %s: present (see -o yaml for detail)\n", name)
+	}
+}
+
+func condRank(t apis.ConditionType) int {
+	switch t {
+	case "EngineReady":
+		return 0
+	case "DecoderReady":
+		return 1
+	case "RouterReady":
+		return 2
+	case "IngressReady":
+		return 3
+	case apis.ConditionReady:
+		return 5
+	default:
+		return 4
+	}
+}

--- a/pkg/cli/cmd/status/render_test.go
+++ b/pkg/cli/cmd/status/render_test.go
@@ -1,0 +1,136 @@
+package status
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+var update = flag.Bool("update", false, "rewrite golden files")
+
+func assertGolden(t *testing.T, name string, got []byte) {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	if *update {
+		require.NoError(t, os.WriteFile(path, got, 0o644))
+	}
+	want, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(want), string(got))
+}
+
+func TestRenderNotReady(t *testing.T) {
+	r := &report{
+		ISVC: &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "llama-70b", Namespace: "team-a"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Model:   &v1beta1.ModelRef{Name: "llama-3-3-70b"},
+				Runtime: &v1beta1.ServingRuntimeRef{Name: "srt-llama-70b"},
+			},
+			Status: v1beta1.InferenceServiceStatus{
+				Status: duckv1.Status{Conditions: duckv1.Conditions{
+					{Type: "EngineReady", Status: corev1.ConditionTrue},
+					{Type: "DecoderReady", Status: corev1.ConditionFalse, Reason: "RevisionFailed", Message: "0/1 replicas ready"},
+					{Type: apis.ConditionReady, Status: corev1.ConditionFalse, Reason: "DecoderNotReady"},
+				}},
+				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+					v1beta1.EngineComponent:  {LatestCreatedRevision: "llama-70b-engine-00002"},
+					v1beta1.DecoderComponent: {LatestCreatedRevision: "llama-70b-decoder-00002"},
+				},
+			},
+		},
+		Pods: map[v1beta1.ComponentType][]corev1.Pod{
+			v1beta1.EngineComponent: {{
+				ObjectMeta: metav1.ObjectMeta{Name: "llama-70b-engine-5d4-x2p"},
+				Spec:       corev1.PodSpec{NodeName: "gpu-node-1"},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true}, {Ready: true},
+				}},
+			}},
+			v1beta1.DecoderComponent: {{
+				ObjectMeta: metav1.ObjectMeta{Name: "llama-70b-decoder-7c9-k4m"},
+				Status:     corev1.PodStatus{Phase: corev1.PodPending, ContainerStatuses: []corev1.ContainerStatus{{}, {}}},
+			}},
+		},
+		Events: []corev1.Event{{
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "llama-70b-decoder-7c9-k4m"},
+			Reason:         "FailedScheduling",
+			Message:        "0/12 nodes: insufficient nvidia.com/gpu",
+		}},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, render(r, &buf))
+	assertGolden(t, "status_notready.golden", buf.Bytes())
+}
+
+// TestRenderShowsUnlabeledPods pins the forward-note from Task 3.1: gather()
+// buckets pods missing the component label under ComponentType(""), and the
+// renderer must surface them (as an explicit "(unlabeled)" section) rather
+// than silently dropping them because they fall outside componentOrder.
+func TestRenderShowsUnlabeledPods(t *testing.T) {
+	r := &report{
+		ISVC: &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "orphan-pods", Namespace: "team-b"},
+			Status: v1beta1.InferenceServiceStatus{
+				Status: duckv1.Status{Conditions: duckv1.Conditions{
+					{Type: apis.ConditionReady, Status: corev1.ConditionTrue},
+				}},
+			},
+		},
+		Pods: map[v1beta1.ComponentType][]corev1.Pod{
+			v1beta1.EngineComponent: {{
+				ObjectMeta: metav1.ObjectMeta{Name: "orphan-pods-engine-1"},
+				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			}},
+			v1beta1.ComponentType(""): {{
+				ObjectMeta: metav1.ObjectMeta{Name: "orphan-pods-stray-7f8"},
+				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			}},
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, render(r, &buf))
+	assertGolden(t, "status_unlabeled.golden", buf.Bytes())
+	// Belt-and-suspenders: fail even if a golden update ever masks a
+	// regression here (blind `-update` reruns would still hide a dropped
+	// pod otherwise).
+	assert.Contains(t, buf.String(), "(unlabeled)")
+	assert.Contains(t, buf.String(), "orphan-pods-stray-7f8")
+}
+
+// TestRenderShowsOptionalStatusSections pins the v1-deferred presence
+// indicators for Traffic/Canary/Placement/RolloutCoordination: full
+// rendering is follow-up work, but their presence must never be silently
+// omitted from the report. TestRenderNotReady (all four nil) already pins
+// the absent case via its golden file.
+func TestRenderShowsOptionalStatusSections(t *testing.T) {
+	r := &report{
+		ISVC: &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "llama-70b", Namespace: "team-a"},
+			Status: v1beta1.InferenceServiceStatus{
+				Traffic:             &v1beta1.TrafficStatus{},
+				Canary:              &v1beta1.CanaryStatus{},
+				Placement:           &v1beta1.PlacementStatus{},
+				RolloutCoordination: &v1beta1.RolloutCoordinationStatus{},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, render(r, &buf))
+	out := buf.String()
+	assert.Contains(t, out, "  Traffic: present (see -o yaml for detail)\n")
+	assert.Contains(t, out, "  Canary: present (see -o yaml for detail)\n")
+	assert.Contains(t, out, "  Placement: present (see -o yaml for detail)\n")
+	assert.Contains(t, out, "  RolloutCoordination: present (see -o yaml for detail)\n")
+}

--- a/pkg/cli/cmd/status/status.go
+++ b/pkg/cli/cmd/status/status.go
@@ -1,0 +1,28 @@
+package status
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/factory"
+)
+
+func NewCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status INFERENCESERVICE",
+		Short: "Show the full readiness story of an InferenceService",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ns, _, err := f.Namespace()
+			if err != nil {
+				return err
+			}
+			r, err := gather(cmd.Context(), f, ns, args[0])
+			if err != nil {
+				return err
+			}
+			return render(r, streams.Out)
+		},
+	}
+	return cmd
+}

--- a/pkg/cli/cmd/status/testdata/status_notready.golden
+++ b/pkg/cli/cmd/status/testdata/status_notready.golden
@@ -1,0 +1,26 @@
+Name:       llama-70b
+Namespace:  team-a
+Ready:      false
+Model:      llama-3-3-70b
+Runtime:    srt-llama-70b
+
+Conditions:
+  TYPE           STATUS   REASON            MESSAGE
+  EngineReady    True     -                 -
+  DecoderReady   False    RevisionFailed    0/1 replicas ready
+  Ready          False    DecoderNotReady   -
+
+Components:
+  engine   revision llama-70b-engine-00002
+    POD                        PHASE     READY   RESTARTS   NODE
+    llama-70b-engine-5d4-x2p   Running   2/2     0          gpu-node-1
+  decoder   revision llama-70b-decoder-00002
+    POD                         PHASE     READY   RESTARTS   NODE
+    llama-70b-decoder-7c9-k4m   Pending   0/2     0          -
+
+Model Status:
+  Transition: -
+
+Recent Warning Events:
+  OBJECT                          REASON             MESSAGE
+  Pod/llama-70b-decoder-7c9-k4m   FailedScheduling   0/12 nodes: insufficient nvidia.com/gpu

--- a/pkg/cli/cmd/status/testdata/status_unlabeled.golden
+++ b/pkg/cli/cmd/status/testdata/status_unlabeled.golden
@@ -1,0 +1,19 @@
+Name:       orphan-pods
+Namespace:  team-b
+Ready:      true
+Runtime:    (auto-selected)
+
+Conditions:
+  TYPE    STATUS   REASON   MESSAGE
+  Ready   True     -        -
+
+Components:
+  engine   revision -
+    POD                    PHASE     READY   RESTARTS   NODE
+    orphan-pods-engine-1   Running   0/0     0          -
+  (unlabeled)   revision -
+    POD                     PHASE     READY   RESTARTS   NODE
+    orphan-pods-stray-7f8   Running   0/0     0          -
+
+Model Status:
+  Transition: -

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"sigs.k8s.io/ome/pkg/cli/cmd/get"
+	"sigs.k8s.io/ome/pkg/cli/cmd/status"
 	"sigs.k8s.io/ome/pkg/cli/cmd/version"
 	"sigs.k8s.io/ome/pkg/cli/factory"
 )
@@ -33,8 +34,9 @@ component-aware log streaming.`,
 	configFlags.AddFlags(cmd.PersistentFlags())
 
 	// Command families. Keep alphabetical.
-	// (status/runtime/logs are added by later PRs; get/version below.)
+	// (runtime/logs are added by later PRs; get/status/version below.)
 	cmd.AddCommand(get.NewCmd(f, streams))
+	cmd.AddCommand(status.NewCmd(f, streams))
 	cmd.AddCommand(version.NewCmd(f, streams))
 
 	return cmd


### PR DESCRIPTION
## What this PR does

Third implementation PR for OEP-0011 (oeps/0011-kubectl-ome-plugin): adds `kubectl ome status <inferenceservice>`.

- Assembles the full readiness story in one view: conditions table (EngineReady/DecoderReady/RouterReady/IngressReady/Ready with reasons), per-component sections with live pods (phase/ready/restarts/node, discovered via the ome.io/inferenceservice + component labels), model status, and recent Warning events for the service and its pods
- Pods with a missing component label are rendered under an explicit (unlabeled) section rather than dropped
- Optional status sections (traffic/canary/placement/rollout coordination) surface as one-line presence indicators
- Informational contract: exit code reflects only whether data could be gathered, never service health
- Golden-file rendered output; gather layer unit-tested against fake clientsets

## Why we need it

OEP-0011 (merged, #736): diagnosing a stuck InferenceService today takes several kubectl calls and manual correlation across conditions, pods, and events. Builds on the scaffold (#747) and lands after get (#754).

## How to test

go test ./pkg/cli/...; make kubectl-ome && ./bin/kubectl-ome status <isvc> -n <ns>

## Checklist

- [x] Tests added/updated
- [ ] Docs updated (docs page lands with the release PR per the OEP plan)
- [x] Scoped test suite passes locally (go test ./pkg/cli/... — full make test requires the Rust xet toolchain, unaffected by this PR)