### PR TITLE
[Core] kubectl ome status: fix READY column, hint, add cmd tests

### DIFF
--- a/pkg/cli/cmd/status/render.go
+++ b/pkg/cli/cmd/status/render.go
@@ -129,7 +129,7 @@ func writeComponent(w io.Writer, label string, spec v1beta1.ComponentStatusSpec,
 		}
 		podTable.Rows = append(podTable.Rows, []string{
 			"    " + p.Name, string(p.Status.Phase),
-			fmt.Sprintf("%d/%d", ready, len(p.Status.ContainerStatuses)),
+			fmt.Sprintf("%d/%d", ready, len(p.Spec.Containers)),
 			fmt.Sprintf("%d", restarts), printers.OrDash(p.Spec.NodeName),
 		})
 	}
@@ -142,7 +142,7 @@ func writeComponent(w io.Writer, label string, spec v1beta1.ComponentStatusSpec,
 // dropped from the report.
 func writeOptionalSection(w io.Writer, name string, present bool) {
 	if present {
-		fmt.Fprintf(w, "  %s: present (see -o yaml for detail)\n", name)
+		fmt.Fprintf(w, "  %s: present (inspect with kubectl get inferenceservice -o yaml)\n", name)
 	}
 }
 

--- a/pkg/cli/cmd/status/render_test.go
+++ b/pkg/cli/cmd/status/render_test.go
@@ -53,13 +53,17 @@ func TestRenderNotReady(t *testing.T) {
 		Pods: map[v1beta1.ComponentType][]corev1.Pod{
 			v1beta1.EngineComponent: {{
 				ObjectMeta: metav1.ObjectMeta{Name: "llama-70b-engine-5d4-x2p"},
-				Spec:       corev1.PodSpec{NodeName: "gpu-node-1"},
+				Spec: corev1.PodSpec{
+					NodeName:   "gpu-node-1",
+					Containers: []corev1.Container{{Name: "engine"}, {Name: "engine-metrics"}},
+				},
 				Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{
 					{Ready: true}, {Ready: true},
 				}},
 			}},
 			v1beta1.DecoderComponent: {{
 				ObjectMeta: metav1.ObjectMeta{Name: "llama-70b-decoder-7c9-k4m"},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "decoder"}, {Name: "decoder-metrics"}}},
 				Status:     corev1.PodStatus{Phase: corev1.PodPending, ContainerStatuses: []corev1.ContainerStatus{{}, {}}},
 			}},
 		},
@@ -91,11 +95,17 @@ func TestRenderShowsUnlabeledPods(t *testing.T) {
 		Pods: map[v1beta1.ComponentType][]corev1.Pod{
 			v1beta1.EngineComponent: {{
 				ObjectMeta: metav1.ObjectMeta{Name: "orphan-pods-engine-1"},
-				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "engine"}}},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true},
+				}},
 			}},
 			v1beta1.ComponentType(""): {{
 				ObjectMeta: metav1.ObjectMeta{Name: "orphan-pods-stray-7f8"},
-				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true},
+				}},
 			}},
 		},
 	}
@@ -129,8 +139,8 @@ func TestRenderShowsOptionalStatusSections(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, render(r, &buf))
 	out := buf.String()
-	assert.Contains(t, out, "  Traffic: present (see -o yaml for detail)\n")
-	assert.Contains(t, out, "  Canary: present (see -o yaml for detail)\n")
-	assert.Contains(t, out, "  Placement: present (see -o yaml for detail)\n")
-	assert.Contains(t, out, "  RolloutCoordination: present (see -o yaml for detail)\n")
+	assert.Contains(t, out, "  Traffic: present (inspect with kubectl get inferenceservice -o yaml)\n")
+	assert.Contains(t, out, "  Canary: present (inspect with kubectl get inferenceservice -o yaml)\n")
+	assert.Contains(t, out, "  Placement: present (inspect with kubectl get inferenceservice -o yaml)\n")
+	assert.Contains(t, out, "  RolloutCoordination: present (inspect with kubectl get inferenceservice -o yaml)\n")
 }

--- a/pkg/cli/cmd/status/status_test.go
+++ b/pkg/cli/cmd/status/status_test.go
@@ -1,0 +1,58 @@
+package status
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+)
+
+func execute(t *testing.T, f factory.Factory, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	streams := genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &out, ErrOut: &out}
+	cmd := NewCmd(f, streams)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestStatusHappyPath(t *testing.T) {
+	f := factory.Static{
+		OME: omefake.NewSimpleClientset(&v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo-isvc", Namespace: "team-a"},
+		}),
+		Kube: kubefake.NewSimpleClientset(),
+		NS:   "team-a",
+	}
+	out, err := execute(t, f, "demo-isvc")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Name:       demo-isvc")
+}
+
+func TestStatusRequiresExactlyOneArg(t *testing.T) {
+	_, err := execute(t, factory.Static{})
+	require.Error(t, err)
+
+	_, err = execute(t, factory.Static{}, "a", "b")
+	require.Error(t, err)
+}
+
+func TestStatusNotFound(t *testing.T) {
+	f := factory.Static{
+		OME:  omefake.NewSimpleClientset(),
+		Kube: kubefake.NewSimpleClientset(),
+		NS:   "team-a",
+	}
+	_, err := execute(t, f, "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/pkg/cli/cmd/status/testdata/status_unlabeled.golden
+++ b/pkg/cli/cmd/status/testdata/status_unlabeled.golden
@@ -10,10 +10,10 @@ Conditions:
 Components:
   engine   revision -
     POD                    PHASE     READY   RESTARTS   NODE
-    orphan-pods-engine-1   Running   0/0     0          -
+    orphan-pods-engine-1   Running   1/1     0          -
   (unlabeled)   revision -
     POD                     PHASE     READY   RESTARTS   NODE
-    orphan-pods-stray-7f8   Running   0/0     0          -
+    orphan-pods-stray-7f8   Running   1/1     0          -
 
 Model Status:
   Transition: -


### PR DESCRIPTION
## What this PR does

Follow-up to #756 (merged): addresses three Important findings from code
review that landed after #756 was already merged, so they need a separate
PR rather than an update to the closed one.

- **READY column denominator.** `render.go` computed pod READY as
  `ready/len(Status.ContainerStatuses)`; kubectl's convention is
  `ready/len(Spec.Containers)`. Fixed the formula and the test fixtures
  (every fixture pod now carries a realistic `Spec.Containers`); regenerated
  `testdata/status_unlabeled.golden` — the two `Running` pods it covers now
  correctly show `1/1` instead of the previous `0/0`.
- **Optional-section hint.** The `Traffic`/`Canary`/`Placement`/
  `RolloutCoordination` presence line referenced a `-o yaml` flag `status`
  doesn't have. Changed it to point at a command that actually exists:
  `present (inspect with kubectl get inferenceservice -o yaml)`.
- **Command tests.** `status.go` shipped with zero tests, unlike its
  siblings (`version_test.go`, `get_test.go`). Added
  `pkg/cli/cmd/status/status_test.go`: happy path (fake clientsets, asserts
  rendered output), arg-count validation (0 and 2 args both error), and
  not-found error propagation.

## Why we need it

Fixes real, review-confirmed bugs in the `kubectl ome status` output
shipped by #756: the READY column was silently wrong for any pod (a
regression a user would hit on literally every healthy pod), and the
optional-section hint sent users to a flag that doesn't exist.

## How to test

go test ./pkg/cli/...; make kubectl-ome && ./bin/kubectl-ome status <isvc> -n <ns>

## Checklist

- [x] Tests added/updated
- [x] Scoped test suite passes locally (go test ./pkg/cli/... — full make test requires the Rust xet toolchain, unaffected by this PR)