### PR TITLE
[Bugfix] get: FORMATS column empty against older OME runtimes

### DIFF
--- a/pkg/cli/cmd/get/columns_test.go
+++ b/pkg/cli/cmd/get/columns_test.go
@@ -195,3 +195,97 @@ func TestLongTailColumnsWrongType(t *testing.T) {
 		}
 	}
 }
+
+// TestRuntimeFormatsColumnFallback pins a fix for the FORMATS column rendering "-"
+// on clusters running older OME operators that populate the deprecated flat
+// .name field instead of the nested .modelFormat.name. The column now falls back
+// to .modelFormat.name when the flat field is unset, maintaining version-skew
+// tolerance (OEP-0011).
+func TestRuntimeFormatsColumnFallback(t *testing.T) {
+	e, err := resolve("runtimes")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		runtime  runtime.Object
+		expected string
+	}{
+		{
+			name: "nested modelFormat.name only (old operator v1.2.1)",
+			runtime: &v1beta1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "old-runtime"},
+				Spec: v1beta1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1beta1.SupportedModelFormat{
+						{
+							Name:        "", // deprecated field empty
+							ModelFormat: &v1beta1.ModelFormat{Name: "safetensors"},
+						},
+					},
+				},
+			},
+			expected: "safetensors",
+		},
+		{
+			name: "mixed: flat name and nested modelFormat.name",
+			runtime: &v1beta1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "mixed-runtime"},
+				Spec: v1beta1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1beta1.SupportedModelFormat{
+						{
+							Name:        "onnx", // new field
+							ModelFormat: &v1beta1.ModelFormat{Name: "onnx"},
+						},
+						{
+							Name:        "", // deprecated field empty
+							ModelFormat: &v1beta1.ModelFormat{Name: "safetensors"},
+						},
+					},
+				},
+			},
+			expected: "onnx,safetensors",
+		},
+		{
+			name: "both empty (neither flat nor nested)",
+			runtime: &v1beta1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty-runtime"},
+				Spec: v1beta1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1beta1.SupportedModelFormat{
+						{
+							Name:        "",
+							ModelFormat: &v1beta1.ModelFormat{Name: ""},
+						},
+					},
+				},
+			},
+			expected: "-",
+		},
+		{
+			name: "nil ModelFormat with empty Name",
+			runtime: &v1beta1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "nil-modelformat"},
+				Spec: v1beta1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1beta1.SupportedModelFormat{
+						{
+							Name:        "",
+							ModelFormat: nil,
+						},
+					},
+				},
+			},
+			expected: "-",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ""
+			for _, c := range e.Columns {
+				if c.Name == "FORMATS" {
+					got = c.Extract(tc.runtime)
+					break
+				}
+			}
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/cli/cmd/get/registry.go
+++ b/pkg/cli/cmd/get/registry.go
@@ -397,7 +397,12 @@ func runtimeColumns(withScope bool) []column {
 			fmts := s.SupportedModelFormats
 			names := make([]string, 0, len(fmts))
 			for _, sf := range fmts {
-				names = append(names, sf.Name)
+				switch {
+				case sf.Name != "":
+					names = append(names, sf.Name)
+				case sf.ModelFormat != nil && sf.ModelFormat.Name != "":
+					names = append(names, sf.ModelFormat.Name)
+				}
 			}
 			if len(names) > 3 {
 				return strings.Join(names[:3], ",") + fmt.Sprintf(",+%d", len(names)-3)


### PR DESCRIPTION
## What this PR does

`kubectl ome get runtimes` showed FORMATS as `-` for every runtime on clusters running older OME releases: old operators fill the nested `supportedModelFormats[].modelFormat.name` while the deprecated flat `.name` (which the column read) is empty. The column now falls back to `modelFormat.name` when the flat field is unset.

## Why we need it

Found during read-only validation of the CLI (OEP-0011) against a live v1.2.1 cluster — version-skew tolerance is an explicit OEP goal.

## How to test

go test ./pkg/cli/cmd/get/...; against an older cluster: kubectl ome get runtimes now shows format names.

## Checklist

- [x] Tests added/updated
- [ ] Docs updated (N/A)
- [x] Scoped test suite passes locally (go test ./pkg/cli/... — full make test requires the Rust xet toolchain, unaffected by this PR)