### PR TITLE
[Core] kubectl ome runtime explain: selection transparency

### DIFF
--- a/pkg/cli/cmd/runtime/explain.go
+++ b/pkg/cli/cmd/runtime/explain.go
@@ -108,7 +108,7 @@ func (o *explainOptions) Run(ctx context.Context, f factory.Factory) error {
 		})
 	}
 	for _, c := range candidates {
-		if matched[runtimeKey{c.name, c.isCluster}] {
+		if matched[runtimeKey(c)] {
 			continue
 		}
 		reason := "supports the model but has no supportedModelFormats[].autoSelect=true entry, so automatic selection skips it (pin it explicitly via spec.runtime.name instead)"

--- a/pkg/cli/cmd/runtime/explain.go
+++ b/pkg/cli/cmd/runtime/explain.go
@@ -1,0 +1,223 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/apierror"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/printers"
+	"sigs.k8s.io/ome/pkg/runtimeselector"
+)
+
+type explainOptions struct {
+	genericiooptions.IOStreams
+	Model string
+	ISVC  string
+}
+
+func newExplainCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	o := &explainOptions{IOStreams: streams}
+	cmd := &cobra.Command{
+		Use:   "explain (--model NAME | --isvc NAME)",
+		Short: "Explain which serving runtimes match a model and why",
+		Long: `Runs the operator's own runtime-selection engine (pkg/runtimeselector)
+against the live cluster and prints every namespace-scoped and cluster-scoped
+serving runtime it considered, whether each is compatible with the model, and
+why -- including runtimes that were rejected.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run(cmd.Context(), f)
+		},
+	}
+	cmd.Flags().StringVar(&o.Model, "model", "", "Explain runtime selection for this BaseModel/ClusterBaseModel")
+	cmd.Flags().StringVar(&o.ISVC, "isvc", "", "Explain runtime selection for this InferenceService's model")
+	return cmd
+}
+
+func (o *explainOptions) Validate() error {
+	if (o.Model == "") == (o.ISVC == "") {
+		return fmt.Errorf("exactly one of --model or --isvc is required")
+	}
+	return nil
+}
+
+func (o *explainOptions) Run(ctx context.Context, f factory.Factory) error {
+	ns, _, err := f.Namespace()
+	if err != nil {
+		return err
+	}
+	modelSpec, isvc, err := o.resolveTarget(ctx, f, ns)
+	if err != nil {
+		return err
+	}
+	if o.ISVC != "" && isvc.Spec.Runtime != nil {
+		fmt.Fprintf(o.ErrOut, "Note: InferenceService %q pins spec.runtime=%q; the table below shows what automatic selection would choose, which may differ from what is currently deployed.\n", o.ISVC, isvc.Spec.Runtime.Name)
+	}
+
+	ctrl, err := f.RuntimeClient()
+	if err != nil {
+		return err
+	}
+	selector := runtimeselector.New(ctrl)
+
+	// GetCompatibleRuntimes is the operator's actual auto-select ranking:
+	// every entry it returns already passed compatibility, auto-select
+	// eligibility and scoring, so these are unconditionally "Yes".
+	matches, err := selector.GetCompatibleRuntimes(ctx, modelSpec, isvc, ns)
+	if err != nil {
+		return apierror.Friendly(err)
+	}
+
+	// GetCompatibleRuntimes silently drops everything that isn't a match --
+	// disabled runtimes, format/size mismatches, and runtimes with no
+	// autoSelect-enabled format never appear in its result at all. The OEP
+	// requires rejected runtimes to show up too, with a reason, so list every
+	// runtime the selector could have considered and re-validate whichever
+	// ones didn't make the cut.
+	candidates, err := listCandidateRuntimes(ctx, ctrl, ns)
+	if err != nil {
+		return apierror.Friendly(err)
+	}
+	if len(matches) == 0 && len(candidates) == 0 {
+		fmt.Fprintf(o.ErrOut, "No serving runtimes found in namespace %q or at cluster scope.\n", ns)
+		return nil
+	}
+
+	matched := make(map[runtimeKey]bool, len(matches))
+	table := printers.Table{Headers: []string{"RUNTIME", "SCOPE", "COMPATIBLE", "PRIORITY", "WEIGHT", "REASON"}}
+	for _, m := range matches {
+		matched[runtimeKey{m.Name, m.IsCluster}] = true
+		table.Rows = append(table.Rows, []string{
+			m.Name, scopeLabel(m.IsCluster), "Yes",
+			fmt.Sprintf("%d", m.MatchDetails.Priority),
+			fmt.Sprintf("%d", m.MatchDetails.Weight),
+			printers.OrDash(strings.Join(m.MatchDetails.Reasons, "; ")),
+		})
+	}
+	for _, c := range candidates {
+		if matched[runtimeKey{c.name, c.isCluster}] {
+			continue
+		}
+		reason := "supports the model but has no supportedModelFormats[].autoSelect=true entry, so automatic selection skips it (pin it explicitly via spec.runtime.name instead)"
+		if err := selector.ValidateRuntime(ctx, c.name, modelSpec, isvc); err != nil {
+			reason = rejectionReason(err)
+		}
+		table.Rows = append(table.Rows, []string{c.name, scopeLabel(c.isCluster), "No", "-", "-", reason})
+	}
+
+	return table.Write(o.Out)
+}
+
+// resolveTarget loads the model spec (and, for --isvc, the service) using the
+// operator's resolution order: namespaced BaseModel first, then
+// ClusterBaseModel.
+func (o *explainOptions) resolveTarget(ctx context.Context, f factory.Factory, ns string) (*v1beta1.BaseModelSpec, *v1beta1.InferenceService, error) {
+	ome, err := f.OMEClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	modelName := o.Model
+	// Synthetic isvc gives the selector namespace context on the --model path.
+	isvc := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
+	if o.ISVC != "" {
+		got, err := ome.OmeV1beta1().InferenceServices(ns).Get(ctx, o.ISVC, metav1.GetOptions{})
+		if err != nil {
+			return nil, nil, apierror.Friendly(err)
+		}
+		if got.Spec.Model == nil {
+			return nil, nil, fmt.Errorf("InferenceService %q has no spec.model; pass --model instead", o.ISVC)
+		}
+		isvc = got
+		modelName = got.Spec.Model.Name
+	}
+	if bm, err := ome.OmeV1beta1().BaseModels(ns).Get(ctx, modelName, metav1.GetOptions{}); err == nil {
+		return &bm.Spec, isvc, nil
+	} else if !kerrors.IsNotFound(err) {
+		return nil, nil, apierror.Friendly(err)
+	}
+	cbm, err := ome.OmeV1beta1().ClusterBaseModels().Get(ctx, modelName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, apierror.Friendly(err)
+	}
+	return &cbm.Spec, isvc, nil
+}
+
+// runtimeKey identifies a runtime by name and scope; namespace-scoped and
+// cluster-scoped runtimes sharing a name are distinct candidates, matching
+// how pkg/runtimeselector itself never deduplicates across scope.
+type runtimeKey struct {
+	name      string
+	isCluster bool
+}
+
+type runtimeCandidate struct {
+	name      string
+	isCluster bool
+}
+
+// listCandidateRuntimes enumerates every runtime GetCompatibleRuntimes could
+// have considered: namespace-scoped runtimes in ns, plus every cluster-scoped
+// runtime. This mirrors pkg/runtimeselector's own fetch (namespace runtimes
+// always precede cluster ones) so rejected runtimes can be re-validated for a
+// reason instead of silently vanishing from the table.
+func listCandidateRuntimes(ctx context.Context, c ctrlclient.Client, ns string) ([]runtimeCandidate, error) {
+	var out []runtimeCandidate
+
+	nsRuntimes := &v1beta1.ServingRuntimeList{}
+	if err := c.List(ctx, nsRuntimes, ctrlclient.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	for _, rt := range nsRuntimes.Items {
+		out = append(out, runtimeCandidate{name: rt.Name})
+	}
+
+	clusterRuntimes := &v1beta1.ClusterServingRuntimeList{}
+	if err := c.List(ctx, clusterRuntimes); err != nil {
+		return nil, err
+	}
+	for _, rt := range clusterRuntimes.Items {
+		out = append(out, runtimeCandidate{name: rt.Name, isCluster: true})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].isCluster != out[j].isCluster {
+			return !out[i].isCluster // namespace-scoped first, matching GetCompatibleRuntimes' ordering
+		}
+		return out[i].name < out[j].name
+	})
+	return out, nil
+}
+
+// rejectionReason extracts a human-readable, non-redundant reason from the
+// errors ValidateRuntime returns. Unrecognized error types fall back to
+// err.Error() so the table always has something to show.
+func rejectionReason(err error) string {
+	switch e := err.(type) {
+	case *runtimeselector.RuntimeCompatibilityError:
+		return e.Reason
+	case *runtimeselector.RuntimeDisabledError:
+		return "runtime is disabled"
+	default:
+		return err.Error()
+	}
+}
+
+func scopeLabel(isCluster bool) string {
+	if isCluster {
+		return "Cluster"
+	}
+	return "Namespaced"
+}

--- a/pkg/cli/cmd/runtime/explain_test.go
+++ b/pkg/cli/cmd/runtime/explain_test.go
@@ -1,0 +1,241 @@
+package runtime
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	omefake "sigs.k8s.io/ome/pkg/client/clientset/versioned/fake"
+)
+
+func scheme(t *testing.T) *k8sruntime.Scheme {
+	t.Helper()
+	s := k8sruntime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(v1beta1.AddToScheme(s))
+	return s
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func execute(t *testing.T, f factory.Factory, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	streams := genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &out, ErrOut: &out}
+	cmd := NewCmd(f, streams)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// row returns the whitespace-split fields of the output line whose first
+// column is name, so tests can assert specific columns (e.g. COMPATIBLE)
+// instead of substring-searching the whole table.
+func row(t *testing.T, out, name string) []string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == name {
+			return fields
+		}
+	}
+	t.Fatalf("no output row for %q in:\n%s", name, out)
+	return nil
+}
+
+// autoSelectFormat builds a SupportedModelFormat that compareSupportedModelFormats
+// (pkg/runtimeselector/matcher.go) will match against a BaseModel with the
+// given ModelFormat.Name, and that CalculateScore will treat as auto-select
+// eligible -- both required for the runtime to appear in GetCompatibleRuntimes'
+// output at all. See pkg/runtimeselector/selector_test.go for the reference
+// fixture shape.
+func autoSelectFormat(format string) v1beta1.SupportedModelFormat {
+	return v1beta1.SupportedModelFormat{
+		ModelFormat: &v1beta1.ModelFormat{Name: format},
+		AutoSelect:  ptr(true),
+	}
+}
+
+func TestExplainRequiresExactlyOneTarget(t *testing.T) {
+	_, err := execute(t, factory.Static{NS: "d"}, "explain")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one of --model or --isvc")
+
+	_, err = execute(t, factory.Static{NS: "d"}, "explain", "--model", "m", "--isvc", "s")
+	require.Error(t, err)
+}
+
+func TestExplainRanksRuntimes(t *testing.T) {
+	format := "safetensors"
+	size := "70B"
+	model := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-70b"},
+		Spec: v1beta1.BaseModelSpec{
+			ModelFormat:        v1beta1.ModelFormat{Name: format},
+			ModelParameterSize: &size,
+		},
+	}
+	compatible := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "srt-llama"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{autoSelectFormat(format)},
+		},
+	}
+	ctrl := ctrlfake.NewClientBuilder().WithScheme(scheme(t)).
+		WithObjects(model, compatible).Build()
+	f := factory.Static{
+		OME:     omefake.NewSimpleClientset(model),
+		Runtime: ctrl,
+		NS:      "team-a",
+	}
+	out, err := execute(t, f, "explain", "--model", "llama-70b")
+	require.NoError(t, err)
+	assert.Contains(t, out, "RUNTIME")
+
+	got := row(t, out, "srt-llama")
+	require.Len(t, got, 6, "row: %v", got)
+	assert.Equal(t, "Cluster", got[1])
+	assert.Equal(t, "Yes", got[2], "srt-llama supports the model's format and has autoSelect enabled, so GetCompatibleRuntimes must return it")
+}
+
+// TestExplainListsIncompatibleRuntimeWithReason pins down the semantics
+// documented in explain.go: GetCompatibleRuntimes only ever returns matches
+// (see pkg/runtimeselector/selector.go evaluateRuntime), so a runtime it
+// silently drops must still show up here, marked incompatible, with a reason.
+func TestExplainListsIncompatibleRuntimeWithReason(t *testing.T) {
+	format := "safetensors"
+	model := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-70b"},
+		Spec:       v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: format}},
+	}
+	compatible := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "srt-llama"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{autoSelectFormat(format)},
+		},
+	}
+	// srt-onnx supports a different format entirely: GetCompatibleRuntimes
+	// drops it silently, but explain must still list it as incompatible.
+	incompatible := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "srt-onnx"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{autoSelectFormat("onnx")},
+		},
+	}
+	ctrl := ctrlfake.NewClientBuilder().WithScheme(scheme(t)).
+		WithObjects(model, compatible, incompatible).Build()
+	f := factory.Static{
+		OME:     omefake.NewSimpleClientset(model),
+		Runtime: ctrl,
+		NS:      "team-a",
+	}
+	out, err := execute(t, f, "explain", "--model", "llama-70b")
+	require.NoError(t, err)
+
+	rejected := row(t, out, "srt-onnx")
+	assert.Equal(t, "No", rejected[2])
+	assert.Contains(t, out, "not in supported formats", "rejection reason should explain the format mismatch")
+
+	accepted := row(t, out, "srt-llama")
+	assert.Equal(t, "Yes", accepted[2])
+}
+
+// TestExplainPrefersNamespacedBaseModel exercises resolveTarget's precedence:
+// a namespaced BaseModel must win over a ClusterBaseModel of the same name.
+func TestExplainPrefersNamespacedBaseModel(t *testing.T) {
+	format := "safetensors"
+	nsModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-70b", Namespace: "team-a"},
+		Spec:       v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: format}},
+	}
+	// Same name, different (unsupported-by-any-runtime) format: if
+	// resolveTarget picked this one by mistake, srt-llama would never match.
+	clusterModel := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-70b"},
+		Spec:       v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: "onnx"}},
+	}
+	rt := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "srt-llama"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{autoSelectFormat(format)},
+		},
+	}
+	ctrl := ctrlfake.NewClientBuilder().WithScheme(scheme(t)).WithObjects(rt).Build()
+	f := factory.Static{
+		OME:     omefake.NewSimpleClientset(nsModel, clusterModel),
+		Runtime: ctrl,
+		NS:      "team-a",
+	}
+	out, err := execute(t, f, "explain", "--model", "llama-70b")
+	require.NoError(t, err)
+	got := row(t, out, "srt-llama")
+	assert.Equal(t, "Yes", got[2])
+}
+
+// TestExplainISVCPath covers --isvc resolution (model looked up via
+// spec.model) and the spec.runtime pin note.
+func TestExplainISVCPath(t *testing.T) {
+	format := "safetensors"
+	model := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-70b"},
+		Spec:       v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: format}},
+	}
+	rt := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "srt-llama"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{autoSelectFormat(format)},
+		},
+	}
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-isvc", Namespace: "team-a"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Model:   &v1beta1.ModelRef{Name: "llama-70b"},
+			Runtime: &v1beta1.ServingRuntimeRef{Name: "srt-llama"},
+		},
+	}
+	ctrl := ctrlfake.NewClientBuilder().WithScheme(scheme(t)).WithObjects(rt).Build()
+	f := factory.Static{
+		OME:     omefake.NewSimpleClientset(model, isvc),
+		Runtime: ctrl,
+		NS:      "team-a",
+	}
+	out, err := execute(t, f, "explain", "--isvc", "my-isvc")
+	require.NoError(t, err)
+	got := row(t, out, "srt-llama")
+	assert.Equal(t, "Yes", got[2])
+	assert.Contains(t, out, `pins spec.runtime="srt-llama"`)
+}
+
+func TestExplainISVCWithoutModelErrors(t *testing.T) {
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-isvc", Namespace: "team-a"},
+	}
+	f := factory.Static{
+		OME: omefake.NewSimpleClientset(isvc),
+		NS:  "team-a",
+	}
+	_, err := execute(t, f, "explain", "--isvc", "my-isvc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no spec.model")
+}
+
+func TestExplainModelNotFound(t *testing.T) {
+	f := factory.Static{
+		OME: omefake.NewSimpleClientset(),
+		NS:  "team-a",
+	}
+	_, err := execute(t, f, "explain", "--model", "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/pkg/cli/cmd/runtime/runtime.go
+++ b/pkg/cli/cmd/runtime/runtime.go
@@ -1,0 +1,18 @@
+// Package runtime implements `kubectl ome runtime` subcommands.
+package runtime
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/factory"
+)
+
+func NewCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runtime",
+		Short: "Inspect OME runtime selection",
+	}
+	cmd.AddCommand(newExplainCmd(f, streams))
+	return cmd
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"sigs.k8s.io/ome/pkg/cli/cmd/get"
+	runtimecmd "sigs.k8s.io/ome/pkg/cli/cmd/runtime"
 	"sigs.k8s.io/ome/pkg/cli/cmd/status"
 	"sigs.k8s.io/ome/pkg/cli/cmd/version"
 	"sigs.k8s.io/ome/pkg/cli/factory"
@@ -34,8 +35,9 @@ component-aware log streaming.`,
 	configFlags.AddFlags(cmd.PersistentFlags())
 
 	// Command families. Keep alphabetical.
-	// (runtime/logs are added by later PRs; get/status/version below.)
+	// (logs is added by a later PR; get/runtime/status/version below.)
 	cmd.AddCommand(get.NewCmd(f, streams))
+	cmd.AddCommand(runtimecmd.NewCmd(f, streams))
 	cmd.AddCommand(status.NewCmd(f, streams))
 	cmd.AddCommand(version.NewCmd(f, streams))
 


### PR DESCRIPTION
## What this PR does

Fourth implementation PR for OEP-0011 (oeps/0011-kubectl-ome-plugin): adds `kubectl ome runtime explain (--model NAME | --isvc NAME)`.

- Runs the operator's own pkg/runtimeselector against the cluster and prints the ranked verdict: RUNTIME / SCOPE / COMPATIBLE / PRIORITY / WEIGHT / REASON per serving runtime
- Model resolution mirrors the operator: namespaced BaseModel first, ClusterBaseModel fallback; --isvc path explains an existing service's model (with its spec.runtime override context)
- Zero drift by construction: the scoring code is the controller's, reached through a lazily-built controller-runtime client
- Friendly errors for missing models/CRDs; read-only

## Why we need it

OEP-0011 (merged, #736): runtime selection is a weighted decision inside the operator, invisible from outside — when no runtime matches a model, users see only a failed reconcile. This is the "why" command.

## How to test

go test ./pkg/cli/...; make kubectl-ome && ./bin/kubectl-ome runtime explain --model <name>

## Checklist

- [x] Tests added/updated
- [ ] Docs updated (docs page lands with the release PR per the OEP plan)
- [x] Scoped test suite passes locally (go test ./pkg/cli/... — full make test requires the Rust xet toolchain, unaffected by this PR)