### PR TITLE
[Core] kubectl ome logs: component-aware log streaming

### DIFF
--- a/pkg/cli/cmd/logs/logs.go
+++ b/pkg/cli/cmd/logs/logs.go
@@ -90,6 +90,12 @@ func (o *Options) Run(ctx context.Context, f factory.Factory) error {
 		req := kube.CoreV1().Pods(ns).GetLogs(p.Name, &po)
 		reader, err := req.Stream(ctx)
 		if err != nil {
+			// Don't leak the API-server log connections already opened for
+			// earlier pods in this loop: multiplex() never gets to run its
+			// deferred Close on them since we're bailing out before the call.
+			for _, s := range streams {
+				_ = s.Reader.Close()
+			}
 			return fmt.Errorf("streaming logs for pod %s: %w", p.Name, err)
 		}
 		prefix := ""

--- a/pkg/cli/cmd/logs/logs.go
+++ b/pkg/cli/cmd/logs/logs.go
@@ -1,0 +1,116 @@
+package logs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+type Options struct {
+	genericiooptions.IOStreams
+	Name      string
+	Component string
+	Container string
+	Follow    bool
+	Tail      int64
+	Since     time.Duration
+}
+
+func NewCmd(f factory.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	o := &Options{IOStreams: streams, Tail: -1}
+	cmd := &cobra.Command{
+		Use:   "logs INFERENCESERVICE",
+		Short: "Stream logs from the pods behind an InferenceService",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.Name = args[0]
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run(cmd.Context(), f)
+		},
+	}
+	cmd.Flags().StringVarP(&o.Component, "component", "c", "", "Only this component: engine, decoder or router")
+	cmd.Flags().StringVar(&o.Container, "container", "", "Container name (default: the OME main container, falling back to the pod's first container)")
+	cmd.Flags().BoolVarP(&o.Follow, "follow", "f", false, "Stream new log lines as they arrive")
+	cmd.Flags().Int64Var(&o.Tail, "tail", o.Tail, "Lines of recent log to show per pod (-1 for all)")
+	cmd.Flags().DurationVar(&o.Since, "since", 0, "Only logs newer than this duration (e.g. 10m)")
+	return cmd
+}
+
+func (o *Options) Validate() error {
+	switch o.Component {
+	case "", "engine", "decoder", "router":
+		return nil
+	default:
+		return fmt.Errorf("invalid component %q (valid: engine, decoder, router)", o.Component)
+	}
+}
+
+func (o *Options) Run(ctx context.Context, f factory.Factory) error {
+	ns, _, err := f.Namespace()
+	if err != nil {
+		return err
+	}
+	kube, err := f.KubeClient()
+	if err != nil {
+		return err
+	}
+	selector := fmt.Sprintf("%s=%s", constants.InferenceServiceLabel, o.Name)
+	if o.Component != "" {
+		selector += fmt.Sprintf(",%s=%s", constants.OMEComponentLabel, o.Component)
+	}
+	pods, err := kube.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no pods found for InferenceService %q in namespace %q (selector %s)", o.Name, ns, selector)
+	}
+	opts := &corev1.PodLogOptions{Follow: o.Follow}
+	if o.Tail >= 0 {
+		opts.TailLines = &o.Tail
+	}
+	if o.Since > 0 {
+		secs := int64(o.Since.Seconds())
+		opts.SinceSeconds = &secs
+	}
+	var streams []namedStream
+	for _, p := range pods.Items {
+		po := *opts
+		po.Container = o.containerFor(&p)
+		req := kube.CoreV1().Pods(ns).GetLogs(p.Name, &po)
+		reader, err := req.Stream(ctx)
+		if err != nil {
+			return fmt.Errorf("streaming logs for pod %s: %w", p.Name, err)
+		}
+		prefix := ""
+		if len(pods.Items) > 1 {
+			prefix = fmt.Sprintf("[%s/%s] ", p.Labels[constants.OMEComponentLabel], p.Name)
+		}
+		streams = append(streams, namedStream{Prefix: prefix, Reader: reader})
+	}
+	return multiplex(streams, o.Out)
+}
+
+// containerFor picks --container if set, else the OME main container when the
+// pod has one, else the first container.
+func (o *Options) containerFor(p *corev1.Pod) string {
+	if o.Container != "" {
+		return o.Container
+	}
+	for _, c := range p.Spec.Containers {
+		if c.Name == constants.MainContainerName {
+			return c.Name
+		}
+	}
+	return "" // empty lets the API default to the only/first container
+}

--- a/pkg/cli/cmd/logs/logs_test.go
+++ b/pkg/cli/cmd/logs/logs_test.go
@@ -1,0 +1,76 @@
+package logs
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func pod(name, isvc, component string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: "team-a",
+		Labels: map[string]string{
+			constants.InferenceServiceLabel: isvc,
+			constants.OMEComponentLabel:     component,
+		},
+	}}
+}
+
+func execute(t *testing.T, f factory.Factory, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	streams := genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: &out, ErrOut: &out}
+	cmd := NewCmd(f, streams)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestLogsPrefixesMultiplePods(t *testing.T) {
+	f := factory.Static{
+		Kube: kubefake.NewSimpleClientset(
+			pod("llama-engine-1", "llama", "engine"),
+			pod("llama-decoder-1", "llama", "decoder"),
+		),
+		NS: "team-a",
+	}
+	out, err := execute(t, f, "llama")
+	require.NoError(t, err)
+	assert.Contains(t, out, "[engine/llama-engine-1] fake logs")
+	assert.Contains(t, out, "[decoder/llama-decoder-1] fake logs")
+}
+
+func TestLogsComponentFilterSinglePodNoPrefix(t *testing.T) {
+	f := factory.Static{
+		Kube: kubefake.NewSimpleClientset(
+			pod("llama-engine-1", "llama", "engine"),
+			pod("llama-decoder-1", "llama", "decoder"),
+		),
+		NS: "team-a",
+	}
+	out, err := execute(t, f, "llama", "-c", "engine")
+	require.NoError(t, err)
+	assert.Equal(t, "fake logs\n", out)
+}
+
+func TestLogsNoPodsIsError(t *testing.T) {
+	f := factory.Static{Kube: kubefake.NewSimpleClientset(), NS: "team-a"}
+	_, err := execute(t, f, "llama")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no pods found")
+}
+
+func TestLogsRejectsBadComponent(t *testing.T) {
+	_, err := execute(t, factory.Static{NS: "d"}, "llama", "-c", "gpu")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid component")
+}

--- a/pkg/cli/cmd/logs/multiplex.go
+++ b/pkg/cli/cmd/logs/multiplex.go
@@ -1,0 +1,51 @@
+// Package logs implements `kubectl ome logs`: component-aware log streaming
+// for the pods behind an InferenceService.
+package logs
+
+import (
+	"bufio"
+	"io"
+	"sync"
+)
+
+type namedStream struct {
+	Prefix string
+	Reader io.ReadCloser
+}
+
+// multiplex copies every stream to out line-by-line, prefixing each line,
+// serialized by a mutex so lines never interleave mid-line. Blocks until all
+// streams hit EOF (or error); reader close is guaranteed.
+func multiplex(streams []namedStream, out io.Writer) error {
+	var (
+		mu   sync.Mutex
+		wg   sync.WaitGroup
+		errs = make([]error, len(streams))
+	)
+	for i, s := range streams {
+		wg.Add(1)
+		go func(i int, s namedStream) {
+			defer wg.Done()
+			defer s.Reader.Close()
+			scanner := bufio.NewScanner(s.Reader)
+			scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+			for scanner.Scan() {
+				mu.Lock()
+				_, werr := io.WriteString(out, s.Prefix+scanner.Text()+"\n")
+				mu.Unlock()
+				if werr != nil {
+					errs[i] = werr
+					return
+				}
+			}
+			errs[i] = scanner.Err()
+		}(i, s)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cli/cmd/logs/multiplex_test.go
+++ b/pkg/cli/cmd/logs/multiplex_test.go
@@ -1,0 +1,39 @@
+package logs
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rc(s string) io.ReadCloser { return io.NopCloser(strings.NewReader(s)) }
+
+func TestMultiplexPrefixesEveryLine(t *testing.T) {
+	var out bytes.Buffer
+	err := multiplex([]namedStream{
+		{Prefix: "[engine/p1] ", Reader: rc("a\nb\n")},
+		{Prefix: "[decoder/p2] ", Reader: rc("c\n")},
+	}, &out)
+	require.NoError(t, err)
+	got := out.String()
+	assert.Contains(t, got, "[engine/p1] a\n")
+	assert.Contains(t, got, "[engine/p1] b\n")
+	assert.Contains(t, got, "[decoder/p2] c\n")
+}
+
+func TestMultiplexSingleStreamNoPrefix(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, multiplex([]namedStream{{Prefix: "", Reader: rc("raw\n")}}, &out))
+	assert.Equal(t, "raw\n", out.String())
+}
+
+func TestMultiplexDoesNotInterleaveWithinALine(t *testing.T) {
+	long := strings.Repeat("x", 64*1024) // exceeds default bufio.Scanner token size guard
+	var out bytes.Buffer
+	require.NoError(t, multiplex([]namedStream{{Prefix: "[e/p] ", Reader: rc(long + "\n")}}, &out))
+	assert.Equal(t, "[e/p] "+long+"\n", out.String())
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"sigs.k8s.io/ome/pkg/cli/cmd/get"
+	"sigs.k8s.io/ome/pkg/cli/cmd/logs"
 	runtimecmd "sigs.k8s.io/ome/pkg/cli/cmd/runtime"
 	"sigs.k8s.io/ome/pkg/cli/cmd/status"
 	"sigs.k8s.io/ome/pkg/cli/cmd/version"
@@ -35,8 +36,8 @@ component-aware log streaming.`,
 	configFlags.AddFlags(cmd.PersistentFlags())
 
 	// Command families. Keep alphabetical.
-	// (logs is added by a later PR; get/runtime/status/version below.)
 	cmd.AddCommand(get.NewCmd(f, streams))
+	cmd.AddCommand(logs.NewCmd(f, streams))
 	cmd.AddCommand(runtimecmd.NewCmd(f, streams))
 	cmd.AddCommand(status.NewCmd(f, streams))
 	cmd.AddCommand(version.NewCmd(f, streams))


### PR DESCRIPTION
## What this PR does

Fifth implementation PR for OEP-0011 (oeps/0011-kubectl-ome-plugin): adds `kubectl ome logs <inferenceservice>`.

- Resolves the pods behind an InferenceService via the ome.io/inferenceservice label (optionally narrowed by component via -c engine|decoder|router) and streams their logs
- Multiple streams multiplex line-by-line with [component/pod] prefixes; single-stream output stays unprefixed so pipes stay clean
- -f/--follow, --tail, --since map to pod log options; --container overrides the default (the OME main container, falling back to the pod's first container)
- Line multiplexer is a pure, separately tested unit (interleaving, prefixing, large-line handling)

## Why we need it

OEP-0011 (merged, #736): tailing an engine's logs today requires discovering pod names and OME's label conventions first.

## How to test

go test ./pkg/cli/...; make kubectl-ome && ./bin/kubectl-ome logs <isvc> -c engine -f

## Checklist

- [x] Tests added/updated
- [ ] Docs updated (docs page lands with the release PR per the OEP plan)
- [x] Scoped test suite passes locally (go test ./pkg/cli/... — full make test requires the Rust xet toolchain, unaffected by this PR)