### PR TITLE
[Bugfix] explain: REASON text masks real rejection cause

### DIFF
--- a/pkg/cli/cmd/runtime/explain.go
+++ b/pkg/cli/cmd/runtime/explain.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/ome/pkg/cli/apierror"
 	"sigs.k8s.io/ome/pkg/cli/factory"
 	"sigs.k8s.io/ome/pkg/cli/printers"
+	"sigs.k8s.io/ome/pkg/runtimeinheritance"
 	"sigs.k8s.io/ome/pkg/runtimeselector"
 )
 
@@ -72,6 +73,13 @@ func (o *explainOptions) Run(ctx context.Context, f factory.Factory) error {
 		return err
 	}
 	selector := runtimeselector.New(ctrl)
+	// A standalone matcher/scorer pair, built from the exact same defaults
+	// runtimeselector.New wires up internally, so explain.go can recompute
+	// compatibility/auto-select/score details for a specific spec instead of
+	// only getting a yes/no verdict out of the Selector interface.
+	cfg := runtimeselector.NewConfig(ctrl)
+	matcherImpl := runtimeselector.NewDefaultRuntimeMatcher(cfg)
+	scorerImpl := runtimeselector.NewDefaultRuntimeScorer(cfg)
 
 	// GetCompatibleRuntimes is the operator's actual auto-select ranking:
 	// every entry it returns already passed compatibility, auto-select
@@ -107,14 +115,14 @@ func (o *explainOptions) Run(ctx context.Context, f factory.Factory) error {
 			printers.OrDash(strings.Join(m.MatchDetails.Reasons, "; ")),
 		})
 	}
+	// Cluster-scoped candidates whose name is shadowed by a namespace-scoped
+	// runtime of the same name need special handling below (defect b).
+	shadowed := shadowedClusterNames(candidates)
 	for _, c := range candidates {
 		if matched[runtimeKey(c)] {
 			continue
 		}
-		reason := "supports the model but has no supportedModelFormats[].autoSelect=true entry, so automatic selection skips it (pin it explicitly via spec.runtime.name instead)"
-		if err := selector.ValidateRuntime(ctx, c.name, modelSpec, isvc); err != nil {
-			reason = rejectionReason(err)
-		}
+		reason := candidateReason(ctx, selector, ctrl, matcherImpl, scorerImpl, c, shadowed[c.name], ns, modelSpec, isvc)
 		table.Rows = append(table.Rows, []string{c.name, scopeLabel(c.isCluster), "No", "-", "-", reason})
 	}
 
@@ -213,6 +221,165 @@ func rejectionReason(err error) string {
 	default:
 		return err.Error()
 	}
+}
+
+// shadowedClusterNames returns the set of names that identify both a
+// cluster-scoped and a namespace-scoped candidate in candidates.
+// pkg/runtimeinheritance documents name-based shadowing as an intentional
+// pattern (a namespace-scoped runtime overrides a cluster-scoped one of the
+// same name), but it also defeats ValidateRuntime's name-only,
+// namespaced-first resolution (pkg/runtimeselector/fetcher.go GetRuntime)
+// for the cluster-scoped side -- see candidateReason.
+func shadowedClusterNames(candidates []runtimeCandidate) map[string]bool {
+	nsNames := make(map[string]bool)
+	for _, c := range candidates {
+		if !c.isCluster {
+			nsNames[c.name] = true
+		}
+	}
+	shadowed := make(map[string]bool)
+	for _, c := range candidates {
+		if c.isCluster && nsNames[c.name] {
+			shadowed[c.name] = true
+		}
+	}
+	return shadowed
+}
+
+// candidateReason produces the REASON text for a candidate GetCompatibleRuntimes
+// did not return. Two defects made this text unreliable before:
+//
+//   - (a) A hardcoded "no autoSelect entry" reason was shown whenever
+//     ValidateRuntime returned nil, but ValidateRuntime only checks
+//     compatibility. GetCompatibleRuntimes' evaluateRuntime
+//     (pkg/runtimeselector/selector.go) additionally requires an
+//     autoSelect-enabled *matching* format and a positive score
+//     (pkg/runtimeselector/scorer.go CalculateScore), so a compatible
+//     runtime can be excluded for reasons the hardcoded text never
+//     considered: the matching format specifically isn't autoSelect-enabled
+//     (even though a different format on the same runtime is), or its score
+//     computes to 0 (e.g. an explicit Priority of 0).
+//   - (b) ValidateRuntime resolves a runtime by name only, namespaced first
+//     (pkg/runtimeselector/fetcher.go GetRuntime), so re-validating a
+//     cluster-scoped candidate whose name collides with a namespace-scoped
+//     runtime of the same name silently validated the WRONG object.
+//
+// shadowedByNamespaced (only meaningful when c.isCluster) signals case (b).
+func candidateReason(
+	ctx context.Context,
+	sel runtimeselector.Selector,
+	ctrl ctrlclient.Client,
+	matcher runtimeselector.RuntimeMatcher,
+	scorer runtimeselector.RuntimeScorer,
+	c runtimeCandidate,
+	shadowedByNamespaced bool,
+	ns string,
+	model *v1beta1.BaseModelSpec,
+	isvc *v1beta1.InferenceService,
+) string {
+	if c.isCluster && shadowedByNamespaced {
+		// fetcher.GetRuntime (used by both ValidateRuntime and
+		// Selector.GetRuntime) always checks the namespace-scoped runtime of
+		// this name first, so calling either here would silently grade the
+		// NAMESPACED object and report its reason on this CLUSTER row.
+		// ResolveClusterRuntime only ever Gets a ClusterServingRuntime, so
+		// it cannot be shadowed the same way -- resolve (with inheritance,
+		// same as ValidateRuntime would apply) and evaluate directly.
+		spec, _, err := runtimeinheritance.ResolveClusterRuntime(ctx, ctrl, c.name)
+		if err != nil {
+			return fmt.Sprintf("shadowed by a namespaced runtime of the same name, so it could not be re-validated by name; resolving the cluster runtime directly also failed: %v", err)
+		}
+		return evaluateReason(matcher, scorer, spec, model, isvc, c.name)
+	}
+
+	if err := sel.ValidateRuntime(ctx, c.name, model, isvc); err != nil {
+		return rejectionReason(err)
+	}
+
+	// ValidateRuntime agrees the runtime is compatible, yet it is missing
+	// from GetCompatibleRuntimes -- defect (a): recompute the real
+	// auto-select/score cause instead of assuming "no autoSelect entry".
+	spec, _, err := sel.GetRuntime(ctx, c.name, ns)
+	if err != nil {
+		return "runtime is compatible but was not auto-selected, and the exact cause could not be recomputed: " + err.Error()
+	}
+	return evaluateReason(matcher, scorer, spec, model, isvc, c.name)
+}
+
+// evaluateReason evaluates spec against model/isvc directly with the exported
+// matcher/scorer and returns the REASON text for why it is not a match.
+// Mirrors, in order, the checks that keep a runtime out of
+// GetCompatibleRuntimes' matches: compatibility (disabled, accelerator
+// class, deployment mode, format, size -- all folded into
+// matcher.GetCompatibilityDetails), then evaluateRuntime's auto-select gates
+// (pkg/runtimeselector/selector.go): some format has autoSelect=true, the
+// specific matching format has autoSelect=true, and CalculateScore > 0.
+func evaluateReason(
+	matcher runtimeselector.RuntimeMatcher,
+	scorer runtimeselector.RuntimeScorer,
+	spec *v1beta1.ServingRuntimeSpec,
+	model *v1beta1.BaseModelSpec,
+	isvc *v1beta1.InferenceService,
+	name string,
+) string {
+	report, err := matcher.GetCompatibilityDetails(spec, model, isvc, name)
+	if err != nil {
+		return err.Error()
+	}
+	if !report.IsCompatible {
+		if len(report.IncompatibilityReasons) > 0 {
+			return report.IncompatibilityReasons[0]
+		}
+		return "incompatible model format"
+	}
+
+	if !hasAutoSelectFormat(spec) {
+		return "supports the model but has no supportedModelFormats[].autoSelect=true entry, so automatic selection skips it (pin it explicitly via spec.runtime.name instead)"
+	}
+	if !report.MatchDetails.AutoSelectEnabled {
+		return fmt.Sprintf(
+			"matching format %s is not autoSelect-enabled (a different supportedModelFormats entry on this runtime has autoSelect=true, but not the one that matches this model)",
+			matchingFormatName(spec, model))
+	}
+
+	if score, scoreErr := scorer.CalculateScore(spec, model); scoreErr == nil && score <= 0 {
+		if report.MatchDetails.Priority == 0 {
+			return "auto-select score is 0 (format priority 0)"
+		}
+		return "auto-select score is 0"
+	}
+
+	return "compatible and auto-select eligible, but automatic selection did not choose it (unexpected)"
+}
+
+// hasAutoSelectFormat reports whether ANY supportedModelFormats entry has
+// autoSelect=true, regardless of whether that entry is the one that matches
+// this particular model. Faithfully replicates the unexported
+// runtimeHasAutoSelectFormat in pkg/runtimeselector/matcher.go, which gates
+// GetCompatibleRuntimes' evaluateRuntime (pkg/runtimeselector/selector.go)
+// and isn't itself exported.
+func hasAutoSelectFormat(spec *v1beta1.ServingRuntimeSpec) bool {
+	for _, format := range spec.SupportedModelFormats {
+		if format.AutoSelect != nil && *format.AutoSelect {
+			return true
+		}
+	}
+	return false
+}
+
+// matchingFormatName returns the ModelFormat.Name of the supportedModelFormats
+// entry that determines compatibility for model, using the same primary key
+// (ModelFormat.Name equality) that pkg/runtimeselector/matcher.go's
+// unexported compareSupportedModelFormats checks first. Used only to make
+// the REASON text specific -- the compatible/incompatible verdict itself
+// always comes from matcher.GetCompatibilityDetails, never from this lookup.
+func matchingFormatName(spec *v1beta1.ServingRuntimeSpec, model *v1beta1.BaseModelSpec) string {
+	for _, format := range spec.SupportedModelFormats {
+		if format.ModelFormat != nil && format.ModelFormat.Name == model.ModelFormat.Name {
+			return format.ModelFormat.Name
+		}
+	}
+	return model.ModelFormat.Name
 }
 
 func scopeLabel(isCluster bool) string {

--- a/pkg/cli/cmd/runtime/explain_test.go
+++ b/pkg/cli/cmd/runtime/explain_test.go
@@ -239,3 +239,166 @@ func TestExplainModelNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
+
+// TestExplainNamesMatchingFormatCause pins down defect (a), case 2: the
+// supportedModelFormats entry that actually matches the model has no
+// autoSelect=true, but a *different*, non-matching entry on the same runtime
+// does. ValidateRuntime ignores autoSelect entirely (it only checks
+// compatibility) so it returns nil here; the old code took that nil to mean
+// "must be missing an autoSelect entry altogether" and printed that hardcoded
+// reason, which is false -- srt-mixed has one, just not on the matching
+// format. See pkg/runtimeselector/scorer.go CalculateScore: it skips only
+// explicitly autoSelect=false formats, so the matching (explicitly
+// non-autoSelect) format contributes nothing and the non-matching autoSelect
+// format scores 0 too (wrong ModelFormat.Name), leaving the runtime out of
+// GetCompatibleRuntimes' matches entirely.
+func TestExplainNamesMatchingFormatCause(t *testing.T) {
+	format := "safetensors"
+	model := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-70b"},
+		Spec:       v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: format}},
+	}
+	rt := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "srt-mixed"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				// Matches the model's format, but explicitly opts out of auto-select.
+				{ModelFormat: &v1beta1.ModelFormat{Name: format}, AutoSelect: ptr(false)},
+				// Auto-select enabled, but for a format that does not match this model.
+				{ModelFormat: &v1beta1.ModelFormat{Name: "onnx"}, AutoSelect: ptr(true)},
+			},
+		},
+	}
+	ctrl := ctrlfake.NewClientBuilder().WithScheme(scheme(t)).WithObjects(model, rt).Build()
+	f := factory.Static{
+		OME:     omefake.NewSimpleClientset(model),
+		Runtime: ctrl,
+		NS:      "team-a",
+	}
+	out, err := execute(t, f, "explain", "--model", "llama-70b")
+	require.NoError(t, err)
+
+	got := row(t, out, "srt-mixed")
+	require.GreaterOrEqual(t, len(got), 3, "row: %v", got)
+	assert.Equal(t, "No", got[2])
+	assert.Contains(t, out, "not autoSelect-enabled", "reason must name the matching-format cause")
+	assert.Contains(t, out, "safetensors", "reason should identify the matching format by name")
+	assert.NotContains(t, out, "no supportedModelFormats[].autoSelect=true entry",
+		"srt-mixed DOES have an autoSelect=true entry (onnx) -- must not claim none exists")
+}
+
+// TestExplainNamesZeroScoreCause pins down defect (a), case 3: the matching
+// format IS autoSelect-enabled, but its explicit Priority of 0 drives
+// scorer.CalculateScore (pkg/runtimeselector/scorer.go) to 0, which
+// evaluateRuntime (pkg/runtimeselector/selector.go) treats the same as "no
+// match". ValidateRuntime is blind to score entirely, so it returns nil; the
+// reason must name the zero score/priority instead of falsely claiming no
+// autoSelect entry exists.
+func TestExplainNamesZeroScoreCause(t *testing.T) {
+	format := "safetensors"
+	model := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-70b"},
+		Spec:       v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: format}},
+	}
+	rt := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "srt-zero-priority"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{
+				{
+					ModelFormat: &v1beta1.ModelFormat{Name: format},
+					AutoSelect:  ptr(true),
+					Priority:    ptr(int32(0)),
+				},
+			},
+		},
+	}
+	ctrl := ctrlfake.NewClientBuilder().WithScheme(scheme(t)).WithObjects(model, rt).Build()
+	f := factory.Static{
+		OME:     omefake.NewSimpleClientset(model),
+		Runtime: ctrl,
+		NS:      "team-a",
+	}
+	out, err := execute(t, f, "explain", "--model", "llama-70b")
+	require.NoError(t, err)
+
+	got := row(t, out, "srt-zero-priority")
+	require.GreaterOrEqual(t, len(got), 3, "row: %v", got)
+	assert.Equal(t, "No", got[2])
+	assert.Contains(t, out, "score is 0", "reason should name the zero auto-select score")
+	assert.Contains(t, out, "priority 0", "reason should point at the explicit zero priority")
+	assert.NotContains(t, out, "no supportedModelFormats[].autoSelect=true entry",
+		"srt-zero-priority DOES have an autoSelect=true entry -- must not claim none exists")
+}
+
+// TestExplainClusterRowReflectsClusterSpecWhenShadowed pins down defect (b):
+// ValidateRuntime resolves a runtime by name only, namespaced-first
+// (pkg/runtimeselector/fetcher.go GetRuntime), so re-validating a
+// cluster-scoped candidate whose name collides with a namespace-scoped
+// runtime of the same name must not silently grade the namespaced object.
+// Same-named shadowing across scopes is an intentional pattern
+// (pkg/runtimeinheritance), not user error, so explain must still get it
+// right.
+func TestExplainClusterRowReflectsClusterSpecWhenShadowed(t *testing.T) {
+	format := "safetensors"
+	model := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-70b"},
+		Spec:       v1beta1.BaseModelSpec{ModelFormat: v1beta1.ModelFormat{Name: format}},
+	}
+	// Namespaced "shared" is fully compatible and auto-select eligible --
+	// GetCompatibleRuntimes must return it as a "Yes" row, unaffected by the
+	// cluster row's fix.
+	nsRuntime := &v1beta1.ServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "team-a"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{autoSelectFormat(format)},
+		},
+	}
+	// Cluster "shared" supports a totally different format. ValidateRuntime("shared")
+	// would resolve the NAMESPACED runtime above (namespaced-first, name-only),
+	// see it's compatible, and return nil -- masking the cluster object's real
+	// (and different) incompatibility if explain.go trusted that nil here.
+	clusterRuntime := &v1beta1.ClusterServingRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared"},
+		Spec: v1beta1.ServingRuntimeSpec{
+			SupportedModelFormats: []v1beta1.SupportedModelFormat{autoSelectFormat("onnx")},
+		},
+	}
+	ctrl := ctrlfake.NewClientBuilder().WithScheme(scheme(t)).
+		WithObjects(model, nsRuntime, clusterRuntime).Build()
+	f := factory.Static{
+		OME:     omefake.NewSimpleClientset(model),
+		Runtime: ctrl,
+		NS:      "team-a",
+	}
+	out, err := execute(t, f, "explain", "--model", "llama-70b")
+	require.NoError(t, err)
+
+	var nsLine, clusterLine string
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "shared" {
+			continue
+		}
+		switch fields[1] {
+		case "Namespaced":
+			nsLine = line
+		case "Cluster":
+			clusterLine = line
+		}
+	}
+	require.NotEmpty(t, nsLine, "expected a Namespaced row for shared:\n%s", out)
+	require.NotEmpty(t, clusterLine, "expected a Cluster row for shared:\n%s", out)
+
+	nsFields := strings.Fields(nsLine)
+	assert.Equal(t, "Yes", nsFields[2], "namespaced runtime is compatible and must be unaffected by the cluster row's fix")
+
+	clusterFields := strings.Fields(clusterLine)
+	assert.Equal(t, "No", clusterFields[2])
+	// The cluster runtime's real defect is a format mismatch (onnx vs
+	// safetensors) -- the reason must come from THAT object, not the
+	// namespaced runtime's compatibility, and not a generic
+	// autoSelect-missing claim (the cluster runtime's own format DOES have
+	// autoSelect=true).
+	assert.Contains(t, clusterLine, "onnx",
+		"cluster row's reason should come from the cluster object's own format mismatch")
+}


### PR DESCRIPTION
## What this PR does

Post-merge review of #759 confirmed two defects in `kubectl ome runtime explain`'s REASON column (COMPATIBLE verdicts were always correct):

- A non-matched runtime that passes ValidateRuntime got a hardcoded "no autoSelect entry" reason — factually wrong when the real cause is a non-auto-selectable matching format or an explicit priority-0 (zero score) drop. The reason is now recomputed from the actual per-format auto-select/score semantics.
- ValidateRuntime resolves by name only (namespaced shadows cluster), so a cluster-scoped candidate sharing a name with a namespaced runtime had its rejection reason computed against the wrong object. Same-name rows are now evaluated against the correct scope's spec.

## Why we need it

The whole point of `runtime explain` is trustworthy "why" output; a wrong reason is worse than none. Follow-up to #759 (OEP-0011).

## How to test

go test ./pkg/cli/cmd/runtime/...

## Checklist

- [x] Tests added/updated
- [ ] Docs updated (N/A)
- [x] Scoped test suite passes locally (go test ./pkg/cli/... — full make test requires the Rust xet toolchain, unaffected by this PR)