### PR TITLE
[CI/Tests] kubectl-ome release packaging, krew manifest and docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -352,3 +352,54 @@ jobs:
           prerelease: ${{ contains(needs.prepare.outputs.tag, 'rc') || contains(needs.prepare.outputs.tag, 'alpha') || contains(needs.prepare.outputs.tag, 'beta') }}
           files: |
             release-assets/*
+
+  cli-artifacts:
+    name: Package kubectl-ome for krew
+    runs-on: ubuntu-latest
+    needs: [prepare, create-release]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Cross-compile
+        run: make kubectl-ome-cross GIT_TAG="${{ needs.prepare.outputs.tag }}"
+      - name: Package archives and checksums
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.prepare.outputs.tag }}"
+          mkdir -p dist
+          for os in linux darwin windows; do
+            for arch in amd64 arm64; do
+              ext=""; [ "$os" = "windows" ] && ext=".exe"
+              staging="dist/staging_${os}_${arch}"
+              mkdir -p "$staging"
+              cp "bin/cross/kubectl-ome_${os}_${arch}${ext}" "$staging/kubectl-ome${ext}"
+              cp LICENSE "$staging/"
+              tar -czf "dist/kubectl-ome_${VERSION}_${os}_${arch}.tar.gz" -C "$staging" .
+              rm -r "$staging"
+            done
+          done
+          (cd dist && sha256sum *.tar.gz > kubectl-ome_checksums.txt)
+      - name: Stamp krew manifest
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.prepare.outputs.tag }}"
+          cp hack/krew/ome.yaml dist/ome.yaml
+          sed -i "s/VERSION/${VERSION}/g" dist/ome.yaml
+          for os in linux darwin windows; do
+            for arch in amd64 arm64; do
+              sum=$(sha256sum "dist/kubectl-ome_${VERSION}_${os}_${arch}.tar.gz" | cut -d' ' -f1)
+              key="SHA256_$(echo "${os}_${arch}" | tr a-z A-Z)"
+              sed -i "s/${key}/${sum}/" dist/ome.yaml
+            done
+          done
+          grep -q "SHA256_" dist/ome.yaml && { echo "unstamped placeholder left"; exit 1; } || true
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ needs.prepare.outputs.tag }}" dist/*.tar.gz dist/kubectl-ome_checksums.txt dist/ome.yaml --clobber

--- a/hack/krew/ome.yaml
+++ b/hack/krew/ome.yaml
@@ -1,0 +1,43 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ome
+spec:
+  version: VERSION
+  homepage: https://github.com/ome-projects/ome
+  shortDescription: Inspect OME models, runtimes and inference services
+  description: |
+    Official CLI for OME (Open Model Engine), the Kubernetes operator for
+    LLM serving. Provides model-centric listings across OME resources,
+    one-view InferenceService readiness diagnosis, runtime-selection
+    explanations powered by the operator's own scoring engine, and
+    component-aware log streaming.
+  caveats: |
+    This plugin is read-only and needs get/list on ome.io resources plus
+    pods, pods/log and events. See the docs for an example ClusterRole:
+    https://ome-projects.github.io/ome/docs/tasks/kubectl-ome/
+  platforms:
+    - selector: {matchLabels: {os: linux, arch: amd64}}
+      uri: https://github.com/ome-projects/ome/releases/download/VERSION/kubectl-ome_VERSION_linux_amd64.tar.gz
+      sha256: SHA256_LINUX_AMD64
+      bin: kubectl-ome
+    - selector: {matchLabels: {os: linux, arch: arm64}}
+      uri: https://github.com/ome-projects/ome/releases/download/VERSION/kubectl-ome_VERSION_linux_arm64.tar.gz
+      sha256: SHA256_LINUX_ARM64
+      bin: kubectl-ome
+    - selector: {matchLabels: {os: darwin, arch: amd64}}
+      uri: https://github.com/ome-projects/ome/releases/download/VERSION/kubectl-ome_VERSION_darwin_amd64.tar.gz
+      sha256: SHA256_DARWIN_AMD64
+      bin: kubectl-ome
+    - selector: {matchLabels: {os: darwin, arch: arm64}}
+      uri: https://github.com/ome-projects/ome/releases/download/VERSION/kubectl-ome_VERSION_darwin_arm64.tar.gz
+      sha256: SHA256_DARWIN_ARM64
+      bin: kubectl-ome
+    - selector: {matchLabels: {os: windows, arch: amd64}}
+      uri: https://github.com/ome-projects/ome/releases/download/VERSION/kubectl-ome_VERSION_windows_amd64.tar.gz
+      sha256: SHA256_WINDOWS_AMD64
+      bin: kubectl-ome.exe
+    - selector: {matchLabels: {os: windows, arch: arm64}}
+      uri: https://github.com/ome-projects/ome/releases/download/VERSION/kubectl-ome_VERSION_windows_arm64.tar.gz
+      sha256: SHA256_WINDOWS_ARM64
+      bin: kubectl-ome.exe

--- a/site/content/en/docs/tasks/kubectl-ome.md
+++ b/site/content/en/docs/tasks/kubectl-ome.md
@@ -1,0 +1,64 @@
+---
+title: "kubectl-ome Plugin"
+linkTitle: "kubectl-ome"
+weight: 20
+description: >
+  Install and use the official OME CLI as a kubectl plugin
+---
+
+## Install
+
+Via [krew](https://krew.sigs.k8s.io/) once the plugin is accepted into the index:
+
+```bash
+kubectl krew install ome
+```
+
+Until then, install straight from a GitHub release:
+
+```bash
+VERSION=v0.10.0  # pick the release you want
+kubectl krew install --manifest-url \
+  https://github.com/ome-projects/ome/releases/download/${VERSION}/ome.yaml
+```
+
+## Commands
+
+| Command | What it shows |
+| --- | --- |
+| `kubectl ome get isvc` | InferenceServices with model, runtime, readiness and URL |
+| `kubectl ome get models -A` | BaseModels and ClusterBaseModels in one listing |
+| `kubectl ome get runtimes` | ServingRuntimes and ClusterServingRuntimes in one listing |
+| `kubectl ome status my-isvc` | Conditions, per-component pods, model status and warning events |
+| `kubectl ome runtime explain --model my-model` | Which runtimes match the model, ranked, with rejection reasons |
+| `kubectl ome logs my-isvc -c engine -f` | Live logs from the engine pods |
+| `kubectl ome version` | Client and operator versions |
+
+Every command accepts the standard kubectl connection flags
+(`--kubeconfig`, `--context`, `-n`); listings accept `-o json|yaml|wide`,
+`-A` and `-l`. Human-readable output is not a stable scripting interface
+before GA — script against `-o json`.
+
+## Required RBAC
+
+The plugin is read-only. A minimal ClusterRole:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubectl-ome-reader
+rules:
+  - apiGroups: ["ome.io"]
+    resources: ["*"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods", "events"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get"]
+```


### PR DESCRIPTION
## What this PR does

Final implementation PR for OEP-0011 (oeps/0011-kubectl-ome-plugin): release automation and distribution for the kubectl-ome plugin.

- Release workflow gains a cli-artifacts job: cross-compiles CGO_ENABLED=0 for linux/darwin/windows × amd64/arm64, packages six tar.gz archives (binary + LICENSE) with a checksums file, stamps version + per-platform sha256 into the krew manifest, and uploads everything to the GitHub release (with a placeholder-left guard that fails the job if stamping missed anything)
- hack/krew/ome.yaml: krew plugin manifest template (all six platforms; bin kubectl-ome, .exe on windows)
- Docs page (site/content/en/docs/tasks/kubectl-ome.md): install via krew (index + manifest-url interim path), command tour, standard flags, RBAC example ClusterRole

After the next tagged release: validate with `kubectl krew install --manifest-url=<release ome.yaml>`, then submit plugins/ome.yaml to kubernetes-sigs/krew-index, then automate bumps with krew-release-bot.

## Why we need it

OEP-0011 (merged, #736): krew is the delivery channel; alpha graduation requires archives + manifest in release assets.

## How to test

Packaging logic proven locally (transcript in PR description is omitted; see the job steps): make kubectl-ome-cross + archive/checksum/stamp steps produce 6 archives, 6-line checksums, fully-stamped manifest. Workflow YAML validated. Docs render via the site's Hugo build.

## Checklist

- [x] Tests added/updated (workflow-level guards; packaging proven locally)
- [x] Docs updated
- [x] Scoped test suite passes locally (no Go code changed)