### PR TITLE
[Core] CLI API-load hardening: pagination and scoped queries

### DIFF
--- a/pkg/cli/cmd/get/get_test.go
+++ b/pkg/cli/cmd/get/get_test.go
@@ -203,3 +203,20 @@ func TestGetNameWithSelectorRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot be combined with --selector")
 }
+
+// TestGetSelectorSurvivesPaging pins the pagination helper's contract to
+// preserve a caller-supplied --selector: chunking a list through
+// Limit/Continue must never silently drop LabelSelector filtering.
+func TestGetSelectorSurvivesPaging(t *testing.T) {
+	tagged := fixtureISVC("gpu-isvc", "team-a")
+	tagged.Labels = map[string]string{"tier": "gpu"}
+	untagged := fixtureISVC("cpu-isvc", "team-a")
+	f := factory.Static{
+		OME: omefake.NewSimpleClientset(tagged, untagged),
+		NS:  "team-a",
+	}
+	out, err := execute(t, f, "isvc", "-l", "tier=gpu")
+	require.NoError(t, err)
+	assert.Contains(t, out, "gpu-isvc")
+	assert.NotContains(t, out, "cpu-isvc")
+}

--- a/pkg/cli/cmd/get/registry.go
+++ b/pkg/cli/cmd/get/registry.go
@@ -17,6 +17,7 @@ import (
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/paging"
 	"sigs.k8s.io/ome/pkg/cli/printers"
 )
 
@@ -133,15 +134,18 @@ var isvcEntry = &entry{
 		if err != nil {
 			return nil, err
 		}
-		l, err := c.OmeV1beta1().InferenceServices(ns).List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]runtime.Object, 0, len(l.Items))
-		for i := range l.Items {
-			out = append(out, &l.Items[i])
-		}
-		return out, nil
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().InferenceServices(ns).List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
 		c, err := f.OMEClient()
@@ -259,20 +263,38 @@ var modelsEntry = &entry{
 			return nil, err
 		}
 		var out []runtime.Object
-		bms, err := c.OmeV1beta1().BaseModels(ns).List(ctx, opts)
+		bms, err := paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().BaseModels(ns).List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 		if err != nil {
 			return nil, err
 		}
-		for i := range bms.Items {
-			out = append(out, &bms.Items[i])
-		}
-		cbms, err := c.OmeV1beta1().ClusterBaseModels().List(ctx, opts)
+		out = append(out, bms...)
+		cbms, err := paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().ClusterBaseModels().List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 		if err != nil {
 			return nil, err
 		}
-		for i := range cbms.Items {
-			out = append(out, &cbms.Items[i])
-		}
+		out = append(out, cbms...)
 		return out, nil
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
@@ -299,15 +321,18 @@ var baseModelsEntry = &entry{
 		if err != nil {
 			return nil, err
 		}
-		l, err := c.OmeV1beta1().BaseModels(ns).List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]runtime.Object, 0, len(l.Items))
-		for i := range l.Items {
-			out = append(out, &l.Items[i])
-		}
-		return out, nil
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().BaseModels(ns).List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
 		c, err := f.OMEClient()
@@ -328,15 +353,18 @@ var clusterBaseModelsEntry = &entry{
 		if err != nil {
 			return nil, err
 		}
-		l, err := c.OmeV1beta1().ClusterBaseModels().List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]runtime.Object, 0, len(l.Items))
-		for i := range l.Items {
-			out = append(out, &l.Items[i])
-		}
-		return out, nil
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().ClusterBaseModels().List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
 		c, err := f.OMEClient()
@@ -435,20 +463,38 @@ var runtimesEntry = &entry{
 			return nil, err
 		}
 		var out []runtime.Object
-		srts, err := c.OmeV1beta1().ServingRuntimes(ns).List(ctx, opts)
+		srts, err := paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().ServingRuntimes(ns).List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 		if err != nil {
 			return nil, err
 		}
-		for i := range srts.Items {
-			out = append(out, &srts.Items[i])
-		}
-		csrts, err := c.OmeV1beta1().ClusterServingRuntimes().List(ctx, opts)
+		out = append(out, srts...)
+		csrts, err := paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().ClusterServingRuntimes().List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 		if err != nil {
 			return nil, err
 		}
-		for i := range csrts.Items {
-			out = append(out, &csrts.Items[i])
-		}
+		out = append(out, csrts...)
 		return out, nil
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
@@ -475,15 +521,18 @@ var servingRuntimesEntry = &entry{
 		if err != nil {
 			return nil, err
 		}
-		l, err := c.OmeV1beta1().ServingRuntimes(ns).List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]runtime.Object, 0, len(l.Items))
-		for i := range l.Items {
-			out = append(out, &l.Items[i])
-		}
-		return out, nil
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().ServingRuntimes(ns).List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
 		c, err := f.OMEClient()
@@ -504,15 +553,18 @@ var clusterServingRuntimesEntry = &entry{
 		if err != nil {
 			return nil, err
 		}
-		l, err := c.OmeV1beta1().ClusterServingRuntimes().List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]runtime.Object, 0, len(l.Items))
-		for i := range l.Items {
-			out = append(out, &l.Items[i])
-		}
-		return out, nil
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().ClusterServingRuntimes().List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
 		c, err := f.OMEClient()
@@ -538,15 +590,18 @@ var acceleratorClassesEntry = &entry{
 		if err != nil {
 			return nil, err
 		}
-		l, err := c.OmeV1beta1().AcceleratorClasses().List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]runtime.Object, 0, len(l.Items))
-		for i := range l.Items {
-			out = append(out, &l.Items[i])
-		}
-		return out, nil
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().AcceleratorClasses().List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
 		c, err := f.OMEClient()
@@ -571,15 +626,18 @@ var benchmarkJobsEntry = &entry{
 		if err != nil {
 			return nil, err
 		}
-		l, err := c.OmeV1beta1().BenchmarkJobs(ns).List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]runtime.Object, 0, len(l.Items))
-		for i := range l.Items {
-			out = append(out, &l.Items[i])
-		}
-		return out, nil
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().BenchmarkJobs(ns).List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
 		c, err := f.OMEClient()
@@ -609,15 +667,18 @@ var fineTunedWeightsEntry = &entry{
 		if err != nil {
 			return nil, err
 		}
-		l, err := c.OmeV1beta1().FineTunedWeights().List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]runtime.Object, 0, len(l.Items))
-		for i := range l.Items {
-			out = append(out, &l.Items[i])
-		}
-		return out, nil
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().FineTunedWeights().List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
 		c, err := f.OMEClient()
@@ -644,15 +705,18 @@ var inferenceReplicasEntry = &entry{
 		if err != nil {
 			return nil, err
 		}
-		l, err := c.OmeV1beta1().InferenceReplicas(ns).List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]runtime.Object, 0, len(l.Items))
-		for i := range l.Items {
-			out = append(out, &l.Items[i])
-		}
-		return out, nil
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().InferenceReplicas(ns).List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
 		c, err := f.OMEClient()
@@ -683,15 +747,18 @@ var workloadClustersEntry = &entry{
 		if err != nil {
 			return nil, err
 		}
-		l, err := c.OmeV1beta1().WorkloadClusters().List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		out := make([]runtime.Object, 0, len(l.Items))
-		for i := range l.Items {
-			out = append(out, &l.Items[i])
-		}
-		return out, nil
+		return paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+			pageOpts.LabelSelector = opts.LabelSelector
+			l, err := c.OmeV1beta1().WorkloadClusters().List(ctx, pageOpts)
+			if err != nil {
+				return nil, "", err
+			}
+			items := make([]runtime.Object, 0, len(l.Items))
+			for i := range l.Items {
+				items = append(items, &l.Items[i])
+			}
+			return items, l.Continue, nil
+		})
 	},
 	GetOne: func(ctx context.Context, f factory.Factory, ns, name string) (runtime.Object, error) {
 		c, err := f.OMEClient()

--- a/pkg/cli/cmd/logs/logs.go
+++ b/pkg/cli/cmd/logs/logs.go
@@ -8,9 +8,11 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/paging"
 	"sigs.k8s.io/ome/pkg/constants"
 )
 
@@ -68,11 +70,26 @@ func (o *Options) Run(ctx context.Context, f factory.Factory) error {
 	if o.Component != "" {
 		selector += fmt.Sprintf(",%s=%s", constants.OMEComponentLabel, o.Component)
 	}
-	pods, err := kube.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	podObjs, err := paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+		pageOpts.LabelSelector = selector
+		l, err := kube.CoreV1().Pods(ns).List(ctx, pageOpts)
+		if err != nil {
+			return nil, "", err
+		}
+		items := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			items = append(items, &l.Items[i])
+		}
+		return items, l.Continue, nil
+	})
 	if err != nil {
 		return err
 	}
-	if len(pods.Items) == 0 {
+	pods := make([]corev1.Pod, 0, len(podObjs))
+	for _, obj := range podObjs {
+		pods = append(pods, *obj.(*corev1.Pod))
+	}
+	if len(pods) == 0 {
 		return fmt.Errorf("no pods found for InferenceService %q in namespace %q (selector %s)", o.Name, ns, selector)
 	}
 	opts := &corev1.PodLogOptions{Follow: o.Follow}
@@ -84,7 +101,7 @@ func (o *Options) Run(ctx context.Context, f factory.Factory) error {
 		opts.SinceSeconds = &secs
 	}
 	var streams []namedStream
-	for _, p := range pods.Items {
+	for _, p := range pods {
 		po := *opts
 		po.Container = o.containerFor(&p)
 		req := kube.CoreV1().Pods(ns).GetLogs(p.Name, &po)
@@ -99,7 +116,7 @@ func (o *Options) Run(ctx context.Context, f factory.Factory) error {
 			return fmt.Errorf("streaming logs for pod %s: %w", p.Name, err)
 		}
 		prefix := ""
-		if len(pods.Items) > 1 {
+		if len(pods) > 1 {
 			prefix = fmt.Sprintf("[%s/%s] ", p.Labels[constants.OMEComponentLabel], p.Name)
 		}
 		streams = append(streams, namedStream{Prefix: prefix, Reader: reader})

--- a/pkg/cli/cmd/status/gather.go
+++ b/pkg/cli/cmd/status/gather.go
@@ -8,10 +8,14 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/cli/apierror"
 	"sigs.k8s.io/ome/pkg/cli/factory"
+	"sigs.k8s.io/ome/pkg/cli/paging"
 	"sigs.k8s.io/ome/pkg/constants"
 )
 
@@ -34,29 +38,83 @@ func gather(ctx context.Context, f factory.Factory, ns, name string) (*report, e
 	if err != nil {
 		return nil, err
 	}
-	pods, err := kube.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", constants.InferenceServiceLabel, name),
+	podSelector := fmt.Sprintf("%s=%s", constants.InferenceServiceLabel, name)
+	podObjs, err := paging.ListAllPaged(ctx, func(pageOpts metav1.ListOptions) ([]runtime.Object, string, error) {
+		pageOpts.LabelSelector = podSelector
+		l, err := kube.CoreV1().Pods(ns).List(ctx, pageOpts)
+		if err != nil {
+			return nil, "", err
+		}
+		items := make([]runtime.Object, 0, len(l.Items))
+		for i := range l.Items {
+			items = append(items, &l.Items[i])
+		}
+		return items, l.Continue, nil
 	})
 	if err != nil {
 		return nil, err
 	}
+	pods := make([]corev1.Pod, 0, len(podObjs))
+	for _, obj := range podObjs {
+		pods = append(pods, *obj.(*corev1.Pod))
+	}
+
 	r := &report{ISVC: isvc, Pods: map[v1beta1.ComponentType][]corev1.Pod{}}
-	ours := map[string]bool{name: true} // involvedObject names we care about
-	for _, p := range pods.Items {
+	for _, p := range pods {
 		component := v1beta1.ComponentType(p.Labels[constants.OMEComponentLabel])
 		r.Pods[component] = append(r.Pods[component], p)
-		ours[p.Name] = true
 	}
-	events, err := kube.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
-		FieldSelector: "type=" + corev1.EventTypeWarning,
-	})
+
+	// Warning events, scoped per involved object (the kubectl-describe
+	// pattern) instead of one namespace-wide "type=Warning" list filtered
+	// client-side: one tiny field-selector query for the InferenceService,
+	// plus one for each of its pods. seen dedupes by event UID across those
+	// queries.
+	seen := map[types.UID]bool{}
+	isvcEvents, err := eventsForObject(ctx, kube, ns, name, "InferenceService")
 	if err != nil {
 		return nil, err
 	}
-	for _, e := range events.Items {
-		if e.Type == corev1.EventTypeWarning && ours[e.InvolvedObject.Name] {
-			r.Events = append(r.Events, e)
+	r.Events = mergeWarningEvents(r.Events, seen, isvcEvents, name, "InferenceService")
+	for _, p := range pods {
+		podEvents, err := eventsForObject(ctx, kube, ns, p.Name, "Pod")
+		if err != nil {
+			return nil, err
 		}
+		r.Events = mergeWarningEvents(r.Events, seen, podEvents, p.Name, "Pod")
 	}
 	return r, nil
+}
+
+// eventsForObject fetches the Warning events for a single involved object
+// (kubectl-describe's pattern): a field-selector query keeps each response
+// tiny instead of listing every Warning event in the namespace.
+func eventsForObject(ctx context.Context, kube kubernetes.Interface, ns, name, kind string) ([]corev1.Event, error) {
+	sel := fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=%s,type=%s", name, kind, corev1.EventTypeWarning)
+	l, err := kube.CoreV1().Events(ns).List(ctx, metav1.ListOptions{FieldSelector: sel})
+	if err != nil {
+		return nil, err
+	}
+	return l.Items, nil
+}
+
+// mergeWarningEvents appends the events from one eventsForObject query onto
+// acc, keeping only Warning events whose InvolvedObject actually matches
+// (name, kind) -- defense in depth, since a field-selector-blind source
+// (the fake clientset in tests, or a misbehaving API server) would
+// otherwise leak unrelated events through -- and deduping by UID against
+// seen, which callers thread across every per-object query so the same
+// event is never counted twice.
+func mergeWarningEvents(acc []corev1.Event, seen map[types.UID]bool, events []corev1.Event, wantName, wantKind string) []corev1.Event {
+	for _, e := range events {
+		if e.Type != corev1.EventTypeWarning || e.InvolvedObject.Name != wantName || e.InvolvedObject.Kind != wantKind {
+			continue
+		}
+		if seen[e.UID] {
+			continue
+		}
+		seen[e.UID] = true
+		acc = append(acc, e)
+	}
+	return acc
 }

--- a/pkg/cli/cmd/status/gather_test.go
+++ b/pkg/cli/cmd/status/gather_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/cli/factory"
@@ -67,4 +71,118 @@ func TestGatherKeepsOnlyWarningEventsForOurObjects(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, r.Events, 1)
 	assert.Equal(t, "FailedScheduling", r.Events[0].Reason)
+}
+
+// TestGatherIssuesFieldSelectorEventQueriesPerObject pins the kubectl-describe
+// pattern: gather() must query events per involved object (the
+// InferenceService, then each pod) with a field selector, rather than
+// listing every Warning event in the namespace. The fake clientset ignores
+// field selectors when serving the request (so this cannot be observed via
+// gather()'s output), but it still parses and records the selector actually
+// sent -- capture it with a reactor and check it real-selector-matches the
+// right object and rejects a wrong one.
+func TestGatherIssuesFieldSelectorEventQueriesPerObject(t *testing.T) {
+	kube := kubefake.NewSimpleClientset(pod("llama-engine-1", "team-a", "llama", "engine"))
+	var restrictions []ktesting.ListRestrictions
+	kube.PrependReactor("list", "events", func(action ktesting.Action) (bool, runtime.Object, error) {
+		la := action.(ktesting.ListActionImpl)
+		restrictions = append(restrictions, la.GetListRestrictions())
+		return false, nil, nil // fall through to the default tracker-backed reactor
+	})
+	f := factory.Static{
+		OME:  omefake.NewSimpleClientset(&v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: "llama", Namespace: "team-a"}}),
+		Kube: kube,
+		NS:   "team-a",
+	}
+
+	_, err := gather(context.Background(), f, "team-a", "llama")
+
+	require.NoError(t, err)
+	require.Len(t, restrictions, 2, "one events query for the InferenceService, one for its pod")
+
+	// Fields.Matches only checks that the selector's *required* terms hold;
+	// it does not fail just because the candidate has extra keys. So
+	// asserting Matches() on a full {name,kind,type} set alone would not
+	// notice a selector that forgot to require "kind" at all. Nail that
+	// down explicitly with RequiresExactMatch, then use Matches() with a
+	// same-name-but-wrong-kind candidate (the real scenario this guards:
+	// an InferenceService and a Pod that happen to share a name) as a
+	// second, semantic check that kind is actually load-bearing.
+	kind0, found0 := restrictions[0].Fields.RequiresExactMatch("involvedObject.kind")
+	require.True(t, found0, "InferenceService query must require involvedObject.kind")
+	assert.Equal(t, "InferenceService", kind0)
+	name0, found0n := restrictions[0].Fields.RequiresExactMatch("involvedObject.name")
+	require.True(t, found0n)
+	assert.Equal(t, "llama", name0)
+	assert.True(t, restrictions[0].Fields.Matches(fields.Set{
+		"involvedObject.name": "llama", "involvedObject.kind": "InferenceService", "type": "Warning",
+	}), "first query scopes to the InferenceService")
+	assert.False(t, restrictions[0].Fields.Matches(fields.Set{
+		"involvedObject.name": "llama", "involvedObject.kind": "Pod", "type": "Warning",
+	}), "must not match a same-named Pod -- kind has to discriminate too")
+	assert.False(t, restrictions[0].Fields.Matches(fields.Set{
+		"involvedObject.name": "someone-else", "involvedObject.kind": "InferenceService", "type": "Warning",
+	}), "must not match some other object's events")
+
+	kind1, found1 := restrictions[1].Fields.RequiresExactMatch("involvedObject.kind")
+	require.True(t, found1, "Pod query must require involvedObject.kind")
+	assert.Equal(t, "Pod", kind1)
+	assert.True(t, restrictions[1].Fields.Matches(fields.Set{
+		"involvedObject.name": "llama-engine-1", "involvedObject.kind": "Pod", "type": "Warning",
+	}), "second query scopes to the pod")
+	assert.False(t, restrictions[1].Fields.Matches(fields.Set{
+		"involvedObject.name": "llama-engine-1", "involvedObject.kind": "InferenceService", "type": "Warning",
+	}), "must not match an InferenceService that happens to share the pod's name")
+}
+
+// TestMergeWarningEventsFiltersByTypeNameAndKind is the defense-in-depth
+// client-side check that must survive even though the field selector
+// already does this filtering server-side: a field-selector-blind source
+// (the fake clientset in tests, or a misbehaving API server) must not leak
+// unrelated events into the report.
+func TestMergeWarningEventsFiltersByTypeNameAndKind(t *testing.T) {
+	want := corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{UID: "uid-1"},
+		Type:           corev1.EventTypeWarning,
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "llama-engine-1"},
+	}
+	wrongType := corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{UID: "uid-2"},
+		Type:           corev1.EventTypeNormal,
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "llama-engine-1"},
+	}
+	wrongName := corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{UID: "uid-3"},
+		Type:           corev1.EventTypeWarning,
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "unrelated"},
+	}
+	wrongKind := corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{UID: "uid-4"},
+		Type:           corev1.EventTypeWarning,
+		InvolvedObject: corev1.ObjectReference{Kind: "InferenceService", Name: "llama-engine-1"},
+	}
+
+	got := mergeWarningEvents(nil, map[types.UID]bool{},
+		[]corev1.Event{want, wrongType, wrongName, wrongKind}, "llama-engine-1", "Pod")
+
+	require.Len(t, got, 1)
+	assert.Equal(t, types.UID("uid-1"), got[0].UID)
+}
+
+// TestMergeWarningEventsDedupesByUIDAcrossQueries mirrors gather()'s real
+// usage: one shared `seen` map threaded across several per-object queries
+// (InferenceService, then each pod). An event that would otherwise be
+// counted twice must survive only once.
+func TestMergeWarningEventsDedupesByUIDAcrossQueries(t *testing.T) {
+	e := corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{UID: "dup-uid"},
+		Type:           corev1.EventTypeWarning,
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "llama-engine-1"},
+	}
+	seen := map[types.UID]bool{}
+	var acc []corev1.Event
+	acc = mergeWarningEvents(acc, seen, []corev1.Event{e}, "llama-engine-1", "Pod")
+	acc = mergeWarningEvents(acc, seen, []corev1.Event{e}, "llama-engine-1", "Pod")
+
+	assert.Len(t, acc, 1, "the same event UID must not be appended twice across queries")
 }

--- a/pkg/cli/factory/factory.go
+++ b/pkg/cli/factory/factory.go
@@ -58,12 +58,31 @@ func (f *defaultFactory) RESTConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	// CLI bursts many small reads (status fans out to pods/events); avoid
-	// client-side throttling stalls.
+	// CLI bursts many small reads (status fans out to pods/events, one
+	// field-selector query per involved object); match kubectl's own
+	// client-side rate limits (QPS 50 / Burst 300) so those fan-out bursts
+	// don't stall on client-side throttling before a request even reaches
+	// the API server.
 	cfg.QPS = 50
-	cfg.Burst = 100
+	cfg.Burst = 300
 	f.rest = cfg
 	return cfg, nil
+}
+
+// protobufConfig returns a COPY of cfg negotiating protobuf the way kubectl
+// itself does for core types (pods, events, deployments, ...): smaller,
+// faster-to-decode responses than JSON. It never mutates cfg -- KubeClient
+// is the only caller, and cfg is the same *rest.Config shared with
+// OMEClient/RuntimeClient, which must keep negotiating JSON. The OME CRD
+// clientset and the controller-runtime client intentionally do NOT get this
+// treatment: CRDs do not serve protobuf (only Kubernetes' built-in types
+// do), so a protobuf-negotiating client against a CRD would just add a
+// failed content-type negotiation round trip to every request.
+func protobufConfig(cfg *rest.Config) *rest.Config {
+	cp := rest.CopyConfig(cfg)
+	cp.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	cp.ContentType = "application/vnd.kubernetes.protobuf"
+	return cp
 }
 
 func (f *defaultFactory) KubeClient() (kubernetes.Interface, error) {
@@ -77,7 +96,9 @@ func (f *defaultFactory) KubeClient() (kubernetes.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	c, err := kubernetes.NewForConfig(cfg)
+	// Core-type traffic (pods/events/...) gets protobuf, kubectl-style; see
+	// protobufConfig's doc comment for why this must be a copy.
+	c, err := kubernetes.NewForConfig(protobufConfig(cfg))
 	if err != nil {
 		return nil, err
 	}
@@ -94,6 +115,9 @@ func (f *defaultFactory) OMEClient() (versioned.Interface, error) {
 		return f.ome, nil
 	}
 	f.mu.Unlock()
+	// Deliberately uses the shared cfg as-is (default JSON content type),
+	// unlike KubeClient(): CRDs do not serve protobuf, so the OME typed
+	// clientset must keep negotiating JSON.
 	cfg, err := f.RESTConfig()
 	if err != nil {
 		return nil, err
@@ -115,6 +139,8 @@ func (f *defaultFactory) RuntimeClient() (ctrlclient.Client, error) {
 		return f.runtime, nil
 	}
 	f.mu.Unlock()
+	// Same reasoning as OMEClient(): this reuses ome.io/v1beta1 CRD types,
+	// so it must keep the shared cfg's default JSON content type too.
 	cfg, err := f.RESTConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/cli/factory/factory_test.go
+++ b/pkg/cli/factory/factory_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
 )
 
 func TestNamespaceDefaultsWhenUnset(t *testing.T) {
@@ -29,4 +30,76 @@ func TestNamespaceExplicitFlagWins(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "team-a", ns)
 	assert.True(t, explicit)
+}
+
+// TestRESTConfigBurstMatchesKubectlParity pins the client-side rate limits
+// the CLI bumped to kubectl's own defaults: status/get fan out many small
+// reads (pods, events, per-object queries) and must not trip client-side
+// throttling on a cluster with lots of resources.
+func TestRESTConfigBurstMatchesKubectlParity(t *testing.T) {
+	flags := genericclioptions.NewConfigFlags(true)
+	empty := ""
+	flags.KubeConfig = &empty
+	f := New(flags)
+	cfg, err := f.RESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, float32(50), cfg.QPS)
+	assert.Equal(t, 300, cfg.Burst)
+}
+
+// TestProtobufConfigNegotiatesProtobufWithoutMutatingInput exercises the
+// pure copy-and-negotiate helper KubeClient() uses to get kubectl-style
+// protobuf negotiation for core-type traffic, in isolation from any real
+// REST config loading.
+func TestProtobufConfigNegotiatesProtobufWithoutMutatingInput(t *testing.T) {
+	base := &rest.Config{Host: "https://cluster.example:6443", Burst: 300}
+
+	got := protobufConfig(base)
+
+	assert.Equal(t, "application/vnd.kubernetes.protobuf,application/json", got.AcceptContentTypes)
+	assert.Equal(t, "application/vnd.kubernetes.protobuf", got.ContentType)
+	// Same server, same rate limits -- only content negotiation changed.
+	assert.Equal(t, base.Host, got.Host)
+	assert.Equal(t, base.Burst, got.Burst)
+	// The input must come back untouched: OMEClient/RuntimeClient share the
+	// same underlying *rest.Config and must keep negotiating JSON (CRDs
+	// don't serve protobuf).
+	assert.Empty(t, base.AcceptContentTypes)
+	assert.Empty(t, base.ContentType)
+}
+
+// TestKubeClientDoesNotLeakProtobufIntoSharedConfig is the end-to-end
+// regression for protobufConfig's COPY requirement: building the real
+// core-type client must not mutate the *rest.Config that OMEClient and
+// RuntimeClient go on to share.
+func TestKubeClientDoesNotLeakProtobufIntoSharedConfig(t *testing.T) {
+	flags := genericclioptions.NewConfigFlags(true)
+	empty := ""
+	flags.KubeConfig = &empty
+	f := New(flags)
+
+	_, err := f.KubeClient()
+	require.NoError(t, err)
+
+	cfg, err := f.RESTConfig()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.ContentType, "shared RESTConfig must stay JSON for OME/runtime clients")
+	assert.Empty(t, cfg.AcceptContentTypes)
+}
+
+// TestOMEClientKeepsJSONConfig pins the requirement that the OME typed
+// clientset never negotiates protobuf (CRDs don't serve it).
+func TestOMEClientKeepsJSONConfig(t *testing.T) {
+	flags := genericclioptions.NewConfigFlags(true)
+	empty := ""
+	flags.KubeConfig = &empty
+	f := New(flags)
+
+	_, err := f.OMEClient()
+	require.NoError(t, err)
+
+	cfg, err := f.RESTConfig()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.ContentType)
+	assert.Empty(t, cfg.AcceptContentTypes)
 }

--- a/pkg/cli/paging/paging.go
+++ b/pkg/cli/paging/paging.go
@@ -1,0 +1,50 @@
+// Package paging drains paginated Kubernetes list APIs in bounded chunks
+// instead of issuing a single unbounded LIST, so the CLI never pulls an
+// entire large collection into memory (or the API server's) in one request.
+package paging
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ChunkSize is the page size used for every paginated list the CLI issues,
+// matching kubectl's own default list chunk size.
+const ChunkSize = 500
+
+// PageFunc fetches one page of a list. opts carries that page's Limit and
+// Continue token, set by ListAllPaged; the closure is responsible for
+// merging in any base query fields (LabelSelector, FieldSelector, ...) from
+// the caller's own request before issuing the underlying List call. It
+// returns the page's items and the response's continue token -- an empty
+// token means the list is exhausted.
+type PageFunc func(opts metav1.ListOptions) (items []runtime.Object, continueToken string, err error)
+
+// ListAllPaged drains a paginated list API, kubectl-style: it fetches
+// ChunkSize items per request, feeding each response's continue token into
+// the next request, until the server returns no more continue tokens.
+//
+// Callers close over their own context and base ListOptions (e.g.
+// LabelSelector) inside page; ListAllPaged itself only ever sets Limit and
+// Continue, so it stays agnostic to whatever else a specific list call
+// needs.
+func ListAllPaged(ctx context.Context, page PageFunc) ([]runtime.Object, error) {
+	var out []runtime.Object
+	opts := metav1.ListOptions{Limit: ChunkSize}
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		items, cont, err := page(opts)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, items...)
+		if cont == "" {
+			return out, nil
+		}
+		opts = metav1.ListOptions{Limit: ChunkSize, Continue: cont}
+	}
+}

--- a/pkg/cli/paging/paging_test.go
+++ b/pkg/cli/paging/paging_test.go
@@ -1,0 +1,99 @@
+package paging
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// fakeObj is a minimal runtime.Object double so these tests can exercise
+// ListAllPaged's control flow without depending on any concrete API type.
+type fakeObj struct {
+	metav1.TypeMeta
+	N string
+}
+
+func (f *fakeObj) DeepCopyObject() runtime.Object {
+	c := *f
+	return &c
+}
+
+func obj(n string) runtime.Object { return &fakeObj{N: n} }
+
+func TestListAllPagedDrainsThreePagesFollowingContinueTokens(t *testing.T) {
+	pages := [][]runtime.Object{
+		{obj("a"), obj("b")},
+		{obj("c")},
+		{obj("d"), obj("e")},
+	}
+	tokens := []string{"tok-1", "tok-2", ""} // empty token on the 3rd page ends the list
+	var gotOpts []metav1.ListOptions
+	call := 0
+	page := func(opts metav1.ListOptions) ([]runtime.Object, string, error) {
+		gotOpts = append(gotOpts, opts)
+		items := pages[call]
+		tok := tokens[call]
+		call++
+		return items, tok, nil
+	}
+
+	got, err := ListAllPaged(context.Background(), page)
+
+	require.NoError(t, err)
+	require.Len(t, got, 5)
+	assert.Equal(t, 3, call, "page should be called exactly once per page")
+
+	// Every request asks for a full chunk...
+	for _, o := range gotOpts {
+		assert.Equal(t, int64(ChunkSize), o.Limit)
+	}
+	// ...and each page's continue token becomes the *next* request's
+	// Continue -- the first request has none yet.
+	assert.Empty(t, gotOpts[0].Continue, "first page has no continue token yet")
+	assert.Equal(t, "tok-1", gotOpts[1].Continue)
+	assert.Equal(t, "tok-2", gotOpts[2].Continue)
+}
+
+func TestListAllPagedPropagatesErrorMidStreamAndStopsPaging(t *testing.T) {
+	boom := errors.New("etcd is on fire")
+	call := 0
+	page := func(opts metav1.ListOptions) ([]runtime.Object, string, error) {
+		call++
+		if call == 1 {
+			return []runtime.Object{obj("a")}, "tok-1", nil
+		}
+		return nil, "", boom
+	}
+
+	got, err := ListAllPaged(context.Background(), page)
+
+	require.ErrorIs(t, err, boom)
+	assert.Nil(t, got, "a mid-stream error should not return a partial page")
+	assert.Equal(t, 2, call, "paging must stop at the failing page, not retry or continue")
+}
+
+func TestListAllPagedEmptyResultStopsAfterOneCall(t *testing.T) {
+	call := 0
+	page := func(opts metav1.ListOptions) ([]runtime.Object, string, error) {
+		call++
+		return nil, "", nil
+	}
+
+	got, err := ListAllPaged(context.Background(), page)
+
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.Equal(t, 1, call, "an empty first page with no continue token must not be re-fetched")
+}
+
+func TestChunkSizeMatchesKubectlDefault(t *testing.T) {
+	// Pin the documented contract (500-item chunks, kubectl parity) so a
+	// change here is a deliberate, reviewed decision rather than an
+	// accidental drift.
+	assert.EqualValues(t, 500, ChunkSize)
+}


### PR DESCRIPTION
## What this PR does

Hardens the kubectl-ome CLI against large clusters so it never hammers the API server:

- Every list (all 12 get registry entries incl. merged views, status pod lookup, logs pod lookup) now drains in kubectl-style 500-item chunks (Limit/Continue) via a shared, unit-tested paging helper instead of single unbounded LIST calls
- kubectl ome status no longer lists every Warning event in the namespace and filters client-side: it issues tiny per-object field-selector queries (involvedObject.name/kind + type=Warning) for the InferenceService and each of its pods, deduped by UID — the kubectl-describe pattern
- Core-type traffic (pods/events/deployments) negotiates protobuf like kubectl does (smaller payloads); the OME CRD clientset intentionally stays JSON (CRDs don't serve protobuf)
- Client-side rate limits aligned with kubectl (QPS 50, Burst 300)

client-go stays pinned to the operator module's k8s line (v0.33.13) by design — bumping the k8s dependency line is a repo-wide decision, not a CLI-local one.

## Why we need it

Follow-up to the OEP-0011 command PRs: unbounded LISTs and namespace-wide event scans are fine on dev clusters and pathological on big ones.

## How to test

go test ./pkg/cli/...

## Checklist

- [x] Tests added/updated
- [ ] Docs updated (N/A — no user-facing behavior change)
- [x] Scoped test suite passes locally (go test ./pkg/cli/... — full make test requires the Rust xet toolchain, unaffected by this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resource retrieval now handles paginated results consistently, ensuring complete listings without losing label filters.
  - Logs and status commands now work reliably across resources with many pods.
  - Status warnings are filtered to the relevant resources and duplicate events are removed.

- **Performance**
  - Improved client request throughput and Kubernetes API communication.

- **Reliability**
  - Added safeguards for interrupted or failed paginated requests, preserving clear error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->