### PR TITLE
[Core] Alfred snapshot foundation (OEP-0008)

### DIFF
--- a/pkg/alfred/snapshot/builder.go
+++ b/pkg/alfred/snapshot/builder.go
@@ -1,0 +1,529 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	isvcutils "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils"
+	"sigs.k8s.io/ome/pkg/migration"
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+const (
+	// caScaleDownDisabledAnnotation is the operator-set cluster-autoscaler
+	// annotation excluding a node from scale-down.
+	caScaleDownDisabledAnnotation = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+	// caToBeDeletedTaint is the taint the cluster-autoscaler places on a
+	// node it is actively deleting.
+	caToBeDeletedTaint = "ToBeDeletedByClusterAutoscaler"
+
+	// defaultWorkloadPriority is the alfred.ome.io/priority value assumed
+	// when the annotation is absent or unparsable.
+	defaultWorkloadPriority = 0.5
+)
+
+// DefaultTriggerConditions is the node-condition set that marks a node
+// Unhealthy when no configuration overrides it.
+var DefaultTriggerConditions = []string{"GpuUnhealthy"}
+
+// Options configures a snapshot build. The zero value is usable: default
+// trigger conditions, no preemptible labels, workloads movable by default.
+type Options struct {
+	// TriggerConditions are the node condition types that mark a node
+	// Unhealthy (policies.nodeHealth.triggerConditions).
+	TriggerConditions []string
+	// PreemptibleLabels are node-label keys whose presence (with any
+	// value but "false") marks a node spot/preemptible.
+	PreemptibleLabels []string
+	// DefaultMovable is the cluster-wide movable default a workload
+	// inherits when it carries no alfred.ome.io/movable annotation.
+	DefaultMovable *bool
+	// OMENativeAvailable is the caller's discovery result; recorded
+	// verbatim on the snapshot.
+	OMENativeAvailable bool
+	// Now overrides the clock (tests); nil means time.Now.
+	Now func() time.Time
+}
+
+func (o *Options) triggerConditions() []string {
+	if len(o.TriggerConditions) == 0 {
+		return DefaultTriggerConditions
+	}
+	return o.TriggerConditions
+}
+
+func (o *Options) defaultMovable() bool {
+	if o.DefaultMovable == nil {
+		return true
+	}
+	return *o.DefaultMovable
+}
+
+func (o *Options) now() time.Time {
+	if o.Now == nil {
+		return time.Now()
+	}
+	return o.Now()
+}
+
+// Build assembles a ClusterSnapshot from the cluster through a read-only
+// client. It never writes, and it degrades per-object rather than failing
+// wholesale wherever one broken object should not blind the caretaker (model
+// resolution); only the core lists (nodes, pods, InferenceServices,
+// accelerator classes) are load-bearing enough to fail the build.
+func Build(ctx context.Context, r client.Reader, opts Options) (*ClusterSnapshot, error) {
+	s := &ClusterSnapshot{
+		Timestamp:          opts.now(),
+		Nodes:              map[string]*Node{},
+		Workloads:          map[types.NamespacedName]*Workload{},
+		Models:             map[ModelKey]*ModelAvailability{},
+		OMENativeAvailable: opts.OMENativeAvailable,
+	}
+
+	var nodeList corev1.NodeList
+	if err := r.List(ctx, &nodeList); err != nil {
+		return nil, fmt.Errorf("list nodes: %w", err)
+	}
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		s.Nodes[node.Name] = buildNode(node, &opts)
+	}
+
+	var podList corev1.PodList
+	if err := r.List(ctx, &podList); err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+	// isvcPods groups OME pods by owning ISVC and component for workload
+	// assembly below; node occupancy is filled in the same pass.
+	isvcPods := map[types.NamespacedName]map[v1beta1.ComponentType][]PodInfo{}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		ingestPod(s, pod, isvcPods, &opts)
+	}
+	for _, n := range s.Nodes {
+		n.FreeGPUs = n.TotalGPUs - n.AllocatedGPUs
+		if n.FreeGPUs < 0 {
+			// Overcommit cannot happen for extended resources; clamp
+			// defensively so scoring never sees negative free capacity.
+			n.FreeGPUs = 0
+		}
+	}
+	sort.Slice(s.PendingPods, func(i, j int) bool {
+		if s.PendingPods[i].Namespace != s.PendingPods[j].Namespace {
+			return s.PendingPods[i].Namespace < s.PendingPods[j].Namespace
+		}
+		return s.PendingPods[i].Name < s.PendingPods[j].Name
+	})
+
+	var isvcList v1beta1.InferenceServiceList
+	if err := r.List(ctx, &isvcList); err != nil {
+		return nil, fmt.Errorf("list inferenceservices: %w", err)
+	}
+	for i := range isvcList.Items {
+		isvc := &isvcList.Items[i]
+		key := types.NamespacedName{Namespace: isvc.Namespace, Name: isvc.Name}
+		s.Workloads[key] = buildWorkload(isvc, isvcPods[key], &opts)
+	}
+
+	resolveModels(ctx, r, s)
+	attributePendingPools(s)
+	return s, nil
+}
+
+func buildNode(node *corev1.Node, opts *Options) *Node {
+	resource, total := NodeGPUAllocatable(node)
+	n := &Node{
+		Name:              node.Name,
+		Labels:            node.Labels,
+		GPUPool:           GPUPoolForNode(node, resource),
+		GPUResource:       resource,
+		TotalGPUs:         total,
+		Cordoned:          node.Spec.Unschedulable,
+		ScaleDownDisabled: node.Annotations[caScaleDownDisabledAnnotation] == "true",
+	}
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == caToBeDeletedTaint {
+			n.ScaleDownMarked = true
+			break
+		}
+	}
+	for _, key := range opts.PreemptibleLabels {
+		if value, ok := node.Labels[key]; ok && value != "false" {
+			n.Preemptible = true
+			break
+		}
+	}
+	triggers := opts.triggerConditions()
+	for _, cond := range node.Status.Conditions {
+		if cond.Status != corev1.ConditionTrue {
+			continue
+		}
+		for _, trigger := range triggers {
+			if string(cond.Type) == trigger {
+				n.Unhealthy = true
+				n.UnhealthyConditions = append(n.UnhealthyConditions, trigger)
+				break
+			}
+		}
+	}
+	sort.Strings(n.UnhealthyConditions)
+	return n
+}
+
+// ingestPod routes one pod into node occupancy, workload grouping, and
+// pending pressure as applicable.
+func ingestPod(s *ClusterSnapshot, pod *corev1.Pod, isvcPods map[types.NamespacedName]map[v1beta1.ComponentType][]PodInfo, opts *Options) {
+	gpus := PodGPURequest(pod)
+	isvcName := pod.Labels[constants.InferenceServicePodLabelKey]
+	component := v1beta1.ComponentType(pod.Labels[constants.OMEComponentLabel])
+
+	info := PodInfo{
+		Namespace:   pod.Namespace,
+		Name:        pod.Name,
+		Node:        pod.Spec.NodeName,
+		GPUs:        gpus,
+		Ready:       podIsReady(pod),
+		Terminating: pod.DeletionTimestamp != nil,
+	}
+	if pod.Status.StartTime != nil {
+		t := pod.Status.StartTime.Time
+		info.StartTime = &t
+	}
+	if isvcName != "" {
+		info.ISVC = types.NamespacedName{Namespace: pod.Namespace, Name: isvcName}
+		info.Component = component
+	}
+
+	// Node occupancy: GPU-holding pods only.
+	if gpus > 0 && podHoldsGPUs(pod) {
+		if node, ok := s.Nodes[pod.Spec.NodeName]; ok {
+			node.AllocatedGPUs += gpus
+			if info.Terminating {
+				node.TerminatingGPUs += gpus
+			}
+			if isvcName != "" {
+				node.OMEPods = append(node.OMEPods, info)
+			} else {
+				node.OtherOccupants = append(node.OtherOccupants, info)
+			}
+		}
+	}
+
+	// Workload grouping: every scheduled OME pod, GPU-bearing or not (a
+	// router holds no GPUs but is still a component instance). Unscheduled
+	// pods are demand, not instances — they surface through PendingPods.
+	if isvcName != "" && pod.Spec.NodeName != "" && pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
+		byComponent, ok := isvcPods[info.ISVC]
+		if !ok {
+			byComponent = map[v1beta1.ComponentType][]PodInfo{}
+			isvcPods[info.ISVC] = byComponent
+		}
+		byComponent[component] = append(byComponent[component], info)
+	}
+
+	// Pending pressure: unscheduled GPU demand.
+	if gpus > 0 && pod.Spec.NodeName == "" && pod.Status.Phase == corev1.PodPending && pod.DeletionTimestamp == nil {
+		s.PendingPods = append(s.PendingPods, PendingPod{
+			Namespace:    pod.Namespace,
+			Name:         pod.Name,
+			ISVC:         info.ISVC,
+			GPUsNeeded:   gpus,
+			NodeSelector: pod.Spec.NodeSelector,
+			PendingSince: pendingSince(pod),
+			Virtual:      false,
+		})
+	}
+}
+
+// pendingSince prefers the PodScheduled=False transition time (when the
+// scheduler first failed to place the pod) and falls back to creation time.
+func pendingSince(pod *corev1.Pod) time.Time {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse && !cond.LastTransitionTime.IsZero() {
+			return cond.LastTransitionTime.Time
+		}
+	}
+	return pod.CreationTimestamp.Time
+}
+
+func buildWorkload(isvc *v1beta1.InferenceService, pods map[v1beta1.ComponentType][]PodInfo, opts *Options) *Workload {
+	w := &Workload{
+		NamespacedName: types.NamespacedName{Namespace: isvc.Namespace, Name: isvc.Name},
+		ISVC:           isvc,
+		Components:     map[v1beta1.ComponentType]*Component{},
+		Movable:        opts.defaultMovable(),
+		Priority:       defaultWorkloadPriority,
+	}
+	applyWorkloadOverrides(w, isvc.Annotations)
+
+	if isvc.Spec.Model != nil {
+		kind := ModelKindClusterBaseModel
+		if isvc.Spec.Model.Kind != nil && *isvc.Spec.Model.Kind != "" {
+			kind = *isvc.Spec.Model.Kind
+		}
+		w.ModelKey = ModelKey{Kind: kind, Name: isvc.Spec.Model.Name}
+		if kind == ModelKindBaseModel {
+			w.ModelKey.Namespace = isvc.Namespace
+		}
+	}
+
+	engineMode, decoderMode, routerMode, err := isvcutils.DetermineDeploymentModes(
+		isvc.Spec.Engine, isvc.Spec.Decoder, isvc.Spec.Router, nil, isvc.Spec.DeploymentMode)
+	if err != nil {
+		// An ISVC without an engine spec is invalid but may transiently
+		// exist; fall back to the default mode so its pods still appear.
+		engineMode, decoderMode, routerMode = constants.RawDeployment, constants.RawDeployment, constants.RawDeployment
+	}
+	specComponents := []struct {
+		ctype   v1beta1.ComponentType
+		present bool
+		mode    constants.DeploymentModeType
+	}{
+		{v1beta1.EngineComponent, isvc.Spec.Engine != nil, engineMode},
+		{v1beta1.DecoderComponent, isvc.Spec.Decoder != nil, decoderMode},
+		{v1beta1.RouterComponent, isvc.Spec.Router != nil, routerMode},
+	}
+	for _, sc := range specComponents {
+		if !sc.present && len(pods[sc.ctype]) == 0 {
+			continue
+		}
+		w.Components[sc.ctype] = &Component{
+			Type:           sc.ctype,
+			DeploymentMode: sc.mode,
+			Instances:      buildInstances(sc.mode, pods[sc.ctype]),
+		}
+	}
+
+	applyMigrationState(w, isvc)
+	return w
+}
+
+// buildInstances maps a component's pods onto Instances: one Instance per pod
+// for RawDeployment (each replica moves alone), one atomic Instance holding
+// every pod for multi-pod modes (the group must move together).
+func buildInstances(mode constants.DeploymentModeType, pods []PodInfo) []*Instance {
+	if len(pods) == 0 {
+		return nil
+	}
+	sorted := make([]PodInfo, len(pods))
+	copy(sorted, pods)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	if mode == constants.RawDeployment {
+		instances := make([]*Instance, 0, len(sorted))
+		for i, pod := range sorted {
+			instances = append(instances, newInstance(int32(i), []PodInfo{pod}))
+		}
+		return instances
+	}
+	return []*Instance{newInstance(0, sorted)}
+}
+
+func newInstance(index int32, pods []PodInfo) *Instance {
+	inst := &Instance{Index: index, Pods: pods, NodesSet: map[string]int{}}
+	for _, pod := range pods {
+		inst.TotalGPUs += pod.GPUs
+		if pod.Node != "" {
+			inst.NodesSet[pod.Node]++
+		}
+		if pod.Ready {
+			inst.ReadyPods++
+		}
+	}
+	return inst
+}
+
+func applyWorkloadOverrides(w *Workload, annotations map[string]string) {
+	if value, ok := annotations[constants.AlfredMovableAnnotationKey]; ok {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			w.Movable = parsed
+		}
+	}
+	if value, ok := annotations[constants.AlfredPriorityAnnotationKey]; ok {
+		if parsed, err := strconv.ParseFloat(value, 64); err == nil && parsed >= 0 && parsed <= 1 {
+			w.Priority = parsed
+		}
+	}
+	if value, ok := annotations[constants.AlfredCooldownMinutesAnnotationKey]; ok {
+		if minutes, err := strconv.Atoi(value); err == nil && minutes >= 0 {
+			d := time.Duration(minutes) * time.Minute
+			w.CooldownOverride = &d
+		}
+	}
+	w.TenantGroup = annotations[constants.AlfredTenantGroupAnnotationKey]
+	w.SpotPolicy = annotations[constants.AlfredSpotPolicyAnnotationKey]
+}
+
+// applyMigrationState reconstructs cooldown and in-flight state from durable
+// cluster state (request annotations + MigrationHistory), so it survives
+// Alfred leader failover by construction.
+func applyMigrationState(w *Workload, isvc *v1beta1.InferenceService) {
+	inFlight := map[string]InFlight{}
+
+	requests, malformed := migration.ExtractRequests(isvc.Annotations)
+	// Malformed request annotations are kept visible: the workload still
+	// carries a write the executor must ack-reject, and hiding it would
+	// make the workload look clean to policies and the reporter.
+	for _, m := range malformed {
+		if w.MalformedRequests == nil {
+			w.MalformedRequests = map[string]string{}
+		}
+		w.MalformedRequests[m.UUID] = m.Err.Error()
+	}
+	for _, req := range requests {
+		inFlight[req.UUID] = InFlight{
+			UUID:        req.UUID,
+			Component:   v1beta1.ComponentType(req.Request.Component),
+			FromNode:    req.Request.FromNode,
+			RequestedAt: req.Request.RequestedAt.Time,
+		}
+	}
+
+	for i := range isvc.Status.MigrationHistory {
+		entry := &isvc.Status.MigrationHistory[i]
+		if entry.Phase.Terminal() {
+			// Terminal history overrides a still-present request
+			// annotation for the same UUID: the executor acks in two
+			// writes (append the terminal entry, then clear the
+			// annotation), and a snapshot taken between them must not
+			// report the finished migration as in flight.
+			delete(inFlight, entry.ID)
+			at := entry.RequestedAt.Time
+			if entry.CompletedAt != nil {
+				at = entry.CompletedAt.Time
+			}
+			if w.LastMigration == nil || at.After(*w.LastMigration) {
+				last := at
+				w.LastMigration = &last
+			}
+			continue
+		}
+		// Non-terminal history is authoritative over the bare
+		// annotation: it carries mode and phase.
+		inFlight[entry.ID] = InFlight{
+			UUID:        entry.ID,
+			Component:   entry.Component,
+			Mode:        entry.Mode,
+			Phase:       entry.Phase,
+			RequestedAt: entry.RequestedAt.Time,
+		}
+	}
+
+	if len(inFlight) == 0 {
+		return
+	}
+	w.ActiveMigrations = make([]InFlight, 0, len(inFlight))
+	for _, f := range inFlight {
+		w.ActiveMigrations = append(w.ActiveMigrations, f)
+	}
+	sort.Slice(w.ActiveMigrations, func(i, j int) bool { return w.ActiveMigrations[i].UUID < w.ActiveMigrations[j].UUID })
+}
+
+// resolveModels resolves availability for every model referenced by at least
+// one workload. Failures are recorded per model, never fatal.
+func resolveModels(ctx context.Context, r client.Reader, s *ClusterSnapshot) {
+	for _, w := range s.Workloads {
+		key := w.ModelKey
+		if key.Zero() {
+			continue
+		}
+		if _, done := s.Models[key]; done {
+			continue
+		}
+		avail := &ModelAvailability{Key: key}
+		s.Models[key] = avail
+
+		var spec *v1beta1.BaseModelSpec
+		switch key.Kind {
+		case ModelKindBaseModel:
+			var bm v1beta1.BaseModel
+			if err := r.Get(ctx, types.NamespacedName{Namespace: key.Namespace, Name: key.Name}, &bm); err != nil {
+				avail.ResolveError = fmt.Sprintf("get basemodel: %v", err)
+				continue
+			}
+			spec = &bm.Spec
+		case ModelKindClusterBaseModel:
+			var cbm v1beta1.ClusterBaseModel
+			if err := r.Get(ctx, types.NamespacedName{Name: key.Name}, &cbm); err != nil {
+				avail.ResolveError = fmt.Sprintf("get clusterbasemodel: %v", err)
+				continue
+			}
+			spec = &cbm.Spec
+		default:
+			avail.ResolveError = fmt.Sprintf("unsupported model kind %q", key.Kind)
+			continue
+		}
+
+		uri := ""
+		if spec.Storage != nil && spec.Storage.StorageUri != nil {
+			uri = *spec.Storage.StorageUri
+		}
+		if strings.HasPrefix(uri, storage.PVCStoragePrefix) {
+			avail.Backend = BackendPVC
+			resolvePVCAvailability(ctx, r, avail, key.Namespace, uri, s.Nodes)
+			continue
+		}
+		avail.Backend = BackendPerNode
+		avail.NodesReady = nodesReadyForModel(s.Nodes, key)
+	}
+}
+
+// attributePendingPools attributes each pending pod's demand to a hardware
+// pool: the pool is unambiguous when the pod's nodeSelector is satisfiable
+// by exactly one pool's nodes. Ambiguous or unconstrained demand stays
+// unattributed ("" — counted toward every pool by scoring). This is a
+// documented heuristic; the candidate simulator, not the score, verifies
+// real placements.
+func attributePendingPools(s *ClusterSnapshot) {
+	poolNodes := map[string][]*Node{}
+	for _, n := range s.Nodes {
+		if n.TotalGPUs > 0 {
+			poolNodes[n.GPUPool] = append(poolNodes[n.GPUPool], n)
+		}
+	}
+	if len(poolNodes) == 1 {
+		for pool := range poolNodes {
+			for i := range s.PendingPods {
+				s.PendingPods[i].GPUPool = pool
+			}
+		}
+		return
+	}
+	for i := range s.PendingPods {
+		pending := &s.PendingPods[i]
+		if len(pending.NodeSelector) == 0 {
+			continue
+		}
+		var matches []string
+		for pool, nodes := range poolNodes {
+			for _, n := range nodes {
+				if labelsSatisfy(n.Labels, pending.NodeSelector) {
+					matches = append(matches, pool)
+					break
+				}
+			}
+		}
+		if len(matches) == 1 {
+			pending.GPUPool = matches[0]
+		}
+	}
+}
+
+func labelsSatisfy(labels, selector map[string]string) bool {
+	for k, v := range selector {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/alfred/snapshot/builder_test.go
+++ b/pkg/alfred/snapshot/builder_test.go
@@ -1,0 +1,463 @@
+package snapshot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/migration"
+)
+
+var (
+	buildNow    = time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	pendingAt   = metav1.NewTime(buildNow.Add(-20 * time.Minute))
+	completedAt = metav1.NewTime(buildNow.Add(-2 * time.Hour))
+)
+
+func strPtr(s string) *string { return &s }
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return scheme
+}
+
+// testPool is the GFD product label all test nodes carry, and therefore the
+// hardware pool they resolve to.
+const testPool = "NVIDIA-H100-80GB-HBM3"
+
+func gpuNode(name string, gpus string, mutate func(*corev1.Node)) *corev1.Node {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{
+			"nvidia.com/gpu.product": testPool,
+		}},
+		Status: corev1.NodeStatus{Allocatable: corev1.ResourceList{
+			"nvidia.com/gpu":   resource.MustParse(gpus),
+			corev1.ResourceCPU: resource.MustParse("64"),
+		}},
+	}
+	if mutate != nil {
+		mutate(node)
+	}
+	return node
+}
+
+func omePod(namespace, name, node, isvc string, component string, gpus int64, ready bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				constants.InferenceServicePodLabelKey: isvc,
+				constants.OMEComponentLabel:           component,
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: node},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	if gpus > 0 {
+		pod.Spec.Containers = []corev1.Container{{
+			Name: "main",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				"nvidia.com/gpu": *resource.NewQuantity(gpus, resource.DecimalSI),
+			}},
+		}}
+	} else {
+		pod.Spec.Containers = []corev1.Container{{Name: "main"}}
+	}
+	start := metav1.NewTime(buildNow.Add(-24 * time.Hour))
+	pod.Status.StartTime = &start
+	if ready {
+		pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	}
+	return pod
+}
+
+func buildTestSnapshot(t *testing.T) *ClusterSnapshot {
+	t.Helper()
+
+	requestPayload, err := (&migration.Request{
+		SchemaVersion: migration.SchemaVersionV1,
+		Component:     "engine",
+		FromNode:      "node1",
+		RequestedAt:   metav1.NewTime(buildNow.Add(-time.Minute)),
+	}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ackedPayload shares its UUID ("done-1") with a terminal history entry
+	// below — the ack-race window where the executor has recorded the
+	// terminal outcome but not yet cleared the annotation.
+	ackedPayload, err := (&migration.Request{
+		SchemaVersion: migration.SchemaVersionV1,
+		Component:     "engine",
+		FromNode:      "node2",
+		RequestedAt:   metav1.NewTime(buildNow.Add(-3 * time.Hour)),
+	}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	llamaLabel := constants.GetClusterBaseModelLabel("llama")
+
+	node1 := gpuNode("node1", "8", func(n *corev1.Node) {
+		n.Annotations = map[string]string{"cluster-autoscaler.kubernetes.io/scale-down-disabled": "true"}
+		n.Labels[llamaLabel] = "Ready"
+		n.Labels["topology.kubernetes.io/zone"] = "z1"
+	})
+	node2 := gpuNode("node2", "8", func(n *corev1.Node) {
+		n.Labels[llamaLabel] = "Ready"
+		n.Status.Conditions = []corev1.NodeCondition{{Type: "GpuUnhealthy", Status: corev1.ConditionTrue}}
+	})
+	node3 := gpuNode("node3", "8", func(n *corev1.Node) {
+		n.Spec.Unschedulable = true
+		n.Spec.Taints = []corev1.Taint{{Key: "ToBeDeletedByClusterAutoscaler", Value: "123", Effect: corev1.TaintEffectNoSchedule}}
+		n.Labels["node.kubernetes.io/preemptible"] = "true"
+		n.Labels[llamaLabel] = "Updating" // not Ready
+	})
+
+	engineA1 := omePod("prod", "svc-a-engine-1", "node1", "svc-a", "engine", 2, true)
+	// Requests-only pod exercises the limits→requests fallback.
+	engineA2 := omePod("prod", "svc-a-engine-2", "node2", "svc-a", "engine", 0, false)
+	engineA2.Spec.Containers = []corev1.Container{{
+		Name: "main",
+		Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+			"nvidia.com/gpu": resource.MustParse("1"),
+		}},
+	}}
+	routerA := omePod("prod", "svc-a-router-1", "node1", "svc-a", "router", 0, true)
+
+	notebook := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team", Name: "notebook-1"},
+		Spec: corev1.PodSpec{NodeName: "node1", Containers: []corev1.Container{{
+			Name: "nb",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				"nvidia.com/gpu": resource.MustParse("3"),
+			}},
+		}}},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	deletionTime := metav1.NewTime(buildNow.Add(-time.Minute))
+	terminating := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "team",
+			Name:              "batch-1",
+			DeletionTimestamp: &deletionTime,
+			Finalizers:        []string{"test/finalizer"},
+		},
+		Spec: corev1.PodSpec{NodeName: "node2", Containers: []corev1.Container{{
+			Name: "job",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				"nvidia.com/gpu": resource.MustParse("2"),
+			}},
+		}}},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	pending := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "prod",
+			Name:      "svc-a-engine-pending",
+			Labels: map[string]string{
+				constants.InferenceServicePodLabelKey: "svc-a",
+				constants.OMEComponentLabel:           "engine",
+			},
+			CreationTimestamp: metav1.NewTime(buildNow.Add(-30 * time.Minute)),
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "main",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				"nvidia.com/gpu": resource.MustParse("8"),
+			}},
+		}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Type: corev1.PodScheduled, Status: corev1.ConditionFalse,
+				Reason: corev1.PodReasonUnschedulable, LastTransitionTime: pendingAt,
+			}},
+		},
+	}
+
+	isvcA := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "prod",
+			Name:      "svc-a",
+			Annotations: map[string]string{
+				constants.AlfredMovableAnnotationKey:         "false",
+				constants.AlfredPriorityAnnotationKey:        "0.2",
+				constants.AlfredCooldownMinutesAnnotationKey: "60",
+				constants.AlfredTenantGroupAnnotationKey:     "team-alpha",
+				migration.AnnotationKey("req-1"):             requestPayload,
+				migration.AnnotationKey("done-1"):            ackedPayload,
+				migration.AnnotationKey("bad-1"):             "{not-json",
+			},
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Engine: &v1beta1.EngineSpec{},
+			Model:  &v1beta1.ModelRef{Name: "llama", Kind: strPtr("ClusterBaseModel")},
+		},
+		Status: v1beta1.InferenceServiceStatus{
+			MigrationHistory: []v1beta1.MigrationHistoryEntry{
+				{
+					ID: "done-1", Component: v1beta1.EngineComponent, Mode: v1beta1.MigrationModeSurge,
+					Phase: v1beta1.MigrationPhaseCompleted, RequestedAt: metav1.NewTime(buildNow.Add(-3 * time.Hour)),
+					CompletedAt: &completedAt,
+				},
+				{
+					ID: "hist-1", Component: v1beta1.EngineComponent, Mode: v1beta1.MigrationModeSurge,
+					Phase: v1beta1.MigrationPhaseSurgePending, RequestedAt: metav1.NewTime(buildNow.Add(-5 * time.Minute)),
+				},
+			},
+		},
+	}
+
+	isvcPVC := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "svc-pvc"},
+		Spec: v1beta1.InferenceServiceSpec{
+			Engine: &v1beta1.EngineSpec{},
+			Model:  &v1beta1.ModelRef{Name: "pvc-model", Kind: strPtr("BaseModel")},
+		},
+	}
+
+	llama := &v1beta1.ClusterBaseModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: strPtr("oci://n/ns/b/models/o/llama"),
+		}},
+	}
+	pvcModel := &v1beta1.BaseModel{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "pvc-model"},
+		Spec: v1beta1.BaseModelSpec{Storage: &v1beta1.StorageSpec{
+			StorageUri: strPtr("pvc://weights/models/llama"),
+		}},
+	}
+	weightsPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "weights"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			VolumeName:  "pv-weights",
+		},
+	}
+	weightsPV := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-weights"},
+		Spec: corev1.PersistentVolumeSpec{
+			NodeAffinity: &corev1.VolumeNodeAffinity{Required: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key: "topology.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"z1"},
+					}},
+				}},
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithObjects(
+			node1, node2, node3,
+			engineA1, engineA2, routerA, notebook, terminating, pending,
+			isvcA, isvcPVC, llama, pvcModel, weightsPVC, weightsPV,
+		).
+		Build()
+
+	snap, err := Build(context.Background(), client.Reader(fakeClient), Options{
+		PreemptibleLabels: []string{"node.kubernetes.io/preemptible"},
+		Now:               func() time.Time { return buildNow },
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return snap
+}
+
+func TestBuildNodeAccounting(t *testing.T) {
+	snap := buildTestSnapshot(t)
+
+	node1 := snap.Nodes["node1"]
+	if node1 == nil {
+		t.Fatal("node1 missing")
+	}
+	if node1.TotalGPUs != 8 || node1.AllocatedGPUs != 5 || node1.FreeGPUs != 3 {
+		t.Fatalf("node1 accounting: total=%d allocated=%d free=%d, want 8/5/3", node1.TotalGPUs, node1.AllocatedGPUs, node1.FreeGPUs)
+	}
+	if !node1.ScaleDownDisabled || node1.Cordoned || node1.Unhealthy {
+		t.Fatalf("node1 flags: %+v", node1)
+	}
+	if len(node1.OMEPods) != 1 || len(node1.OtherOccupants) != 1 {
+		t.Fatalf("node1 occupants: ome=%d other=%d, want 1/1", len(node1.OMEPods), len(node1.OtherOccupants))
+	}
+	if node1.GPUPool != testPool || node1.GPUResource != "nvidia.com/gpu" {
+		t.Fatalf("node1 pool/resource: %q/%q", node1.GPUPool, node1.GPUResource)
+	}
+
+	node2 := snap.Nodes["node2"]
+	if node2.AllocatedGPUs != 3 || node2.FreeGPUs != 5 || node2.TerminatingGPUs != 2 {
+		t.Fatalf("node2 accounting: allocated=%d free=%d terminating=%d, want 3/5/2", node2.AllocatedGPUs, node2.FreeGPUs, node2.TerminatingGPUs)
+	}
+	if !node2.Unhealthy || len(node2.UnhealthyConditions) != 1 || node2.UnhealthyConditions[0] != "GpuUnhealthy" {
+		t.Fatalf("node2 health: %+v", node2)
+	}
+
+	node3 := snap.Nodes["node3"]
+	if !node3.Cordoned || !node3.ScaleDownMarked || !node3.Preemptible {
+		t.Fatalf("node3 flags: %+v", node3)
+	}
+}
+
+func TestBuildWorkloads(t *testing.T) {
+	snap := buildTestSnapshot(t)
+
+	svcA := snap.Workloads[types.NamespacedName{Namespace: "prod", Name: "svc-a"}]
+	if svcA == nil {
+		t.Fatal("svc-a missing")
+	}
+	if svcA.Movable {
+		t.Fatal("svc-a should be movable=false from annotation")
+	}
+	if svcA.Priority != 0.2 || svcA.TenantGroup != "team-alpha" {
+		t.Fatalf("svc-a overrides: priority=%v tenant=%q", svcA.Priority, svcA.TenantGroup)
+	}
+	if svcA.CooldownOverride == nil || *svcA.CooldownOverride != time.Hour {
+		t.Fatalf("svc-a cooldown override: %v", svcA.CooldownOverride)
+	}
+
+	engine := svcA.Components[v1beta1.EngineComponent]
+	if engine == nil || engine.DeploymentMode != constants.RawDeployment {
+		t.Fatalf("engine component: %+v", engine)
+	}
+	if len(engine.Instances) != 2 {
+		t.Fatalf("engine instances: %d, want 2 (one per RawDeployment pod)", len(engine.Instances))
+	}
+	if engine.Instances[0].Pods[0].Name != "svc-a-engine-1" || engine.Instances[0].TotalGPUs != 2 || engine.Instances[0].ReadyPods != 1 {
+		t.Fatalf("instance 0: %+v", engine.Instances[0])
+	}
+	if engine.Instances[1].Pods[0].GPUs != 1 || engine.Instances[1].ReadyPods != 0 {
+		t.Fatalf("instance 1 (requests fallback, not ready): %+v", engine.Instances[1])
+	}
+
+	// Router pods exist without a router spec: component still appears.
+	router := svcA.Components[v1beta1.RouterComponent]
+	if router == nil || len(router.Instances) != 1 || router.Instances[0].TotalGPUs != 0 {
+		t.Fatalf("router component from pods only: %+v", router)
+	}
+
+	if svcA.LastMigration == nil || !svcA.LastMigration.Equal(completedAt.Time) {
+		t.Fatalf("LastMigration: %v, want %v", svcA.LastMigration, completedAt.Time)
+	}
+	// done-1 has a terminal history entry AND a lingering request
+	// annotation (the ack-race window): it must not be in flight.
+	if len(svcA.ActiveMigrations) != 2 {
+		t.Fatalf("ActiveMigrations: %+v, want annotation req-1 + history hist-1 only", svcA.ActiveMigrations)
+	}
+	for _, f := range svcA.ActiveMigrations {
+		if f.UUID == "done-1" {
+			t.Fatalf("terminal history must override the lingering done-1 annotation: %+v", svcA.ActiveMigrations)
+		}
+	}
+	// A corrupt request annotation must stay visible, not make the
+	// workload look clean.
+	if reason := svcA.MalformedRequests["bad-1"]; reason == "" {
+		t.Fatalf("malformed request bad-1 not surfaced: %+v", svcA.MalformedRequests)
+	}
+	if svcA.ActiveMigrations[0].UUID != "hist-1" || svcA.ActiveMigrations[0].Phase != v1beta1.MigrationPhaseSurgePending {
+		t.Fatalf("ActiveMigrations[0]: %+v", svcA.ActiveMigrations[0])
+	}
+	if svcA.ActiveMigrations[1].UUID != "req-1" || svcA.ActiveMigrations[1].FromNode != "node1" {
+		t.Fatalf("ActiveMigrations[1]: %+v", svcA.ActiveMigrations[1])
+	}
+}
+
+func TestBuildPendingPods(t *testing.T) {
+	snap := buildTestSnapshot(t)
+
+	if len(snap.PendingPods) != 1 {
+		t.Fatalf("pending pods: %+v", snap.PendingPods)
+	}
+	p := snap.PendingPods[0]
+	if p.GPUsNeeded != 8 || p.Virtual {
+		t.Fatalf("pending pod: %+v", p)
+	}
+	if p.ISVC != (types.NamespacedName{Namespace: "prod", Name: "svc-a"}) {
+		t.Fatalf("pending ISVC attribution: %+v", p.ISVC)
+	}
+	if !p.PendingSince.Equal(pendingAt.Time) {
+		t.Fatalf("PendingSince = %v, want PodScheduled transition %v", p.PendingSince, pendingAt.Time)
+	}
+	// Single-pool cluster: demand is attributed to that pool.
+	if p.GPUPool != testPool {
+		t.Fatalf("pool attribution: %q, want %q", p.GPUPool, testPool)
+	}
+}
+
+func TestBuildModelAvailability(t *testing.T) {
+	snap := buildTestSnapshot(t)
+
+	llama := snap.Models[ModelKey{Kind: "ClusterBaseModel", Name: "llama"}]
+	if llama == nil {
+		t.Fatal("llama availability missing")
+	}
+	if llama.Backend != BackendPerNode || llama.ResolveError != "" {
+		t.Fatalf("llama: %+v", llama)
+	}
+	// node3's label value is Updating, so only node1/node2 are Ready.
+	if len(llama.NodesReady) != 2 || llama.NodesReady[0] != "node1" || llama.NodesReady[1] != "node2" {
+		t.Fatalf("llama NodesReady: %v", llama.NodesReady)
+	}
+
+	pvcModel := snap.Models[ModelKey{Kind: "BaseModel", Namespace: "prod", Name: "pvc-model"}]
+	if pvcModel == nil {
+		t.Fatal("pvc-model availability missing")
+	}
+	if pvcModel.Backend != BackendPVC || !pvcModel.VolumePinned {
+		t.Fatalf("pvc-model should be PVC-backed and RWO-pinned: %+v", pvcModel)
+	}
+	if len(pvcModel.PVCAccessModes) != 1 || pvcModel.PVCAccessModes[0] != string(corev1.ReadWriteOnce) {
+		t.Fatalf("pvc-model access modes: %v", pvcModel.PVCAccessModes)
+	}
+	// Zone z1 affinity reaches only node1.
+	if len(pvcModel.PVCTopologyNodes) != 1 || pvcModel.PVCTopologyNodes[0] != "node1" {
+		t.Fatalf("pvc-model topology: %v", pvcModel.PVCTopologyNodes)
+	}
+}
+
+func TestSnapshotHelpers(t *testing.T) {
+	snap := buildTestSnapshot(t)
+
+	pools := snap.GPUPools()
+	if len(pools) != 1 || pools[0] != testPool {
+		t.Fatalf("GPUPools: %v", pools)
+	}
+	if got := len(snap.PoolNodes(testPool)); got != 3 {
+		t.Fatalf("PoolNodes(%s): %d, want 3", testPool, got)
+	}
+
+	derived := snap.WithVirtualPending([]PendingPod{{Name: "virtual-1", GPUsNeeded: 8, Virtual: true}})
+	if len(derived.PendingPods) != len(snap.PendingPods)+1 {
+		t.Fatal("WithVirtualPending should append")
+	}
+	if len(snap.PendingPods) != 1 {
+		t.Fatal("WithVirtualPending must not mutate the receiver")
+	}
+	if snap.WithVirtualPending(nil) != snap {
+		t.Fatal("WithVirtualPending(nil) should return the receiver")
+	}
+}

--- a/pkg/alfred/snapshot/gpu.go
+++ b/pkg/alfred/snapshot/gpu.go
@@ -1,0 +1,126 @@
+package snapshot
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// GPU resource-name matching. Alfred owns this set: capacity is computed from
+// node allocatable and pod requests directly, with no dependency on
+// AcceleratorClass status accounting.
+var (
+	exactGPUResources = map[corev1.ResourceName]struct{}{
+		corev1.ResourceName(constants.NvidiaGPUResourceType): {}, // nvidia.com/gpu
+		"amd.com/gpu": {},
+	}
+	prefixGPUResources = []string{
+		"nvidia.com/mig-", // MIG partitions (nvidia.com/mig-1g.5gb, ...)
+		"gpu.intel.com/",  // Intel GPU resources (excluding memory below)
+	}
+	// Intel exposes memory as a resource under the same prefix; it is not
+	// a schedulable accelerator count.
+	excludedGPUResourceSubstrings = []string{"memory"}
+)
+
+// IsGPUResource reports whether a resource name counts as a GPU accelerator.
+func IsGPUResource(name corev1.ResourceName) bool {
+	if _, ok := exactGPUResources[name]; ok {
+		return true
+	}
+	s := string(name)
+	for _, prefix := range prefixGPUResources {
+		if strings.HasPrefix(s, prefix) {
+			for _, excluded := range excludedGPUResourceSubstrings {
+				if strings.Contains(s, excluded) {
+					return false
+				}
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// NodeGPUAllocatable returns the node's GPU resource name and allocatable
+// count. Allocatable is used deliberately (not capacity): it is what the
+// scheduler can actually place against. Nodes exposing several GPU resource
+// names (rare; e.g. mixed MIG profiles) report the largest pool.
+func NodeGPUAllocatable(node *corev1.Node) (string, int64) {
+	var bestName string
+	var bestCount int64
+	for name, quantity := range node.Status.Allocatable {
+		if !IsGPUResource(name) {
+			continue
+		}
+		if count := quantity.Value(); count > bestCount {
+			bestName, bestCount = string(name), count
+		}
+	}
+	return bestName, bestCount
+}
+
+// PodGPURequest returns the pod's total GPU request across its regular
+// containers plus native sidecars (init containers with restartPolicy
+// Always), which run for the pod's whole lifetime and hold their resources
+// at steady state. Ordinary init containers are ignored: they release
+// resources before serving starts.
+func PodGPURequest(pod *corev1.Pod) int64 {
+	var total int64
+	for i := range pod.Spec.Containers {
+		total += containerGPURequest(&pod.Spec.Containers[i])
+	}
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
+		if c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			total += containerGPURequest(c)
+		}
+	}
+	return total
+}
+
+// containerGPURequest evaluates each GPU resource independently: its limit
+// when present, else its request. Extended resources normally carry equal
+// limits and requests, but an unrelated (e.g. CPU-only) limits section must
+// never suppress a GPU request, and a resource must never be double-counted
+// when it appears in both maps.
+func containerGPURequest(c *corev1.Container) int64 {
+	var total int64
+	for name, quantity := range c.Resources.Limits {
+		if IsGPUResource(name) {
+			total += quantity.Value()
+		}
+	}
+	for name, quantity := range c.Resources.Requests {
+		if !IsGPUResource(name) {
+			continue
+		}
+		if _, limited := c.Resources.Limits[name]; limited {
+			continue
+		}
+		total += quantity.Value()
+	}
+	return total
+}
+
+// podHoldsGPUs reports whether the pod currently counts against node GPU
+// capacity: it is bound to a node and not in a terminal phase. Terminating
+// (deletion-timestamped) pods still hold their GPUs until they exit.
+func podHoldsGPUs(pod *corev1.Pod) bool {
+	if pod.Spec.NodeName == "" {
+		return false
+	}
+	return pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed
+}
+
+// podIsReady reports the pod's Ready condition.
+func podIsReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/pkg/alfred/snapshot/gpu_test.go
+++ b/pkg/alfred/snapshot/gpu_test.go
@@ -1,0 +1,138 @@
+package snapshot
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsGPUResource(t *testing.T) {
+	cases := []struct {
+		name corev1.ResourceName
+		want bool
+	}{
+		{"nvidia.com/gpu", true},
+		{"amd.com/gpu", true},
+		{"nvidia.com/mig-1g.5gb", true},
+		{"nvidia.com/mig-3g.20gb", true},
+		{"gpu.intel.com/i915", true},
+		{"gpu.intel.com/i915_monitoring_memory", false}, // memory, not accelerators
+		{"cpu", false},
+		{"memory", false},
+		{"nvidia.com/gpu-memory", false}, // not the exact resource, no matching prefix
+		{"example.com/gpu", false},
+	}
+	for _, tc := range cases {
+		if got := IsGPUResource(tc.name); got != tc.want {
+			t.Errorf("IsGPUResource(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestNodeGPUAllocatable(t *testing.T) {
+	node := &corev1.Node{
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("64"),
+				corev1.ResourceMemory: resource.MustParse("512Gi"),
+				"nvidia.com/gpu":      resource.MustParse("8"),
+			},
+		},
+	}
+	name, count := NodeGPUAllocatable(node)
+	if name != "nvidia.com/gpu" || count != 8 {
+		t.Fatalf("got (%q, %d), want (nvidia.com/gpu, 8)", name, count)
+	}
+
+	gpuless := &corev1.Node{Status: corev1.NodeStatus{Allocatable: corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("8"),
+	}}}
+	if name, count := NodeGPUAllocatable(gpuless); name != "" || count != 0 {
+		t.Fatalf("gpuless node: got (%q, %d), want empty", name, count)
+	}
+
+	// Several GPU resource names on one node: the largest pool wins.
+	mixed := &corev1.Node{Status: corev1.NodeStatus{Allocatable: corev1.ResourceList{
+		"nvidia.com/gpu":        resource.MustParse("2"),
+		"nvidia.com/mig-1g.5gb": resource.MustParse("6"),
+	}}}
+	if name, count := NodeGPUAllocatable(mixed); name != "nvidia.com/mig-1g.5gb" || count != 6 {
+		t.Fatalf("mixed node: got (%q, %d), want (nvidia.com/mig-1g.5gb, 6)", name, count)
+	}
+}
+
+func podWith(limits, requests corev1.ResourceList) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p"},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:      "main",
+			Resources: corev1.ResourceRequirements{Limits: limits, Requests: requests},
+		}}},
+	}
+}
+
+func TestPodGPURequest(t *testing.T) {
+	// Limits are the canonical place for extended resources.
+	viaLimits := podWith(corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}, nil)
+	if got := PodGPURequest(viaLimits); got != 2 {
+		t.Fatalf("limits path: got %d, want 2", got)
+	}
+
+	// Requests fallback when the container sets no limits at all.
+	viaRequests := podWith(nil, corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")})
+	if got := PodGPURequest(viaRequests); got != 1 {
+		t.Fatalf("requests fallback: got %d, want 1", got)
+	}
+
+	// A CPU-only limits section must not suppress a GPU request: each
+	// resource is evaluated independently.
+	cpuLimitOnly := podWith(
+		corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("4")},
+	)
+	if got := PodGPURequest(cpuLimitOnly); got != 4 {
+		t.Fatalf("cpu-limit-only path: got %d, want 4", got)
+	}
+
+	// A GPU resource in both maps is counted once, via its limit.
+	both := podWith(
+		corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")},
+		corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")},
+	)
+	if got := PodGPURequest(both); got != 2 {
+		t.Fatalf("limit+request path: got %d, want 2 (no double count)", got)
+	}
+
+	// Multi-container sums.
+	multi := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+		{Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}}},
+		{Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{"nvidia.com/mig-1g.5gb": resource.MustParse("1")}}},
+	}}}
+	if got := PodGPURequest(multi); got != 3 {
+		t.Fatalf("multi-container: got %d, want 3", got)
+	}
+
+	if got := PodGPURequest(podWith(nil, nil)); got != 0 {
+		t.Fatalf("no resources: got %d, want 0", got)
+	}
+}
+
+func TestPodGPURequestInitContainers(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	gpuOne := corev1.ResourceRequirements{Limits: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}}
+
+	pod := &corev1.Pod{Spec: corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "main", Resources: gpuOne}},
+		InitContainers: []corev1.Container{
+			// Native sidecar: holds its GPU for the pod's lifetime.
+			{Name: "sidecar", RestartPolicy: &always, Resources: gpuOne},
+			// Ordinary init container: releases resources before serving.
+			{Name: "init", Resources: gpuOne},
+		},
+	}}
+	if got := PodGPURequest(pod); got != 2 {
+		t.Fatalf("got %d, want 2 (main + native sidecar; plain init excluded)", got)
+	}
+}

--- a/pkg/alfred/snapshot/models.go
+++ b/pkg/alfred/snapshot/models.go
@@ -1,0 +1,41 @@
+package snapshot
+
+import (
+	"sort"
+
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// ModelReadyLabelValue is the node-label value the model-agent's node-label
+// reconciler writes when a per-node model copy is ready (the other values are
+// Updating and Failed). The label key comes from
+// constants.GetClusterBaseModelLabel / constants.GetBaseModelLabel — those
+// helpers MUST be used to build keys, because long model names are
+// SHA256-truncated.
+const ModelReadyLabelValue = "Ready"
+
+// modelReadinessLabelKey returns the node-label key that carries per-node
+// readiness for the model.
+func modelReadinessLabelKey(key ModelKey) string {
+	if key.Kind == ModelKindBaseModel {
+		return constants.GetBaseModelLabel(key.Namespace, key.Name)
+	}
+	return constants.GetClusterBaseModelLabel(key.Name)
+}
+
+// nodesReadyForModel scans node labels for the model's readiness label and
+// returns the sorted list of nodes where the copy is Ready. Node labels are
+// the source of truth here (not BaseModel.Status.NodesReady): they are what
+// the model-readiness nodeSelector — and therefore the scheduler — actually
+// enforces.
+func nodesReadyForModel(nodes map[string]*Node, key ModelKey) []string {
+	labelKey := modelReadinessLabelKey(key)
+	var ready []string
+	for name, node := range nodes {
+		if node.Labels[labelKey] == ModelReadyLabelValue {
+			ready = append(ready, name)
+		}
+	}
+	sort.Strings(ready)
+	return ready
+}

--- a/pkg/alfred/snapshot/pools.go
+++ b/pkg/alfred/snapshot/pools.go
@@ -1,0 +1,44 @@
+package snapshot
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/utils"
+)
+
+// gfdGPUProductLabel is written by NVIDIA GPU feature discovery
+// (e.g. "NVIDIA-H100-80GB-HBM3") and is the most precise pool signal when
+// present.
+const gfdGPUProductLabel = "nvidia.com/gpu.product"
+
+// GPUPoolForNode derives the hardware-pool key scoring partitions on, from
+// the node itself — deliberately NOT from AcceleratorClass.Status.Nodes.
+// AcceleratorClass is a workload-selection surface, and several shape-scoped
+// classes (H100x1, H100x2, H100x4, H100x8) may all claim the same node, so
+// class membership does not partition hardware; any first-wins tie-break
+// would split one physical pool across classes and corrupt per-pool scoring.
+//
+// Precedence:
+//  1. The GPU product label (GPU feature discovery), when installed.
+//  2. The instance-type label mapped through the shape catalog
+//     (utils.GetInstanceTypeShortName; BM.GPU.H100.8 -> H100; unknown
+//     shapes key by the shape string itself, which still groups identical
+//     hardware).
+//  3. The GPU resource name (nvidia.com/gpu, amd.com/gpu, a MIG profile) —
+//     coarse, but never mixes vendors or MIG geometries.
+func GPUPoolForNode(node *corev1.Node, gpuResource string) string {
+	if product := node.Labels[gfdGPUProductLabel]; product != "" {
+		return product
+	}
+	shape := node.Labels[constants.NodeInstanceShapeLabel]
+	if shape == "" {
+		shape = node.Labels[constants.DeprecatedNodeInstanceShapeLabel]
+	}
+	if shape != "" {
+		if short, err := utils.GetInstanceTypeShortName(shape); err == nil && short != "" {
+			return short
+		}
+	}
+	return gpuResource
+}

--- a/pkg/alfred/snapshot/pools_test.go
+++ b/pkg/alfred/snapshot/pools_test.go
@@ -1,0 +1,67 @@
+package snapshot
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func nodeWithLabels(labels map[string]string) *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n", Labels: labels}}
+}
+
+func TestGPUPoolForNode(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{
+			name:   "gpu product label wins",
+			labels: map[string]string{"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3", "node.kubernetes.io/instance-type": "BM.GPU.H100.8"},
+			want:   "NVIDIA-H100-80GB-HBM3",
+		},
+		{
+			name:   "known instance shape maps to the GPU model",
+			labels: map[string]string{"node.kubernetes.io/instance-type": "BM.GPU.H100.8"},
+			want:   "H100",
+		},
+		{
+			name:   "deprecated shape label honored",
+			labels: map[string]string{"beta.kubernetes.io/instance-type": "BM.GPU.H200.8"},
+			want:   "H200",
+		},
+		{
+			// The shape catalog falls back to the shape string itself:
+			// still one consistent pool per identical hardware shape.
+			name:   "unknown shape keys by the shape",
+			labels: map[string]string{"node.kubernetes.io/instance-type": "BM.GPU.FUTURE.8"},
+			want:   "BM.GPU.FUTURE.8",
+		},
+		{
+			name:   "no labels falls back to the GPU resource name",
+			labels: nil,
+			want:   "nvidia.com/gpu",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GPUPoolForNode(nodeWithLabels(tc.labels), "nvidia.com/gpu"); got != tc.want {
+				t.Fatalf("GPUPoolForNode = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Overlapping AcceleratorClass claims (H100x1..x8 all listing one node) are
+// exactly why the pool key must come from the node, not the class CRD: two
+// nodes of identical hardware must resolve to the same pool no matter what
+// classes claim them.
+func TestGPUPoolIgnoresClassOverlap(t *testing.T) {
+	a := GPUPoolForNode(nodeWithLabels(map[string]string{"node.kubernetes.io/instance-type": "BM.GPU.H100.8"}), "nvidia.com/gpu")
+	b := GPUPoolForNode(nodeWithLabels(map[string]string{"node.kubernetes.io/instance-type": "BM.GPU.H100-NC.8"}), "nvidia.com/gpu")
+	if a != b || a != "H100" {
+		t.Fatalf("identical hardware must share one pool: %q vs %q", a, b)
+	}
+}

--- a/pkg/alfred/snapshot/pvc.go
+++ b/pkg/alfred/snapshot/pvc.go
@@ -1,0 +1,177 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/utils/storage"
+)
+
+// resolvePVCAvailability fills a BackendPVC ModelAvailability from the claim
+// behind a pvc:// storage URI:
+//
+//   - Access modes decide migratability: RWX (and ROX — model weights are
+//     read-only at inference time) volumes mount on many nodes, so any
+//     topology-compatible node is a target and no model pull is ever needed.
+//     RWO/RWOP volumes attach to one node at a time; a surge replacement
+//     cannot attach while the source pod holds the volume, so the workload is
+//     VolumePinned (advisory-only).
+//   - The bound PV's node affinity yields the CSI-reachable node set; an
+//     unbound claim or a PV without affinity means unconstrained (nil).
+//
+// Resolution failures land in ResolveError rather than failing the snapshot:
+// one broken model must not blind Alfred to the rest of the cluster.
+func resolvePVCAvailability(ctx context.Context, r client.Reader, avail *ModelAvailability, defaultNamespace, storageURI string, nodes map[string]*Node) {
+	components, err := storage.ParsePVCStorageURI(storageURI)
+	if err != nil {
+		avail.ResolveError = fmt.Sprintf("parse pvc storage uri: %v", err)
+		return
+	}
+	namespace := components.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	if namespace == "" {
+		avail.ResolveError = "pvc namespace unresolved (cluster-scoped model with no namespace in uri)"
+		return
+	}
+
+	var pvc corev1.PersistentVolumeClaim
+	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: components.PVCName}, &pvc); err != nil {
+		avail.ResolveError = fmt.Sprintf("get pvc %s/%s: %v", namespace, components.PVCName, err)
+		return
+	}
+
+	modes := pvc.Spec.AccessModes
+
+	var pv *corev1.PersistentVolume
+	if pvc.Spec.VolumeName != "" {
+		var fetched corev1.PersistentVolume
+		if err := r.Get(ctx, types.NamespacedName{Name: pvc.Spec.VolumeName}, &fetched); err != nil {
+			avail.ResolveError = fmt.Sprintf("get pv %s: %v", pvc.Spec.VolumeName, err)
+			return
+		}
+		pv = &fetched
+		if len(modes) == 0 {
+			modes = pv.Spec.AccessModes
+		}
+	}
+
+	for _, m := range modes {
+		avail.PVCAccessModes = append(avail.PVCAccessModes, string(m))
+	}
+	avail.VolumePinned = volumePinned(modes)
+
+	if pv != nil && pv.Spec.NodeAffinity != nil && pv.Spec.NodeAffinity.Required != nil {
+		var reachable []string
+		for name, node := range nodes {
+			if matchNodeSelector(node.Labels, name, pv.Spec.NodeAffinity.Required) {
+				reachable = append(reachable, name)
+			}
+		}
+		sort.Strings(reachable)
+		// Non-nil even when empty: an affinity that matches no node is a
+		// real "no feasible target", distinct from unconstrained (nil).
+		if reachable == nil {
+			reachable = []string{}
+		}
+		avail.PVCTopologyNodes = reachable
+	}
+}
+
+// volumePinned reports whether the access modes pin the volume to a single
+// node at a time. A volume offering RWX or ROX is multi-node mountable and
+// therefore migratable regardless of what else it offers.
+func volumePinned(modes []corev1.PersistentVolumeAccessMode) bool {
+	for _, m := range modes {
+		if m == corev1.ReadWriteMany || m == corev1.ReadOnlyMany {
+			return false
+		}
+	}
+	return true
+}
+
+// matchNodeSelector evaluates a corev1.NodeSelector (terms OR'd, expressions
+// within a term AND'd) against a node's labels and name. Implemented locally
+// because k8s.io/component-helpers is not a module dependency.
+func matchNodeSelector(labels map[string]string, nodeName string, selector *corev1.NodeSelector) bool {
+	for i := range selector.NodeSelectorTerms {
+		if matchNodeSelectorTerm(labels, nodeName, &selector.NodeSelectorTerms[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchNodeSelectorTerm(labels map[string]string, nodeName string, term *corev1.NodeSelectorTerm) bool {
+	if len(term.MatchExpressions) == 0 && len(term.MatchFields) == 0 {
+		return false
+	}
+	for i := range term.MatchExpressions {
+		expr := &term.MatchExpressions[i]
+		value, exists := labels[expr.Key]
+		if !matchRequirement(value, exists, expr) {
+			return false
+		}
+	}
+	for i := range term.MatchFields {
+		expr := &term.MatchFields[i]
+		// metadata.name is the only supported node field selector.
+		if expr.Key != "metadata.name" {
+			return false
+		}
+		if !matchRequirement(nodeName, true, expr) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchRequirement(value string, exists bool, expr *corev1.NodeSelectorRequirement) bool {
+	switch expr.Operator {
+	case corev1.NodeSelectorOpIn:
+		if !exists {
+			return false
+		}
+		for _, v := range expr.Values {
+			if v == value {
+				return true
+			}
+		}
+		return false
+	case corev1.NodeSelectorOpNotIn:
+		if !exists {
+			return true
+		}
+		for _, v := range expr.Values {
+			if v == value {
+				return false
+			}
+		}
+		return true
+	case corev1.NodeSelectorOpExists:
+		return exists
+	case corev1.NodeSelectorOpDoesNotExist:
+		return !exists
+	case corev1.NodeSelectorOpGt, corev1.NodeSelectorOpLt:
+		if !exists || len(expr.Values) != 1 {
+			return false
+		}
+		lhs, err1 := strconv.ParseInt(value, 10, 64)
+		rhs, err2 := strconv.ParseInt(expr.Values[0], 10, 64)
+		if err1 != nil || err2 != nil {
+			return false
+		}
+		if expr.Operator == corev1.NodeSelectorOpGt {
+			return lhs > rhs
+		}
+		return lhs < rhs
+	}
+	return false
+}

--- a/pkg/alfred/snapshot/pvc_test.go
+++ b/pkg/alfred/snapshot/pvc_test.go
@@ -1,0 +1,103 @@
+package snapshot
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestVolumePinned(t *testing.T) {
+	cases := []struct {
+		name  string
+		modes []corev1.PersistentVolumeAccessMode
+		want  bool
+	}{
+		{"rwx", []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}, false},
+		{"rox", []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}, false},
+		{"rwo", []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, true},
+		{"rwop", []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod}, true},
+		{"rwo+rwx is migratable", []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce, corev1.ReadWriteMany}, false},
+		{"empty pins conservatively", nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := volumePinned(tc.modes); got != tc.want {
+				t.Fatalf("volumePinned(%v) = %v, want %v", tc.modes, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchNodeSelector(t *testing.T) {
+	labels := map[string]string{
+		"topology.kubernetes.io/zone": "z1",
+		"disktype":                    "ssd",
+		"gpus":                        "8",
+	}
+	term := func(exprs ...corev1.NodeSelectorRequirement) *corev1.NodeSelector {
+		return &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{MatchExpressions: exprs}}}
+	}
+
+	cases := []struct {
+		name     string
+		selector *corev1.NodeSelector
+		want     bool
+	}{
+		{"in matches", term(corev1.NodeSelectorRequirement{
+			Key: "topology.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"z1", "z2"},
+		}), true},
+		{"in misses", term(corev1.NodeSelectorRequirement{
+			Key: "topology.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"z9"},
+		}), false},
+		{"NotIn on absent key matches", term(corev1.NodeSelectorRequirement{
+			Key: "absent", Operator: corev1.NodeSelectorOpNotIn, Values: []string{"x"},
+		}), true},
+		{"exists", term(corev1.NodeSelectorRequirement{Key: "disktype", Operator: corev1.NodeSelectorOpExists}), true},
+		{"doesnotexist fails on present key", term(corev1.NodeSelectorRequirement{
+			Key: "disktype", Operator: corev1.NodeSelectorOpDoesNotExist,
+		}), false},
+		{"and within term", term(
+			corev1.NodeSelectorRequirement{Key: "topology.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"z1"}},
+			corev1.NodeSelectorRequirement{Key: "disktype", Operator: corev1.NodeSelectorOpIn, Values: []string{"hdd"}},
+		), false},
+		{"or across terms", &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: "disktype", Operator: corev1.NodeSelectorOpIn, Values: []string{"hdd"}}}},
+			{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: "disktype", Operator: corev1.NodeSelectorOpIn, Values: []string{"ssd"}}}},
+		}}, true},
+		{"empty term never matches", &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{}}}, false},
+		{"gt matches numerically", term(corev1.NodeSelectorRequirement{
+			Key: "gpus", Operator: corev1.NodeSelectorOpGt, Values: []string{"4"},
+		}), true},
+		{"lt fails when value is larger", term(corev1.NodeSelectorRequirement{
+			Key: "gpus", Operator: corev1.NodeSelectorOpLt, Values: []string{"4"},
+		}), false},
+		{"gt on unparsable value fails closed", term(corev1.NodeSelectorRequirement{
+			Key: "disktype", Operator: corev1.NodeSelectorOpGt, Values: []string{"4"},
+		}), false},
+		{"unsupported match field fails the term", &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+			MatchFields: []corev1.NodeSelectorRequirement{{
+				Key: "spec.unschedulable", Operator: corev1.NodeSelectorOpIn, Values: []string{"false"},
+			}},
+		}}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := matchNodeSelector(labels, "node1", tc.selector); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// metadata.name field selector.
+	byName := &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+		MatchFields: []corev1.NodeSelectorRequirement{{
+			Key: "metadata.name", Operator: corev1.NodeSelectorOpIn, Values: []string{"node1"},
+		}},
+	}}}
+	if !matchNodeSelector(labels, "node1", byName) {
+		t.Fatal("metadata.name In [node1] should match node1")
+	}
+	if matchNodeSelector(labels, "node2", byName) {
+		t.Fatal("metadata.name In [node1] should not match node2")
+	}
+}

--- a/pkg/alfred/snapshot/types.go
+++ b/pkg/alfred/snapshot/types.go
@@ -1,0 +1,336 @@
+// Package snapshot builds Alfred's ClusterSnapshot: an immutable, in-memory
+// model of the physical GPU layer — nodes and their GPU accounting, OME
+// workloads broken into components and instances, model availability, and
+// pending-pod pressure — captured once per loop and shared read-only across
+// every policy (OEP-0008).
+package snapshot
+
+import (
+	"sort"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// ClusterSnapshot is the read surface every Alfred policy consumes. It is
+// built once per observation pass and never mutated afterwards; policies that
+// need hypothetical state derive a copy (see WithVirtualPending).
+type ClusterSnapshot struct {
+	// Timestamp is when the snapshot was built.
+	Timestamp time.Time
+
+	// Nodes indexes every node in the cluster by name, GPU-bearing or not
+	// (GPU-less nodes carry TotalGPUs == 0 and are ignored by scoring).
+	Nodes map[string]*Node
+
+	// Workloads indexes every InferenceService by namespace/name.
+	Workloads map[types.NamespacedName]*Workload
+
+	// Models indexes model availability by ModelKey for every model
+	// referenced by at least one workload.
+	Models map[ModelKey]*ModelAvailability
+
+	// PendingPods are unscheduled GPU-requesting pods, real and virtual
+	// (a virtual entry is a blocked evacuation fed back by the engine).
+	PendingPods []PendingPod
+
+	// OMENativeAvailable records whether an OMENative executor is
+	// available on this cluster; when false, multi-pod OMENative
+	// candidates degrade to advisory.
+	OMENativeAvailable bool
+}
+
+// Node is one node's physical GPU state plus the placement-relevant flags
+// policies filter on.
+type Node struct {
+	Name string
+
+	// Labels is the node's label set, retained because model readiness,
+	// spot detection, and PVC topology all resolve against it.
+	Labels map[string]string
+
+	// GPUPool is the hardware-pool key scoring partitions on (free L4s
+	// must never mask H100 fragmentation). Derived from the node itself
+	// via GPUPoolForNode — GPU product label, instance shape, or the GPU
+	// resource name — never from AcceleratorClass.Status.Nodes, which is
+	// a selection surface that shape-scoped classes (H100x1..x8) can all
+	// claim without partitioning hardware. Empty only on GPU-less nodes.
+	GPUPool string
+
+	// GPUResource is the extended resource name this node exposes
+	// (e.g. nvidia.com/gpu); empty when the node has no GPU resource.
+	GPUResource string
+
+	// TotalGPUs is the node's allocatable GPU count.
+	TotalGPUs int64
+	// AllocatedGPUs is the sum of GPU requests of non-terminal pods
+	// bound to this node (OME-managed or not).
+	AllocatedGPUs int64
+	// FreeGPUs = TotalGPUs - AllocatedGPUs, floored at zero.
+	FreeGPUs int64
+	// TerminatingGPUs is the share of AllocatedGPUs held by pods with a
+	// deletion timestamp — capacity that is about to free but must not be
+	// treated as free yet.
+	TerminatingGPUs int64
+
+	// Unhealthy is set when any configured trigger condition (default
+	// GpuUnhealthy) is True on the node.
+	Unhealthy bool
+	// UnhealthyConditions lists which trigger conditions were True.
+	UnhealthyConditions []string
+	// Cordoned mirrors spec.unschedulable.
+	Cordoned bool
+	// ScaleDownDisabled mirrors the cluster-autoscaler
+	// scale-down-disabled annotation.
+	ScaleDownDisabled bool
+	// ScaleDownMarked is set when the cluster-autoscaler has tainted the
+	// node for deletion (ToBeDeletedByClusterAutoscaler).
+	ScaleDownMarked bool
+	// Preemptible is set when the node matches a configured
+	// spot/preemptible label.
+	Preemptible bool
+	// Suspect is set by the engine for nodes inside their post-evacuation
+	// suspicion window; such nodes are excluded from every policy's
+	// target hints even after the health condition clears. The builder
+	// always leaves it false.
+	Suspect bool
+
+	// OMEPods are the OME-managed GPU pods bound to this node.
+	OMEPods []PodInfo
+	// OtherOccupants are non-OME GPU pods (notebooks, batch jobs, ...):
+	// they count against capacity but are never migration candidates.
+	OtherOccupants []PodInfo
+}
+
+// PodInfo is the slice of pod state the snapshot keeps per GPU-consuming pod.
+type PodInfo struct {
+	Namespace string
+	Name      string
+	Node      string
+	// GPUs is the pod's GPU request.
+	GPUs int64
+	// Ready reports the pod Ready condition.
+	Ready bool
+	// Terminating reports a non-nil deletion timestamp.
+	Terminating bool
+	// StartTime is pod.status.startTime when set (drives the
+	// authorship-blind placement cooldown).
+	StartTime *time.Time
+	// ISVC is the owning InferenceService (zero for non-OME pods).
+	ISVC types.NamespacedName
+	// Component is the OME component label value (engine/decoder/router);
+	// empty for non-OME pods.
+	Component v1beta1.ComponentType
+}
+
+// Workload is one InferenceService with everything policies need to reason
+// about moving it.
+type Workload struct {
+	NamespacedName types.NamespacedName
+
+	// ISVC is the source object (read-only; shared with the informer
+	// cache — never mutate).
+	ISVC *v1beta1.InferenceService
+
+	// Components maps component type to its resolved state; only
+	// components present in the spec appear.
+	Components map[v1beta1.ComponentType]*Component
+
+	// ModelKey identifies the referenced model in Models; zero-valued
+	// when the workload references no model.
+	ModelKey ModelKey
+
+	// Movable is the effective per-workload gate: the
+	// alfred.ome.io/movable annotation when present, else the
+	// cluster-wide default.
+	Movable bool
+	// Priority is alfred.ome.io/priority (default 0.5; lower = more
+	// protected).
+	Priority float64
+	// CooldownOverride is alfred.ome.io/cooldown-minutes when set.
+	CooldownOverride *time.Duration
+	// TenantGroup is alfred.ome.io/tenant-group ("" = namespace-scoped).
+	TenantGroup string
+	// SpotPolicy is alfred.ome.io/spot-policy (avoid|migrate|ignore; ""
+	// = cluster default).
+	SpotPolicy string
+
+	// LastMigration is the completion time of the newest terminal
+	// MigrationHistory entry (CompletedAt when set, else RequestedAt);
+	// it drives the per-workload cooldown.
+	LastMigration *time.Time
+	// ActiveMigrations are in-flight requests: live request annotations
+	// plus non-terminal MigrationHistory entries, one per UUID.
+	ActiveMigrations []InFlight
+	// MalformedRequests maps request-annotation UUIDs that failed parse
+	// or validation to the reason. The workload still carries a write the
+	// executor must ack-reject, and the reporter can surface it; hiding
+	// a corrupt request would make the workload look clean.
+	MalformedRequests map[string]string
+}
+
+// Component is one component (engine/decoder/router) of a workload.
+type Component struct {
+	Type v1beta1.ComponentType
+	// DeploymentMode is the resolved per-component mode (RawDeployment,
+	// MultiNode, OMENative, ...), which determines the execution surface.
+	DeploymentMode constants.DeploymentModeType
+	// Instances are the atomic units Alfred reasons about: one per pod
+	// for RawDeployment; one per atomic group for multi-pod modes.
+	Instances []*Instance
+}
+
+// Instance is the atomic migration unit: a single pod for RawDeployment, an
+// atomic multi-pod group for MultiNode/OMENative.
+type Instance struct {
+	// Index is a stable ordinal within the component (pod-name order).
+	Index int32
+	// Pods are the member pods.
+	Pods []PodInfo
+	// NodesSet counts member pods per node.
+	NodesSet map[string]int
+	// TotalGPUs is the summed GPU request of all member pods — the
+	// instance's surge footprint.
+	TotalGPUs int64
+	// ReadyPods counts members whose Ready condition is true.
+	ReadyPods int32
+}
+
+// InFlight is one in-flight migration touching a workload, reconstructed
+// from cluster state (request annotations and non-terminal MigrationHistory
+// entries) so it survives Alfred leader failover.
+type InFlight struct {
+	UUID      string
+	Component v1beta1.ComponentType
+	// Mode is empty while the request is annotation-only (the executor
+	// fixes the mode at admission).
+	Mode v1beta1.MigrationMode
+	// Phase is empty while the request is annotation-only.
+	Phase       v1beta1.MigrationPhase
+	FromNode    string
+	RequestedAt time.Time
+}
+
+// Model reference kinds for ModelKey.Kind.
+const (
+	ModelKindBaseModel        = "BaseModel"
+	ModelKindClusterBaseModel = "ClusterBaseModel"
+)
+
+// ModelKey identifies a referenced model. Namespace is empty for
+// ClusterBaseModel.
+type ModelKey struct {
+	Kind      string // ModelKindBaseModel | ModelKindClusterBaseModel
+	Namespace string
+	Name      string
+}
+
+// Zero reports whether the key is unset.
+func (k ModelKey) Zero() bool { return k.Name == "" }
+
+// Model storage backends.
+const (
+	// BackendPerNode models are downloaded per node by the model-agent;
+	// readiness is per-node (node labels / Status.NodesReady).
+	BackendPerNode = "PerNode"
+	// BackendPVC models live on a PersistentVolume; there is no per-node
+	// copy and readiness filtering must not apply — reachability is the
+	// volume's CSI topology.
+	BackendPVC = "PVC"
+)
+
+// ModelAvailability is the storage-aware answer to "where can this model's
+// workloads run".
+type ModelAvailability struct {
+	Key     ModelKey
+	Backend string
+
+	// NodesReady lists nodes whose model-readiness label is Ready
+	// (BackendPerNode only; derived from node labels, the same predicate
+	// the scheduler enforces through the readiness nodeSelector).
+	NodesReady []string
+
+	// PVCAccessModes are the claim's access modes (BackendPVC only).
+	PVCAccessModes []string
+	// PVCTopologyNodes are the nodes satisfying the bound PV's node
+	// affinity; nil means unconstrained (BackendPVC only).
+	PVCTopologyNodes []string
+	// VolumePinned is set for RWO/RWOP-backed models: the volume attaches
+	// to one node at a time, so no surge-shaped mechanism can move the
+	// workload — candidates degrade to advisory (VolumePinned).
+	VolumePinned bool
+	// ResolveError records why availability could not be resolved (e.g.
+	// the model object or PVC is missing); policies treat the model as
+	// having no feasible target and surface the reason.
+	ResolveError string
+}
+
+// PendingPod is one unscheduled GPU demand, real or virtual.
+type PendingPod struct {
+	Namespace string
+	Name      string
+	// ISVC is the owning InferenceService (zero for non-OME pods).
+	ISVC types.NamespacedName
+	// GPUsNeeded is the pod's GPU request.
+	GPUsNeeded int64
+	// NodeSelector is the pod's nodeSelector, retained for pool
+	// attribution.
+	NodeSelector map[string]string
+	// GPUPool is the demand's pool attribution; empty when the pod's
+	// constraints match no single pool (counts toward every pool).
+	GPUPool string
+	// PendingSince is when the pod became unschedulable (drives
+	// pending-pressure urgency).
+	PendingSince time.Time
+	// Virtual marks a blocked evacuation fed back by the engine rather
+	// than a real pod.
+	Virtual bool
+}
+
+// WithVirtualPending derives a snapshot with extra virtual pending pods
+// appended. The receiver is not modified; maps and slices other than
+// PendingPods are shared, which is safe because snapshots are read-only by
+// contract.
+func (s *ClusterSnapshot) WithVirtualPending(virtual []PendingPod) *ClusterSnapshot {
+	if len(virtual) == 0 {
+		return s
+	}
+	derived := *s
+	derived.PendingPods = make([]PendingPod, 0, len(s.PendingPods)+len(virtual))
+	derived.PendingPods = append(derived.PendingPods, s.PendingPods...)
+	derived.PendingPods = append(derived.PendingPods, virtual...)
+	return &derived
+}
+
+// PoolNodes returns the GPU-bearing nodes of one hardware pool, in map order
+// (callers needing determinism sort the result).
+func (s *ClusterSnapshot) PoolNodes(pool string) []*Node {
+	var nodes []*Node
+	for _, n := range s.Nodes {
+		if n.GPUPool == pool && n.TotalGPUs > 0 {
+			nodes = append(nodes, n)
+		}
+	}
+	return nodes
+}
+
+// GPUPools returns the sorted set of hardware pools that have at least one
+// GPU-bearing node.
+func (s *ClusterSnapshot) GPUPools() []string {
+	seen := map[string]struct{}{}
+	var pools []string
+	for _, n := range s.Nodes {
+		if n.TotalGPUs == 0 {
+			continue
+		}
+		if _, ok := seen[n.GPUPool]; !ok {
+			seen[n.GPUPool] = struct{}{}
+			pools = append(pools, n.GPUPool)
+		}
+	}
+	sort.Strings(pools)
+	return pools
+}

--- a/pkg/alfred/testutil/builder.go
+++ b/pkg/alfred/testutil/builder.go
@@ -1,0 +1,256 @@
+// Package testutil provides the shared synthetic ClusterSnapshot harness
+// used by Alfred's policy, arbiter, and chaos tests. Building snapshots
+// directly — no fake clients, no informers — is what keeps every policy a
+// table-testable pure function of the snapshot (OEP-0008).
+package testutil
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// ReferenceTime is the fixed "now" synthetic snapshots are built against, so
+// age-based logic is deterministic in tests.
+var ReferenceTime = time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+// SnapshotBuilder assembles a snapshot.ClusterSnapshot fluently.
+type SnapshotBuilder struct {
+	s          *snapshot.ClusterSnapshot
+	podCounter int
+}
+
+// NewSnapshot returns a builder for an empty cluster at ReferenceTime.
+func NewSnapshot() *SnapshotBuilder {
+	return &SnapshotBuilder{
+		s: &snapshot.ClusterSnapshot{
+			Timestamp:          ReferenceTime,
+			Nodes:              map[string]*snapshot.Node{},
+			Workloads:          map[types.NamespacedName]*snapshot.Workload{},
+			Models:             map[snapshot.ModelKey]*snapshot.ModelAvailability{},
+			OMENativeAvailable: true,
+		},
+	}
+}
+
+// NodeOption mutates a node under construction.
+type NodeOption func(*snapshot.Node)
+
+// NodeUnhealthy marks the node unhealthy with the given trigger conditions
+// (GpuUnhealthy when none given).
+func NodeUnhealthy(conditions ...string) NodeOption {
+	return func(n *snapshot.Node) {
+		n.Unhealthy = true
+		if len(conditions) == 0 {
+			conditions = []string{"GpuUnhealthy"}
+		}
+		n.UnhealthyConditions = append(n.UnhealthyConditions, conditions...)
+	}
+}
+
+// NodeCordoned marks the node cordoned.
+func NodeCordoned() NodeOption { return func(n *snapshot.Node) { n.Cordoned = true } }
+
+// NodePreemptible marks the node spot/preemptible.
+func NodePreemptible() NodeOption { return func(n *snapshot.Node) { n.Preemptible = true } }
+
+// NodeScaleDownDisabled sets the CA scale-down-disabled flag.
+func NodeScaleDownDisabled() NodeOption { return func(n *snapshot.Node) { n.ScaleDownDisabled = true } }
+
+// NodeScaleDownMarked sets the CA to-be-deleted flag.
+func NodeScaleDownMarked() NodeOption { return func(n *snapshot.Node) { n.ScaleDownMarked = true } }
+
+// NodeSuspect puts the node inside a suspicion window.
+func NodeSuspect() NodeOption { return func(n *snapshot.Node) { n.Suspect = true } }
+
+// NodeLabels merges labels onto the node.
+func NodeLabels(labels map[string]string) NodeOption {
+	return func(n *snapshot.Node) {
+		for k, v := range labels {
+			n.Labels[k] = v
+		}
+	}
+}
+
+// WithNode adds a GPU node of the given hardware pool and size. Each
+// node may be defined once: redefining a name would silently discard the
+// occupancy other builder calls already accumulated on it (AllocatedGPUs,
+// OMEPods, OtherOccupants) while workload pods keep referencing the node —
+// an inconsistent snapshot. Use ConfigureNode to mutate an existing node.
+func (b *SnapshotBuilder) WithNode(name, pool string, totalGPUs int64, opts ...NodeOption) *SnapshotBuilder {
+	if _, exists := b.s.Nodes[name]; exists {
+		panic(fmt.Sprintf("testutil: node %q already defined; use ConfigureNode to modify it", name))
+	}
+	n := &snapshot.Node{
+		Name:        name,
+		Labels:      map[string]string{},
+		GPUPool:     pool,
+		GPUResource: constants.NvidiaGPUResourceType,
+		TotalGPUs:   totalGPUs,
+	}
+	for _, opt := range opts {
+		opt(n)
+	}
+	b.s.Nodes[name] = n
+	return b
+}
+
+// WithOMENative sets the snapshot's OMENative availability.
+func (b *SnapshotBuilder) WithOMENative(available bool) *SnapshotBuilder {
+	b.s.OMENativeAvailable = available
+	return b
+}
+
+// WithOtherOccupant places a non-OME GPU pod (a notebook, a batch job) on a
+// node: it counts against capacity but is never a candidate.
+func (b *SnapshotBuilder) WithOtherOccupant(node string, gpus int64) *SnapshotBuilder {
+	n := b.mustNode(node)
+	pod := snapshot.PodInfo{
+		Namespace: "other",
+		Name:      b.nextPodName("occupant"),
+		Node:      node,
+		GPUs:      gpus,
+		Ready:     true,
+	}
+	n.OtherOccupants = append(n.OtherOccupants, pod)
+	n.AllocatedGPUs += gpus
+	return b
+}
+
+// WithInstance adds one single-pod Instance of a workload's component on a
+// node, creating the workload and component as needed. The workload key is
+// "namespace/name".
+func (b *SnapshotBuilder) WithInstance(workload string, ctype v1beta1.ComponentType, mode constants.DeploymentModeType, node string, gpus int64) *SnapshotBuilder {
+	return b.WithMultiPodInstance(workload, ctype, mode, gpus, node)
+}
+
+// WithMultiPodInstance adds one Instance whose pods (gpusPerPod each) sit on
+// the given nodes — an atomic multi-pod group when len(nodes) > 1.
+func (b *SnapshotBuilder) WithMultiPodInstance(workload string, ctype v1beta1.ComponentType, mode constants.DeploymentModeType, gpusPerPod int64, nodes ...string) *SnapshotBuilder {
+	w := b.ensureWorkload(workload)
+	component, ok := w.Components[ctype]
+	if !ok {
+		component = &snapshot.Component{Type: ctype, DeploymentMode: mode}
+		w.Components[ctype] = component
+	}
+	component.DeploymentMode = mode
+
+	inst := &snapshot.Instance{
+		Index:    int32(len(component.Instances)),
+		NodesSet: map[string]int{},
+	}
+	for _, nodeName := range nodes {
+		n := b.mustNode(nodeName)
+		pod := snapshot.PodInfo{
+			Namespace: w.NamespacedName.Namespace,
+			Name:      b.nextPodName(w.NamespacedName.Name + "-" + string(ctype)),
+			Node:      nodeName,
+			GPUs:      gpusPerPod,
+			Ready:     true,
+			ISVC:      w.NamespacedName,
+			Component: ctype,
+		}
+		start := ReferenceTime.Add(-24 * time.Hour)
+		pod.StartTime = &start
+		inst.Pods = append(inst.Pods, pod)
+		inst.NodesSet[nodeName]++
+		inst.TotalGPUs += gpusPerPod
+		inst.ReadyPods++
+		if gpusPerPod > 0 {
+			n.AllocatedGPUs += gpusPerPod
+			n.OMEPods = append(n.OMEPods, pod)
+		}
+	}
+	component.Instances = append(component.Instances, inst)
+	return b
+}
+
+// WithPendingPod adds a real pending GPU pod that has waited for age.
+func (b *SnapshotBuilder) WithPendingPod(gpus int64, age time.Duration, pool string) *SnapshotBuilder {
+	b.s.PendingPods = append(b.s.PendingPods, snapshot.PendingPod{
+		Namespace:    "pending",
+		Name:         b.nextPodName("pending"),
+		GPUsNeeded:   gpus,
+		GPUPool:      pool,
+		PendingSince: ReferenceTime.Add(-age),
+	})
+	return b
+}
+
+// WithModel registers model availability and points a workload at it.
+func (b *SnapshotBuilder) WithModel(workload string, avail *snapshot.ModelAvailability) *SnapshotBuilder {
+	w := b.ensureWorkload(workload)
+	w.ModelKey = avail.Key
+	b.s.Models[avail.Key] = avail
+	return b
+}
+
+// ConfigureWorkload applies arbitrary mutations to a workload (movable,
+// priority, cooldown state, active migrations, ...), creating it if needed.
+func (b *SnapshotBuilder) ConfigureWorkload(workload string, fn func(*snapshot.Workload)) *SnapshotBuilder {
+	fn(b.ensureWorkload(workload))
+	return b
+}
+
+// ConfigureNode applies arbitrary mutations to an existing node.
+func (b *SnapshotBuilder) ConfigureNode(node string, fn func(*snapshot.Node)) *SnapshotBuilder {
+	fn(b.mustNode(node))
+	return b
+}
+
+// Build finalizes derived fields (free GPUs, ordering) and returns the
+// snapshot. The builder must not be reused afterwards.
+func (b *SnapshotBuilder) Build() *snapshot.ClusterSnapshot {
+	for _, n := range b.s.Nodes {
+		n.FreeGPUs = n.TotalGPUs - n.AllocatedGPUs
+		if n.FreeGPUs < 0 {
+			n.FreeGPUs = 0
+		}
+	}
+	sort.Slice(b.s.PendingPods, func(i, j int) bool {
+		if b.s.PendingPods[i].Namespace != b.s.PendingPods[j].Namespace {
+			return b.s.PendingPods[i].Namespace < b.s.PendingPods[j].Namespace
+		}
+		return b.s.PendingPods[i].Name < b.s.PendingPods[j].Name
+	})
+	return b.s
+}
+
+func (b *SnapshotBuilder) ensureWorkload(key string) *snapshot.Workload {
+	parts := strings.Split(key, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		panic(fmt.Sprintf("testutil: workload key %q must be namespace/name", key))
+	}
+	name := types.NamespacedName{Namespace: parts[0], Name: parts[1]}
+	if w, ok := b.s.Workloads[name]; ok {
+		return w
+	}
+	w := &snapshot.Workload{
+		NamespacedName: name,
+		Components:     map[v1beta1.ComponentType]*snapshot.Component{},
+		Movable:        true,
+		Priority:       0.5,
+	}
+	b.s.Workloads[name] = w
+	return w
+}
+
+func (b *SnapshotBuilder) mustNode(name string) *snapshot.Node {
+	n, ok := b.s.Nodes[name]
+	if !ok {
+		panic(fmt.Sprintf("testutil: node %q not defined; call WithNode first", name))
+	}
+	return n
+}
+
+func (b *SnapshotBuilder) nextPodName(prefix string) string {
+	b.podCounter++
+	return fmt.Sprintf("%s-%d", prefix, b.podCounter)
+}

--- a/pkg/alfred/testutil/builder_test.go
+++ b/pkg/alfred/testutil/builder_test.go
@@ -1,0 +1,90 @@
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+func TestSnapshotBuilder(t *testing.T) {
+	snap := NewSnapshot().
+		WithNode("node1", "h100", 8).
+		WithNode("node2", "h100", 8, NodeUnhealthy()).
+		WithNode("node3", "a100", 4, NodeCordoned(), NodePreemptible()).
+		WithInstance("prod/svc-a", v1beta1.EngineComponent, constants.RawDeployment, "node1", 2).
+		WithMultiPodInstance("prod/svc-b", v1beta1.EngineComponent, constants.OMENative, 8, "node1", "node2").
+		WithOtherOccupant("node2", 3).
+		WithPendingPod(8, 20*time.Minute, "h100").
+		ConfigureWorkload("prod/svc-a", func(w *snapshot.Workload) { w.Movable = false }).
+		Build()
+
+	node1 := snap.Nodes["node1"]
+	if node1.AllocatedGPUs != 10 || node1.FreeGPUs != 0 {
+		t.Fatalf("node1: allocated=%d free=%d, want 10/0 (floored)", node1.AllocatedGPUs, node1.FreeGPUs)
+	}
+	node2 := snap.Nodes["node2"]
+	if node2.AllocatedGPUs != 11 || node2.FreeGPUs != 0 || !node2.Unhealthy {
+		t.Fatalf("node2: %+v", node2)
+	}
+	if !snap.Nodes["node3"].Cordoned || !snap.Nodes["node3"].Preemptible {
+		t.Fatalf("node3 flags: %+v", snap.Nodes["node3"])
+	}
+
+	svcA := snap.Workloads[types.NamespacedName{Namespace: "prod", Name: "svc-a"}]
+	if svcA.Movable {
+		t.Fatal("ConfigureWorkload should have set Movable=false")
+	}
+	if len(svcA.Components[v1beta1.EngineComponent].Instances) != 1 {
+		t.Fatalf("svc-a instances: %+v", svcA.Components[v1beta1.EngineComponent].Instances)
+	}
+
+	svcB := snap.Workloads[types.NamespacedName{Namespace: "prod", Name: "svc-b"}]
+	inst := svcB.Components[v1beta1.EngineComponent].Instances[0]
+	if inst.TotalGPUs != 16 || len(inst.Pods) != 2 || inst.NodesSet["node1"] != 1 || inst.NodesSet["node2"] != 1 {
+		t.Fatalf("multi-pod instance: %+v", inst)
+	}
+
+	if len(snap.PendingPods) != 1 || snap.PendingPods[0].GPUsNeeded != 8 {
+		t.Fatalf("pending: %+v", snap.PendingPods)
+	}
+	if got := snap.PendingPods[0].PendingSince; !got.Equal(ReferenceTime.Add(-20 * time.Minute)) {
+		t.Fatalf("pending age: %v", got)
+	}
+}
+
+// A workload key must be exactly namespace/name with both segments non-empty;
+// anything else would mint an invalid synthetic NamespacedName.
+func TestEnsureWorkloadRejectsMalformedKeys(t *testing.T) {
+	for _, key := range []string{"prod/", "/svc", "prod/svc/extra", "plain", ""} {
+		t.Run(key, func(t *testing.T) {
+			b := NewSnapshot().WithNode("node1", "h100", 8)
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("workload key %q must panic", key)
+				}
+			}()
+			b.WithInstance(key, v1beta1.EngineComponent, constants.RawDeployment, "node1", 1)
+		})
+	}
+}
+
+// Redefining a node would silently discard occupancy accumulated by earlier
+// builder calls while workload pods keep referencing it; the builder must
+// refuse instead of producing an inconsistent snapshot.
+func TestWithNodeRejectsRedefinition(t *testing.T) {
+	b := NewSnapshot().
+		WithNode("node1", "h100", 8).
+		WithInstance("prod/svc-a", v1beta1.EngineComponent, constants.RawDeployment, "node1", 2)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("duplicate WithNode must panic, not overwrite the node")
+		}
+	}()
+	b.WithNode("node1", "h100", 8)
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -12,11 +12,14 @@ import (
 	"knative.dev/pkg/network"
 )
 
+// OMEAPIGroupName is the OME API group and the prefix of every ome.io
+// annotation key.
+const OMEAPIGroupName = "ome.io"
+
 // OME Constants
 var (
-	OMEName         = "ome"
-	OMEAPIGroupName = "ome.io"
-	OMENamespace    = getEnvOrDefault("POD_NAMESPACE", "ome")
+	OMEName      = "ome"
+	OMENamespace = getEnvOrDefault("POD_NAMESPACE", "ome")
 )
 
 // Runtime revision (ServingRuntime spec snapshot) constants. OME snapshots a
@@ -185,6 +188,39 @@ var (
 	BaseModelDecryptionKeyName    = OMEAPIGroupName + "/base-model-decryption-key-name"
 	BaseModelDecryptionSecretName = OMEAPIGroupName + "/base-model-decryption-secret-name"
 	DisableModelDecryption        = OMEAPIGroupName + "/disable-model-decryption"
+)
+
+// Migration-request contract and Alfred caretaker annotations (OEP-0008).
+const (
+	// MigrationRequestAnnotationPrefix prefixes the UUID-suffixed
+	// migration-request annotations (`ome.io/migration-request-v1-<uuid>`)
+	// written by Alfred's dispatcher onto an InferenceService. The
+	// controller that owns the addressed component consumes the request,
+	// executes the move, clears the annotation, and records the outcome in
+	// Status.MigrationHistory. Wire payload in pkg/migration.
+	MigrationRequestAnnotationPrefix = OMEAPIGroupName + "/migration-request-v1-"
+
+	// AlfredAPIGroupName groups the per-workload caretaker annotations an
+	// operator sets on an InferenceService to gate Alfred's policies.
+	AlfredAPIGroupName = "alfred.ome.io"
+	// AlfredMovableAnnotationKey opts a workload out of ("false") or into
+	// ("true") every Alfred policy; wins over the cluster-wide default.
+	AlfredMovableAnnotationKey = AlfredAPIGroupName + "/movable"
+	// AlfredPriorityAnnotationKey is a float in [0, 1]; lower = more
+	// protected when Alfred orders candidates.
+	AlfredPriorityAnnotationKey = AlfredAPIGroupName + "/priority"
+	// AlfredCooldownMinutesAnnotationKey overrides the per-workload
+	// migration cooldown for this workload.
+	AlfredCooldownMinutesAnnotationKey = AlfredAPIGroupName + "/cooldown-minutes"
+	// AlfredOptOutReasonAnnotationKey is a free-text operator note
+	// explaining an opt-out; surfaced in events, never parsed.
+	AlfredOptOutReasonAnnotationKey = AlfredAPIGroupName + "/opt-out-reason"
+	// AlfredTenantGroupAnnotationKey opts same-group workloads across
+	// namespaces into cross-tenant optimization.
+	AlfredTenantGroupAnnotationKey = AlfredAPIGroupName + "/tenant-group"
+	// AlfredSpotPolicyAnnotationKey overrides the cluster spot policy for
+	// this workload: avoid | migrate | ignore.
+	AlfredSpotPolicyAnnotationKey = AlfredAPIGroupName + "/spot-policy"
 )
 
 // Label Constants

--- a/pkg/migration/request.go
+++ b/pkg/migration/request.go
@@ -1,0 +1,180 @@
+// Package migration defines the OEP-0008 migration-request wire contract:
+// the UUID-keyed `ome.io/migration-request-v1-<uuid>` InferenceService
+// annotation and its JSON payload.
+//
+// The contract is shared by three parties:
+//   - Alfred (the caretaker): its dispatcher writes requests, and its
+//     snapshot builder parses in-flight ones.
+//   - The InferenceService controller: executes requests addressed to
+//     RawDeployment components and acks by clearing the annotation and
+//     appending a Status.MigrationHistory entry.
+//   - A future OMENative controller: executes requests addressed to
+//     OMENative Instances through the same annotation.
+//
+// Requests are idempotent by UUID: re-writing the same key with the same
+// payload is a no-op for a consumer already processing it, and a consumer
+// finding the UUID terminal in MigrationHistory clears the key silently.
+package migration
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// SchemaVersionV1 is the only request schema version defined today.
+// Consumers must reject unknown versions explicitly (additive unknown fields
+// within a version are ignored; behavior-changing fields require a new
+// version).
+const SchemaVersionV1 = "v1"
+
+// ErrUnsupportedSchemaVersion is wrapped by Validate for requests carrying a
+// schema version the consumer does not implement, so executors can branch on
+// it (errors.Is) and surface `UnsupportedSchemaVersion` outcomes.
+var ErrUnsupportedSchemaVersion = errors.New("unsupported migration-request schema version")
+
+// componentValues mirrors the v1beta1 ComponentType enum. Kept as strings so
+// the wire package stays free of API-type dependencies.
+var componentValues = map[string]struct{}{
+	"engine":  {},
+	"decoder": {},
+	"router":  {},
+}
+
+// Request is the JSON payload stored as the value of a
+// `ome.io/migration-request-v1-<uuid>` annotation.
+type Request struct {
+	// SchemaVersion is the wire-contract version; always "v1" today.
+	SchemaVersion string `json:"schemaVersion"`
+	// Component addresses one component of the InferenceService
+	// (engine, decoder, or router).
+	Component string `json:"component"`
+	// Instance is the Instance index the request addresses. For a
+	// RawDeployment component the executor treats it as advisory (the
+	// pod is located by FromNode, not by index).
+	Instance int32 `json:"instance"`
+	// Reason records why the requester wants the move
+	// (e.g. "fragmentation", "nodeUnhealthy").
+	Reason string `json:"reason,omitempty"`
+	// FromNode is the node the addressed Instance should leave.
+	FromNode string `json:"fromNode"`
+	// HintTargetNodes is a ranked, advisory list of preferred
+	// destinations; the scheduler makes the final placement.
+	HintTargetNodes []string `json:"hintTargetNodes,omitempty"`
+	// RequestedAt is when the requester created this request; consumers
+	// auto-clear requests that stay unacknowledged past the stale window.
+	RequestedAt metav1.Time `json:"requestedAt"`
+	// RequestedBy identifies the writer (e.g. "alfred-controller").
+	RequestedBy string `json:"requestedBy,omitempty"`
+}
+
+// Parsed is one well-formed request extracted from an annotation map.
+type Parsed struct {
+	// UUID is the request identity, taken from the annotation-key suffix.
+	UUID    string
+	Request Request
+}
+
+// Malformed is one request annotation that could not be parsed or failed
+// validation. Consumers ack-reject these (clear the key, record the error)
+// rather than ignoring them, so a bad write cannot linger forever.
+type Malformed struct {
+	Key  string
+	UUID string
+	Err  error
+}
+
+// AnnotationKey returns the annotation key for a request UUID.
+func AnnotationKey(uuid string) string {
+	return constants.MigrationRequestAnnotationPrefix + uuid
+}
+
+// IsAnnotationKey reports whether key is a migration-request annotation.
+//
+// The suffix is deliberately an opaque request identity, not a
+// format-validated UUID. Consumers must see every prefixed key so their
+// parse/GC step can ack-reject garbage by clearing it — a key-level format
+// filter would make a bad write invisible and leave it lingering on the
+// InferenceService forever. Correctness is gated by payload validation
+// (Validate), and idempotency only needs suffix equality, not RFC-4122 form.
+func IsAnnotationKey(key string) bool {
+	return strings.HasPrefix(key, constants.MigrationRequestAnnotationPrefix) &&
+		len(key) > len(constants.MigrationRequestAnnotationPrefix)
+}
+
+// UUIDFromAnnotationKey extracts the request UUID from an annotation key.
+func UUIDFromAnnotationKey(key string) (string, bool) {
+	if !IsAnnotationKey(key) {
+		return "", false
+	}
+	return key[len(constants.MigrationRequestAnnotationPrefix):], true
+}
+
+// Marshal renders the request as its annotation value.
+func (r *Request) Marshal() (string, error) {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// Validate checks the request against the v1 contract.
+func (r *Request) Validate() error {
+	if r.SchemaVersion != SchemaVersionV1 {
+		return fmt.Errorf("%w: %q", ErrUnsupportedSchemaVersion, r.SchemaVersion)
+	}
+	if _, ok := componentValues[r.Component]; !ok {
+		return fmt.Errorf("unknown component %q (want engine, decoder, or router)", r.Component)
+	}
+	if r.FromNode == "" {
+		return errors.New("fromNode must be set")
+	}
+	if r.Instance < 0 {
+		return fmt.Errorf("instance must be >= 0, got %d", r.Instance)
+	}
+	if r.RequestedAt.IsZero() {
+		return errors.New("requestedAt must be set")
+	}
+	return nil
+}
+
+// ExtractRequests scans an annotation map for migration-request keys and
+// splits them into well-formed and malformed requests. Well-formed requests
+// are returned oldest-first (by RequestedAt, then UUID) so consumers process
+// deterministically; malformed ones are returned sorted by key.
+func ExtractRequests(annotations map[string]string) ([]Parsed, []Malformed) {
+	var valid []Parsed
+	var malformed []Malformed
+	for key, value := range annotations {
+		uuid, ok := UUIDFromAnnotationKey(key)
+		if !ok {
+			continue
+		}
+		var req Request
+		if err := json.Unmarshal([]byte(value), &req); err != nil {
+			malformed = append(malformed, Malformed{Key: key, UUID: uuid, Err: fmt.Errorf("invalid JSON payload: %w", err)})
+			continue
+		}
+		if err := req.Validate(); err != nil {
+			malformed = append(malformed, Malformed{Key: key, UUID: uuid, Err: err})
+			continue
+		}
+		valid = append(valid, Parsed{UUID: uuid, Request: req})
+	}
+	sort.Slice(valid, func(i, j int) bool {
+		ti, tj := valid[i].Request.RequestedAt.Time, valid[j].Request.RequestedAt.Time
+		if !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+		return valid[i].UUID < valid[j].UUID
+	})
+	sort.Slice(malformed, func(i, j int) bool { return malformed[i].Key < malformed[j].Key })
+	return valid, malformed
+}

--- a/pkg/migration/request_test.go
+++ b/pkg/migration/request_test.go
@@ -1,0 +1,152 @@
+package migration
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+var testTime = metav1.NewTime(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+
+func validRequest() Request {
+	return Request{
+		SchemaVersion:   SchemaVersionV1,
+		Component:       "engine",
+		Instance:        0,
+		Reason:          "fragmentation",
+		FromNode:        "node1",
+		HintTargetNodes: []string{"node3", "node7"},
+		RequestedAt:     testTime,
+		RequestedBy:     "alfred-controller",
+	}
+}
+
+func TestAnnotationKeyRoundtrip(t *testing.T) {
+	key := AnnotationKey("abc-123")
+	if key != constants.MigrationRequestAnnotationPrefix+"abc-123" {
+		t.Fatalf("unexpected key %q", key)
+	}
+	if !IsAnnotationKey(key) {
+		t.Fatalf("IsAnnotationKey(%q) = false", key)
+	}
+	uuid, ok := UUIDFromAnnotationKey(key)
+	if !ok || uuid != "abc-123" {
+		t.Fatalf("UUIDFromAnnotationKey(%q) = %q, %v", key, uuid, ok)
+	}
+}
+
+func TestIsAnnotationKeyRejectsNonRequests(t *testing.T) {
+	for _, key := range []string{
+		"ome.io/deploymentMode",
+		"ome.io/migration-restart",
+		constants.MigrationRequestAnnotationPrefix, // prefix with no UUID
+		"alfred.ome.io/movable",
+	} {
+		if IsAnnotationKey(key) {
+			t.Errorf("IsAnnotationKey(%q) = true, want false", key)
+		}
+	}
+}
+
+func TestMarshalParseRoundtrip(t *testing.T) {
+	req := validRequest()
+	payload, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	valid, malformed := ExtractRequests(map[string]string{AnnotationKey("u1"): payload})
+	if len(malformed) != 0 {
+		t.Fatalf("unexpected malformed: %+v", malformed)
+	}
+	if len(valid) != 1 || valid[0].UUID != "u1" {
+		t.Fatalf("unexpected valid: %+v", valid)
+	}
+	got := valid[0].Request
+	if got.Component != "engine" || got.FromNode != "node1" || len(got.HintTargetNodes) != 2 || !got.RequestedAt.Equal(&testTime) {
+		t.Fatalf("roundtrip mismatch: %+v", got)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*Request)
+		wantErr bool
+		wantIs  error
+	}{
+		{name: "valid", mutate: func(r *Request) {}},
+		{name: "unsupported schema", mutate: func(r *Request) { r.SchemaVersion = "v2" }, wantErr: true, wantIs: ErrUnsupportedSchemaVersion},
+		{name: "unknown component", mutate: func(r *Request) { r.Component = "sidecar" }, wantErr: true},
+		{name: "missing fromNode", mutate: func(r *Request) { r.FromNode = "" }, wantErr: true},
+		{name: "negative instance", mutate: func(r *Request) { r.Instance = -1 }, wantErr: true},
+		{name: "missing requestedAt", mutate: func(r *Request) { r.RequestedAt = metav1.Time{} }, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validRequest()
+			tc.mutate(&req)
+			err := req.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("want error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want nil, got %v", err)
+			}
+			if tc.wantIs != nil && !errors.Is(err, tc.wantIs) {
+				t.Fatalf("want errors.Is(%v), got %v", tc.wantIs, err)
+			}
+		})
+	}
+}
+
+func TestExtractRequestsSplitsAndSorts(t *testing.T) {
+	older := validRequest()
+	older.RequestedAt = metav1.NewTime(testTime.Add(-time.Hour))
+	olderPayload, _ := older.Marshal()
+
+	newer := validRequest()
+	newerPayload, _ := newer.Marshal()
+
+	badSchema := validRequest()
+	badSchema.SchemaVersion = "v9"
+	badSchemaPayload, _ := badSchema.Marshal()
+
+	annotations := map[string]string{
+		AnnotationKey("newer"):  newerPayload,
+		AnnotationKey("older"):  olderPayload,
+		AnnotationKey("json"):   "{not-json",
+		AnnotationKey("schema"): badSchemaPayload,
+		"ome.io/deploymentMode": "RawDeployment", // ignored
+	}
+	valid, malformed := ExtractRequests(annotations)
+
+	if len(valid) != 2 || valid[0].UUID != "older" || valid[1].UUID != "newer" {
+		t.Fatalf("want [older newer], got %+v", valid)
+	}
+	if len(malformed) != 2 {
+		t.Fatalf("want 2 malformed, got %+v", malformed)
+	}
+	if malformed[0].UUID != "json" || malformed[1].UUID != "schema" {
+		t.Fatalf("malformed order/content mismatch: %+v", malformed)
+	}
+	if !errors.Is(malformed[1].Err, ErrUnsupportedSchemaVersion) {
+		t.Fatalf("schema malformed should wrap ErrUnsupportedSchemaVersion, got %v", malformed[1].Err)
+	}
+}
+
+func TestExtractRequestsTiesBreakOnUUID(t *testing.T) {
+	a, b := validRequest(), validRequest()
+	payloadA, _ := a.Marshal()
+	payloadB, _ := b.Marshal()
+	valid, _ := ExtractRequests(map[string]string{
+		AnnotationKey("bbb"): payloadB,
+		AnnotationKey("aaa"): payloadA,
+	})
+	if len(valid) != 2 || valid[0].UUID != "aaa" || valid[1].UUID != "bbb" {
+		t.Fatalf("want UUID tie-break [aaa bbb], got %+v", valid)
+	}
+}


### PR DESCRIPTION
## What this PR does

First change set for OEP-0008 (Alfred GPU Cluster Caretaker): the read-only
foundation every later stage builds on. No controller wiring — nothing consumes
these packages yet, and there is no behavior change to existing components.

- **`pkg/migration`** — the migration-request wire contract
  (`ome.io/migration-request-v1-<uuid>` annotation payload), shared by its three
  parties: Alfred's dispatcher (writer), the InferenceService controller
  executor (consumer, future PR), and a future OMENative controller. UUID-keyed
  and idempotent, schema-versioned (`v1`, unknown versions rejected explicitly),
  with deterministic oldest-first extraction and validation.
- **`pkg/constants`** — the request-annotation prefix and the `alfred.ome.io/*`
  per-workload caretaker keys (`movable`, `priority`, `cooldown-minutes`,
  `opt-out-reason`, `tenant-group`, `spot-policy`).
- **`pkg/alfred/snapshot`** — the immutable `ClusterSnapshot` read surface:
  - Per-node GPU accounting computed from `node.status.allocatable` minus
    non-terminal pod requests (terminating pods tracked separately); Alfred owns
    its GPU resource-name set (`nvidia.com/gpu`, `nvidia.com/mig-*`,
    `amd.com/gpu`, `gpu.intel.com/*`).
  - Node flags: unhealthy per configurable trigger conditions (default
    `GpuUnhealthy`), cordon, cluster-autoscaler scale-down markers, and
    spot/preemptible labels.
  - Accelerator-class membership from `AcceleratorClass.Status.Nodes` (the only
    populated status field; the dead accelerator-count fields are never read).
  - Workloads → components → instances: one instance per pod for RawDeployment,
    one atomic group for multi-pod modes; per-workload annotation overrides.
  - In-flight migrations reconstructed from request annotations plus
    `Status.MigrationHistory` — durable cluster state, so Alfred leader failover
    re-derives instead of resuming.
  - Storage-aware model availability: per-node readiness from node labels via
    `constants.GetClusterBaseModelLabel`/`GetBaseModelLabel` (SHA-truncation
    safe); PVC-backed models resolve access modes and PV CSI topology instead,
    with RWO/RWOP volumes marked `VolumePinned` (no surge-shaped mechanism can
    move them).
  - Pending GPU pods with age and accelerator-class attribution.
- **`pkg/alfred/testutil`** — the synthetic snapshot harness later policy,
  arbiter, and chaos tests build on.

## Testing

- Unit tests for the wire contract, GPU accounting, PVC/node-affinity matching,
  and a fake-client end-to-end builder scenario (mixed healthy/unhealthy/spot
  nodes, OME + non-OME occupants, terminating and pending pods, per-node and
  RWO-PVC models, active + historical migrations).
- `go build ./...`, `go vet`, and the existing InferenceService controller
  suite (with `KUBEBUILDER_ASSETS`) all pass.

## Notes

Part of a stacked series implementing the OEP-0008 Alpha scope:
snapshot foundation (this PR) → Alfred binary + observation loop → defrag
scoring. Design: `oeps/0008-alfred-gpu-cluster-caretaker/README.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cluster snapshot capabilities covering node health, GPU capacity, workload occupancy, pending demand, migrations, and hardware pools.
  - Added GPU detection and accounting across supported resource names and accelerator types.
  - Added model readiness and PVC-backed model availability tracking, including storage topology and resolution errors.
  - Added standardized migration request handling with validation, ordering, and malformed-request reporting.
- **Tests**
  - Added comprehensive coverage for snapshots, GPU accounting, model availability, storage matching, migration requests, and synthetic test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->