### PR TITLE
[Core] Alfred binary skeleton and observation loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,13 @@ ome-manager: xet-build ## 🏗️  Build ome-manager binary.
 	$(GO_BUILD_ENV) $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o bin/manager ./cmd/manager
 	@echo "✅ Build complete"
 
+.PHONY: alfred
+alfred: ## 🎩 Build alfred (GPU cluster caretaker) binary.
+	@echo "🎩 Building alfred..."
+	@mkdir -p bin
+	CGO_ENABLED=0 $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o bin/alfred ./cmd/alfred
+	@echo "✅ Build complete"
+
 .PHONY: model-agent
 model-agent: xet-build ## 🤖 Build model-agent binary.
 	@echo "🤖 Building model-agent..."

--- a/cmd/alfred/main.go
+++ b/cmd/alfred/main.go
@@ -1,0 +1,259 @@
+// Alfred is the OME GPU cluster caretaker (OEP-0008): a leader-elected
+// controller that observes the physical GPU layer, recommends corrective
+// migrations, and — only in execute mode — actuates them through the
+// migration-request annotation executed by the workload-owning controllers.
+//
+// This binary wires two loops onto a controller-runtime manager:
+//   - the observation loop (every replica): snapshot + gauges, read-only;
+//   - the decision loop (leader only): policies → arbiter → reporter →
+//     dispatcher (added by later change sets).
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/metrics"
+	"sigs.k8s.io/ome/pkg/alfred/observer"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("alfred-setup")
+)
+
+// Leader-election parameters per OEP-0008 §Leader election (mirrors
+// cluster-autoscaler's pattern).
+const (
+	leaderElectionID = "alfred.ome.io"
+	leaseDuration    = 15 * time.Second
+	renewDeadline    = 10 * time.Second
+	retryPeriod      = 2 * time.Second
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
+}
+
+// Options holds the command-line configuration.
+type Options struct {
+	metricsAddr          string
+	probeAddr            string
+	enableLeaderElection bool
+	namespace            string
+	configMapName        string
+	configMapKey         string
+	zapOpts              zap.Options
+}
+
+// DefaultOptions returns the flag defaults. The namespace defaults from the
+// POD_NAMESPACE downward-API variable so the deployment needs no explicit
+// flag.
+func DefaultOptions() Options {
+	return Options{
+		metricsAddr:          ":8080",
+		probeAddr:            ":8081",
+		enableLeaderElection: true,
+		namespace:            constants.OMENamespace,
+		configMapName:        "alfred-config",
+		configMapKey:         "config.yaml",
+	}
+}
+
+// GetOptions parses flags into Options.
+func GetOptions() Options {
+	opts := DefaultOptions()
+	flag.StringVar(&opts.metricsAddr, "metrics-bind-address", opts.metricsAddr, "The address the metric endpoint binds to.")
+	flag.StringVar(&opts.probeAddr, "health-probe-bind-address", opts.probeAddr, "The address the probe endpoint binds to.")
+	flag.BoolVar(&opts.enableLeaderElection, "leader-elect", opts.enableLeaderElection,
+		"Enable leader election. Only the leader runs the decision loop; all replicas observe.")
+	flag.StringVar(&opts.namespace, "namespace", opts.namespace,
+		"Namespace holding Alfred's ConfigMaps and leader-election Lease.")
+	flag.StringVar(&opts.configMapName, "config-name", opts.configMapName, "Name of the Alfred configuration ConfigMap.")
+	flag.StringVar(&opts.configMapKey, "config-key", opts.configMapKey, "Key inside the ConfigMap holding config.yaml.")
+	opts.zapOpts.BindFlags(flag.CommandLine)
+	flag.Parse()
+	return opts
+}
+
+func main() {
+	opts := GetOptions()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts.zapOpts)))
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), manager.Options{
+		Scheme:                  scheme,
+		Metrics:                 metricsserver.Options{BindAddress: opts.metricsAddr},
+		HealthProbeBindAddress:  opts.probeAddr,
+		LeaderElection:          opts.enableLeaderElection,
+		LeaderElectionID:        leaderElectionID,
+		LeaderElectionNamespace: opts.namespace,
+		LeaseDuration:           ptr(leaseDuration),
+		RenewDeadline:           ptr(renewDeadline),
+		RetryPeriod:             ptr(retryPeriod),
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				// Alfred reads ConfigMaps only in its own namespace
+				// (alfred-config, alfred-recommendations); do not
+				// cache the rest of the cluster's ConfigMaps.
+				&corev1.ConfigMap{}: {
+					Namespaces: map[string]cache.Config{opts.namespace: {}},
+				},
+				// The pod cache is cluster-wide by design (non-OME
+				// GPU occupants count against capacity); the
+				// transform bounds its memory cost.
+				&corev1.Pod{}: {Transform: podCacheTransform},
+			},
+		},
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to create manager")
+		os.Exit(1)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, "spec.nodeName",
+		func(obj client.Object) []string {
+			pod := obj.(*corev1.Pod)
+			if pod.Spec.NodeName == "" {
+				return nil
+			}
+			return []string{pod.Spec.NodeName}
+		}); err != nil {
+		setupLog.Error(err, "unable to index pods by spec.nodeName")
+		os.Exit(1)
+	}
+
+	alfredMetrics := metrics.New(nil)
+	store := config.NewStore()
+
+	watcher := &config.Watcher{
+		Cache:     mgr.GetCache(),
+		Namespace: opts.namespace,
+		Name:      opts.configMapName,
+		Key:       opts.configMapKey,
+		Store:     store,
+		Log:       ctrl.Log.WithName("alfred-config"),
+		Recorder:  mgr.GetEventRecorderFor("alfred"),
+		Observer:  alfredMetrics,
+	}
+	if err := mgr.Add(watcher); err != nil {
+		setupLog.Error(err, "unable to add config watcher")
+		os.Exit(1)
+	}
+
+	observationLoop := &observer.Loop{
+		Reader:  mgr.GetClient(),
+		Store:   store,
+		Metrics: alfredMetrics,
+		Log:     ctrl.Log.WithName("alfred-observer"),
+	}
+	if err := mgr.Add(observationLoop); err != nil {
+		setupLog.Error(err, "unable to add observation loop")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	ctx := ctrl.SetupSignalHandler()
+
+	// alfred_leader_status: 0 on every replica until this one wins the
+	// Lease; only the leader runs the decision loop.
+	go func() {
+		pod := podIdentity()
+		alfredMetrics.LeaderStatus.WithLabelValues(pod).Set(0)
+		select {
+		case <-mgr.Elected():
+			alfredMetrics.LeaderStatus.WithLabelValues(pod).Set(1)
+		case <-ctx.Done():
+		}
+	}()
+
+	setupLog.Info("starting alfred",
+		"namespace", opts.namespace, "config", opts.configMapName, "leaderElection", opts.enableLeaderElection)
+	if err := mgr.Start(ctx); err != nil {
+		setupLog.Error(err, "problem running alfred")
+		os.Exit(1)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func podIdentity() string {
+	if pod := os.Getenv("POD_NAME"); pod != "" {
+		return pod
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return hostname
+}
+
+// podCacheTransform strips the pod fields the snapshot never reads before
+// they enter the informer cache. Caching every pod in a large cluster is
+// Alfred's dominant memory cost; this keeps only scheduling-relevant state:
+// labels, node name, node selector, container resources, phase, conditions,
+// start/deletion timestamps.
+func podCacheTransform(obj interface{}) (interface{}, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+	pod.ManagedFields = nil
+	pod.Annotations = nil
+	pod.OwnerReferences = nil
+
+	trimContainers := func(containers []corev1.Container) {
+		for i := range containers {
+			c := &containers[i]
+			c.Command = nil
+			c.Args = nil
+			c.Env = nil
+			c.EnvFrom = nil
+			c.VolumeMounts = nil
+			c.VolumeDevices = nil
+			c.Ports = nil
+			c.Lifecycle = nil
+			c.LivenessProbe = nil
+			c.ReadinessProbe = nil
+			c.StartupProbe = nil
+			c.SecurityContext = nil
+		}
+	}
+	trimContainers(pod.Spec.Containers)
+	trimContainers(pod.Spec.InitContainers)
+	pod.Spec.EphemeralContainers = nil
+	pod.Spec.Volumes = nil
+	pod.Spec.ImagePullSecrets = nil
+	pod.Spec.Affinity = nil
+	pod.Spec.Tolerations = nil
+
+	pod.Status.ContainerStatuses = nil
+	pod.Status.InitContainerStatuses = nil
+	pod.Status.EphemeralContainerStatuses = nil
+	return pod, nil
+}

--- a/cmd/alfred/main_test.go
+++ b/cmd/alfred/main_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func resetFlags(t *testing.T, args []string) {
+	t.Helper()
+	oldArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	})
+	flag.CommandLine = flag.NewFlagSet(args[0], flag.ExitOnError)
+	os.Args = args
+}
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+	if opts.metricsAddr != ":8080" || opts.probeAddr != ":8081" {
+		t.Fatalf("default addresses: %+v", opts)
+	}
+	if !opts.enableLeaderElection {
+		t.Fatal("leader election must default on")
+	}
+	if opts.configMapName != "alfred-config" || opts.configMapKey != "config.yaml" {
+		t.Fatalf("default config source: %+v", opts)
+	}
+	if opts.namespace == "" {
+		t.Fatal("namespace must have a default")
+	}
+}
+
+func TestGetOptionsDefaults(t *testing.T) {
+	resetFlags(t, []string{"alfred"})
+	opts := GetOptions()
+	if opts.metricsAddr != ":8080" || opts.probeAddr != ":8081" {
+		t.Fatalf("defaults not applied: %+v", opts)
+	}
+	if !opts.enableLeaderElection || opts.configMapName != "alfred-config" || opts.configMapKey != "config.yaml" {
+		t.Fatalf("defaults not applied: %+v", opts)
+	}
+}
+
+func TestGetOptionsCustom(t *testing.T) {
+	resetFlags(t, []string{
+		"alfred",
+		"--metrics-bind-address=:9090",
+		"--health-probe-bind-address=:9091",
+		"--leader-elect=false",
+		"--namespace=caretaker",
+		"--config-name=my-config",
+		"--config-key=alfred.yaml",
+	})
+	opts := GetOptions()
+	if opts.metricsAddr != ":9090" || opts.probeAddr != ":9091" {
+		t.Fatalf("addresses not parsed: %+v", opts)
+	}
+	if opts.enableLeaderElection {
+		t.Fatal("--leader-elect=false not parsed")
+	}
+	if opts.namespace != "caretaker" || opts.configMapName != "my-config" || opts.configMapKey != "alfred.yaml" {
+		t.Fatalf("config source not parsed: %+v", opts)
+	}
+}
+
+func TestPodCacheTransform(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "p",
+			Labels:      map[string]string{"keep": "me"},
+			Annotations: map[string]string{"drop": "me"},
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kubelet"},
+			},
+			OwnerReferences: []metav1.OwnerReference{{Name: "rs"}},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:     "node1",
+			NodeSelector: map[string]string{"pool": "h100"},
+			Containers: []corev1.Container{{
+				Name:    "main",
+				Command: []string{"serve"},
+				Env:     []corev1.EnvVar{{Name: "X", Value: "1"}},
+				Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("2"),
+				}},
+				VolumeMounts: []corev1.VolumeMount{{Name: "v"}},
+			}},
+			InitContainers: []corev1.Container{{
+				Name:          "sidecar",
+				RestartPolicy: &always,
+				Env:           []corev1.EnvVar{{Name: "Y", Value: "2"}},
+			}},
+			Volumes:     []corev1.Volume{{Name: "v"}},
+			Tolerations: []corev1.Toleration{{Key: "gpu"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "main"}},
+		},
+	}
+
+	out, err := podCacheTransform(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := out.(*corev1.Pod)
+
+	// Stripped: everything the snapshot never reads.
+	if got.Annotations != nil || got.ManagedFields != nil || got.OwnerReferences != nil {
+		t.Fatalf("metadata not stripped: %+v", got.ObjectMeta)
+	}
+	if got.Spec.Volumes != nil || got.Spec.Tolerations != nil {
+		t.Fatalf("spec not stripped: %+v", got.Spec)
+	}
+	if c := got.Spec.Containers[0]; c.Command != nil || c.Env != nil || c.VolumeMounts != nil {
+		t.Fatalf("container not stripped: %+v", c)
+	}
+	if got.Spec.InitContainers[0].Env != nil {
+		t.Fatalf("init container not stripped: %+v", got.Spec.InitContainers[0])
+	}
+	if got.Status.ContainerStatuses != nil {
+		t.Fatalf("status not stripped: %+v", got.Status)
+	}
+
+	// Kept: everything the snapshot reads.
+	if got.Labels["keep"] != "me" || got.Spec.NodeName != "node1" || got.Spec.NodeSelector["pool"] != "h100" {
+		t.Fatalf("needed fields lost: %+v", got)
+	}
+	if got.Spec.Containers[0].Resources.Limits.Name("nvidia.com/gpu", resource.DecimalSI).Value() != 2 {
+		t.Fatalf("resources lost: %+v", got.Spec.Containers[0].Resources)
+	}
+	if got.Spec.InitContainers[0].RestartPolicy == nil {
+		t.Fatal("sidecar restart policy lost (GPU accounting needs it)")
+	}
+	if got.Status.Phase != corev1.PodRunning {
+		t.Fatalf("phase lost: %+v", got.Status)
+	}
+
+	// Non-pod objects pass through untouched.
+	cm := &corev1.ConfigMap{}
+	if out, err := podCacheTransform(cm); err != nil || out != cm {
+		t.Fatalf("non-pod transform: %v %v", out, err)
+	}
+}
+
+func TestPodIdentity(t *testing.T) {
+	t.Setenv("POD_NAME", "alfred-0")
+	if got := podIdentity(); got != "alfred-0" {
+		t.Fatalf("podIdentity = %q, want alfred-0", got)
+	}
+	t.Setenv("POD_NAME", "")
+	if got := podIdentity(); got == "" {
+		t.Fatal("podIdentity must fall back to hostname")
+	}
+}
+
+func TestPtr(t *testing.T) {
+	if v := ptr(42); *v != 42 {
+		t.Fatalf("ptr: %v", *v)
+	}
+}

--- a/dockerfiles/alfred.Dockerfile
+++ b/dockerfiles/alfred.Dockerfile
@@ -1,0 +1,53 @@
+# Configurable base image - must be declared before any FROM statement
+# Defaults to Oracle Linux 10 for parity with the other OME images
+# Can be overridden with --build-arg BASE_IMAGE=ubuntu:24.04
+ARG BASE_IMAGE=oraclelinux:10-slim
+
+# Build the alfred binary (pure Go — no Rust/XET, CGO disabled)
+FROM golang:1.25 AS builder
+
+# Build arguments for cross-compilation
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+# Build arguments for version info
+ARG VERSION
+ARG GIT_TAG
+ARG GIT_COMMIT
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -a \
+    -ldflags "-X sigs.k8s.io/ome/pkg/version.GitVersion=${GIT_TAG} -X sigs.k8s.io/ome/pkg/version.GitCommit=${GIT_COMMIT}" \
+    -o alfred ./cmd/alfred
+
+# Use the base image specified at the top of the file
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN if [ -f /usr/bin/microdnf ]; then \
+        microdnf update -y && \
+        microdnf install -y ca-certificates && \
+        microdnf clean all; \
+    elif [ -f /usr/bin/apt-get ]; then \
+        apt-get update && apt-get install -y ca-certificates && \
+        apt-get upgrade -y && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi
+WORKDIR /
+COPY --from=builder /workspace/alfred .
+USER 65532:65532
+
+ENTRYPOINT ["/alfred"]

--- a/pkg/alfred/config/config.go
+++ b/pkg/alfred/config/config.go
@@ -1,0 +1,394 @@
+// Package config loads and hot-reloads Alfred's configuration from the
+// alfred-config ConfigMap (key config.yaml), with schema validation and a
+// last-known-good fallback: a fat-fingered edit must never leave the
+// caretaker acting on a half-parsed policy (OEP-0008).
+package config
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// Operating modes.
+const (
+	// ModeRecommendOnly runs policies, arbitration, and reporting but
+	// never dispatches — the safe default.
+	ModeRecommendOnly = "recommend-only"
+	// ModeExecute additionally lets the dispatcher write
+	// migration-request annotations.
+	ModeExecute = "execute"
+)
+
+// Aggressiveness values (a scoring knob, never a safety bypass).
+const (
+	AggressivenessConservative = "conservative"
+	AggressivenessBalanced     = "balanced"
+	AggressivenessAggressive   = "aggressive"
+)
+
+// EarlyTickNodeConditionChange is the only earlyTickOn trigger defined today.
+const EarlyTickNodeConditionChange = "NodeConditionChange"
+
+// SupportedSchemaVersion is the config schema this build understands.
+const SupportedSchemaVersion = 1
+
+// Config is the full alfred-config schema. Load returns a fully-defaulted
+// value: every pointer field is non-nil and every duration/count positive, so
+// consumers never re-default.
+type Config struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Mode          string `json:"mode"`
+
+	DecisionLoopInterval    metav1.Duration `json:"decisionLoopInterval"`
+	ObservationLoopInterval metav1.Duration `json:"observationLoopInterval"`
+	// EarlyTickOn advances the next decision tick on the named events;
+	// empty disables advancement. A pass is never interrupted.
+	EarlyTickOn []string `json:"earlyTickOn"`
+
+	Policies Policies `json:"policies"`
+
+	DefaultMovable                 *bool `json:"defaultMovable"`
+	RecentPlacementCooldownMinutes int   `json:"recentPlacementCooldownMinutes"`
+	PerWorkloadCooldownMinutes     int   `json:"perWorkloadCooldownMinutes"`
+	PerNodeCooldownMinutes         int   `json:"perNodeCooldownMinutes"`
+
+	RawDeploymentMigrationEnabled *bool `json:"rawDeploymentMigrationEnabled"`
+	OMENativeMigrationEnabled     *bool `json:"omenativeMigrationEnabled"`
+	LWSRecommendationsEnabled     *bool `json:"lwsRecommendationsEnabled"`
+
+	RecommendationsConfigMapEnabled *bool  `json:"recommendationsConfigMapEnabled"`
+	RecommendationsConfigMapName    string `json:"recommendationsConfigMapName"`
+
+	MaxInFlightMigrations      int `json:"maxInFlightMigrations"`
+	MaxMigrationsPerHour       int `json:"maxMigrationsPerHour"`
+	EmergencyPendingAgeMinutes int `json:"emergencyPendingAgeMinutes"`
+
+	// MaintenanceWindows gate defragmentation dispatch (node-health
+	// evacuation deliberately overrides them). Empty means no windows —
+	// defrag may dispatch at any time.
+	MaintenanceWindows []MaintenanceWindow `json:"maintenanceWindows"`
+
+	SpotPolicy SpotPolicy `json:"spotPolicy"`
+
+	AllowCrossTenantOptimization *bool `json:"allowCrossTenantOptimization"`
+
+	LogLevel          string `json:"logLevel"`
+	StructuredLogging *bool  `json:"structuredLogging"`
+}
+
+// Policies groups the per-policy blocks.
+type Policies struct {
+	Defragmentation Defragmentation `json:"defragmentation"`
+	NodeHealth      NodeHealth      `json:"nodeHealth"`
+}
+
+// Defragmentation is Policy #1's block.
+type Defragmentation struct {
+	Enabled                *bool    `json:"enabled"`
+	FragmentationThreshold *float64 `json:"fragmentationThreshold"`
+	Aggressiveness         string   `json:"aggressiveness"`
+	Scoring                Scoring  `json:"scoring"`
+}
+
+// Scoring holds the fragmentation-score knobs (OEP-0008 §Fragmentation
+// scoring).
+type Scoring struct {
+	// SizeLadder is the within-node demand-size ladder, ascending.
+	SizeLadder []int `json:"sizeLadder"`
+	// DemandBlendLambda blends observed demand with the static prior:
+	// 0 = pure observed, 1 = pure prior.
+	DemandBlendLambda *float64 `json:"demandBlendLambda"`
+	// SizePrior is the static prior over demand sizes, keyed by size.
+	SizePrior map[string]float64 `json:"sizePrior"`
+	// PendingUrgencyTauMinutes is tau in the pending-pressure term.
+	PendingUrgencyTauMinutes int `json:"pendingUrgencyTauMinutes"`
+}
+
+// NodeHealth is Policy #2's block.
+type NodeHealth struct {
+	Enabled        *bool  `json:"enabled"`
+	Aggressiveness string `json:"aggressiveness"`
+	// TriggerConditions are the node conditions that trigger evacuation;
+	// consumed from existing signals, never detected by Alfred.
+	TriggerConditions []string `json:"triggerConditions"`
+	// SignalOnly emits the remediation signal but never evacuates.
+	SignalOnly bool `json:"signalOnly"`
+	// HealthCooldownFloorMinutes is the per-workload cooldown floor for
+	// NodeUnhealthy candidates (instead of the standard cooldown).
+	HealthCooldownFloorMinutes int `json:"healthCooldownFloorMinutes"`
+	// NodeSuspicionWindowMinutes keeps evacuated nodes out of target
+	// hints even after the condition clears.
+	NodeSuspicionWindowMinutes int `json:"nodeSuspicionWindowMinutes"`
+}
+
+// SpotPolicy configures spot/preemptible node handling.
+type SpotPolicy struct {
+	AvoidAsTarget     *bool    `json:"avoidAsTarget"`
+	PreferAsSource    *bool    `json:"preferAsSource"`
+	PreemptibleLabels []string `json:"preemptibleLabels"`
+}
+
+// MaintenanceWindow is a weekly UTC window. Days use three-letter English
+// names (Mon..Sun); Start/End are "HH:MM" with Start < End.
+type MaintenanceWindow struct {
+	Days  []string `json:"days"`
+	Start string   `json:"start"`
+	End   string   `json:"end"`
+}
+
+// Default returns the fully-defaulted configuration: recommend-only, both
+// policies enabled, the OEP's conservative safety bounds.
+func Default() *Config {
+	cfg := &Config{SchemaVersion: SupportedSchemaVersion}
+	cfg.applyDefaults()
+	return cfg
+}
+
+// Load parses and validates raw config.yaml content, returning a
+// fully-defaulted Config or an error describing the first violation.
+func Load(raw []byte) (*Config, error) {
+	cfg := &Config{}
+	if err := yaml.UnmarshalStrict(raw, cfg); err != nil {
+		return nil, fmt.Errorf("parse config.yaml: %w", err)
+	}
+	cfg.applyDefaults()
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func boolPtr(b bool) *bool        { return &b }
+func floatPtr(f float64) *float64 { return &f }
+func minutes(m int) time.Duration { return time.Duration(m) * time.Minute }
+func defaultInt(v *int, d int) {
+	if *v == 0 {
+		*v = d
+	}
+}
+func defaultStr(v *string, d string) {
+	if *v == "" {
+		*v = d
+	}
+}
+
+func (c *Config) applyDefaults() {
+	defaultStr(&c.Mode, ModeRecommendOnly)
+	if c.DecisionLoopInterval.Duration == 0 {
+		c.DecisionLoopInterval = metav1.Duration{Duration: 5 * time.Minute}
+	}
+	if c.ObservationLoopInterval.Duration == 0 {
+		c.ObservationLoopInterval = metav1.Duration{Duration: 30 * time.Second}
+	}
+	if c.EarlyTickOn == nil {
+		c.EarlyTickOn = []string{EarlyTickNodeConditionChange}
+	}
+
+	d := &c.Policies.Defragmentation
+	if d.Enabled == nil {
+		d.Enabled = boolPtr(true)
+	}
+	if d.FragmentationThreshold == nil {
+		d.FragmentationThreshold = floatPtr(0.25)
+	}
+	defaultStr(&d.Aggressiveness, AggressivenessBalanced)
+	if len(d.Scoring.SizeLadder) == 0 {
+		d.Scoring.SizeLadder = []int{1, 2, 4, 8}
+	}
+	if d.Scoring.DemandBlendLambda == nil {
+		d.Scoring.DemandBlendLambda = floatPtr(0.3)
+	}
+	if len(d.Scoring.SizePrior) == 0 {
+		d.Scoring.SizePrior = map[string]float64{"1": 0.1, "2": 0.1, "4": 0.2, "8": 0.6}
+	}
+	defaultInt(&d.Scoring.PendingUrgencyTauMinutes, 30)
+
+	n := &c.Policies.NodeHealth
+	if n.Enabled == nil {
+		n.Enabled = boolPtr(true)
+	}
+	defaultStr(&n.Aggressiveness, AggressivenessBalanced)
+	if len(n.TriggerConditions) == 0 {
+		n.TriggerConditions = []string{"GpuUnhealthy"}
+	}
+	defaultInt(&n.HealthCooldownFloorMinutes, 5)
+	defaultInt(&n.NodeSuspicionWindowMinutes, 30)
+
+	if c.DefaultMovable == nil {
+		c.DefaultMovable = boolPtr(true)
+	}
+	defaultInt(&c.RecentPlacementCooldownMinutes, 10)
+	defaultInt(&c.PerWorkloadCooldownMinutes, 30)
+	defaultInt(&c.PerNodeCooldownMinutes, 10)
+
+	if c.RawDeploymentMigrationEnabled == nil {
+		c.RawDeploymentMigrationEnabled = boolPtr(true)
+	}
+	if c.OMENativeMigrationEnabled == nil {
+		c.OMENativeMigrationEnabled = boolPtr(true)
+	}
+	if c.LWSRecommendationsEnabled == nil {
+		c.LWSRecommendationsEnabled = boolPtr(true)
+	}
+	if c.RecommendationsConfigMapEnabled == nil {
+		c.RecommendationsConfigMapEnabled = boolPtr(true)
+	}
+	defaultStr(&c.RecommendationsConfigMapName, "alfred-recommendations")
+
+	defaultInt(&c.MaxInFlightMigrations, 3)
+	defaultInt(&c.MaxMigrationsPerHour, 10)
+	defaultInt(&c.EmergencyPendingAgeMinutes, 10)
+
+	if c.SpotPolicy.AvoidAsTarget == nil {
+		c.SpotPolicy.AvoidAsTarget = boolPtr(true)
+	}
+	if c.SpotPolicy.PreferAsSource == nil {
+		c.SpotPolicy.PreferAsSource = boolPtr(true)
+	}
+	if c.SpotPolicy.PreemptibleLabels == nil {
+		c.SpotPolicy.PreemptibleLabels = []string{
+			"node.kubernetes.io/preemptible",
+			"cloud.google.com/gke-preemptible",
+		}
+	}
+
+	if c.AllowCrossTenantOptimization == nil {
+		c.AllowCrossTenantOptimization = boolPtr(true)
+	}
+	defaultStr(&c.LogLevel, "info")
+	if c.StructuredLogging == nil {
+		c.StructuredLogging = boolPtr(true)
+	}
+}
+
+var validDays = map[string]struct{}{
+	"Mon": {}, "Tue": {}, "Wed": {}, "Thu": {}, "Fri": {}, "Sat": {}, "Sun": {},
+}
+
+var validAggressiveness = map[string]struct{}{
+	AggressivenessConservative: {}, AggressivenessBalanced: {}, AggressivenessAggressive: {},
+}
+
+func (c *Config) validate() error {
+	if c.SchemaVersion != SupportedSchemaVersion {
+		return fmt.Errorf("unsupported schemaVersion %d (supported: %d)", c.SchemaVersion, SupportedSchemaVersion)
+	}
+	if c.Mode != ModeRecommendOnly && c.Mode != ModeExecute {
+		return fmt.Errorf("mode must be %q or %q, got %q", ModeRecommendOnly, ModeExecute, c.Mode)
+	}
+	if c.DecisionLoopInterval.Duration < time.Second {
+		return fmt.Errorf("decisionLoopInterval must be >= 1s, got %s", c.DecisionLoopInterval.Duration)
+	}
+	if c.ObservationLoopInterval.Duration < time.Second {
+		return fmt.Errorf("observationLoopInterval must be >= 1s, got %s", c.ObservationLoopInterval.Duration)
+	}
+	for _, trigger := range c.EarlyTickOn {
+		if trigger != EarlyTickNodeConditionChange {
+			return fmt.Errorf("unknown earlyTickOn trigger %q", trigger)
+		}
+	}
+
+	d := &c.Policies.Defragmentation
+	if t := *d.FragmentationThreshold; t < 0 || t > 1 {
+		return fmt.Errorf("policies.defragmentation.fragmentationThreshold must be in [0, 1], got %v", t)
+	}
+	if _, ok := validAggressiveness[d.Aggressiveness]; !ok {
+		return fmt.Errorf("policies.defragmentation.aggressiveness %q invalid", d.Aggressiveness)
+	}
+	if l := *d.Scoring.DemandBlendLambda; l < 0 || l > 1 {
+		return fmt.Errorf("policies.defragmentation.scoring.demandBlendLambda must be in [0, 1], got %v", l)
+	}
+	if !sort.IntsAreSorted(d.Scoring.SizeLadder) {
+		return fmt.Errorf("policies.defragmentation.scoring.sizeLadder must be ascending, got %v", d.Scoring.SizeLadder)
+	}
+	for _, size := range d.Scoring.SizeLadder {
+		if size <= 0 {
+			return fmt.Errorf("policies.defragmentation.scoring.sizeLadder entries must be positive, got %v", d.Scoring.SizeLadder)
+		}
+	}
+	var priorSum float64
+	for key, weight := range d.Scoring.SizePrior {
+		var size int
+		if _, err := fmt.Sscanf(key, "%d", &size); err != nil || size <= 0 {
+			return fmt.Errorf("policies.defragmentation.scoring.sizePrior key %q is not a positive size", key)
+		}
+		if weight < 0 {
+			return fmt.Errorf("policies.defragmentation.scoring.sizePrior[%s] must be >= 0, got %v", key, weight)
+		}
+		priorSum += weight
+	}
+	if priorSum < 0.99 || priorSum > 1.01 {
+		return fmt.Errorf("policies.defragmentation.scoring.sizePrior must sum to 1, got %v", priorSum)
+	}
+
+	n := &c.Policies.NodeHealth
+	if _, ok := validAggressiveness[n.Aggressiveness]; !ok {
+		return fmt.Errorf("policies.nodeHealth.aggressiveness %q invalid", n.Aggressiveness)
+	}
+
+	// Zero values were defaulted above, so anything non-positive here is an
+	// explicit negative — which would invert cooldown and cap arithmetic.
+	positives := []struct {
+		name  string
+		value int
+	}{
+		{"recentPlacementCooldownMinutes", c.RecentPlacementCooldownMinutes},
+		{"perWorkloadCooldownMinutes", c.PerWorkloadCooldownMinutes},
+		{"perNodeCooldownMinutes", c.PerNodeCooldownMinutes},
+		{"maxInFlightMigrations", c.MaxInFlightMigrations},
+		{"maxMigrationsPerHour", c.MaxMigrationsPerHour},
+		{"emergencyPendingAgeMinutes", c.EmergencyPendingAgeMinutes},
+		{"policies.defragmentation.scoring.pendingUrgencyTauMinutes", d.Scoring.PendingUrgencyTauMinutes},
+		{"policies.nodeHealth.healthCooldownFloorMinutes", n.HealthCooldownFloorMinutes},
+		{"policies.nodeHealth.nodeSuspicionWindowMinutes", n.NodeSuspicionWindowMinutes},
+	}
+	for _, p := range positives {
+		if p.value <= 0 {
+			return fmt.Errorf("%s must be positive, got %d", p.name, p.value)
+		}
+	}
+
+	for i, w := range c.MaintenanceWindows {
+		if len(w.Days) == 0 {
+			return fmt.Errorf("maintenanceWindows[%d].days must not be empty", i)
+		}
+		for _, day := range w.Days {
+			if _, ok := validDays[day]; !ok {
+				return fmt.Errorf("maintenanceWindows[%d] has unknown day %q (want Mon..Sun)", i, day)
+			}
+		}
+		for _, hhmm := range []string{w.Start, w.End} {
+			if _, err := time.Parse("15:04", hhmm); err != nil {
+				return fmt.Errorf("maintenanceWindows[%d] time %q must be HH:MM", i, hhmm)
+			}
+		}
+		start, _ := time.Parse("15:04", w.Start)
+		end, _ := time.Parse("15:04", w.End)
+		if !start.Before(end) {
+			return fmt.Errorf("maintenanceWindows[%d] start %q must be before end %q", i, w.Start, w.End)
+		}
+	}
+	return nil
+}
+
+// Convenience accessors for duration-typed bounds.
+
+func (c *Config) RecentPlacementCooldown() time.Duration {
+	return minutes(c.RecentPlacementCooldownMinutes)
+}
+func (c *Config) PerWorkloadCooldown() time.Duration { return minutes(c.PerWorkloadCooldownMinutes) }
+func (c *Config) PerNodeCooldown() time.Duration     { return minutes(c.PerNodeCooldownMinutes) }
+func (c *Config) HealthCooldownFloor() time.Duration {
+	return minutes(c.Policies.NodeHealth.HealthCooldownFloorMinutes)
+}
+func (c *Config) NodeSuspicionWindow() time.Duration {
+	return minutes(c.Policies.NodeHealth.NodeSuspicionWindowMinutes)
+}
+func (c *Config) EmergencyPendingAge() time.Duration { return minutes(c.EmergencyPendingAgeMinutes) }
+func (c *Config) PendingUrgencyTau() time.Duration {
+	return minutes(c.Policies.Defragmentation.Scoring.PendingUrgencyTauMinutes)
+}

--- a/pkg/alfred/config/config_test.go
+++ b/pkg/alfred/config/config_test.go
@@ -1,0 +1,191 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultIsSafeAndComplete(t *testing.T) {
+	cfg := Default()
+
+	if cfg.Mode != ModeRecommendOnly {
+		t.Fatalf("default mode = %q, want recommend-only", cfg.Mode)
+	}
+	if cfg.DecisionLoopInterval.Duration != 5*time.Minute || cfg.ObservationLoopInterval.Duration != 30*time.Second {
+		t.Fatalf("default intervals: %v / %v", cfg.DecisionLoopInterval, cfg.ObservationLoopInterval)
+	}
+	if len(cfg.EarlyTickOn) != 1 || cfg.EarlyTickOn[0] != EarlyTickNodeConditionChange {
+		t.Fatalf("default earlyTickOn: %v", cfg.EarlyTickOn)
+	}
+
+	d := cfg.Policies.Defragmentation
+	if !*d.Enabled || *d.FragmentationThreshold != 0.25 || d.Aggressiveness != AggressivenessBalanced {
+		t.Fatalf("defrag defaults: %+v", d)
+	}
+	if got := d.Scoring.SizeLadder; len(got) != 4 || got[0] != 1 || got[3] != 8 {
+		t.Fatalf("size ladder: %v", got)
+	}
+	if *d.Scoring.DemandBlendLambda != 0.3 || d.Scoring.SizePrior["8"] != 0.6 {
+		t.Fatalf("scoring defaults: %+v", d.Scoring)
+	}
+
+	n := cfg.Policies.NodeHealth
+	if !*n.Enabled || n.HealthCooldownFloorMinutes != 5 || n.NodeSuspicionWindowMinutes != 30 {
+		t.Fatalf("nodeHealth defaults: %+v", n)
+	}
+	if len(n.TriggerConditions) != 1 || n.TriggerConditions[0] != "GpuUnhealthy" {
+		t.Fatalf("trigger conditions: %v", n.TriggerConditions)
+	}
+
+	if cfg.MaxInFlightMigrations != 3 || cfg.MaxMigrationsPerHour != 10 {
+		t.Fatalf("caps: %d/%d", cfg.MaxInFlightMigrations, cfg.MaxMigrationsPerHour)
+	}
+	if cfg.PerWorkloadCooldown() != 30*time.Minute || cfg.PerNodeCooldown() != 10*time.Minute ||
+		cfg.RecentPlacementCooldown() != 10*time.Minute {
+		t.Fatal("cooldown accessors mismatch")
+	}
+	if cfg.HealthCooldownFloor() != 5*time.Minute || cfg.NodeSuspicionWindow() != 30*time.Minute {
+		t.Fatal("health accessors mismatch")
+	}
+	if cfg.EmergencyPendingAge() != 10*time.Minute || cfg.PendingUrgencyTau() != 30*time.Minute {
+		t.Fatal("urgency accessors mismatch")
+	}
+	if !*cfg.DefaultMovable || !*cfg.RawDeploymentMigrationEnabled || !*cfg.OMENativeMigrationEnabled {
+		t.Fatal("execution-surface defaults should be enabled")
+	}
+	if cfg.RecommendationsConfigMapName != "alfred-recommendations" {
+		t.Fatalf("recommendations configmap name: %q", cfg.RecommendationsConfigMapName)
+	}
+	if !*cfg.SpotPolicy.AvoidAsTarget || len(cfg.SpotPolicy.PreemptibleLabels) != 2 {
+		t.Fatalf("spot defaults: %+v", cfg.SpotPolicy)
+	}
+}
+
+func TestLoadParsesTheOEPSchema(t *testing.T) {
+	raw := []byte(`
+schemaVersion: 1
+mode: execute
+decisionLoopInterval: 2m
+observationLoopInterval: 15s
+earlyTickOn: [NodeConditionChange]
+policies:
+  defragmentation:
+    enabled: true
+    fragmentationThreshold: 0.4
+    aggressiveness: conservative
+    scoring:
+      sizeLadder: [1, 2, 4]
+      demandBlendLambda: 0.5
+      sizePrior:
+        "1": 0.2
+        "2": 0.3
+        "4": 0.5
+      pendingUrgencyTauMinutes: 15
+  nodeHealth:
+    enabled: false
+    triggerConditions: [GpuUnhealthy, NodeNotReady]
+    healthCooldownFloorMinutes: 3
+defaultMovable: false
+recentPlacementCooldownMinutes: 20
+maxInFlightMigrations: 5
+maintenanceWindows:
+  - days: [Mon, Tue, Wed, Thu, Fri]
+    start: "09:00"
+    end: "17:00"
+spotPolicy:
+  avoidAsTarget: false
+  preemptibleLabels: [custom.io/spot]
+logLevel: debug
+`)
+	cfg, err := Load(raw)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Mode != ModeExecute || cfg.DecisionLoopInterval.Duration != 2*time.Minute {
+		t.Fatalf("top-level parse: %+v", cfg)
+	}
+	if *cfg.Policies.Defragmentation.FragmentationThreshold != 0.4 ||
+		cfg.Policies.Defragmentation.Aggressiveness != AggressivenessConservative {
+		t.Fatalf("defrag parse: %+v", cfg.Policies.Defragmentation)
+	}
+	if cfg.Policies.Defragmentation.Scoring.PendingUrgencyTauMinutes != 15 {
+		t.Fatalf("tau parse: %+v", cfg.Policies.Defragmentation.Scoring)
+	}
+	if *cfg.Policies.NodeHealth.Enabled || len(cfg.Policies.NodeHealth.TriggerConditions) != 2 {
+		t.Fatalf("nodeHealth parse: %+v", cfg.Policies.NodeHealth)
+	}
+	if *cfg.DefaultMovable || cfg.RecentPlacementCooldownMinutes != 20 || cfg.MaxInFlightMigrations != 5 {
+		t.Fatalf("workload defaults parse: %+v", cfg)
+	}
+	if len(cfg.MaintenanceWindows) != 1 || cfg.MaintenanceWindows[0].Start != "09:00" {
+		t.Fatalf("windows parse: %+v", cfg.MaintenanceWindows)
+	}
+	if *cfg.SpotPolicy.AvoidAsTarget || cfg.SpotPolicy.PreemptibleLabels[0] != "custom.io/spot" {
+		t.Fatalf("spot parse: %+v", cfg.SpotPolicy)
+	}
+	// Unset sections still default.
+	if cfg.MaxMigrationsPerHour != 10 || cfg.PerWorkloadCooldownMinutes != 30 {
+		t.Fatalf("defaults on unset keys: %+v", cfg)
+	}
+}
+
+func TestLoadRejectsInvalidConfigs(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{"unknown schema version", "schemaVersion: 2", "unsupported schemaVersion"},
+		{"bad mode", "schemaVersion: 1\nmode: dry-run", "mode must be"},
+		{"threshold out of range", "schemaVersion: 1\npolicies:\n  defragmentation:\n    fragmentationThreshold: 1.5", "fragmentationThreshold"},
+		{"lambda out of range", "schemaVersion: 1\npolicies:\n  defragmentation:\n    scoring:\n      demandBlendLambda: -0.1", "demandBlendLambda"},
+		{"unsorted ladder", "schemaVersion: 1\npolicies:\n  defragmentation:\n    scoring:\n      sizeLadder: [4, 2, 8]", "sizeLadder must be ascending"},
+		{"prior does not sum to 1", "schemaVersion: 1\npolicies:\n  defragmentation:\n    scoring:\n      sizePrior:\n        \"8\": 0.5", "must sum to 1"},
+		{"prior bad key", "schemaVersion: 1\npolicies:\n  defragmentation:\n    scoring:\n      sizePrior:\n        big: 1.0", "not a positive size"},
+		{"unknown early tick", "schemaVersion: 1\nearlyTickOn: [PodDeleted]", "unknown earlyTickOn"},
+		{"bad aggressiveness", "schemaVersion: 1\npolicies:\n  nodeHealth:\n    aggressiveness: yolo", "aggressiveness"},
+		{"bad window day", "schemaVersion: 1\nmaintenanceWindows:\n  - days: [Monday]\n    start: \"09:00\"\n    end: \"17:00\"", "unknown day"},
+		{"bad window time", "schemaVersion: 1\nmaintenanceWindows:\n  - days: [Mon]\n    start: \"9am\"\n    end: \"17:00\"", "must be HH:MM"},
+		{"inverted window", "schemaVersion: 1\nmaintenanceWindows:\n  - days: [Mon]\n    start: \"17:00\"\n    end: \"09:00\"", "must be before end"},
+		{"unknown field", "schemaVersion: 1\nmodee: execute", "parse config.yaml"},
+		{"interval too small", "schemaVersion: 1\ndecisionLoopInterval: 100ms", "decisionLoopInterval"},
+		{"negative cooldown", "schemaVersion: 1\nrecentPlacementCooldownMinutes: -5", "must be positive"},
+		{"negative cap", "schemaVersion: 1\nmaxInFlightMigrations: -1", "must be positive"},
+		{"negative tau", "schemaVersion: 1\npolicies:\n  defragmentation:\n    scoring:\n      pendingUrgencyTauMinutes: -30", "must be positive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load([]byte(tc.yaml))
+			if err == nil {
+				t.Fatal("want error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestStoreLastKnownGood(t *testing.T) {
+	store := NewStore()
+	if store.Get().Mode != ModeRecommendOnly {
+		t.Fatal("store must boot with safe defaults")
+	}
+
+	outcome, err := store.Update([]byte("schemaVersion: 1\nmode: execute"))
+	if err != nil || outcome != OutcomeSuccess {
+		t.Fatalf("valid update: %v/%v", outcome, err)
+	}
+	if store.Get().Mode != ModeExecute {
+		t.Fatal("update should activate the new config")
+	}
+
+	outcome, err = store.Update([]byte("schemaVersion: 99"))
+	if err == nil || outcome != OutcomeFailure {
+		t.Fatalf("invalid update should fail: %v/%v", outcome, err)
+	}
+	if store.Get().Mode != ModeExecute {
+		t.Fatal("failed update must keep last-known-good")
+	}
+}

--- a/pkg/alfred/config/store.go
+++ b/pkg/alfred/config/store.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"sync/atomic"
+)
+
+// Reload outcomes, used as the alfred_policy_reload_total outcome label.
+const (
+	OutcomeSuccess = "success"
+	OutcomeFailure = "failure"
+)
+
+// Store holds the active configuration with last-known-good semantics: a
+// failed Update leaves the previous config serving. Reads are lock-free and
+// safe from any goroutine; the returned *Config is shared and must be treated
+// as immutable.
+type Store struct {
+	current atomic.Pointer[Config]
+}
+
+// NewStore returns a store serving the built-in defaults until the first
+// successful Update — Alfred starts safe (recommend-only) even if the
+// ConfigMap is missing or broken at boot.
+func NewStore() *Store {
+	s := &Store{}
+	s.current.Store(Default())
+	return s
+}
+
+// Get returns the active configuration.
+func (s *Store) Get() *Config {
+	return s.current.Load()
+}
+
+// Update parses and validates raw config.yaml content. On success the new
+// config becomes active and OutcomeSuccess is returned; on failure the
+// previous config stays active and OutcomeFailure is returned with the
+// validation error.
+func (s *Store) Update(raw []byte) (string, error) {
+	cfg, err := Load(raw)
+	if err != nil {
+		return OutcomeFailure, err
+	}
+	s.current.Store(cfg)
+	return OutcomeSuccess, nil
+}

--- a/pkg/alfred/config/watcher.go
+++ b/pkg/alfred/config/watcher.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// ReloadObserver is notified of every reload attempt's outcome; the metrics
+// package implements it (alfred_policy_reload_total).
+type ReloadObserver interface {
+	ObserveConfigReload(outcome string)
+}
+
+// Watcher hot-reloads the Store from the alfred-config ConfigMap through the
+// manager's informer cache. It runs on every replica (config is needed
+// before and regardless of leadership) and never restarts Alfred: a change
+// takes effect on the next loop pass that calls Store.Get.
+type Watcher struct {
+	Cache     ctrlcache.Cache
+	Namespace string
+	Name      string
+	// Key is the ConfigMap key holding the YAML document (config.yaml).
+	Key      string
+	Store    *Store
+	Log      logr.Logger
+	Recorder record.EventRecorder
+	Observer ReloadObserver
+
+	// lastApplied dedups informer resyncs: reprocessing an unchanged
+	// document must not inflate the reload metric. lastMissing tracks the
+	// distinct "key absent" state (not representable as a document value,
+	// including the empty string) so a persistently broken ConfigMap is
+	// reported once, not once per resync.
+	lastApplied string
+	lastMissing bool
+	seeded      bool
+}
+
+var _ manager.Runnable = &Watcher{}
+var _ manager.LeaderElectionRunnable = &Watcher{}
+
+// NeedLeaderElection returns false: every replica loads config.
+func (w *Watcher) NeedLeaderElection() bool { return false }
+
+// Start registers the event handler and blocks until the context ends.
+func (w *Watcher) Start(ctx context.Context) error {
+	informer, err := w.Cache.GetInformer(ctx, &corev1.ConfigMap{})
+	if err != nil {
+		return fmt.Errorf("get configmap informer: %w", err)
+	}
+	registration, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) { w.observe(obj) },
+		UpdateFunc: func(_, newObj interface{}) {
+			w.observe(newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			// Deletion keeps last-known-good; log loudly so the
+			// operator knows edits will not land.
+			w.Log.Info("alfred-config ConfigMap deleted; keeping last-known-good configuration",
+				"namespace", w.Namespace, "name", w.Name)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("register configmap handler: %w", err)
+	}
+	defer func() {
+		_ = informer.RemoveEventHandler(registration)
+	}()
+	<-ctx.Done()
+	return nil
+}
+
+func (w *Watcher) observe(obj interface{}) {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok || cm.Namespace != w.Namespace || cm.Name != w.Name {
+		return
+	}
+	w.Apply(cm)
+}
+
+// Apply processes one ConfigMap state. Exposed for tests; the informer path
+// funnels here.
+func (w *Watcher) Apply(cm *corev1.ConfigMap) {
+	raw, ok := cm.Data[w.Key]
+	if !ok {
+		if w.seeded && w.lastMissing {
+			return
+		}
+		w.seeded, w.lastMissing = true, true
+		w.reloadFailed(cm, fmt.Errorf("ConfigMap %s/%s has no %q key", cm.Namespace, cm.Name, w.Key))
+		return
+	}
+	w.lastMissing = false
+	if w.seeded && raw == w.lastApplied {
+		return
+	}
+	outcome, err := w.Store.Update([]byte(raw))
+	if w.Observer != nil {
+		w.Observer.ObserveConfigReload(outcome)
+	}
+	if err != nil {
+		// The document is remembered even on failure so a broken edit
+		// is reported once, not on every resync.
+		w.seeded, w.lastApplied = true, raw
+		if w.Recorder != nil {
+			w.Recorder.Eventf(cm, corev1.EventTypeWarning, "PolicyReloadFailed",
+				"alfred-config rejected, keeping last-known-good: %v", err)
+		}
+		w.Log.Error(err, "config reload failed; keeping last-known-good")
+		return
+	}
+	w.seeded, w.lastApplied = true, raw
+	w.Log.Info("config reloaded", "mode", w.Store.Get().Mode)
+}
+
+func (w *Watcher) reloadFailed(cm *corev1.ConfigMap, err error) {
+	if w.Observer != nil {
+		w.Observer.ObserveConfigReload(OutcomeFailure)
+	}
+	if w.Recorder != nil {
+		w.Recorder.Eventf(cm, corev1.EventTypeWarning, "PolicyReloadFailed", "%v", err)
+	}
+	w.Log.Error(err, "config reload failed; keeping last-known-good")
+}

--- a/pkg/alfred/config/watcher_test.go
+++ b/pkg/alfred/config/watcher_test.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+type countingObserver struct {
+	success, failure int
+}
+
+func (c *countingObserver) ObserveConfigReload(outcome string) {
+	if outcome == OutcomeSuccess {
+		c.success++
+	} else {
+		c.failure++
+	}
+}
+
+func configMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ome", Name: "alfred-config"},
+		Data:       data,
+	}
+}
+
+func newTestWatcher() (*Watcher, *countingObserver, *record.FakeRecorder) {
+	observer := &countingObserver{}
+	recorder := record.NewFakeRecorder(10)
+	w := &Watcher{
+		Namespace: "ome",
+		Name:      "alfred-config",
+		Key:       "config.yaml",
+		Store:     NewStore(),
+		Log:       logr.Discard(),
+		Recorder:  recorder,
+		Observer:  observer,
+	}
+	return w, observer, recorder
+}
+
+func TestWatcherAppliesValidConfig(t *testing.T) {
+	w, observer, _ := newTestWatcher()
+
+	w.Apply(configMap(map[string]string{"config.yaml": "schemaVersion: 1\nmode: execute"}))
+	if w.Store.Get().Mode != ModeExecute {
+		t.Fatal("config not applied")
+	}
+	if observer.success != 1 || observer.failure != 0 {
+		t.Fatalf("observations: %+v", observer)
+	}
+
+	// Resync with an identical document must not inflate the metric.
+	w.Apply(configMap(map[string]string{"config.yaml": "schemaVersion: 1\nmode: execute"}))
+	if observer.success != 1 {
+		t.Fatalf("resync dedup failed: %+v", observer)
+	}
+}
+
+func TestWatcherKeepsLastKnownGoodOnBadEdit(t *testing.T) {
+	w, observer, recorder := newTestWatcher()
+
+	w.Apply(configMap(map[string]string{"config.yaml": "schemaVersion: 1\nmode: execute"}))
+	w.Apply(configMap(map[string]string{"config.yaml": "schemaVersion: 42"}))
+
+	if w.Store.Get().Mode != ModeExecute {
+		t.Fatal("broken edit must keep last-known-good")
+	}
+	if observer.failure != 1 {
+		t.Fatalf("failure not observed: %+v", observer)
+	}
+	select {
+	case event := <-recorder.Events:
+		if want := "PolicyReloadFailed"; !strings.Contains(event, want) {
+			t.Fatalf("event %q does not mention %q", event, want)
+		}
+	default:
+		t.Fatal("no PolicyReloadFailed event emitted")
+	}
+
+	// The same broken document again is deduped — one loud report, not a
+	// report per resync.
+	w.Apply(configMap(map[string]string{"config.yaml": "schemaVersion: 42"}))
+	if observer.failure != 1 {
+		t.Fatalf("failure dedup failed: %+v", observer)
+	}
+}
+
+func TestWatcherMissingKey(t *testing.T) {
+	w, observer, recorder := newTestWatcher()
+	w.Apply(configMap(map[string]string{"other.yaml": ""}))
+	if observer.failure != 1 {
+		t.Fatalf("missing key should observe failure: %+v", observer)
+	}
+	if w.Store.Get().Mode != ModeRecommendOnly {
+		t.Fatal("defaults must survive a missing key")
+	}
+
+	// The same missing-key state on an informer resync is deduped: one
+	// loud report, not one per resync.
+	w.Apply(configMap(map[string]string{"other.yaml": ""}))
+	if observer.failure != 1 {
+		t.Fatalf("missing-key resync dedup failed: %+v", observer)
+	}
+	if got := len(recorder.Events); got != 1 {
+		t.Fatalf("want exactly one PolicyReloadFailed event, recorder holds %d", got)
+	}
+
+	// The key appearing afterwards reloads normally.
+	w.Apply(configMap(map[string]string{"config.yaml": "schemaVersion: 1\nmode: execute"}))
+	if observer.success != 1 || w.Store.Get().Mode != ModeExecute {
+		t.Fatalf("recovery after missing key failed: %+v", observer)
+	}
+
+	// And a fresh disappearance is reported again (state, not one-shot).
+	w.Apply(configMap(map[string]string{"other.yaml": ""}))
+	if observer.failure != 2 {
+		t.Fatalf("re-disappearance should report once more: %+v", observer)
+	}
+}
+
+func TestWatcherIgnoresOtherConfigMaps(t *testing.T) {
+	w, observer, _ := newTestWatcher()
+	other := configMap(map[string]string{"config.yaml": "schemaVersion: 1\nmode: execute"})
+	other.Name = "not-alfred"
+	w.observe(other)
+	if observer.success != 0 || w.Store.Get().Mode != ModeRecommendOnly {
+		t.Fatal("watcher must ignore unrelated ConfigMaps")
+	}
+}
+
+func TestWatcherNeedsNoLeadership(t *testing.T) {
+	w, _, _ := newTestWatcher()
+	if w.NeedLeaderElection() {
+		t.Fatal("config watcher must run on every replica")
+	}
+}

--- a/pkg/alfred/metrics/metrics.go
+++ b/pkg/alfred/metrics/metrics.go
@@ -1,0 +1,170 @@
+// Package metrics defines every Prometheus series Alfred exports (OEP-0008
+// §Observability), constructed against an injectable registerer so tests can
+// use a private registry. All series share the alfred_ prefix.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Metrics holds every Alfred series. Snapshot-derived gauges are published by
+// the observation loop; decision-side series are emitted only by the engine's
+// Reporter stage.
+type Metrics struct {
+	// Snapshot / fragmentation gauges.
+	ClusterFragmentationScore prometheus.Gauge
+	FragmentationObserved     *prometheus.GaugeVec // acceleratorclass, size
+	FragmentationReclaimable  *prometheus.GaugeVec // acceleratorclass
+	PendingPressure           *prometheus.GaugeVec // acceleratorclass
+	GPUCapacity               *prometheus.GaugeVec // node, status
+	PendingPodCount           prometheus.Gauge
+	PendingPodGPURequirements *prometheus.GaugeVec // size
+	SurgeHeadroomGPUs         *prometheus.GaugeVec // acceleratorclass
+
+	// Recommendation / migration counters (Reporter-only).
+	RecommendationsProduced *prometheus.CounterVec // policy, workload, component, reason, executable
+	RecommendationsAccepted *prometheus.CounterVec // policy, workload, component
+	RecommendationsRejected *prometheus.CounterVec // policy, workload, component, reason
+	MigrationCalls          *prometheus.CounterVec // policy, workload, mode, surface
+	MigrationOutcome        *prometheus.CounterVec // policy, workload, mode, outcome
+	LWSRecommendations      *prometheus.CounterVec // isvc, action
+
+	// Node-health counters (Reporter-only).
+	NodeHealthEvacuations *prometheus.CounterVec // node, workload, surface, outcome
+	NodeHealthSignals     *prometheus.CounterVec // node, reason
+	CooldownOverrides     *prometheus.CounterVec // policy
+
+	// Loop / operational.
+	ObservationLoopDuration prometheus.Histogram
+	DecisionLoopDuration    prometheus.Histogram
+	LeaderStatus            *prometheus.GaugeVec   // pod
+	PolicyReload            *prometheus.CounterVec // outcome
+	CircuitBreakerState     prometheus.Gauge
+	OMENativeUnavailable    prometheus.Gauge
+}
+
+// New constructs and registers every series. A nil registerer registers into
+// the controller-runtime registry served on the manager's metrics endpoint.
+func New(reg prometheus.Registerer) *Metrics {
+	if reg == nil {
+		reg = ctrlmetrics.Registry
+	}
+	factory := promauto.With(reg)
+	return &Metrics{
+		ClusterFragmentationScore: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "alfred_cluster_fragmentation_score",
+			Help: "Combined fragmentation gate value in [0,1]: max over accelerator classes of the reclaimable-or-pending score.",
+		}),
+		FragmentationObserved: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alfred_fragmentation_observed",
+			Help: "Frag(c,s): fraction of class free GPUs a demand of the labeled size cannot use.",
+		}, []string{"acceleratorclass", "size"}),
+		FragmentationReclaimable: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alfred_fragmentation_reclaimable",
+			Help: "Share of observed fragmentation that migrating movable workloads could fix.",
+		}, []string{"acceleratorclass"}),
+		PendingPressure: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alfred_pending_pressure",
+			Help: "P(c): age-weighted pressure from pending pods a repack could seat.",
+		}, []string{"acceleratorclass"}),
+		GPUCapacity: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alfred_gpu_capacity",
+			Help: "Per-node GPU capacity; status is total, allocated, free, or contiguous_max.",
+		}, []string{"node", "status"}),
+		PendingPodCount: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "alfred_pending_pod_count",
+			Help: "Unscheduled GPU-requesting pods, real and virtual.",
+		}),
+		PendingPodGPURequirements: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alfred_pending_pod_gpu_requirements",
+			Help: "Pending GPU demand bucketed by per-pod request size.",
+		}, []string{"size"}),
+		SurgeHeadroomGPUs: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alfred_surge_headroom_gpus",
+			Help: "Largest replacement footprint that could surge right now per class; 0 means surge-shaped migration is infeasible.",
+		}, []string{"acceleratorclass"}),
+
+		RecommendationsProduced: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "alfred_recommendations_produced_total",
+			Help: "Candidates produced by policies, labeled by outcome-relevant attributes.",
+		}, []string{"policy", "workload", "component", "reason", "executable"}),
+		RecommendationsAccepted: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "alfred_recommendations_accepted_total",
+			Help: "Candidates admitted by the arbiter.",
+		}, []string{"policy", "workload", "component"}),
+		RecommendationsRejected: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "alfred_recommendations_rejected_total",
+			Help: "Candidates rejected or withheld by the arbiter, with the drop reason.",
+		}, []string{"policy", "workload", "component", "reason"}),
+		MigrationCalls: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "alfred_migration_calls_total",
+			Help: "Migration requests dispatched; surface is omenative, rollingrestart, or eviction.",
+		}, []string{"policy", "workload", "mode", "surface"}),
+		MigrationOutcome: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "alfred_migration_outcome_total",
+			Help: "Terminal outcomes of dispatched migrations: completed, failed, or timeout.",
+		}, []string{"policy", "workload", "mode", "outcome"}),
+		LWSRecommendations: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "alfred_lws_recommendations_total",
+			Help: "Advisory recommendations for LWS-backed workloads Alfred never executes.",
+		}, []string{"isvc", "action"}),
+
+		NodeHealthEvacuations: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "alfred_nodehealth_evacuations_total",
+			Help: "Evacuation actions Policy #2 dispatched.",
+		}, []string{"node", "workload", "surface", "outcome"}),
+		NodeHealthSignals: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "alfred_nodehealth_signals_total",
+			Help: "Signal-only outcomes where the caretaker emitted a signal instead of acting.",
+		}, []string{"node", "reason"}),
+		CooldownOverrides: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "alfred_cooldown_overrides_total",
+			Help: "Health-evacuation admissions under the standard cooldown (each also emits CooldownOverriddenForEvacuation).",
+		}, []string{"policy"}),
+
+		ObservationLoopDuration: factory.NewHistogram(prometheus.HistogramOpts{
+			Name:    "alfred_observation_loop_duration_seconds",
+			Help:    "Duration of one observation pass (snapshot build + gauge publish).",
+			Buckets: prometheus.DefBuckets,
+		}),
+		DecisionLoopDuration: factory.NewHistogram(prometheus.HistogramOpts{
+			Name:    "alfred_decision_loop_duration_seconds",
+			Help:    "Duration of one decision pass (policies + arbiter + reporter + dispatch).",
+			Buckets: prometheus.DefBuckets,
+		}),
+		LeaderStatus: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alfred_leader_status",
+			Help: "1 on the replica currently holding leadership, 0 otherwise.",
+		}, []string{"pod"}),
+		PolicyReload: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "alfred_policy_reload_total",
+			Help: "Config reload attempts by outcome (success or failure).",
+		}, []string{"outcome"}),
+		CircuitBreakerState: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "alfred_circuit_breaker_state",
+			Help: "1 while the execution circuit breaker is open, 0 while closed.",
+		}),
+		OMENativeUnavailable: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "alfred_omenative_unavailable",
+			Help: "1 while no OMENative executor is available (multi-pod candidates degrade to advisory).",
+		}),
+	}
+}
+
+// ObserveConfigReload implements the config package's ReloadObserver.
+func (m *Metrics) ObserveConfigReload(outcome string) {
+	m.PolicyReload.WithLabelValues(outcome).Inc()
+}
+
+// ResetSnapshotGauges clears the node- and class-keyed snapshot gauges before
+// a republish so series for departed nodes and classes do not linger.
+func (m *Metrics) ResetSnapshotGauges() {
+	m.FragmentationObserved.Reset()
+	m.FragmentationReclaimable.Reset()
+	m.PendingPressure.Reset()
+	m.GPUCapacity.Reset()
+	m.PendingPodGPURequirements.Reset()
+	m.SurgeHeadroomGPUs.Reset()
+}

--- a/pkg/alfred/metrics/metrics_test.go
+++ b/pkg/alfred/metrics/metrics_test.go
@@ -1,0 +1,86 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestNewRegistersEverySeries(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	m := New(registry)
+
+	// Touch one child of every vector so Gather sees each family, then
+	// count families: every declared series must be registered exactly
+	// once (promauto would have panicked on a duplicate registration).
+	m.ClusterFragmentationScore.Set(0.5)
+	m.FragmentationObserved.WithLabelValues("h100", "8").Set(1)
+	m.FragmentationReclaimable.WithLabelValues("h100").Set(0.2)
+	m.PendingPressure.WithLabelValues("h100").Set(0.1)
+	m.GPUCapacity.WithLabelValues("node1", "free").Set(3)
+	m.PendingPodCount.Set(1)
+	m.PendingPodGPURequirements.WithLabelValues("8").Set(1)
+	m.SurgeHeadroomGPUs.WithLabelValues("h100").Set(5)
+	m.RecommendationsProduced.WithLabelValues("defragmentation", "prod/svc", "engine", "fragmentation", "true").Inc()
+	m.RecommendationsAccepted.WithLabelValues("defragmentation", "prod/svc", "engine").Inc()
+	m.RecommendationsRejected.WithLabelValues("defragmentation", "prod/svc", "engine", "Cooldown").Inc()
+	m.MigrationCalls.WithLabelValues("defragmentation", "prod/svc", "RollingUpdate", "rollingrestart").Inc()
+	m.MigrationOutcome.WithLabelValues("defragmentation", "prod/svc", "RollingUpdate", "completed").Inc()
+	m.LWSRecommendations.WithLabelValues("prod/svc", "manual").Inc()
+	m.NodeHealthEvacuations.WithLabelValues("node1", "prod/svc", "omenative", "completed").Inc()
+	m.NodeHealthSignals.WithLabelValues("node1", "RemediationSignal").Inc()
+	m.CooldownOverrides.WithLabelValues("nodehealth").Inc()
+	m.ObservationLoopDuration.Observe(0.1)
+	m.DecisionLoopDuration.Observe(0.2)
+	m.LeaderStatus.WithLabelValues("alfred-0").Set(1)
+	m.PolicyReload.WithLabelValues("success").Inc()
+	m.CircuitBreakerState.Set(0)
+	m.OMENativeUnavailable.Set(1)
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const wantFamilies = 23
+	if len(families) != wantFamilies {
+		t.Fatalf("registered %d metric families, want %d", len(families), wantFamilies)
+	}
+	for _, family := range families {
+		if family.GetHelp() == "" {
+			t.Fatalf("metric %s has no help text", family.GetName())
+		}
+	}
+}
+
+func TestObserveConfigReload(t *testing.T) {
+	m := New(prometheus.NewRegistry())
+	m.ObserveConfigReload("success")
+	m.ObserveConfigReload("failure")
+	m.ObserveConfigReload("failure")
+	if got := promtestutil.ToFloat64(m.PolicyReload.WithLabelValues("success")); got != 1 {
+		t.Fatalf("success reloads = %v, want 1", got)
+	}
+	if got := promtestutil.ToFloat64(m.PolicyReload.WithLabelValues("failure")); got != 2 {
+		t.Fatalf("failure reloads = %v, want 2", got)
+	}
+}
+
+func TestResetSnapshotGauges(t *testing.T) {
+	m := New(prometheus.NewRegistry())
+	m.GPUCapacity.WithLabelValues("node-departed", "free").Set(8)
+	m.SurgeHeadroomGPUs.WithLabelValues("h100").Set(5)
+	m.FragmentationObserved.WithLabelValues("h100", "8").Set(1)
+
+	m.ResetSnapshotGauges()
+
+	for name, count := range map[string]int{
+		"gpu capacity":  promtestutil.CollectAndCount(m.GPUCapacity),
+		"surge":         promtestutil.CollectAndCount(m.SurgeHeadroomGPUs),
+		"fragmentation": promtestutil.CollectAndCount(m.FragmentationObserved),
+	} {
+		if count != 0 {
+			t.Fatalf("%s series survived reset: %d", name, count)
+		}
+	}
+}

--- a/pkg/alfred/observer/loop.go
+++ b/pkg/alfred/observer/loop.go
@@ -1,0 +1,164 @@
+// Package observer runs Alfred's observation loop: rebuild the
+// ClusterSnapshot on a fixed cadence and publish the snapshot-derived
+// Prometheus gauges. The loop runs on every replica (not only the leader) so
+// an operator can scrape any pod, and it only ever reads — actuation lives
+// exclusively in the decision loop's dispatcher (OEP-0008).
+package observer
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/metrics"
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+)
+
+// Loop is the observation-loop Runnable.
+type Loop struct {
+	Reader  client.Reader
+	Store   *config.Store
+	Metrics *metrics.Metrics
+	Log     logr.Logger
+
+	// Scorer publishes the fragmentation gauges
+	// (alfred_cluster_fragmentation_score, alfred_fragmentation_*,
+	// alfred_pending_pressure) from a fresh snapshot. The defrag policy
+	// package wires it; while nil those gauges stay unset.
+	Scorer func(*snapshot.ClusterSnapshot, *config.Config, *metrics.Metrics)
+
+	// OMENativeAvailable reports whether an OMENative executor exists on
+	// this cluster; recorded on every snapshot. Nil means unavailable.
+	OMENativeAvailable func(ctx context.Context) bool
+
+	// Now overrides the clock in tests.
+	Now func() time.Time
+
+	latest atomic.Pointer[snapshot.ClusterSnapshot]
+}
+
+var _ manager.Runnable = &Loop{}
+var _ manager.LeaderElectionRunnable = &Loop{}
+
+// NeedLeaderElection returns false: every replica observes, so gauges keep
+// flowing even while a replica is not leading.
+func (l *Loop) NeedLeaderElection() bool { return false }
+
+// Latest returns the most recent snapshot, or nil before the first pass. The
+// decision loop consumes this — at most one observation interval stale.
+func (l *Loop) Latest() *snapshot.ClusterSnapshot {
+	return l.latest.Load()
+}
+
+// Start runs an immediate first pass, then ticks at the configured
+// observation interval, re-reading the interval every pass so a config
+// reload takes effect without a restart.
+func (l *Loop) Start(ctx context.Context) error {
+	if err := l.RunOnce(ctx); err != nil {
+		// The first pass may race informer sync; log and keep ticking.
+		l.Log.Error(err, "initial observation pass failed")
+	}
+	for {
+		interval := l.Store.Get().ObservationLoopInterval.Duration
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(interval):
+			if err := l.RunOnce(ctx); err != nil {
+				l.Log.Error(err, "observation pass failed")
+			}
+		}
+	}
+}
+
+// RunOnce builds one snapshot and publishes gauges. Exported so tests (and a
+// forced pre-decision refresh) can drive passes directly.
+func (l *Loop) RunOnce(ctx context.Context) error {
+	started := l.now()
+	cfg := l.Store.Get()
+
+	opts := snapshot.Options{
+		TriggerConditions: cfg.Policies.NodeHealth.TriggerConditions,
+		PreemptibleLabels: cfg.SpotPolicy.PreemptibleLabels,
+		DefaultMovable:    cfg.DefaultMovable,
+		Now:               l.Now,
+	}
+	if l.OMENativeAvailable != nil {
+		opts.OMENativeAvailable = l.OMENativeAvailable(ctx)
+	}
+	if opts.OMENativeAvailable {
+		l.Metrics.OMENativeUnavailable.Set(0)
+	} else {
+		l.Metrics.OMENativeUnavailable.Set(1)
+	}
+
+	snap, err := snapshot.Build(ctx, l.Reader, opts)
+	if err != nil {
+		return fmt.Errorf("build snapshot: %w", err)
+	}
+	l.latest.Store(snap)
+	l.publish(snap, cfg)
+	l.Metrics.ObservationLoopDuration.Observe(l.now().Sub(started).Seconds())
+	return nil
+}
+
+func (l *Loop) publish(snap *snapshot.ClusterSnapshot, cfg *config.Config) {
+	m := l.Metrics
+	m.ResetSnapshotGauges()
+
+	for name, node := range snap.Nodes {
+		if node.TotalGPUs == 0 {
+			continue
+		}
+		m.GPUCapacity.WithLabelValues(name, "total").Set(float64(node.TotalGPUs))
+		m.GPUCapacity.WithLabelValues(name, "allocated").Set(float64(node.AllocatedGPUs))
+		m.GPUCapacity.WithLabelValues(name, "free").Set(float64(node.FreeGPUs))
+		// v1 treats intra-node GPUs as fungible; the topology hook
+		// (Q-040) would refine this to true contiguous capacity.
+		m.GPUCapacity.WithLabelValues(name, "contiguous_max").Set(float64(node.FreeGPUs))
+	}
+
+	m.PendingPodCount.Set(float64(len(snap.PendingPods)))
+	pendingBySize := map[int64]int{}
+	for _, p := range snap.PendingPods {
+		pendingBySize[p.GPUsNeeded]++
+	}
+	for size, count := range pendingBySize {
+		m.PendingPodGPURequirements.WithLabelValues(fmt.Sprintf("%d", size)).Set(float64(count))
+	}
+
+	// Surge headroom per hardware pool: the largest single-node free
+	// block — the biggest replacement footprint a surge-shaped migration
+	// could place while its source still holds GPUs. 0 means surge-shaped
+	// candidates degrade to advisory (NoSurgeHeadroom). The metric label
+	// keeps the OEP's `acceleratorclass` name; its value is the pool key.
+	for _, pool := range snap.GPUPools() {
+		var headroom int64
+		for _, node := range snap.PoolNodes(pool) {
+			if node.Cordoned || node.Unhealthy || node.ScaleDownMarked || node.Suspect {
+				continue
+			}
+			if node.FreeGPUs > headroom {
+				headroom = node.FreeGPUs
+			}
+		}
+		m.SurgeHeadroomGPUs.WithLabelValues(pool).Set(float64(headroom))
+	}
+
+	if l.Scorer != nil {
+		l.Scorer(snap, cfg, m)
+	}
+}
+
+func (l *Loop) now() time.Time {
+	if l.Now == nil {
+		return time.Now()
+	}
+	return l.Now()
+}

--- a/pkg/alfred/observer/loop_test.go
+++ b/pkg/alfred/observer/loop_test.go
@@ -1,0 +1,185 @@
+package observer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/metrics"
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+var loopNow = time.Date(2026, 1, 3, 12, 0, 0, 0, time.UTC)
+
+func newTestLoop(t *testing.T) (*Loop, *metrics.Metrics) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{
+			"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3",
+		}},
+		Status: corev1.NodeStatus{Allocatable: corev1.ResourceList{
+			"nvidia.com/gpu": resource.MustParse("8"),
+		}},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team", Name: "occupant"},
+		Spec: corev1.PodSpec{NodeName: "node1", Containers: []corev1.Container{{
+			Name: "main",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				"nvidia.com/gpu": resource.MustParse("3"),
+			}},
+		}}},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	pending := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team", Name: "pending"},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "main",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				"nvidia.com/gpu": resource.MustParse("8"),
+			}},
+		}}},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(node, pod, pending).Build()
+
+	m := metrics.New(prometheus.NewRegistry())
+	loop := &Loop{
+		Reader:  fakeClient,
+		Store:   config.NewStore(),
+		Metrics: m,
+		Log:     logr.Discard(),
+		Now:     func() time.Time { return loopNow },
+	}
+	return loop, m
+}
+
+func TestLoopRunsOnEveryReplica(t *testing.T) {
+	loop, _ := newTestLoop(t)
+	if loop.NeedLeaderElection() {
+		t.Fatal("observation loop must run on every replica")
+	}
+}
+
+func TestStartRunsInitialPassAndStopsOnCancel(t *testing.T) {
+	loop, _ := newTestLoop(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- loop.Start(ctx) }()
+
+	deadline := time.After(5 * time.Second)
+	for loop.Latest() == nil {
+		select {
+		case <-deadline:
+			t.Fatal("Start never completed its initial pass")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error on shutdown: %v", err)
+	}
+}
+
+func TestRunOncePublishesSnapshotGauges(t *testing.T) {
+	loop, m := newTestLoop(t)
+
+	if loop.Latest() != nil {
+		t.Fatal("Latest should be nil before the first pass")
+	}
+	if err := loop.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	snap := loop.Latest()
+	if snap == nil {
+		t.Fatal("Latest should be set after a pass")
+	}
+
+	get := func(vec *prometheus.GaugeVec, labels ...string) float64 {
+		return promtestutil.ToFloat64(vec.WithLabelValues(labels...))
+	}
+	if got := get(m.GPUCapacity, "node1", "total"); got != 8 {
+		t.Fatalf("gpu_capacity total = %v, want 8", got)
+	}
+	if got := get(m.GPUCapacity, "node1", "allocated"); got != 3 {
+		t.Fatalf("gpu_capacity allocated = %v, want 3", got)
+	}
+	if got := get(m.GPUCapacity, "node1", "free"); got != 5 {
+		t.Fatalf("gpu_capacity free = %v, want 5", got)
+	}
+	if got := promtestutil.ToFloat64(m.PendingPodCount); got != 1 {
+		t.Fatalf("pending_pod_count = %v, want 1", got)
+	}
+	if got := get(m.PendingPodGPURequirements, "8"); got != 1 {
+		t.Fatalf("pending_pod_gpu_requirements{8} = %v, want 1", got)
+	}
+	if got := get(m.SurgeHeadroomGPUs, "NVIDIA-H100-80GB-HBM3"); got != 5 {
+		t.Fatalf("surge_headroom_gpus{pool} = %v, want 5 (largest free block)", got)
+	}
+}
+
+func TestRunOnceInvokesScorerHook(t *testing.T) {
+	loop, _ := newTestLoop(t)
+
+	var scored *snapshot.ClusterSnapshot
+	loop.Scorer = func(s *snapshot.ClusterSnapshot, cfg *config.Config, m *metrics.Metrics) {
+		scored = s
+		m.ClusterFragmentationScore.Set(0.42)
+	}
+	if err := loop.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if scored == nil || scored != loop.Latest() {
+		t.Fatal("scorer must receive the freshly built snapshot")
+	}
+	if got := promtestutil.ToFloat64(loop.Metrics.ClusterFragmentationScore); got != 0.42 {
+		t.Fatalf("scorer gauge write lost: %v", got)
+	}
+}
+
+func TestRunOnceRecordsOMENativeDiscovery(t *testing.T) {
+	loop, m := newTestLoop(t)
+	loop.OMENativeAvailable = func(context.Context) bool { return true }
+	if err := loop.RunOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !loop.Latest().OMENativeAvailable {
+		t.Fatal("discovery result must be recorded on the snapshot")
+	}
+	if got := promtestutil.ToFloat64(m.OMENativeUnavailable); got != 0 {
+		t.Fatalf("omenative_unavailable = %v after available discovery, want 0", got)
+	}
+
+	loop.OMENativeAvailable = nil
+	if err := loop.RunOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if loop.Latest().OMENativeAvailable {
+		t.Fatal("nil discovery must record unavailable")
+	}
+	if got := promtestutil.ToFloat64(m.OMENativeUnavailable); got != 1 {
+		t.Fatalf("omenative_unavailable = %v with no executor, want 1", got)
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds the `cmd/alfred` binary: a controller-runtime manager running OEP-0008's
two-loop split — leadership-independent Runnables run on **every** replica, so
observability keeps flowing even on non-leader pods. The decision loop
(policies → arbiter → reporter → dispatcher) comes in later PRs; this binary
observes and reports only and performs **no writes**.

- **`cmd/alfred/main.go`** — flags (manager `Options` pattern), Lease leader
  election (`alfred.ome.io`, 15s/10s/2s per the OEP), health probes, a
  ConfigMap cache scoped to Alfred's namespace, a cluster-wide pod cache
  bounded by a field-stripping transform (non-OME GPU occupants must count
  against capacity, so the cache cannot be label-filtered), a `spec.nodeName`
  pod index, and the `alfred_leader_status` gauge off `mgr.Elected()`.
- **`pkg/alfred/config`** — the full `alfred-config` / `config.yaml` schema
  with OEP defaults, strict parsing, and validation; a hot-reloading `Store`
  with **last-known-good fallback** (a broken edit keeps the previous config
  serving, emits `PolicyReloadFailed`, and increments
  `alfred_policy_reload_total{outcome="failure"}`); boots on safe built-in
  defaults (`mode: recommend-only`) until the ConfigMap loads.
- **`pkg/alfred/metrics`** — every `alfred_*` series from the OEP observability
  section, built against an injectable registerer.
- **`pkg/alfred/observer`** — the observation loop: rebuilds the
  `ClusterSnapshot` each interval (hot-reloaded) and publishes the
  snapshot-derived gauges (`alfred_gpu_capacity`, `alfred_pending_pod_*`,
  `alfred_surge_headroom_gpus`, loop duration). Fragmentation gauges hang off a
  `Scorer` hook the defrag policy wires in the next PR.
- **Build**: `make alfred` (CGO off) and `dockerfiles/alfred.Dockerfile`
  (no Rust/XET dependency).

## Testing

- Config: defaults, full-schema parse, every validation axis, last-known-good
  retention, reload dedup across informer resyncs, missing-key handling.
- Observer: gauge values asserted against a fake cluster via the Prometheus
  test utilities; scorer hook and OMENative-discovery recording covered.
- `NeedLeaderElection()` pinned for both Runnables (config watcher and
  observation loop must run on every replica).
- `make alfred` produces a working binary.

## Notes

Stacked on #766; base is `alfred/a1-snapshot-foundation`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Alfred, a Kubernetes-based workload observation and optimization service.
  - Added configurable recommendation and execution modes with policy validation and safe defaults.
  - Added dynamic ConfigMap configuration reloads while retaining the last valid configuration after errors.
  - Added periodic cluster observation, workload snapshots, health monitoring, and Prometheus metrics.
  - Added health and readiness probes, leader-election support, and containerized deployment.
- **Build**
  - Added a Make target for building the Alfred executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->