### PR TITLE
[Docs] Prefill/decode sample + metadata propagation guide

### DIFF
--- a/config/samples/pd-omenative/00-clusterbasemodel.yaml
+++ b/config/samples/pd-omenative/00-clusterbasemodel.yaml
@@ -1,0 +1,14 @@
+# A placeholder model so the sample can be applied without pulling weights.
+apiVersion: ome.io/v1beta1
+kind: ClusterBaseModel
+metadata:
+  name: demo-model
+spec:
+  vendor: example
+  disabled: false
+  storage:
+    storageUri: hf://example-org/demo-model
+  modelFormat:
+    name: safetensors
+  modelArchitecture: LlamaForCausalLM
+  modelParameterSize: "8B"

--- a/config/samples/pd-omenative/10-clusterservingruntime.yaml
+++ b/config/samples/pd-omenative/10-clusterservingruntime.yaml
@@ -1,0 +1,50 @@
+# A multi-node TPU serving runtime. One pod per node, each claiming a whole
+# node's chips, so pod count and node count line up for a gang. Replace the
+# accelerator name, topology and resource key with what your nodes advertise —
+# the propagation this sample demonstrates is independent of them.
+apiVersion: ome.io/v1beta1
+kind: ClusterServingRuntime
+metadata:
+  name: demo-accelerator-runtime
+spec:
+  disabled: false
+  supportedModelFormats:
+  - name: demo-safetensors
+    modelFormat:
+      name: safetensors
+    modelFramework:
+      name: transformers
+    modelArchitecture: LlamaForCausalLM
+    autoSelect: true
+  engineConfig:
+    # One pod per node, each claiming a whole node's accelerators, so pod count
+    # and node count line up for a gang.
+    nodeSelector:
+      cloud.google.com/gke-tpu-accelerator: tpu7x
+      cloud.google.com/gke-tpu-topology: 2x2x2
+    tolerations:
+    - key: google.com/tpu
+      operator: Equal
+      value: present
+      effect: NoSchedule
+    runner:
+      name: ome-container
+      image: example.com/serving-runtime:demo
+      resources:
+        requests: { cpu: "8", memory: 32Gi, google.com/tpu: "4" }
+        limits: { cpu: "8", memory: 32Gi, google.com/tpu: "4" }
+  decoderConfig:
+    nodeSelector:
+      cloud.google.com/gke-tpu-accelerator: tpu7x
+      cloud.google.com/gke-tpu-topology: 2x2x2
+    tolerations:
+    - key: google.com/tpu
+      operator: Equal
+      value: present
+      effect: NoSchedule
+    runner:
+      name: ome-container
+      image: example.com/serving-runtime:demo
+      resources:
+        requests: { cpu: "8", memory: 32Gi, google.com/tpu: "4" }
+        limits: { cpu: "8", memory: 32Gi, google.com/tpu: "4" }

--- a/config/samples/pd-omenative/20-inferenceservice.yaml
+++ b/config/samples/pd-omenative/20-inferenceservice.yaml
@@ -1,0 +1,118 @@
+---
+# Prefill/decode disaggregation on multi-host accelerator slices.
+#
+# One InferenceService, three Components:
+#   engine  — prefill, KV producer
+#   decoder — decode, KV consumer
+#   router  — fronts both and routes per phase
+#
+# Engine and decoder are each a leader + worker gang that must land inside ONE
+# accelerator slice, so each pins its own topologyKey. Sizing is deliberately
+# asymmetric: prefill and decode do not sustain the same requests/sec per gang,
+# so matching their throughput means different replica counts. Take the ratio
+# from your own measurements — the counts below are small on purpose so the
+# sample applies anywhere.
+#
+# The annotations exist to make metadata propagation observable end to end:
+#   example.com/owner       declared once here, must appear on BOTH gangs
+#   example.com/tier        declared here AND per Component; the Component wins
+#   example.com/slice-hint  a scheduling hint that must survive to the pods
+apiVersion: ome.io/v1beta1
+kind: InferenceService
+metadata:
+  name: pd-demo
+  annotations:
+    ome.io/deploymentMode: OMENative
+    example.com/owner: team-inference
+    example.com/tier: service-level
+    example.com/slice-hint: "2x2x2"
+  labels:
+    # Bump this to restart the workload with no real spec change: it alters the
+    # pod template, so the rollout policy below drives the replacement.
+    bounce: "1"
+spec:
+  deploymentMode: OMENative
+  model:
+    name: demo-model
+  runtime:
+    name: demo-accelerator-runtime
+  engine:
+    # Prefill gang count — the larger share here, since prefill is usually the
+    # bottleneck for long-context traffic.
+    minReplicas: 3
+    maxReplicas: 3
+    annotations:
+      example.com/tier: engine-level
+    # The slice one gang must fit inside. OMENative projects this onto
+    # ir.Spec.TopologyKey; the InferenceReplica controller is what turns it into
+    # the worker->leader affinity, and that controller is not in this build (see
+    # the README). Substitute the node label your platform uses to identify a
+    # single slice — present on every node of the slice, unique per slice.
+    topologyKey: cloud.example.com/accelerator-slice-id
+    # Constrain where gangs may land at all. topologyKey above co-locates one
+    # gang's pods; this bounds the pool they are placed from — here, the zones
+    # that hold the accelerator fleet, so a gang cannot be scheduled into a zone
+    # with no capacity for it.
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+              - us-central1-a
+              - us-central1-b
+    leader:
+      runner:
+        name: ome-container
+    worker:
+      size: 1
+      runner:
+        name: ome-container
+    lifecycle: &componentLifecycle
+      # A cold accelerator compile can take far longer than a normal container
+      # start. Size this to your own compile time, or gangs are torn down
+      # mid-compile and never converge.
+      instanceReadyTimeout: 45m0s
+      migrationPolicy:
+        mode: Auto
+      # A multi-host gang serves only when every pod in it is ready — a partially
+      # ready gang cannot answer a request.
+      readyPolicy: AllPodReady
+      # One crashlooping pod invalidates its whole gang, so replace the gang
+      # rather than the single pod.
+      restartPolicy: RecreateInstanceOnPodRestart
+      updateStrategy:
+        type: SurgeThenDrain
+        rollingUpdate:
+          # Stand up a replacement gang before draining an old one, and never
+          # give up serving capacity mid-roll.
+          maxSurge: 1
+          maxUnavailable: 0
+        inPlaceUpdateStrategy:
+          gracePeriodSeconds: 30
+          markNotReadyDuringLifecycle: true
+  decoder:
+    # Decode gang count, matched against the prefill count above so neither
+    # stage starves the other.
+    minReplicas: 2
+    maxReplicas: 2
+    annotations:
+      example.com/tier: decoder-level
+    # Each decode gang gets its own slice, same as prefill.
+    topologyKey: cloud.example.com/accelerator-slice-id
+    leader:
+      runner:
+        name: ome-container
+    worker:
+      size: 1
+      runner:
+        name: ome-container
+    # Both gangs share one readiness and rollout policy.
+    lifecycle: *componentLifecycle
+  router:
+    minReplicas: 1
+    maxReplicas: 1
+    annotations:
+      example.com/tier: router-level

--- a/config/samples/pd-omenative/30-inferenceservice-gang.yaml
+++ b/config/samples/pd-omenative/30-inferenceservice-gang.yaml
@@ -1,0 +1,76 @@
+---
+# Queue-admitted multi-host gang, via Kueue.
+#
+# A multi-host gang cannot serve until every pod is running, so letting its pods
+# in one at a time is worse than not letting them in at all: partial gangs hold
+# accelerators they cannot use while blocking the gang behind them. Kueue admits
+# against a quota instead — pods are created gated and stay gated until their
+# workload is admitted.
+#
+# Kueue does NOT replace kube-scheduler: its webhook gates the pods, and whichever
+# scheduler is named binds them once admitted. So schedulerName below is an
+# independent knob, not part of admission.
+#
+# This uses MultiNode rather than OMENative on purpose: OME derives the Kueue
+# labels in SetPodLabelsFromAnnotations, which runs in the RawDeployment and
+# MultiNode reconcilers and not on the OMENative projection path. See the README.
+#
+# No deploymentMode is set below — declaring leader + worker is what infers
+# MultiNode. Setting it explicitly would take a per-Component
+# ome.io/deploymentMode annotation, since spec.deploymentMode accepts only
+# OMENative and RawDeployment.
+apiVersion: ome.io/v1beta1
+kind: InferenceService
+metadata:
+  name: gang-demo
+  annotations:
+    # These two annotations are what OME reads. Together they become the Kueue
+    # LABELS on every pod:
+    #   ome.io/dedicated-ai-cluster -> kueue.x-k8s.io/queue-name
+    #   (presence of kueue-enabled) -> kueue.x-k8s.io/priority-class
+    # An annotation on the service becoming a label on the pods — a different
+    # propagation shape from the plain copy the other sample traces.
+    ome.io/dedicated-ai-cluster: accelerator-pool
+    kueue-enabled: "true"
+    example.com/owner: team-inference
+spec:
+  model:
+    name: demo-model
+  runtime:
+    name: demo-accelerator-runtime
+  engine:
+    # One gang. Keep it at one while the pod-group identifiers below are set on
+    # the template: they name a single group, so more replicas would fold every
+    # gang into one group and misreport its size.
+    minReplicas: 1
+    maxReplicas: 1
+    # Kueue treats plain pods as a gang only when they carry a pod-group
+    # identity, and OME does not derive those — set them here. They ride the
+    # normal Component metadata path onto the pod template, which is the same
+    # propagation the other sample traces.
+    #
+    # total-count must equal the pod count of one gang: leader (1) + worker
+    # size (1) = 2.
+    labels:
+      kueue.x-k8s.io/pod-group-name: gang-demo-engine
+    annotations:
+      kueue.x-k8s.io/pod-group-total-count: "2"
+      # Keep one gang inside a single slice. On this path the constraint is
+      # LeaderWorkerSet's: Component annotations are copied onto the LWS object,
+      # and LWS turns this key into the affinity that places each group
+      # exclusively within one domain. spec.<component>.topologyKey does NOT
+      # apply here — it is only read on the OMENative path.
+      leaderworkerset.sigs.k8s.io/exclusive-topology: cloud.example.com/accelerator-slice-id
+    # Override which scheduler binds this Component's pods. The value set here
+    # wins over the runtime's; the default scheduler applies only when neither
+    # sets one. Independent of Kueue, which gates admission either way.
+    schedulerName: scheduler-plugins-scheduler
+    # Declaring leader + worker is what makes this a multi-node gang.
+    leader:
+      runner:
+        name: ome-container
+    worker:
+      # Leader + 1 worker = a 2-pod gang, admitted together or not at all.
+      size: 1
+      runner:
+        name: ome-container

--- a/config/samples/pd-omenative/README.md
+++ b/config/samples/pd-omenative/README.md
@@ -1,0 +1,167 @@
+# Prefill/decode disaggregation, and how metadata reaches the pods
+
+This sample answers one question: **when I put an annotation on an
+InferenceService, where does it end up, and what decides that?** It uses a
+prefill/decode (PD) topology because that is the case where the answer is
+non-obvious — one service, two independently sized Components, each with its own
+pod template.
+
+## Apply it
+
+```sh
+kubectl apply -f config/samples/pd-omenative/
+```
+
+The runtime's `nodeSelector`, `tolerations` and resource key are placeholders for
+whatever your accelerator nodes advertise. Nothing in the propagation described
+below depends on them.
+
+## What the sample models
+
+The shape is taken from a real multi-host accelerator deployment, with every
+site-specific value replaced:
+
+| Pattern | Why it is there |
+|---|---|
+| **Asymmetric gang counts** (engine 3, decoder 2) | prefill and decode do not sustain the same requests/sec per gang, so equal counts starve one stage. Derive the ratio from your own measurements. |
+| **`topologyKey` per Component** | names the slice one gang must fit inside. Read on the OMENative path only, where it is projected onto `ir.Spec.TopologyKey`; the InferenceReplica controller is what turns it into worker→leader affinity, and that controller is absent here. See [Slice co-location by path](#slice-co-location-by-path). |
+| **zone `nodeAffinity`** | bounds the pool gangs are placed from, so a gang is never scheduled into a zone with no accelerator capacity for it. Unlike `topologyKey`, this is plain pod-spec affinity and applies on every path. |
+| **`readyPolicy: AllPodReady`** | a partially ready multi-host gang cannot answer a request, so readiness is all-or-nothing per gang. |
+| **`restartPolicy: RecreateInstanceOnPodRestart`** | one crashlooping pod invalidates its gang's collective state; replacing the gang is the recovery, not restarting the pod. |
+| **`SurgeThenDrain`, `maxUnavailable: 0`** | stand up a replacement gang before draining an old one so a roll never gives up serving capacity. |
+| **Long `instanceReadyTimeout`** | a cold accelerator compile can dwarf a normal container start; too short a budget tears gangs down mid-compile so they never converge. |
+| **`bounce` label** | changes the pod template with no real spec change, which is how you force a restart through the rollout policy above. |
+
+Substitute your own accelerator selector, slice-identity label, topology and
+resource key. None of the propagation below depends on them.
+
+## The annotations in the sample are probes
+
+| Annotation | Declared on | Expected outcome |
+|---|---|---|
+| `example.com/owner` | service only | appears on **both** engine and decoder pods |
+| `example.com/tier` | service **and** each Component | Component value wins (`engine-level` / `decoder-level`) |
+| `example.com/slice-hint` | service only | survives to the pods, so a scheduler can read it |
+
+## Where the merge happens
+
+Per Component, in `processAnnotations` (`components/engine.go`,
+`components/decoder.go`, `components/router.go`):
+
+1. Start from the InferenceService's annotations, dropping any key in
+   `constants.ServiceAnnotationDisallowedList`.
+2. Union the Component's own `annotations` over that — **the Component wins on a
+   key collision**.
+3. `ProcessBaseAnnotations` adds derived entries (model format, model category,
+   fine-tuned weight wiring).
+
+Labels follow the same shape via `processLabels` + `ProcessBaseLabels`.
+
+The result is the Component's ObjectMeta, and that is what reaches the pods. Only
+the last hop differs by deployment mode:
+
+| Mode | Component ObjectMeta lands on | Pods created by |
+|---|---|---|
+| `RawDeployment` | Deployment pod template | this build |
+| `MultiNode` | LeaderWorkerSet pod template | this build |
+| `OMENative` | `InferenceReplica` `spec.runners[].template.metadata` | **not this build** — see below |
+
+`spec.engine.topologyKey` is projected onto `ir.Spec.TopologyKey`. Deriving the
+worker→leader affinity from it is the InferenceReplica controller's job, so in
+this build the key reaches the InferenceReplica and stops there.
+
+### Slice co-location by path
+
+The field that co-locates a gang is not the same on every path, which is easy to
+get wrong because both are named after topology:
+
+| Path | What constrains a gang | Notes |
+|---|---|---|
+| `OMENative` | `spec.<component>.topologyKey` | projected onto `ir.Spec.TopologyKey`; the absent InferenceReplica controller would derive the affinity |
+| `MultiNode` | `leaderworkerset.sigs.k8s.io/exclusive-topology` annotation | Component annotations are copied onto the LWS object, and LWS places each group exclusively within one domain |
+| `RawDeployment` | neither | a single-pod Component has no gang to co-locate |
+
+`spec.<component>.topologyKey` is **ignored on the MultiNode path** — it is not
+passed to the LWS builder — so the gang sample uses the LWS annotation instead.
+`TestCreateLWSCarriesExclusiveTopologyToTheLWSObject` pins that the annotation
+reaches the LWS object, which is where LWS reads it.
+
+## Queue-admitted gangs (Kueue)
+
+`30-inferenceservice-gang.yaml` puts a multi-host gang behind a quota. A gang
+cannot serve until every pod runs, so admitting its pods one at a time is worse
+than not admitting them: partial gangs hold accelerators they cannot use while
+blocking the gang behind them.
+
+OME derives the Kueue labels from two annotations on the service:
+
+| Annotation on the service | Becomes, on every pod |
+|---|---|
+| `ome.io/dedicated-ai-cluster: <queue>` | label `kueue.x-k8s.io/queue-name: <queue>` |
+| `kueue-enabled` (presence) | label `kueue.x-k8s.io/priority-class: kueue-scheduling-high-priority` |
+
+That is a second propagation shape worth knowing: an **annotation on the service
+becomes a label on the pods**, not a copy. `SetPodLabelsFromAnnotations` also has
+a Volcano branch — `ome.io/volcano-queue` becomes `volcano.sh/queue-name`.
+
+`schedulerName` is a separate knob from admission, and the sample sets it to show
+it is passed through: Kueue gates pods through its webhook, and whichever
+scheduler is named binds them once admitted. Point it at a topology-aware
+scheduler, or leave it unset for the default one. Volcano is the exception —
+there `schedulerName: volcano` is load-bearing, because Volcano *is* the
+scheduler doing admission.
+
+Two limits are worth stating plainly:
+
+- **The rewrite runs on the `RawDeployment` and `MultiNode` paths only** —
+  `deployment_reconciler.go` and `lws_reconciler.go` call it; the OMENative
+  projection path does not. A queue annotation on an `OMENative` service derives
+  no queue label today. That is why this sample uses `MultiNode`, which is also
+  the mode that creates pods in this build.
+- **All-or-nothing admission needs a pod-group identity that OME does not
+  derive.** Kueue treats plain pods as one workload only when they carry
+  `kueue.x-k8s.io/pod-group-name` and a matching
+  `kueue.x-k8s.io/pod-group-total-count`. The sample sets them through the normal
+  Component metadata path, which is why it stays at one replica: the values name a
+  single group, so more replicas would fold every gang into one group and
+  misreport its size.
+
+The multi-cluster placement path derives the queue label differently — from the
+`ome.io/local-queue` annotation or the operator-configured `placement.localQueue`
+— so a derived InferenceService lands in the target cluster's queue without these
+annotations.
+
+## Inspecting the projection
+
+In `OMENative` mode each Component becomes one InferenceReplica named
+`<isvc>-<component>`:
+
+```sh
+kubectl get inferencereplica pd-demo-engine -o yaml
+kubectl get inferencereplica pd-demo-engine \
+  -o jsonpath='{.spec.runners[*].template.metadata.annotations}'
+```
+
+Every Runner template carries the merged set, so what you read there is what the
+pods rendered from it will carry. `TestOMENativeProjectionCarriesMergedPodMetadata`
+in `components/ir_projection_test.go` pins this, including that the
+Component-level value wins.
+
+## What this build does not do
+
+`OMENative` mode **projects the InferenceReplica and stops.** No pods are
+rendered from it, because the InferenceReplica controller is not part of this
+repository yet. Concretely, absent here:
+
+- **`InferenceReplica` → pods.** Nothing reconciles an InferenceReplica, so the
+  IR is an inspectable description of intended pods, not a running workload. Use
+  `RawDeployment` or `MultiNode` for a workload that actually starts.
+- **PodGroups / gang admission.** `ir.Spec.TopologyKey` is projected but nothing
+  consumes it here; there is no PodGroup creation and no gang-aware scheduler, so
+  a partially-schedulable gang is not held back.
+- **Slice-aware packing.** Choosing *which* topology domain a gang lands in — and
+  packing several gangs across domains without stranding capacity — is a
+  scheduler concern and lives outside this repository.
+
+For `RawDeployment` and `MultiNode` the full chain works end to end, so those are
+the modes to use when you want to observe annotations on running pods today.


### PR DESCRIPTION
The code change landed in #771, so this is now standalone: 5 sample files, +425, docs only.

Answers one question concretely: **when I put an annotation on an InferenceService, where does it end up, and what decides that?** It uses a prefill/decode topology because that is where the answer is non-obvious — one service, two independently sized gangs, each with its own pod template.

## The annotations are probes, not decoration

| Annotation | Declared on | Expected outcome |
|---|---|---|
| `example.com/owner` | service only | reaches **both** gangs |
| `example.com/tier` | service **and** each Component | Component value wins |
| `example.com/slice-hint` | service only | survives to the pods |

The README traces the merge through `processAnnotations` — ISVC annotations filtered by `ServiceAnnotationDisallowedList`, unioned with the Component's own (Component wins on collision), then `ProcessBaseAnnotations` — and tabulates which hop each deployment mode completes.

## The prefill/decode sample models a real deployment

Its shape is taken from a production multi-host accelerator deployment with every site-specific value replaced. The policies are the point; a thin sample with equal gang counts and no readiness or rollout policy reads as if none of that matters:

| Pattern | Why |
|---|---|
| asymmetric gang counts (engine 3, decoder 2) | prefill and decode do not sustain the same req/s per gang, so equal counts starve a stage |
| `topologyKey` per Component | names the slice one gang must fit inside |
| zone `nodeAffinity` | bounds the pool gangs are placed from, so none lands in a zone without capacity |
| `readyPolicy: AllPodReady` | a partially ready gang cannot answer a request |
| `restartPolicy: RecreateInstanceOnPodRestart` | one bad pod invalidates its gang's collective state |
| `SurgeThenDrain`, `maxUnavailable: 0` | never give up serving capacity mid-roll |
| long `instanceReadyTimeout` | a cold accelerator compile dwarfs a container start; too short and gangs are torn down mid-compile |

## The gang sample covers queue admission

Kueue, which exercises a second propagation shape — **annotations on the service becoming labels on the pods**:

| Annotation on the service | Becomes, on every pod |
|---|---|
| `ome.io/dedicated-ai-cluster: <queue>` | label `kueue.x-k8s.io/queue-name` |
| `kueue-enabled` (presence) | label `kueue.x-k8s.io/priority-class` |

It also shows the per-Component `schedulerName` override, which is independent of Kueue: Kueue gates admission through its webhook rather than replacing the scheduler.

## Slice co-location differs by path

Each sample uses the field its own path actually reads — `topologyKey` on OMENative, LWS's `exclusive-topology` annotation on MultiNode — and the README tabulates that, because both knobs are named after topology and `topologyKey` constrains nothing on the MultiNode path.

## What is absent is stated, not implied

InferenceReplica→pods, PodGroups and gang admission, slice-aware packing, the queue-label rewrite not running on the OMENative path, and pod-group identifiers OME does not derive — which is why the gang sample stays at one replica, since those values name a single group.

Verified: every field survives a strict apply against the generated CRDs on a live apiserver (kwok), nothing pruned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sample configurations for deploying an 8B Llama model with multi-node TPU serving.
  * Added an OMENative inference service example with engine, decoder, and router components.
  * Added a Kueue-admitted gang deployment example with leader and worker workloads.
* **Documentation**
  * Added guidance covering topology, metadata, deployment modes, scheduling integrations, and current limitations.
  * Documented how to inspect projected inference replica descriptions and configure RawDeployment or MultiNode workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->