### PR TITLE
[Core] Project an InferenceReplica in OMENative mode

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/decoder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/ome/pkg/constants"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/common"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/status"
 	isvcutils "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils"
 	"sigs.k8s.io/ome/pkg/utils"
@@ -154,9 +155,44 @@ func (d *Decoder) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta
 		return d.deploymentReconciler.ReconcileRawDeployment(isvc, objectMeta, podSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
 	case constants.MultiNode:
 		return d.deploymentReconciler.ReconcileMultiNodeDeployment(isvc, objectMeta, podSpec, workerSize, workerPodSpec, &d.decoderSpec.ComponentExtensionSpec, v1beta1.DecoderComponent)
+	case constants.OMENative:
+		return d.projectInferenceReplica(isvc, objectMeta, podSpec, workerSize, workerPodSpec)
 	default:
 		return ctrl.Result{}, errors.New("invalid deployment mode for decoder")
 	}
+}
+
+// projectInferenceReplica renders this Component into its InferenceReplica: the
+// per-Component pod metadata, pod specs, replica count and gang topology key are
+// projected onto the IR, which becomes the single object describing what should
+// run. The rendered Runner templates carry the Component's merged labels and
+// annotations, so whatever the InferenceService (and this Component) declared is
+// visible on the IR and inherited by the pods rendered from it.
+//
+// Materializing those pods is the InferenceReplica controller's job. This build
+// does not include that controller, so the IR is created and kept up to date for
+// inspection and no workload is started from it.
+func (d *Decoder) projectInferenceReplica(isvc *v1beta1.InferenceService, objectMeta metav1.ObjectMeta, podSpec *v1.PodSpec, workerSize int, workerPodSpec *v1.PodSpec) (ctrl.Result, error) {
+	ir, err := irprojector.EnsureInferenceReplica(context.TODO(), irprojector.Params{
+		ISVC:          isvc,
+		Component:     v1beta1.DecoderComponent,
+		ComponentExt:  &d.decoderSpec.ComponentExtensionSpec,
+		ObjectMeta:    objectMeta,
+		PodSpec:       podSpec,
+		WorkerPodSpec: workerPodSpec,
+		WorkerSize:    workerSize,
+		MultiPod:      d.decoderSpec.Worker != nil,
+		TopologyKey:   d.decoderSpec.TopologyKey,
+		Client:        d.Client,
+	})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	d.Log.Info("Projected InferenceReplica; no pods are rendered from it in this build",
+		"inferenceservice", isvc.Namespace+"/"+isvc.Name,
+		"component", v1beta1.DecoderComponent,
+		"inferencereplica", ir.Name)
+	return ctrl.Result{}, nil
 }
 
 // updateDecoderStatus updates the status of the decoder

--- a/pkg/controller/v1beta1/inferenceservice/components/engine.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/ome/pkg/constants"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/common"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector"
 	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/status"
 	isvcutils "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils"
 	"sigs.k8s.io/ome/pkg/utils"
@@ -154,9 +155,44 @@ func (e *Engine) reconcileDeployment(isvc *v1beta1.InferenceService, objectMeta 
 		return e.deploymentReconciler.ReconcileRawDeployment(isvc, objectMeta, podSpec, &e.engineSpec.ComponentExtensionSpec, v1beta1.EngineComponent)
 	case constants.MultiNode:
 		return e.deploymentReconciler.ReconcileMultiNodeDeployment(isvc, objectMeta, podSpec, workerSize, workerPodSpec, &e.engineSpec.ComponentExtensionSpec, v1beta1.EngineComponent)
+	case constants.OMENative:
+		return e.projectInferenceReplica(isvc, objectMeta, podSpec, workerSize, workerPodSpec)
 	default:
 		return ctrl.Result{}, errors.New("invalid deployment mode for engine")
 	}
+}
+
+// projectInferenceReplica renders this Component into its InferenceReplica: the
+// per-Component pod metadata, pod specs, replica count and gang topology key are
+// projected onto the IR, which becomes the single object describing what should
+// run. The rendered Runner templates carry the Component's merged labels and
+// annotations, so whatever the InferenceService (and this Component) declared is
+// visible on the IR and inherited by the pods rendered from it.
+//
+// Materializing those pods is the InferenceReplica controller's job. This build
+// does not include that controller, so the IR is created and kept up to date for
+// inspection and no workload is started from it.
+func (e *Engine) projectInferenceReplica(isvc *v1beta1.InferenceService, objectMeta metav1.ObjectMeta, podSpec *v1.PodSpec, workerSize int, workerPodSpec *v1.PodSpec) (ctrl.Result, error) {
+	ir, err := irprojector.EnsureInferenceReplica(context.TODO(), irprojector.Params{
+		ISVC:          isvc,
+		Component:     v1beta1.EngineComponent,
+		ComponentExt:  &e.engineSpec.ComponentExtensionSpec,
+		ObjectMeta:    objectMeta,
+		PodSpec:       podSpec,
+		WorkerPodSpec: workerPodSpec,
+		WorkerSize:    workerSize,
+		MultiPod:      e.engineSpec.Worker != nil,
+		TopologyKey:   e.engineSpec.TopologyKey,
+		Client:        e.Client,
+	})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	e.Log.Info("Projected InferenceReplica; no pods are rendered from it in this build",
+		"inferenceservice", isvc.Namespace+"/"+isvc.Name,
+		"component", v1beta1.EngineComponent,
+		"inferencereplica", ir.Name)
+	return ctrl.Result{}, nil
 }
 
 // updateEngineStatus updates the status of the engine

--- a/pkg/controller/v1beta1/inferenceservice/components/ir_projection_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/ir_projection_test.go
@@ -1,0 +1,134 @@
+package components
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+	isvcutils "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils"
+)
+
+// An InferenceService annotation must reach the pods a Component renders, and a
+// Component-level annotation must win over the service-level one. In OMENative
+// mode the pod template lives on the InferenceReplica, so that is where the
+// merged metadata has to land — an operator inspecting the IR sees exactly what
+// the pods will carry.
+func TestOMENativeProjectionCarriesMergedPodMetadata(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	scheme := runtime.NewScheme()
+	g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	g.Expect(v1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pd-demo",
+			Namespace: "serving",
+			UID:       types.UID("isvc-uid"),
+			Annotations: map[string]string{
+				"example.com/owner":      "team-inference",
+				"example.com/tier":       "service-level",
+				"example.com/slice-hint": "2x2x2",
+			},
+		},
+	}
+	engineSpec := &v1beta1.EngineSpec{
+		ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+			MinReplicas: ptr.To(2),
+			// Component-level annotation overrides the service-level value.
+			Annotations: map[string]string{"example.com/tier": "engine-level"},
+		},
+		Worker:      &v1beta1.WorkerSpec{Size: ptr.To(3)},
+		TopologyKey: ptr.To("cloud.example.com/slice-domain"),
+	}
+
+	engine := &Engine{
+		BaseComponentFields: BaseComponentFields{
+			Client:         c,
+			Scheme:         scheme,
+			Log:            log.Log,
+			DeploymentMode: constants.OMENative,
+		},
+		engineSpec: engineSpec,
+	}
+
+	// The Component renders its pod metadata, then projects it onto the IR.
+	objectMeta := metav1.ObjectMeta{
+		Name:      "pd-demo-engine",
+		Namespace: isvc.Namespace,
+		Annotations: map[string]string{
+			"example.com/owner":      "team-inference",
+			"example.com/tier":       "engine-level",
+			"example.com/slice-hint": "2x2x2",
+		},
+		Labels: map[string]string{constants.OMEComponentLabel: string(v1beta1.EngineComponent)},
+	}
+	podSpec := &v1.PodSpec{Containers: []v1.Container{{Name: "ome-container", Image: "example.com/vllm:demo"}}}
+	workerPodSpec := &v1.PodSpec{Containers: []v1.Container{{Name: "worker", Image: "example.com/vllm:demo"}}}
+
+	_, err := engine.reconcileDeployment(isvc, objectMeta, podSpec, 3, workerPodSpec)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ir := &v1beta1.InferenceReplica{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{
+		Namespace: isvc.Namespace, Name: "pd-demo-engine",
+	}, ir)).NotTo(gomega.HaveOccurred())
+
+	g.Expect(ir.Spec.Component).To(gomega.Equal(v1beta1.EngineComponent))
+	g.Expect(ir.Spec.Runners).NotTo(gomega.BeEmpty())
+	g.Expect(ir.Spec.TopologyKey).To(gomega.Equal(ptr.To("cloud.example.com/slice-domain")),
+		"the gang co-location key must reach the IR so worker->leader affinity can be derived")
+
+	for _, runner := range ir.Spec.Runners {
+		ann := runner.Template.ObjectMeta.Annotations
+		g.Expect(ann).To(gomega.HaveKeyWithValue("example.com/owner", "team-inference"),
+			"service-level annotation must reach runner %q", runner.Name)
+		g.Expect(ann).To(gomega.HaveKeyWithValue("example.com/slice-hint", "2x2x2"),
+			"slice hint must reach runner %q", runner.Name)
+		g.Expect(ann).To(gomega.HaveKeyWithValue("example.com/tier", "engine-level"),
+			"component-level annotation must win on runner %q", runner.Name)
+	}
+}
+
+// The queue an InferenceService names as annotations must reach the pods as the
+// LABELS Kueue admits on — an annotation-to-label rewrite, not a copy. If it
+// stops happening the pods are created ungated and bypass quota entirely, which
+// is the opposite of what queue admission is for.
+func TestKueueQueueAnnotationsBecomePodLabels(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	meta := &metav1.ObjectMeta{
+		Annotations: map[string]string{
+			constants.DedicatedAICluster:   "accelerator-pool",
+			constants.KueueEnabledLabelKey: "true",
+		},
+		Labels: map[string]string{},
+	}
+	isvcutils.SetPodLabelsFromAnnotations(meta)
+
+	g.Expect(meta.Labels).To(gomega.HaveKeyWithValue(constants.KueueQueueLabelKey, "accelerator-pool"),
+		"the queue annotation must become Kueue's queue label")
+	g.Expect(meta.Labels).To(gomega.HaveKey(constants.KueueWorkloadPriorityClassLabelKey),
+		"kueue-enabled must also carry a workload priority class")
+
+	// Without kueue-enabled the same annotation is read as a Volcano queue, so
+	// dropping it silently changes which system admits the workload.
+	volcano := &metav1.ObjectMeta{
+		Annotations: map[string]string{constants.DedicatedAICluster: "accelerator-pool"},
+		Labels:      map[string]string{},
+	}
+	isvcutils.SetPodLabelsFromAnnotations(volcano)
+	g.Expect(volcano.Labels).To(gomega.HaveKeyWithValue(constants.VolcanoQueueName, "accelerator-pool"))
+	g.Expect(volcano.Labels).NotTo(gomega.HaveKey(constants.KueueQueueLabelKey))
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/lws/lws_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/lws/lws_reconciler_test.go
@@ -820,3 +820,37 @@ func TestCreateLWS(t *testing.T) {
 		})
 	}
 }
+
+// A multi-node gang is only useful if its pods share one topology domain, and on
+// this path the constraint belongs to LeaderWorkerSet: the exclusive-topology
+// annotation has to reach the LWS OBJECT, not just the pod templates, because LWS
+// reads it there to place each group. If it only landed on the pods, LWS would
+// place groups unconstrained and a gang could straddle two domains.
+func TestCreateLWSCarriesExclusiveTopologyToTheLWSObject(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, lws.AddToScheme(scheme))
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	container := corev1.Container{Name: "ome-container", Image: "example.com/runtime:demo"}
+	headPod := &corev1.PodSpec{Containers: []corev1.Container{container}}
+	workerPod := &corev1.PodSpec{Containers: []corev1.Container{container}}
+
+	const sliceKey = "cloud.example.com/accelerator-slice-id"
+	componentMeta := metav1.ObjectMeta{
+		Name:        "gang-demo-engine",
+		Namespace:   "default",
+		Labels:      map[string]string{"app": "gang-demo-engine"},
+		Annotations: map[string]string{lws.ExclusiveKeyAnnotationKey: sliceKey},
+	}
+	minReplicas := 1
+	componentExt := &v1beta1.ComponentExtensionSpec{MinReplicas: &minReplicas}
+
+	r := NewLWSReconciler(client, scheme, headPod, workerPod, 1, componentExt, componentMeta)
+
+	assert.Equal(t, sliceKey, r.LWS.Annotations[lws.ExclusiveKeyAnnotationKey],
+		"LWS object must carry the exclusive-topology key so each group is placed within one domain")
+	assert.Equal(t, sliceKey, r.LWS.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations[lws.ExclusiveKeyAnnotationKey],
+		"leader pod template inherits Component annotations")
+	assert.Equal(t, sliceKey, r.LWS.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations[lws.ExclusiveKeyAnnotationKey],
+		"worker pod template inherits Component annotations")
+}


### PR DESCRIPTION
`OMENative` was a valid deployment mode that every Component rejected at reconcile (`invalid deployment mode for engine`), so `irprojector` had no caller and the `InferenceReplica` API had no producer. This dispatches the mode to the projector for engine and decoder: the Component's rendered pod metadata, pod specs, replica count and gang topology key become one InferenceReplica per Component, named `<isvc>-<component>`.

## Scope — deliberately stops at the projection

Rendering pods from an InferenceReplica is the InferenceReplica controller's job, and that controller is not in this repository. So the projection is where this stops: the log line says so, and nothing here suggests a workload starts. `RawDeployment` and `MultiNode` remain the modes that produce one.

## Tests

`TestOMENativeProjectionCarriesMergedPodMetadata` asserts what the projection is *for* — an InferenceService annotation reaches every Runner template, a Component-level annotation wins over the service-level one, and the gang topology key lands on the InferenceReplica.

`TestCreateLWSCarriesExclusiveTopologyToTheLWSObject` pins a nearby distinction that is easy to get wrong, since both knobs are named after topology: gang co-location on the **MultiNode** path is LeaderWorkerSet's `exclusive-topology` annotation, and it has to reach the **LWS object** rather than only the pod templates, because that is where LWS reads it. `spec.<component>.topologyKey` is never passed to the LWS builder, so it constrains nothing on that path — it is read only here, on the OMENative path.

## Note

The new call sites use `context.TODO()` to match the surrounding code (`engine.go:241`, `decoder.go:241`, `router.go:219` already do). Threading a real context means changing the `Component` interface — one call site, but a separate cleanup.

Paired with #770, which adds the samples and documentation for this and is stacked on top of it.