### PR TITLE
[Bugfix] Pass Component autoscaler, requeue on Conflict

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/decoder.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/decoder.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -183,9 +184,20 @@ func (d *Decoder) projectInferenceReplica(isvc *v1beta1.InferenceService, object
 		WorkerSize:    workerSize,
 		MultiPod:      d.decoderSpec.Worker != nil,
 		TopologyKey:   d.decoderSpec.TopologyKey,
-		Client:        d.Client,
+		// The Component's autoscaler is the effective one: ServingRuntime has no
+		// autoscaler surface, and MergeEngineSpec/MergeDecoderSpec have already
+		// folded the runtime's Component config in. Passing nil would clear
+		// ir.Spec.Autoscaler (whole-block replace) and make the projector treat
+		// replicas as its own to overwrite on every pass.
+		ResolvedAutoscaler: d.decoderSpec.Autoscaler,
+		Client:             d.Client,
 	})
 	if err != nil {
+		// A racing create surfaces as Conflict, which the projector documents as
+		// a benign requeue. Returning it as an error would hot-loop on cache lag.
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, err
 	}
 	d.Log.Info("Projected InferenceReplica; no pods are rendered from it in this build",

--- a/pkg/controller/v1beta1/inferenceservice/components/engine.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/engine.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -183,9 +184,20 @@ func (e *Engine) projectInferenceReplica(isvc *v1beta1.InferenceService, objectM
 		WorkerSize:    workerSize,
 		MultiPod:      e.engineSpec.Worker != nil,
 		TopologyKey:   e.engineSpec.TopologyKey,
-		Client:        e.Client,
+		// The Component's autoscaler is the effective one: ServingRuntime has no
+		// autoscaler surface, and MergeEngineSpec/MergeDecoderSpec have already
+		// folded the runtime's Component config in. Passing nil would clear
+		// ir.Spec.Autoscaler (whole-block replace) and make the projector treat
+		// replicas as its own to overwrite on every pass.
+		ResolvedAutoscaler: e.engineSpec.Autoscaler,
+		Client:             e.Client,
 	})
 	if err != nil {
+		// A racing create surfaces as Conflict, which the projector documents as
+		// a benign requeue. Returning it as an error would hot-loop on cache lag.
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, err
 	}
 	e.Log.Info("Projected InferenceReplica; no pods are rendered from it in this build",

--- a/pkg/controller/v1beta1/inferenceservice/components/ir_projection_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/ir_projection_test.go
@@ -2,19 +2,27 @@ package components
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/controllerconfig"
+	"sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/reconcilers/irprojector"
 	isvcutils "sigs.k8s.io/ome/pkg/controller/v1beta1/inferenceservice/utils"
 )
 
@@ -131,4 +139,179 @@ func TestKueueQueueAnnotationsBecomePodLabels(t *testing.T) {
 	isvcutils.SetPodLabelsFromAnnotations(volcano)
 	g.Expect(volcano.Labels).To(gomega.HaveKeyWithValue(constants.VolcanoQueueName, "accelerator-pool"))
 	g.Expect(volcano.Labels).NotTo(gomega.HaveKey(constants.KueueQueueLabelKey))
+}
+
+// projectFor drives a Component's OMENative projection with the given spec
+// overrides, so the same assertion can be made against engine and decoder. A fix
+// applied to one Component and not the other must fail here.
+func projectFor(component v1beta1.ComponentType, c client.Client, scheme *runtime.Scheme,
+	isvc *v1beta1.InferenceService, ext v1beta1.ComponentExtensionSpec) (ctrl.Result, error) {
+	base := BaseComponentFields{
+		Client: c, Scheme: scheme, Log: log.Log, DeploymentMode: constants.OMENative,
+	}
+	podSpec := &v1.PodSpec{Containers: []v1.Container{{Name: "ome-container", Image: "example.com/x:1"}}}
+	meta := metav1.ObjectMeta{
+		Name:      irprojector.InferenceReplicaName(isvc.Name, component),
+		Namespace: isvc.Namespace,
+	}
+	if component == v1beta1.DecoderComponent {
+		d := &Decoder{BaseComponentFields: base, decoderSpec: &v1beta1.DecoderSpec{ComponentExtensionSpec: ext}}
+		return d.reconcileDeployment(isvc, meta, podSpec, 0, nil)
+	}
+	e := &Engine{BaseComponentFields: base, engineSpec: &v1beta1.EngineSpec{ComponentExtensionSpec: ext}}
+	return e.reconcileDeployment(isvc, meta, podSpec, 0, nil)
+}
+
+// The Component's autoscaler must reach the InferenceReplica. ir.Spec.Autoscaler
+// is whole-block replace, so passing nil erases it — and the projector then reads
+// the Component as unmanaged and rewrites ir.Spec.Replicas from minReplicas on
+// every pass, fighting whatever scaled it.
+func TestOMENativeProjectionCarriesComponentAutoscaler(t *testing.T) {
+	for _, component := range []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent} {
+		t.Run(string(component), func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			scheme := runtime.NewScheme()
+			g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+			g.Expect(v1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+
+			isvc := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+				Name: "auto-demo", Namespace: "serving", UID: types.UID("isvc-uid"),
+			}}
+			_, err := projectFor(component, c, scheme, isvc, v1beta1.ComponentExtensionSpec{
+				MinReplicas: ptr.To(2),
+				Autoscaler:  &v1beta1.ComponentAutoscaler{Class: v1beta1.AutoscalerHPA},
+			})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ir := &v1beta1.InferenceReplica{}
+			g.Expect(c.Get(context.Background(), types.NamespacedName{
+				Namespace: isvc.Namespace,
+				Name:      irprojector.InferenceReplicaName(isvc.Name, component),
+			}, ir)).NotTo(gomega.HaveOccurred())
+			g.Expect(ir.Spec.Autoscaler).NotTo(gomega.BeNil(), "autoscaler must not be erased")
+			g.Expect(ir.Spec.Autoscaler.Class).To(gomega.Equal(v1beta1.AutoscalerHPA))
+		})
+	}
+}
+
+// A racing create surfaces as Conflict, which the projector documents as a benign
+// requeue. Returned as an error it becomes an error hot-loop whenever the cache
+// lags behind a create this controller just made.
+func TestOMENativeProjectionConflictRequeuesInsteadOfErroring(t *testing.T) {
+	for _, component := range []v1beta1.ComponentType{v1beta1.EngineComponent, v1beta1.DecoderComponent} {
+		t.Run(string(component), func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			scheme := runtime.NewScheme()
+			g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+			g.Expect(v1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+						return apierrors.NewConflict(
+							schema.GroupResource{Group: v1beta1.SchemeGroupVersion.Group, Resource: "inferencereplicas"},
+							obj.GetName(), errors.New("racing create"))
+					},
+				}).Build()
+
+			isvc := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+				Name: "conflict-demo", Namespace: "serving", UID: types.UID("isvc-uid"),
+			}}
+			res, err := projectFor(component, c, scheme, isvc, v1beta1.ComponentExtensionSpec{
+				MinReplicas: ptr.To(1),
+			})
+			g.Expect(err).NotTo(gomega.HaveOccurred(), "a Conflict must not surface as a reconcile error")
+			g.Expect(res.Requeue).To(gomega.BeTrue(), "a Conflict must requeue")
+		})
+	}
+}
+
+// The projection is only useful if the metadata it carries is the metadata the
+// Component actually renders, so this drives the real merge — reconcileObjectMeta,
+// which is what Reconcile calls — and feeds its output to the projection, for both
+// Components. Hand-building already-merged metadata would assert nothing about the
+// merge itself.
+func TestOMENativeProjectionUsesRenderedComponentMetadata(t *testing.T) {
+	newISVC := func(name string) *v1beta1.InferenceService {
+		return &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "serving", UID: types.UID("isvc-uid"),
+			Annotations: map[string]string{
+				"example.com/owner": "team-inference",
+				"example.com/tier":  "service-level",
+			},
+		}}
+	}
+	podSpec := func() *v1.PodSpec {
+		return &v1.PodSpec{Containers: []v1.Container{{Name: "ome-container", Image: "example.com/x:1"}}}
+	}
+
+	for _, tc := range []struct {
+		name      string
+		component v1beta1.ComponentType
+		project   func(t *testing.T, c client.Client, scheme *runtime.Scheme, isvc *v1beta1.InferenceService) error
+	}{
+		{
+			name:      "engine",
+			component: v1beta1.EngineComponent,
+			project: func(t *testing.T, c client.Client, scheme *runtime.Scheme, isvc *v1beta1.InferenceService) error {
+				spec := &v1beta1.EngineSpec{ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					MinReplicas: ptr.To(1),
+					Annotations: map[string]string{"example.com/tier": "engine-level"},
+				}}
+				e := NewEngine(c, nil, scheme, &controllerconfig.InferenceServicesConfig{},
+					constants.OMENative, nil, nil, spec, nil, "", nil, nil, "").(*Engine)
+				meta, err := e.reconcileObjectMeta(isvc)
+				if err != nil {
+					return err
+				}
+				_, err = e.reconcileDeployment(isvc, meta, podSpec(), 0, nil)
+				return err
+			},
+		},
+		{
+			name:      "decoder",
+			component: v1beta1.DecoderComponent,
+			project: func(t *testing.T, c client.Client, scheme *runtime.Scheme, isvc *v1beta1.InferenceService) error {
+				spec := &v1beta1.DecoderSpec{ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					MinReplicas: ptr.To(1),
+					Annotations: map[string]string{"example.com/tier": "decoder-level"},
+				}}
+				d := NewDecoder(c, nil, scheme, &controllerconfig.InferenceServicesConfig{},
+					constants.OMENative, nil, nil, spec, nil, "", nil, nil, "").(*Decoder)
+				meta, err := d.reconcileObjectMeta(isvc)
+				if err != nil {
+					return err
+				}
+				_, err = d.reconcileDeployment(isvc, meta, podSpec(), 0, nil)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			scheme := runtime.NewScheme()
+			g.Expect(v1beta1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+			g.Expect(v1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+
+			isvc := newISVC("merge-demo")
+			g.Expect(tc.project(t, c, scheme, isvc)).NotTo(gomega.HaveOccurred())
+
+			ir := &v1beta1.InferenceReplica{}
+			g.Expect(c.Get(context.Background(), types.NamespacedName{
+				Namespace: isvc.Namespace,
+				Name:      irprojector.InferenceReplicaName(isvc.Name, tc.component),
+			}, ir)).NotTo(gomega.HaveOccurred())
+			g.Expect(ir.Spec.Runners).NotTo(gomega.BeEmpty())
+
+			for _, runner := range ir.Spec.Runners {
+				ann := runner.Template.ObjectMeta.Annotations
+				g.Expect(ann).To(gomega.HaveKeyWithValue("example.com/owner", "team-inference"),
+					"service annotation must survive the real merge onto runner %q", runner.Name)
+				g.Expect(ann).To(gomega.HaveKeyWithValue("example.com/tier", string(tc.component)+"-level"),
+					"Component annotation must win after the real merge on runner %q", runner.Name)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Follow-up to #771, addressing two defects raised in its review.

## 1. `ResolvedAutoscaler` was never passed

`ir.Spec.Autoscaler` is whole-block replace, so passing nil **erased** it. The projector then read the Component as unmanaged, and `desiredReplicas` took the `!isAutoscalerManaged` branch and rewrote `ir.Spec.Replicas` from `minReplicas` on every pass — fighting whatever had scaled it.

Fixed by passing the Component's own autoscaler, which **is** the effective value upstream: `ServingRuntimeSpec` has no autoscaler field at all, and `MergeEngineSpec` / `MergeDecoderSpec` have already folded the runtime's Component config in. So there is no ISVC↔runtime chain left to resolve here, and no resolver is needed.

## 2. A `Conflict` was returned as a reconcile error

The projector documents `apierrors.IsConflict` as a benign requeue — it *synthesizes* one on the racing-create path, where a create this controller just made is not yet visible through its cache. Returned as an error that is an error hot-loop on cache lag. Now mapped to a requeue.

## Tests

Both fixes are asserted, and **each test fails when its own fix is reverted** (verified independently, so neither passes for the wrong reason):

- reverting the autoscaler pass-through → `autoscaler must not be erased`
- reverting the conflict mapping → `a Conflict must not surface as a reconcile error`

A third test closes the test-gap finding from the same review: it drives the **real merge** — `reconcileObjectMeta`, which is what `Reconcile` calls — into the projection, for **both engine and decoder**. The previous test hand-built already-merged metadata, so it asserted only that a map was copied, not that the Component renders it.

## Not addressed here

The review's scope concern — that this is a simplified adaptation which makes `OMENative` succeed while intentionally creating no workload, where it previously failed loudly — is a design question, not a defect, and deserves its own discussion rather than being settled inside a bugfix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inference service updates when resource conflicts occur by retrying safely instead of reporting errors.
  * Preserved autoscaler settings during inference replica updates.
  * Ensured metadata from engine and decoder configuration is carried through correctly.

* **Tests**
  * Added coverage for autoscaler preservation, conflict retries, and configuration metadata propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->