### PR TITLE
[Core] Defrag candidate selection + placement hints

### DIFF
--- a/pkg/alfred/policy/api.go
+++ b/pkg/alfred/policy/api.go
@@ -1,0 +1,112 @@
+// Package policy defines the contract every Alfred policy implements: a
+// pure, side-effect-free function of the ClusterSnapshot that returns ranked
+// Candidates (OEP-0008 §The engine). A policy holds no client and emits no
+// Event, metric, or ConfigMap entry — the engine routes its output: executable
+// Candidates enter the Arbiter, advisory ones go straight to the Reporter.
+package policy
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// Candidate reasons (event-facing; the dispatcher maps them to the wire
+// contract's lowercase reason values).
+const (
+	ReasonFragmentation     = "Fragmentation"
+	ReasonNodeUnhealthy     = "NodeUnhealthy"
+	ReasonRemediationSignal = "RemediationSignal"
+)
+
+// Advisory reasons: why an emitted Candidate is not executable. Advisory
+// candidates surface through the Reporter only — they never enter arbitration
+// and never consume migration budget.
+const (
+	// AdvisoryNoSurgeHeadroom: the surge-shaped replacement footprint fits
+	// on no feasible target while the source still holds its GPUs.
+	AdvisoryNoSurgeHeadroom = "NoSurgeHeadroom"
+	// AdvisoryVolumePinned: an RWO/RWOP PVC pins the workload to its node;
+	// no migration mechanism can move it.
+	AdvisoryVolumePinned = "VolumePinned"
+	// AdvisoryLWSMigrationUnsupported: LWS tears down the whole group on
+	// pod restart with no surge protection; the safe fix (move the
+	// workload to OMENative) is the operator's.
+	AdvisoryLWSMigrationUnsupported = "LWSMigrationUnsupported"
+	// AdvisoryOMENativeUnavailable: no OMENative executor exists on this
+	// cluster, so the migration verb has no consumer.
+	AdvisoryOMENativeUnavailable = "OMENativeUnavailable"
+	// AdvisoryMigrationSurfaceDisabled: the component's execution surface
+	// is switched off in alfred-config.
+	AdvisoryMigrationSurfaceDisabled = "MigrationSurfaceDisabled"
+	// AdvisoryModelUnresolved: model availability could not be resolved
+	// (see ModelAvailability.ResolveError); the policy treats the model as
+	// having no feasible target and surfaces the reason.
+	AdvisoryModelUnresolved = "ModelUnresolved"
+)
+
+// ComponentWideInstance marks a Candidate that addresses a whole component
+// rather than one Instance (advisories such as VolumePinned or the LWS
+// recommendation). Component-wide candidates are never dispatched.
+const ComponentWideInstance int32 = -1
+
+// Candidate is a single proposed action — "migrate Component X's Instance Y
+// off Node Z" — with explicit, cross-policy-comparable benefit and cost so
+// the Arbiter can rank on a common axis instead of trusting each policy's
+// self-assessment.
+type Candidate struct {
+	// Policy is the emitting policy's Name().
+	Policy string
+
+	Workload  types.NamespacedName
+	Component v1beta1.ComponentType
+	// Instance is the addressed Instance index, or ComponentWideInstance.
+	Instance int32
+	// Mode is the component's resolved deployment mode, which determines
+	// the execution surface.
+	Mode constants.DeploymentModeType
+
+	// Reason is the event-facing cause (Fragmentation, NodeUnhealthy, ...).
+	Reason string
+
+	// FromNode is the node the move vacates (for a multi-node instance,
+	// the node holding the largest share of its GPUs).
+	FromNode string
+	// HintTargetNodes is the ranked, advisory placement preference (top N;
+	// the scheduler makes the final call).
+	HintTargetNodes []string
+
+	// Executable=false marks an advisory finding; AdvisoryReason says why.
+	Executable     bool
+	AdvisoryReason string
+
+	// SurgeShaped records the simulated execution shape: place-then-free
+	// (OMENative Instance surge, single-replica rolling restart) vs
+	// free-then-place (multi-replica targeted eviction).
+	SurgeShaped bool
+	// FootprintGPUs is the instance's GPU footprint. For a surge-shaped
+	// move this much headroom must exist while the source still holds its
+	// GPUs; it is also the ranking tie-break (smaller moves first).
+	FootprintGPUs int64
+
+	// Benefit is the expected improvement (F_observed_before minus
+	// F_observed_after on the simulated post-move state).
+	Benefit float64
+	// Cost is the disruption risk keyed off the migration mode.
+	Cost float64
+	// Score = Benefit - CostWeight*Cost, emergency-boosted when the move
+	// unblocks an over-age pending pod.
+	Score float64
+	// Emergency marks a candidate whose move unblocks a pending pod older
+	// than emergencyPendingAgeMinutes.
+	Emergency bool
+}
+
+// Policy is a pluggable decision module: a pure function of the snapshot.
+type Policy interface {
+	Name() string
+	Evaluate(snap *snapshot.ClusterSnapshot, cfg *config.Config) []Candidate
+}

--- a/pkg/alfred/policy/api.go
+++ b/pkg/alfred/policy/api.go
@@ -29,6 +29,11 @@ const (
 	// AdvisoryNoSurgeHeadroom: the surge-shaped replacement footprint fits
 	// on no feasible target while the source still holds its GPUs.
 	AdvisoryNoSurgeHeadroom = "NoSurgeHeadroom"
+	// AdvisoryNoFeasibleTarget: the free-then-place mirror of
+	// NoSurgeHeadroom — no feasible target can seat the replacement even
+	// once the source releases its GPUs, so evicting would strand it in
+	// Pending.
+	AdvisoryNoFeasibleTarget = "NoFeasibleTarget"
 	// AdvisoryVolumePinned: an RWO/RWOP PVC pins the workload to its node;
 	// no migration mechanism can move it.
 	AdvisoryVolumePinned = "VolumePinned"

--- a/pkg/alfred/policy/defrag/placement.go
+++ b/pkg/alfred/policy/defrag/placement.go
@@ -1,0 +1,106 @@
+package defrag
+
+import (
+	"sort"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+)
+
+// maxHintTargets is the OEP's default top-N for HintTargetNodes.
+const maxHintTargets = 3
+
+// rankTargets returns the pool's feasible placement targets for one per-pod
+// footprint of a workload, consolidation-ranked: fullest first (ascending
+// free, name tie-break), because filling partial holes is what frees whole
+// nodes. The bins already exclude unhealthy, cordoned, CA-deleting, suspect,
+// and (by default) spot nodes; this adds the per-candidate filters — source
+// exclusion, per-workload spot avoidance, and storage-aware model
+// availability. The full ranked list is returned; callers truncate hints to
+// maxHintTargets.
+func rankTargets(snap *snapshot.ClusterSnapshot, cfg *config.Config, bins []binState,
+	w *snapshot.Workload, podGPUs int64, exclude map[string]bool) []string {
+
+	avoidSpot := workloadAvoidsSpotTarget(w, cfg)
+	allowed, constrained := modelNodeSet(snap, w)
+	feasible := make([]binState, 0, len(bins))
+	for _, bin := range bins {
+		if exclude[bin.name] || bin.free < podGPUs {
+			continue
+		}
+		node := snap.Nodes[bin.name]
+		if node == nil {
+			continue
+		}
+		if avoidSpot && node.Preemptible {
+			continue
+		}
+		if constrained {
+			if _, ok := allowed[bin.name]; !ok {
+				continue
+			}
+		}
+		feasible = append(feasible, bin)
+	}
+	sort.Slice(feasible, func(i, j int) bool {
+		if feasible[i].free != feasible[j].free {
+			return feasible[i].free < feasible[j].free
+		}
+		return feasible[i].name < feasible[j].name
+	})
+	ranked := make([]string, len(feasible))
+	for i, bin := range feasible {
+		ranked[i] = bin.name
+	}
+	return ranked
+}
+
+// workloadAvoidsSpotTarget resolves the per-workload spot-policy annotation
+// against the cluster default: "avoid" forces preemptible targets out even
+// when the cluster allows them; "migrate" and "ignore" accept whatever the
+// cluster-wide avoidAsTarget already left in the bins.
+func workloadAvoidsSpotTarget(w *snapshot.Workload, cfg *config.Config) bool {
+	switch w.SpotPolicy {
+	case "avoid":
+		return true
+	case "migrate", "ignore":
+		return false
+	default:
+		return *cfg.SpotPolicy.AvoidAsTarget
+	}
+}
+
+// modelNodeSet is the storage-aware target constraint, built once per
+// ranking call for constant-time membership checks. Per-node models allow
+// only nodes with the readiness label (the same predicate the scheduler
+// enforces through the readiness nodeSelector); PVC-backed models allow the
+// nodes satisfying the volume's CSI topology and must NOT be filtered on
+// per-node readiness. constrained=false means no model constraint applies —
+// no model, an unresolvable one (ResolveError downgrades to advisory
+// upstream, before placement runs), or an unconstrained PVC.
+func modelNodeSet(snap *snapshot.ClusterSnapshot, w *snapshot.Workload) (allowed map[string]struct{}, constrained bool) {
+	if w.ModelKey.Zero() {
+		return nil, false
+	}
+	avail, ok := snap.Models[w.ModelKey]
+	if !ok || avail.ResolveError != "" {
+		return nil, false
+	}
+	var nodes []string
+	switch avail.Backend {
+	case snapshot.BackendPerNode:
+		nodes = avail.NodesReady
+	case snapshot.BackendPVC:
+		if avail.PVCTopologyNodes == nil {
+			return nil, false
+		}
+		nodes = avail.PVCTopologyNodes
+	default:
+		return nil, false
+	}
+	allowed = make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		allowed[node] = struct{}{}
+	}
+	return allowed, true
+}

--- a/pkg/alfred/policy/defrag/policy.go
+++ b/pkg/alfred/policy/defrag/policy.go
@@ -1,0 +1,595 @@
+package defrag
+
+import (
+	"sort"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/policy"
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// PolicyName is the metric/event label value for Policy #1.
+const PolicyName = "defragmentation"
+
+// Disruption cost per migration mode (same unit as Benefit — a share of
+// demand-weighted fragmentation). The OEP fixes the ordering (eviction,
+// rolling restart, and OMENative rolling are low; OMENative surge is
+// medium); the numeric scale is an implementation choice.
+const (
+	costTargetedEviction = 0.05
+	costRollingRestart   = 0.05
+	costOMENativeRolling = 0.05
+	costOMENativeSurge   = 0.15
+)
+
+// emergencyBoostFactor multiplies a positive Score when the move unblocks an
+// over-age pending pod — what lets a starving workload jump the queue ahead
+// of routine consolidation.
+const emergencyBoostFactor = 2.0
+
+// spotSourceBoostFactor multiplies a positive Score when the source node is
+// preemptible and spot policy prefers evacuating such nodes before a
+// preemption event does.
+const spotSourceBoostFactor = 1.25
+
+// costWeight realizes the aggressiveness scoring knob: conservative demands
+// more benefit per unit of disruption, aggressive tolerates more. Never a
+// safety bypass — cooldowns, caps, and the breaker live in the Arbiter.
+func costWeight(aggressiveness string) float64 {
+	switch aggressiveness {
+	case config.AggressivenessConservative:
+		return 1.5
+	case config.AggressivenessAggressive:
+		return 0.5
+	default:
+		return 1.0
+	}
+}
+
+// Policy is Policy #1 (Defragmentation): pure candidate selection over the
+// snapshot. It holds no client; the engine routes its output.
+type Policy struct{}
+
+var _ policy.Policy = &Policy{}
+
+// Name implements policy.Policy.
+func (*Policy) Name() string { return PolicyName }
+
+// evalCtx carries the per-pool evaluation state shared by every candidate.
+type evalCtx struct {
+	snap       *snapshot.ClusterSnapshot
+	cfg        *config.Config
+	pool       string
+	bins       []binState
+	ladder     []int64
+	weights    map[int64]float64
+	totalFree  int64
+	before     float64
+	pendings   []snapshot.PendingPod
+	costWeight float64
+}
+
+// Evaluate turns the snapshot into a ranked []Candidate (OEP-0008
+// §Candidate selection). Gate → enumerate → classify → simulate → score →
+// boost → rank → filter.
+func (*Policy) Evaluate(snap *snapshot.ClusterSnapshot, cfg *config.Config) []policy.Candidate {
+	d := &cfg.Policies.Defragmentation
+	if !*d.Enabled {
+		return nil
+	}
+	scores := ComputeScores(snap, cfg)
+	threshold := *d.FragmentationThreshold
+	if scores.FragmentationScore <= threshold {
+		return nil
+	}
+
+	ladder := int64Ladder(d.Scoring.SizeLadder)
+	prior := parsePrior(d.Scoring.SizePrior)
+	lambda := *d.Scoring.DemandBlendLambda
+	demand := demandByPoolAndSize(snap, ladder)
+	weight := costWeight(d.Aggressiveness)
+	now := snap.Timestamp
+
+	var out []policy.Candidate
+	for _, pool := range snap.GPUPools() {
+		cs := scores.PerPool[pool]
+		// Per-pool gate: you defragment the worst pool — a healthy
+		// pool's near-zero-benefit moves would be pure churn. A pool
+		// with a starving fixable pending is above threshold through
+		// the noisy-OR pressure term.
+		if cs == nil || cs.Score <= threshold {
+			continue
+		}
+		ctx := &evalCtx{
+			snap:       snap,
+			cfg:        cfg,
+			pool:       pool,
+			bins:       schedulableBins(snap, cfg, pool),
+			ladder:     ladder,
+			weights:    demandWeights(ladder, demand[pool], prior, lambda),
+			totalFree:  cs.TotalFree,
+			pendings:   poolPendings(snap, pool),
+			costWeight: weight,
+		}
+		ctx.before = weightedFrag(ctx.bins, ladder, ctx.weights, ctx.totalFree)
+
+		for _, w := range sortedWorkloads(snap) {
+			// Step-1 enumeration filters: movable, no in-flight
+			// migration, outside the per-workload cooldown. (The
+			// Arbiter re-enforces its own bounds on every policy's
+			// output; these pre-filters shape the candidate set.)
+			if !w.Movable || len(w.ActiveMigrations) > 0 || inCooldown(w, cfg, now) {
+				continue
+			}
+			for _, comp := range sortedComponents(w) {
+				out = append(out, evaluateComponent(ctx, w, comp)...)
+			}
+		}
+	}
+
+	// Maintenance windows gate defragmentation dispatch: outside every
+	// window, executable candidates are dropped; advisories carry no
+	// dispatch and survive. (Node-health evacuation deliberately ignores
+	// windows — that policy applies its own rules.)
+	if !maintenanceOpen(cfg, now) {
+		kept := out[:0]
+		for _, c := range out {
+			if !c.Executable {
+				kept = append(kept, c)
+			}
+		}
+		out = kept
+	}
+
+	rankCandidates(out)
+	return out
+}
+
+// evaluateComponent classifies one component by deployment mode (the
+// classification sets Executable, it does not drop the candidate) and
+// evaluates its instances.
+func evaluateComponent(ctx *evalCtx, w *snapshot.Workload, comp *snapshot.Component) []policy.Candidate {
+	switch comp.DeploymentMode {
+	case constants.MultiNode:
+		// LWS-backed groups are unsafe to migrate automatically
+		// (RecreateGroupOnPodRestart tears the group down with no surge
+		// protection) but the opportunity must still surface.
+		if !*ctx.cfg.LWSRecommendationsEnabled {
+			return nil
+		}
+		if componentPrimaryPool(ctx.snap, comp) != ctx.pool {
+			return nil
+		}
+		return []policy.Candidate{advisory(w, comp, policy.ComponentWideInstance,
+			policy.AdvisoryLWSMigrationUnsupported, componentPrimaryNode(comp), largestInstanceGPUs(comp))}
+	case constants.RawDeployment, constants.OMENative:
+		// Executable surfaces, handled below.
+	default:
+		return nil
+	}
+	if componentPrimaryPool(ctx.snap, comp) != ctx.pool {
+		return nil
+	}
+
+	// Component-wide downgrades, most fundamental first; one advisory, not
+	// a stack.
+	from := componentPrimaryNode(comp)
+	footprint := largestInstanceGPUs(comp)
+	if avail := modelOf(ctx.snap, w); avail != nil {
+		if avail.ResolveError != "" {
+			return []policy.Candidate{advisory(w, comp, policy.ComponentWideInstance,
+				policy.AdvisoryModelUnresolved, from, footprint)}
+		}
+		if avail.VolumePinned {
+			// An RWO/RWOP volume attaches to one node at a time and
+			// the source still holds it while any replacement
+			// starts; eviction would only recreate the pod on the
+			// same node.
+			return []policy.Candidate{advisory(w, comp, policy.ComponentWideInstance,
+				policy.AdvisoryVolumePinned, from, footprint)}
+		}
+	}
+	if comp.DeploymentMode == constants.OMENative {
+		if !*ctx.cfg.OMENativeMigrationEnabled {
+			return []policy.Candidate{advisory(w, comp, policy.ComponentWideInstance,
+				policy.AdvisoryMigrationSurfaceDisabled, from, footprint)}
+		}
+		if !ctx.snap.OMENativeAvailable {
+			return []policy.Candidate{advisory(w, comp, policy.ComponentWideInstance,
+				policy.AdvisoryOMENativeUnavailable, from, footprint)}
+		}
+	} else if !*ctx.cfg.RawDeploymentMigrationEnabled {
+		return []policy.Candidate{advisory(w, comp, policy.ComponentWideInstance,
+			policy.AdvisoryMigrationSurfaceDisabled, from, footprint)}
+	}
+
+	ready := readyInstances(comp)
+	instances := append([]*snapshot.Instance(nil), comp.Instances...)
+	sort.Slice(instances, func(i, j int) bool { return instances[i].Index < instances[j].Index })
+
+	var out []policy.Candidate
+	for _, inst := range instances {
+		// Terminating instances are the Arbiter's exclusion; skipping
+		// here is the OEP-sanctioned optimization.
+		if inst.TotalGPUs == 0 || hasTerminating(inst) || !instanceInPool(ctx.snap, inst, ctx.pool) {
+			continue
+		}
+		if c, ok := evaluateInstance(ctx, w, comp, inst, ready); ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// evaluateInstance simulates one prospective move mode-aware (place-then-free
+// for surge shapes, free-then-place only for multi-replica eviction), scores
+// it benefit-minus-cost, and applies the emergency and spot-source boosts.
+func evaluateInstance(ctx *evalCtx, w *snapshot.Workload, comp *snapshot.Component,
+	inst *snapshot.Instance, ready int) (policy.Candidate, bool) {
+
+	prints := instanceFootprints(inst)
+	if len(prints) == 0 {
+		return policy.Candidate{}, false
+	}
+	from := primaryNode(inst)
+	// OMENative migrates an Instance by surging it regardless of replica
+	// count; RawDeployment surges only when evicting the sole ready
+	// replica would be an outage. The controller re-branches at execution
+	// time against live state; the simulation predicts from the snapshot.
+	surgeShaped := comp.DeploymentMode == constants.OMENative || ready <= 1
+
+	exclude := make(map[string]bool, len(inst.NodesSet))
+	for node := range inst.NodesSet {
+		exclude[node] = true
+	}
+	// Rank targets that fit the SMALLEST member pod: a multi-pod
+	// instance's pods land on different targets, and excluding nodes that
+	// only fit the smaller pods would fabricate NoSurgeHeadroom.
+	// placeThenFree re-checks each footprint's size per target; for
+	// single-pod instances min and max coincide.
+	minPod := prints[len(prints)-1].gpus
+	ranked := rankTargets(ctx.snap, ctx.cfg, ctx.bins, w, minPod, exclude)
+
+	var after []binState
+	if surgeShaped {
+		bins, _, ok := placeThenFree(ctx.bins, prints, ranked)
+		if !ok {
+			// Not dispatchable: without surge headroom the migration
+			// would stall in SurgePending until timeout. Surface
+			// "wants to move, no room" instead.
+			c := advisory(w, comp, inst.Index, policy.AdvisoryNoSurgeHeadroom, from, inst.TotalGPUs)
+			c.SurgeShaped = true
+			return c, true
+		}
+		after = bins
+	} else {
+		after, _ = freeThenPlace(ctx.bins, prints[0], ranked)
+	}
+
+	benefit := ctx.before - weightedFrag(after, ctx.ladder, ctx.weights, ctx.totalFree)
+	cost := modeCost(comp.DeploymentMode, len(comp.Instances), ready)
+	score := benefit - ctx.costWeight*cost
+
+	emergency := unblocksOverAgePending(ctx, w, after)
+	if emergency && score > 0 {
+		score *= emergencyBoostFactor
+	}
+	if score > 0 && spotPrefersSource(w, ctx.cfg) {
+		if node := ctx.snap.Nodes[from]; node != nil && node.Preemptible {
+			score *= spotSourceBoostFactor
+		}
+	}
+
+	hints := ranked
+	if len(hints) > maxHintTargets {
+		hints = hints[:maxHintTargets]
+	}
+	return policy.Candidate{
+		Policy:          PolicyName,
+		Workload:        w.NamespacedName,
+		Component:       comp.Type,
+		Instance:        inst.Index,
+		Mode:            comp.DeploymentMode,
+		Reason:          policy.ReasonFragmentation,
+		FromNode:        from,
+		HintTargetNodes: append([]string(nil), hints...),
+		Executable:      true,
+		SurgeShaped:     surgeShaped,
+		FootprintGPUs:   inst.TotalGPUs,
+		Benefit:         benefit,
+		Cost:            cost,
+		Score:           score,
+		Emergency:       emergency,
+	}, true
+}
+
+// modeCost prices disruption per the OEP's cost table.
+func modeCost(mode constants.DeploymentModeType, instanceCount, ready int) float64 {
+	if mode == constants.OMENative {
+		if instanceCount == 1 {
+			return costOMENativeSurge
+		}
+		return costOMENativeRolling
+	}
+	if ready <= 1 {
+		return costRollingRestart
+	}
+	return costTargetedEviction
+}
+
+// unblocksOverAgePending reports whether the simulated after-state seats a
+// pending pod (real or virtual) that the observed state cannot, aged past
+// emergencyPendingAgeMinutes, within the workload's tenant scope.
+func unblocksOverAgePending(ctx *evalCtx, w *snapshot.Workload, after []binState) bool {
+	minAge := ctx.cfg.EmergencyPendingAge()
+	for i := range ctx.pendings {
+		p := &ctx.pendings[i]
+		if ctx.snap.Timestamp.Sub(p.PendingSince) <= minAge {
+			continue
+		}
+		if !tenantCompatible(ctx.snap, ctx.cfg, w, p) {
+			continue
+		}
+		if !canSeat(ctx.bins, p.GPUsNeeded) && canSeat(after, p.GPUsNeeded) {
+			return true
+		}
+	}
+	return false
+}
+
+// tenantCompatible enforces the tenant boundary on the emergency boost: a
+// move is boosted only by pending demand it may legitimately serve — its own
+// namespace, or (when the cluster admin has not vetoed cross-tenant moves) a
+// workload sharing its explicit tenant group. Pure consolidation benefit is
+// pool-wide and needs no tenant check.
+func tenantCompatible(snap *snapshot.ClusterSnapshot, cfg *config.Config, w *snapshot.Workload, p *snapshot.PendingPod) bool {
+	if p.Namespace == w.NamespacedName.Namespace {
+		return true
+	}
+	if !*cfg.AllowCrossTenantOptimization || w.TenantGroup == "" {
+		return false
+	}
+	if p.ISVC.Name == "" {
+		return false
+	}
+	owner, ok := snap.Workloads[p.ISVC]
+	return ok && owner.TenantGroup == w.TenantGroup
+}
+
+// spotPrefersSource resolves the per-workload spot-policy annotation against
+// the cluster default for the source-side boost: "migrate" always boosts,
+// "ignore" never does, anything else follows spotPolicy.preferAsSource.
+func spotPrefersSource(w *snapshot.Workload, cfg *config.Config) bool {
+	switch w.SpotPolicy {
+	case "migrate":
+		return true
+	case "ignore":
+		return false
+	default:
+		return *cfg.SpotPolicy.PreferAsSource
+	}
+}
+
+// inCooldown applies the per-workload cooldown from the newest terminal
+// migration, honoring the alfred.ome.io/cooldown-minutes override.
+func inCooldown(w *snapshot.Workload, cfg *config.Config, now time.Time) bool {
+	if w.LastMigration == nil {
+		return false
+	}
+	cooldown := cfg.PerWorkloadCooldown()
+	if w.CooldownOverride != nil {
+		cooldown = *w.CooldownOverride
+	}
+	return now.Sub(*w.LastMigration) < cooldown
+}
+
+var weekdayNames = map[time.Weekday]string{
+	time.Monday: "Mon", time.Tuesday: "Tue", time.Wednesday: "Wed",
+	time.Thursday: "Thu", time.Friday: "Fri", time.Saturday: "Sat", time.Sunday: "Sun",
+}
+
+// maintenanceOpen reports whether defragmentation may dispatch now: no
+// windows means always, otherwise inside at least one weekly UTC window.
+// Window syntax is validated at config load.
+func maintenanceOpen(cfg *config.Config, now time.Time) bool {
+	if len(cfg.MaintenanceWindows) == 0 {
+		return true
+	}
+	utc := now.UTC()
+	day := weekdayNames[utc.Weekday()]
+	minute := utc.Hour()*60 + utc.Minute()
+	for _, w := range cfg.MaintenanceWindows {
+		dayMatch := false
+		for _, d := range w.Days {
+			if d == day {
+				dayMatch = true
+				break
+			}
+		}
+		if !dayMatch {
+			continue
+		}
+		start, _ := time.Parse("15:04", w.Start)
+		end, _ := time.Parse("15:04", w.End)
+		if minute >= start.Hour()*60+start.Minute() && minute < end.Hour()*60+end.Minute() {
+			return true
+		}
+	}
+	return false
+}
+
+// rankCandidates orders by FinalScore descending, breaking ties toward the
+// smaller footprint — smaller moves fit more often, disrupt less, and each
+// completion frees GPUs that make larger moves feasible later. Remaining
+// ties order deterministically by identity.
+func rankCandidates(out []policy.Candidate) {
+	sort.SliceStable(out, func(i, j int) bool {
+		a, b := &out[i], &out[j]
+		if a.Score != b.Score {
+			return a.Score > b.Score
+		}
+		if a.FootprintGPUs != b.FootprintGPUs {
+			return a.FootprintGPUs < b.FootprintGPUs
+		}
+		if a.Workload.String() != b.Workload.String() {
+			return a.Workload.String() < b.Workload.String()
+		}
+		if a.Component != b.Component {
+			return a.Component < b.Component
+		}
+		return a.Instance < b.Instance
+	})
+}
+
+func advisory(w *snapshot.Workload, comp *snapshot.Component, instance int32, reason, from string, footprint int64) policy.Candidate {
+	return policy.Candidate{
+		Policy:         PolicyName,
+		Workload:       w.NamespacedName,
+		Component:      comp.Type,
+		Instance:       instance,
+		Mode:           comp.DeploymentMode,
+		Reason:         policy.ReasonFragmentation,
+		FromNode:       from,
+		Executable:     false,
+		AdvisoryReason: reason,
+		FootprintGPUs:  footprint,
+	}
+}
+
+// --- snapshot traversal helpers (deterministic ordering throughout) ---
+
+func sortedWorkloads(snap *snapshot.ClusterSnapshot) []*snapshot.Workload {
+	out := make([]*snapshot.Workload, 0, len(snap.Workloads))
+	for _, w := range snap.Workloads {
+		out = append(out, w)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].NamespacedName.String() < out[j].NamespacedName.String()
+	})
+	return out
+}
+
+func sortedComponents(w *snapshot.Workload) []*snapshot.Component {
+	out := make([]*snapshot.Component, 0, len(w.Components))
+	for _, comp := range w.Components {
+		out = append(out, comp)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Type < out[j].Type })
+	return out
+}
+
+func modelOf(snap *snapshot.ClusterSnapshot, w *snapshot.Workload) *snapshot.ModelAvailability {
+	if w.ModelKey.Zero() {
+		return nil
+	}
+	return snap.Models[w.ModelKey]
+}
+
+func readyInstances(comp *snapshot.Component) int {
+	count := 0
+	for _, inst := range comp.Instances {
+		if inst.ReadyPods > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+func hasTerminating(inst *snapshot.Instance) bool {
+	for _, pod := range inst.Pods {
+		if pod.Terminating {
+			return true
+		}
+	}
+	return false
+}
+
+// instanceInPool reports whether every member pod sits on a node of the
+// pool; instances straddling pools (or on unknown nodes) are skipped.
+func instanceInPool(snap *snapshot.ClusterSnapshot, inst *snapshot.Instance, pool string) bool {
+	for node := range inst.NodesSet {
+		n, ok := snap.Nodes[node]
+		if !ok || n.GPUPool != pool {
+			return false
+		}
+	}
+	return len(inst.NodesSet) > 0
+}
+
+// primaryNode is the node holding the largest share of the instance's GPUs
+// (name tie-break) — the FromNode a migration request would carry.
+func primaryNode(inst *snapshot.Instance) string {
+	perNode := map[string]int64{}
+	for _, pod := range inst.Pods {
+		perNode[pod.Node] += pod.GPUs
+	}
+	best, bestGPUs := "", int64(-1)
+	for node, gpus := range perNode {
+		if gpus > bestGPUs || (gpus == bestGPUs && node < best) {
+			best, bestGPUs = node, gpus
+		}
+	}
+	return best
+}
+
+// componentPrimaryNode is primaryNode over all of a component's pods.
+func componentPrimaryNode(comp *snapshot.Component) string {
+	perNode := map[string]int64{}
+	for _, inst := range comp.Instances {
+		for _, pod := range inst.Pods {
+			perNode[pod.Node] += pod.GPUs
+		}
+	}
+	best, bestGPUs := "", int64(-1)
+	for node, gpus := range perNode {
+		if gpus > bestGPUs || (gpus == bestGPUs && node < best) {
+			best, bestGPUs = node, gpus
+		}
+	}
+	return best
+}
+
+// componentPrimaryPool attributes a component to the pool holding the
+// largest share of its GPUs (lexicographic tie-break), so component-wide
+// advisories are emitted exactly once.
+func componentPrimaryPool(snap *snapshot.ClusterSnapshot, comp *snapshot.Component) string {
+	perPool := map[string]int64{}
+	for _, inst := range comp.Instances {
+		for _, pod := range inst.Pods {
+			node, ok := snap.Nodes[pod.Node]
+			if !ok {
+				continue
+			}
+			perPool[node.GPUPool] += pod.GPUs
+		}
+	}
+	best, bestGPUs := "", int64(-1)
+	for pool, gpus := range perPool {
+		if gpus > bestGPUs || (gpus == bestGPUs && pool < best) {
+			best, bestGPUs = pool, gpus
+		}
+	}
+	return best
+}
+
+func largestInstanceGPUs(comp *snapshot.Component) int64 {
+	var largest int64
+	for _, inst := range comp.Instances {
+		if inst.TotalGPUs > largest {
+			largest = inst.TotalGPUs
+		}
+	}
+	return largest
+}
+
+func poolPendings(snap *snapshot.ClusterSnapshot, pool string) []snapshot.PendingPod {
+	var out []snapshot.PendingPod
+	for _, p := range snap.PendingPods {
+		if p.GPUPool == pool || p.GPUPool == "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/pkg/alfred/policy/defrag/policy.go
+++ b/pkg/alfred/policy/defrag/policy.go
@@ -265,7 +265,15 @@ func evaluateInstance(ctx *evalCtx, w *snapshot.Workload, comp *snapshot.Compone
 		}
 		after = bins
 	} else {
-		after, _ = freeThenPlace(ctx.bins, prints[0], ranked)
+		bins, target := freeThenPlace(ctx.bins, prints[0], ranked)
+		if target == "" {
+			// Nowhere to land even once the source frees its GPUs
+			// (a full pool, or a model/spot constraint that empties
+			// the ranking): evicting would strand the replacement
+			// in Pending for no gain. Surface, do not dispatch.
+			return advisory(w, comp, inst.Index, policy.AdvisoryNoFeasibleTarget, from, inst.TotalGPUs), true
+		}
+		after = bins
 	}
 
 	benefit := ctx.before - weightedFrag(after, ctx.ladder, ctx.weights, ctx.totalFree)

--- a/pkg/alfred/policy/defrag/policy_test.go
+++ b/pkg/alfred/policy/defrag/policy_test.go
@@ -1,0 +1,405 @@
+package defrag
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/policy"
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+	"sigs.k8s.io/ome/pkg/alfred/testutil"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+// consolidationBuilder is the canonical single-move scenario: prod/mover's
+// 1-GPU pod on node1 (7 free) can fill node2's hole (1 free), freeing a full
+// 8-GPU node. Observed F = 0.2175, best F = 0 (the pinScenario numbers).
+func consolidationBuilder() *testutil.SnapshotBuilder {
+	b := testutil.NewSnapshot().
+		WithNode("node1", "h100", 8).
+		WithNode("node2", "h100", 8).
+		WithInstance("prod/mover", v1beta1.EngineComponent, constants.RawDeployment, "node1", 1)
+	b.WithOtherOccupant("node2", 7)
+	return b
+}
+
+// lowGate returns a config whose gate the consolidation scenario passes
+// (0.2175 sits below the default 0.25 threshold by design — the default gate
+// is deliberately conservative).
+func lowGate() *config.Config {
+	cfg := config.Default()
+	*cfg.Policies.Defragmentation.FragmentationThreshold = 0.1
+	return cfg
+}
+
+func evaluate(t *testing.T, snap *snapshot.ClusterSnapshot, cfg *config.Config) []policy.Candidate {
+	t.Helper()
+	var p Policy
+	if p.Name() != PolicyName {
+		t.Fatalf("policy name = %q", p.Name())
+	}
+	return p.Evaluate(snap, cfg)
+}
+
+func executables(cands []policy.Candidate) []policy.Candidate {
+	var out []policy.Candidate
+	for _, c := range cands {
+		if c.Executable {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func advisories(cands []policy.Candidate, reason string) []policy.Candidate {
+	var out []policy.Candidate
+	for _, c := range cands {
+		if !c.Executable && c.AdvisoryReason == reason {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// TestGate: below the threshold (or disabled) the policy returns nothing —
+// Alfred stays quiescent on a cluster it cannot improve.
+func TestGate(t *testing.T) {
+	snap := consolidationBuilder().Build()
+
+	if got := evaluate(t, snap, config.Default()); got != nil {
+		// 0.2175 < default 0.25: the reclaimable shape alone must not
+		// wake the policy at default settings.
+		t.Fatalf("below-threshold Evaluate = %v, want nil", got)
+	}
+
+	cfg := lowGate()
+	*cfg.Policies.Defragmentation.Enabled = false
+	if got := evaluate(t, snap, cfg); got != nil {
+		t.Fatalf("disabled Evaluate = %v, want nil", got)
+	}
+}
+
+// TestConsolidationCandidate pins the whole pipeline on the canonical move:
+// surge-shaped (single ready replica), benefit = the full reclaimable 0.2175,
+// cost = rolling restart, hints = the hole it should fill.
+func TestConsolidationCandidate(t *testing.T) {
+	cands := evaluate(t, consolidationBuilder().Build(), lowGate())
+	execs := executables(cands)
+	if len(execs) != 1 {
+		t.Fatalf("want exactly one executable candidate, got %+v", cands)
+	}
+	c := execs[0]
+	if c.Workload.String() != "prod/mover" || c.Component != v1beta1.EngineComponent || c.Instance != 0 {
+		t.Fatalf("candidate identity: %+v", c)
+	}
+	if c.Mode != constants.RawDeployment || !c.SurgeShaped {
+		t.Fatalf("single ready replica must simulate surge-first rolling restart: %+v", c)
+	}
+	if c.FromNode != "node1" {
+		t.Fatalf("FromNode = %q, want node1", c.FromNode)
+	}
+	if len(c.HintTargetNodes) != 1 || c.HintTargetNodes[0] != "node2" {
+		t.Fatalf("hints = %v, want [node2] (fill the hole)", c.HintTargetNodes)
+	}
+	almost(t, "Benefit", c.Benefit, 0.2175)
+	almost(t, "Cost", c.Cost, costRollingRestart)
+	almost(t, "Score", c.Score, 0.2175-costRollingRestart)
+	if c.Emergency {
+		t.Fatal("no pending pod, must not be an emergency")
+	}
+	if c.FootprintGPUs != 1 {
+		t.Fatalf("FootprintGPUs = %d, want 1", c.FootprintGPUs)
+	}
+}
+
+// TestNoSurgeHeadroomAdvisory: an 8-GPU OMENative instance with no 8-free
+// target must not be dispatched — it degrades to advisory instead of
+// stalling in SurgePending until timeout.
+func TestNoSurgeHeadroomAdvisory(t *testing.T) {
+	b := testutil.NewSnapshot().
+		WithNode("node1", "h100", 8).
+		WithNode("node2", "h100", 8).
+		WithNode("node3", "h100", 8).
+		WithInstance("prod/big", v1beta1.EngineComponent, constants.OMENative, "node1", 8).
+		WithInstance("prod/mover", v1beta1.EngineComponent, constants.RawDeployment, "node2", 1)
+	b.WithOtherOccupant("node3", 7)
+	cfg := lowGate()
+	*cfg.Policies.Defragmentation.FragmentationThreshold = 0.05
+
+	cands := evaluate(t, b.Build(), cfg)
+	blocked := advisories(cands, policy.AdvisoryNoSurgeHeadroom)
+	if len(blocked) != 1 {
+		t.Fatalf("want one NoSurgeHeadroom advisory, got %+v", cands)
+	}
+	if blocked[0].Workload.String() != "prod/big" || blocked[0].FromNode != "node1" ||
+		blocked[0].FootprintGPUs != 8 || !blocked[0].SurgeShaped {
+		t.Fatalf("advisory shape: %+v", blocked[0])
+	}
+	execs := executables(cands)
+	if len(execs) != 1 || execs[0].Workload.String() != "prod/mover" {
+		t.Fatalf("the small consolidation move must still be executable: %+v", cands)
+	}
+}
+
+// TestEvictionShape: with two ready replicas the controller would evict, so
+// the simulation is free-then-place and candidates need no surge headroom.
+func TestEvictionShape(t *testing.T) {
+	b := testutil.NewSnapshot().
+		WithNode("node1", "h100", 8).
+		WithNode("node2", "h100", 8).
+		WithNode("node3", "h100", 8).
+		WithInstance("prod/wide", v1beta1.EngineComponent, constants.RawDeployment, "node1", 1).
+		WithInstance("prod/wide", v1beta1.EngineComponent, constants.RawDeployment, "node2", 1)
+	b.WithOtherOccupant("node3", 7)
+	cfg := lowGate()
+	*cfg.Policies.Defragmentation.FragmentationThreshold = 0.01
+
+	execs := executables(evaluate(t, b.Build(), cfg))
+	if len(execs) != 2 {
+		t.Fatalf("want both replicas as candidates, got %+v", execs)
+	}
+	for _, c := range execs {
+		if c.SurgeShaped {
+			t.Fatalf("multi-replica RawDeployment must simulate free-then-place: %+v", c)
+		}
+		almost(t, "Cost", c.Cost, costTargetedEviction)
+	}
+}
+
+// TestEnumerationFilters: cooldown (with override), in-flight migrations,
+// and Movable=false all keep a workload out of the candidate set.
+func TestEnumerationFilters(t *testing.T) {
+	cfg := lowGate()
+
+	recent := testutil.ReferenceTime.Add(-5 * time.Minute)
+	b := consolidationBuilder().ConfigureWorkload("prod/mover", func(w *snapshot.Workload) {
+		w.LastMigration = &recent
+	})
+	if got := executables(evaluate(t, b.Build(), cfg)); len(got) != 0 {
+		t.Fatalf("workload inside the 30m cooldown must not produce candidates: %+v", got)
+	}
+
+	short := time.Minute
+	b = consolidationBuilder().ConfigureWorkload("prod/mover", func(w *snapshot.Workload) {
+		w.LastMigration = &recent
+		w.CooldownOverride = &short
+	})
+	if got := executables(evaluate(t, b.Build(), cfg)); len(got) != 1 {
+		t.Fatalf("cooldown override must re-admit the workload: %+v", got)
+	}
+
+	b = consolidationBuilder().ConfigureWorkload("prod/mover", func(w *snapshot.Workload) {
+		w.ActiveMigrations = []snapshot.InFlight{{UUID: "u1", Component: v1beta1.EngineComponent}}
+	})
+	if got := executables(evaluate(t, b.Build(), cfg)); len(got) != 0 {
+		t.Fatalf("in-flight migration must exclude the workload: %+v", got)
+	}
+
+	b = consolidationBuilder().ConfigureWorkload("prod/mover", func(w *snapshot.Workload) {
+		w.Movable = false
+	})
+	if got := executables(evaluate(t, b.Build(), cfg)); len(got) != 0 {
+		t.Fatalf("Movable=false must exclude the workload: %+v", got)
+	}
+}
+
+// withBystander adds a third node carrying an extra workload without
+// disturbing the mover's consolidation shape (node1 must still reach 8 free).
+func withBystander(workload string, mode constants.DeploymentModeType) *testutil.SnapshotBuilder {
+	return consolidationBuilder().
+		WithNode("node3", "h100", 8).
+		WithInstance(workload, v1beta1.EngineComponent, mode, "node3", 1)
+}
+
+// bystanderGate: the third node dilutes the pool, so the reclaimable share
+// shrinks below the test gate of 0.1; open the gate further.
+func bystanderGate() *config.Config {
+	cfg := lowGate()
+	*cfg.Policies.Defragmentation.FragmentationThreshold = 0.05
+	return cfg
+}
+
+// TestLWSAdvisory: LWS-backed components surface as advisory-only, and the
+// lwsRecommendationsEnabled switch silences them.
+func TestLWSAdvisory(t *testing.T) {
+	build := func() *snapshot.ClusterSnapshot {
+		return withBystander("prod/lws", constants.MultiNode).Build()
+	}
+	cfg := bystanderGate()
+
+	cands := evaluate(t, build(), cfg)
+	lws := advisories(cands, policy.AdvisoryLWSMigrationUnsupported)
+	if len(lws) != 1 {
+		t.Fatalf("want one LWS advisory, got %+v", cands)
+	}
+	if lws[0].Instance != policy.ComponentWideInstance || lws[0].Mode != constants.MultiNode {
+		t.Fatalf("LWS advisory shape: %+v", lws[0])
+	}
+	if len(executables(cands)) != 1 {
+		t.Fatalf("mover must stay executable alongside the advisory: %+v", cands)
+	}
+
+	*cfg.LWSRecommendationsEnabled = false
+	if got := advisories(evaluate(t, build(), cfg), policy.AdvisoryLWSMigrationUnsupported); len(got) != 0 {
+		t.Fatalf("disabled LWS recommendations must not surface: %+v", got)
+	}
+}
+
+// TestVolumePinnedAdvisory: an RWO-backed workload cannot move by any
+// mechanism; it surfaces as advisory while other moves stay executable.
+func TestVolumePinnedAdvisory(t *testing.T) {
+	b := withBystander("prod/pinned", constants.RawDeployment)
+	b.WithModel("prod/pinned", &snapshot.ModelAvailability{
+		Key:            snapshot.ModelKey{Kind: snapshot.ModelKindBaseModel, Namespace: "prod", Name: "rwo"},
+		Backend:        snapshot.BackendPVC,
+		PVCAccessModes: []string{"ReadWriteOnce"},
+		VolumePinned:   true,
+	})
+	cands := evaluate(t, b.Build(), bystanderGate())
+
+	pinned := advisories(cands, policy.AdvisoryVolumePinned)
+	if len(pinned) != 1 || pinned[0].Workload.String() != "prod/pinned" {
+		t.Fatalf("want one VolumePinned advisory for prod/pinned, got %+v", cands)
+	}
+	execs := executables(cands)
+	if len(execs) != 1 || execs[0].Workload.String() != "prod/mover" {
+		t.Fatalf("mover must stay executable: %+v", execs)
+	}
+}
+
+// TestOMENativeUnavailableAdvisory: without an executor the migration verb
+// has no consumer; OMENative candidates degrade to advisory.
+func TestOMENativeUnavailableAdvisory(t *testing.T) {
+	b := withBystander("prod/omen", constants.OMENative).WithOMENative(false)
+	cands := evaluate(t, b.Build(), bystanderGate())
+	degraded := advisories(cands, policy.AdvisoryOMENativeUnavailable)
+	if len(degraded) != 1 || degraded[0].Workload.String() != "prod/omen" {
+		t.Fatalf("want one OMENativeUnavailable advisory, got %+v", cands)
+	}
+}
+
+// TestEmergencyBoost: a move that unblocks an over-age pending pod in the
+// workload's own namespace doubles its score; the same pending in a foreign
+// namespace (no shared tenant group) must not boost it.
+func TestEmergencyBoost(t *testing.T) {
+	cfg := lowGate()
+	oneExecutable := func(b *testutil.SnapshotBuilder) policy.Candidate {
+		t.Helper()
+		execs := executables(evaluate(t, b.Build(), cfg))
+		if len(execs) != 1 {
+			t.Fatalf("want exactly one executable candidate, got %+v", execs)
+		}
+		return execs[0]
+	}
+
+	// The pending demand shifts the blend weights, so the boost baseline
+	// is the identically-shaped cross-namespace run: same weights, same
+	// benefit, no tenant-compatible beneficiary.
+	unboosted := oneExecutable(consolidationBuilder().WithPendingPodIn("other", 8, 30*time.Minute, "h100"))
+	if unboosted.Emergency {
+		t.Fatalf("cross-namespace pending without a shared tenant group must not boost: %+v", unboosted)
+	}
+
+	boosted := oneExecutable(consolidationBuilder().WithPendingPodIn("prod", 8, 30*time.Minute, "h100"))
+	if !boosted.Emergency {
+		t.Fatalf("unblocking an over-age same-namespace pending must be an emergency: %+v", boosted)
+	}
+	almost(t, "boosted score", boosted.Score, unboosted.Score*emergencyBoostFactor)
+
+	if c := oneExecutable(consolidationBuilder().WithPendingPodIn("prod", 8, 5*time.Minute, "h100")); c.Emergency {
+		t.Fatalf("a pending younger than emergencyPendingAgeMinutes must not boost: %+v", c)
+	}
+}
+
+// TestInstanceFootprintsDeterministicOrder: the tie-break must travel with
+// the sorted elements. The mixed-size shape below is the regression: the
+// size comparison swaps the 8s past the 1 first, and a tie-break read
+// through a stale parallel index would then leave "y" ahead of "x".
+func TestInstanceFootprintsDeterministicOrder(t *testing.T) {
+	inst := &snapshot.Instance{Pods: []snapshot.PodInfo{
+		{Namespace: "p", Name: "a", Node: "n1", GPUs: 1},
+		{Namespace: "p", Name: "y", Node: "n2", GPUs: 8},
+		{Namespace: "p", Name: "x", Node: "n3", GPUs: 8},
+	}}
+	got := instanceFootprints(inst)
+	wantNodes := []string{"n3", "n2", "n1"} // 8@p/x, 8@p/y, 1@p/a
+	wantGPUs := []int64{8, 8, 1}
+	if len(got) != len(wantNodes) {
+		t.Fatalf("footprints = %+v", got)
+	}
+	for i := range wantNodes {
+		if got[i].node != wantNodes[i] || got[i].gpus != wantGPUs[i] {
+			t.Fatalf("footprint[%d] = %+v, want %d GPUs from %s (largest first, name tie-break)",
+				i, got[i], wantGPUs[i], wantNodes[i])
+		}
+	}
+}
+
+// TestMaintenanceWindowGatesDispatch: outside every configured window,
+// executable candidates are dropped; advisories survive (they dispatch
+// nothing). ReferenceTime is a Thursday, 12:00 UTC.
+func TestMaintenanceWindowGatesDispatch(t *testing.T) {
+	build := func() *snapshot.ClusterSnapshot {
+		return withBystander("prod/lws", constants.MultiNode).Build()
+	}
+
+	cfg := bystanderGate()
+	cfg.MaintenanceWindows = []config.MaintenanceWindow{{Days: []string{"Mon"}, Start: "09:00", End: "17:00"}}
+	closed := evaluate(t, build(), cfg)
+	if len(executables(closed)) != 0 {
+		t.Fatalf("outside the window executables must be dropped: %+v", closed)
+	}
+	if len(advisories(closed, policy.AdvisoryLWSMigrationUnsupported)) != 1 {
+		t.Fatalf("advisories must survive a closed window: %+v", closed)
+	}
+
+	cfg.MaintenanceWindows = []config.MaintenanceWindow{{Days: []string{"Thu"}, Start: "09:00", End: "17:00"}}
+	if open := evaluate(t, build(), cfg); len(executables(open)) != 1 {
+		t.Fatalf("inside the window the move must dispatch: %+v", open)
+	}
+}
+
+// TestModelReadinessFiltersTargets: per-node models restrict hints to nodes
+// whose readiness label is set — migrating onto a node that must first pull
+// a multi-hundred-GB model defeats the purpose.
+func TestModelReadinessFiltersTargets(t *testing.T) {
+	b := testutil.NewSnapshot().
+		WithNode("node1", "h100", 8).
+		WithNode("node2", "h100", 8).
+		WithNode("node3", "h100", 8).
+		WithInstance("prod/mover", v1beta1.EngineComponent, constants.RawDeployment, "node1", 1)
+	b.WithOtherOccupant("node2", 7)
+	b.WithOtherOccupant("node3", 7)
+	b.WithModel("prod/mover", &snapshot.ModelAvailability{
+		Key:        snapshot.ModelKey{Kind: snapshot.ModelKindBaseModel, Namespace: "prod", Name: "llm"},
+		Backend:    snapshot.BackendPerNode,
+		NodesReady: []string{"node1", "node3"},
+	})
+	cfg := lowGate()
+	*cfg.Policies.Defragmentation.FragmentationThreshold = 0.05
+
+	execs := executables(evaluate(t, b.Build(), cfg))
+	if len(execs) != 1 {
+		t.Fatalf("want the mover candidate, got %+v", execs)
+	}
+	if len(execs[0].HintTargetNodes) != 1 || execs[0].HintTargetNodes[0] != "node3" {
+		t.Fatalf("hints = %v, want [node3] (node2 lacks the model)", execs[0].HintTargetNodes)
+	}
+}
+
+// TestRankingPrefersScoreThenSmallerFootprint: candidates order by score
+// descending; equal scores break toward the smaller footprint.
+func TestRankingPrefersScoreThenSmallerFootprint(t *testing.T) {
+	cands := []policy.Candidate{
+		{Workload: types.NamespacedName{Namespace: "prod", Name: "b"}, Score: 0.1, FootprintGPUs: 8},
+		{Workload: types.NamespacedName{Namespace: "prod", Name: "a"}, Score: 0.1, FootprintGPUs: 2},
+		{Workload: types.NamespacedName{Namespace: "prod", Name: "c"}, Score: 0.3, FootprintGPUs: 8},
+	}
+	rankCandidates(cands)
+	if cands[0].Workload.Name != "c" || cands[1].FootprintGPUs != 2 || cands[2].FootprintGPUs != 8 {
+		t.Fatalf("ranking order wrong: %+v", cands)
+	}
+}

--- a/pkg/alfred/policy/defrag/policy_test.go
+++ b/pkg/alfred/policy/defrag/policy_test.go
@@ -169,6 +169,52 @@ func TestEvictionShape(t *testing.T) {
 	}
 }
 
+// TestEvictionNoFeasibleTargetAdvisory: a replica whose ranking is empty has
+// nowhere to be evicted to — dispatching would strand the replacement in
+// Pending. It degrades to advisory, the free-then-place mirror of
+// NoSurgeHeadroom, while its sibling with a real target stays executable.
+func TestEvictionNoFeasibleTargetAdvisory(t *testing.T) {
+	b := testutil.NewSnapshot().
+		WithNode("node1", "h100", 8).
+		WithNode("node2", "h100", 8).
+		WithNode("node3", "h100", 8).
+		WithInstance("prod/wide", v1beta1.EngineComponent, constants.RawDeployment, "node1", 1).
+		WithInstance("prod/wide", v1beta1.EngineComponent, constants.RawDeployment, "node2", 1)
+	b.WithOtherOccupant("node1", 6)
+	b.WithOtherOccupant("node2", 7)
+	b.WithOtherOccupant("node3", 7)
+	b.WithModel("prod/wide", &snapshot.ModelAvailability{
+		Key:        snapshot.ModelKey{Kind: snapshot.ModelKindBaseModel, Namespace: "prod", Name: "llm"},
+		Backend:    snapshot.BackendPerNode,
+		NodesReady: []string{"node1", "node2"},
+	})
+	cfg := lowGate()
+	*cfg.Policies.Defragmentation.FragmentationThreshold = 0.01
+
+	cands := evaluate(t, b.Build(), cfg)
+
+	// The node1 replica is boxed in: node2 is full and node3 lacks the model.
+	blocked := advisories(cands, policy.AdvisoryNoFeasibleTarget)
+	if len(blocked) != 1 {
+		t.Fatalf("want one NoFeasibleTarget advisory, got %+v", cands)
+	}
+	if blocked[0].FromNode != "node1" || blocked[0].SurgeShaped || blocked[0].FootprintGPUs != 1 {
+		t.Fatalf("advisory shape: %+v", blocked[0])
+	}
+	if len(blocked[0].HintTargetNodes) != 0 {
+		t.Fatalf("advisory must carry no hints, got %v", blocked[0].HintTargetNodes)
+	}
+
+	// The node2 replica can still reach node1's hole: unchanged.
+	execs := executables(cands)
+	if len(execs) != 1 || execs[0].FromNode != "node2" {
+		t.Fatalf("want the node2 replica executable, got %+v", execs)
+	}
+	if len(execs[0].HintTargetNodes) != 1 || execs[0].HintTargetNodes[0] != "node1" {
+		t.Fatalf("hints = %v, want [node1]", execs[0].HintTargetNodes)
+	}
+}
+
 // TestEnumerationFilters: cooldown (with override), in-flight migrations,
 // and Movable=false all keep a workload out of the candidate set.
 func TestEnumerationFilters(t *testing.T) {

--- a/pkg/alfred/policy/defrag/simulate.go
+++ b/pkg/alfred/policy/defrag/simulate.go
@@ -1,0 +1,151 @@
+package defrag
+
+import (
+	"sort"
+
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+)
+
+// footprint is one pod-shaped block of GPUs a simulated move lifts from a
+// source node and re-places on a target.
+type footprint struct {
+	node string
+	gpus int64
+	// name is namespace/name of the source pod — the deterministic
+	// tie-break for equal-sized footprints (it must travel with the
+	// element: a parallel slice would decouple from the sort's swaps).
+	name string
+}
+
+// instanceFootprints returns the instance's per-pod footprints, largest
+// first (pod-name tie-break) for deterministic placement.
+func instanceFootprints(inst *snapshot.Instance) []footprint {
+	prints := make([]footprint, 0, len(inst.Pods))
+	for _, pod := range inst.Pods {
+		if pod.GPUs == 0 || pod.Node == "" {
+			continue
+		}
+		prints = append(prints, footprint{
+			node: pod.Node,
+			gpus: pod.GPUs,
+			name: pod.Namespace + "/" + pod.Name,
+		})
+	}
+	sort.SliceStable(prints, func(i, j int) bool {
+		if prints[i].gpus != prints[j].gpus {
+			return prints[i].gpus > prints[j].gpus
+		}
+		return prints[i].name < prints[j].name
+	})
+	return prints
+}
+
+// weightedFrag recomputes F_observed over a bin distribution with fixed
+// weights and a fixed denominator — the same shared-TotalFree rule scoring
+// uses, so simulated deltas measure slot change, not denominator drift.
+func weightedFrag(bins []binState, ladder []int64, weights map[int64]float64, totalFree int64) float64 {
+	var f float64
+	for _, size := range ladder {
+		f += weights[size] * fragForSize(slotsForSize(bins, size), size, totalFree)
+	}
+	return f
+}
+
+// cloneBins copies a bin distribution so a simulation never mutates the
+// per-pool distribution shared across candidates.
+func cloneBins(bins []binState) []binState {
+	out := make([]binState, len(bins))
+	copy(out, bins)
+	return out
+}
+
+func binIndexByName(bins []binState) map[string]int {
+	index := make(map[string]int, len(bins))
+	for i, bin := range bins {
+		index[bin.name] = i
+	}
+	return index
+}
+
+// placeThenFree simulates a surge-shaped move: every replacement footprint
+// must fit a ranked target while the sources still hold their GPUs; only
+// then are the sources freed and the distribution re-scored. ok=false means
+// no surge-feasible placement exists (NoSurgeHeadroom). A source on an
+// excluded node is not a bin; its freed GPUs stay invisible, exactly like
+// scoring's schedulable-bins rule.
+func placeThenFree(observed []binState, sources []footprint, ranked []string) (after []binState, targets []string, ok bool) {
+	bins := cloneBins(observed)
+	index := binIndexByName(bins)
+
+	for _, src := range sources {
+		placed := false
+		for _, target := range ranked {
+			i, isBin := index[target]
+			if !isBin || bins[i].free < src.gpus {
+				continue
+			}
+			bins[i].free -= src.gpus
+			targets = append(targets, target)
+			placed = true
+			break
+		}
+		if !placed {
+			return nil, nil, false
+		}
+	}
+	for _, src := range sources {
+		if i, isBin := index[src.node]; isBin {
+			bins[i].free += src.gpus
+			if bins[i].free > bins[i].cap {
+				bins[i].free = bins[i].cap
+			}
+		}
+	}
+	return bins, targets, true
+}
+
+// freeThenPlace simulates the multi-replica targeted-eviction path: the
+// source frees first and the replacement may legitimately reuse the freed
+// GPUs — worst case the move under-delivers (benefit 0), it cannot deadlock.
+// The replacement lands on the first ranked target with room, else back on
+// its source when the source is a bin, else nowhere (it would pend). It
+// models a single footprint by construction: eviction applies only to
+// RawDeployment, whose Instances are one pod each.
+func freeThenPlace(observed []binState, source footprint, ranked []string) (after []binState, target string) {
+	bins := cloneBins(observed)
+	index := binIndexByName(bins)
+
+	if i, isBin := index[source.node]; isBin {
+		bins[i].free += source.gpus
+		if bins[i].free > bins[i].cap {
+			bins[i].free = bins[i].cap
+		}
+	}
+	for _, candidate := range ranked {
+		i, isBin := index[candidate]
+		if !isBin || bins[i].free < source.gpus {
+			continue
+		}
+		bins[i].free -= source.gpus
+		return bins, candidate
+	}
+	if i, isBin := index[source.node]; isBin {
+		bins[i].free -= source.gpus
+	}
+	return bins, ""
+}
+
+// canSeat reports whether any single bin could seat the pending pod's
+// footprint. Demands wider than every node are gang business — one move
+// cannot unblock them — and report false by construction.
+func canSeat(bins []binState, gpus int64) bool {
+	if gpus <= 0 {
+		return false
+	}
+	for _, bin := range bins {
+		if bin.free >= gpus {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/alfred/testutil/builder.go
+++ b/pkg/alfred/testutil/builder.go
@@ -179,8 +179,14 @@ func (b *SnapshotBuilder) WithMultiPodInstance(workload string, ctype v1beta1.Co
 
 // WithPendingPod adds a real pending GPU pod that has waited for age.
 func (b *SnapshotBuilder) WithPendingPod(gpus int64, age time.Duration, pool string) *SnapshotBuilder {
+	return b.WithPendingPodIn("pending", gpus, age, pool)
+}
+
+// WithPendingPodIn adds a pending GPU pod in a specific namespace — tenant
+// scoping in policy tests needs control over where pending demand lives.
+func (b *SnapshotBuilder) WithPendingPodIn(namespace string, gpus int64, age time.Duration, pool string) *SnapshotBuilder {
 	b.s.PendingPods = append(b.s.PendingPods, snapshot.PendingPod{
-		Namespace:    "pending",
+		Namespace:    namespace,
 		Name:         b.nextPodName("pending"),
 		GPUsNeeded:   gpus,
 		GPUPool:      pool,


### PR DESCRIPTION
## What

Implements OEP-0008 Policy #1 candidate selection (plan step A4): the defragmentation policy turns a gated snapshot into a ranked `[]Candidate` with placement hints — still a pure, side-effect-free function of the snapshot. The engine (arbiter + reporter, next PRs) consumes the slice; nothing is wired into the binary yet.

- `pkg/alfred/policy/api.go` — the shared policy contract: `Candidate` (benefit/cost/score, executable vs advisory with reason, surge shape, footprint, ranked hints) and the `Policy` interface every Alfred policy implements.
- `pkg/alfred/policy/defrag/policy.go` — §Candidate selection steps 1–8: threshold gate (per pool — you defragment the worst pool), enumeration filters (movable, no in-flight migration, per-workload cooldown incl. the `alfred.ome.io/cooldown-minutes` override), mode classification (OMENative and RawDeployment executable; LWS advisory `LWSMigrationUnsupported`; Knative unmanaged), benefit-minus-cost scoring with the aggressiveness cost weight, emergency boost for over-age pending pods (tenant-scoped), spot prefer-as-source boost, smallest-footprint tie-break, and the maintenance-window dispatch gate (advisories survive a closed window; they dispatch nothing).
- `pkg/alfred/policy/defrag/simulate.go` — mode-aware simulation: **place-then-free** for surge shapes (OMENative Instance surge; single-ready-replica rolling restart) with the `NoSurgeHeadroom` advisory downgrade when no target fits while the source still holds its GPUs; **free-then-place** only for the multi-replica targeted-eviction path (it may under-deliver, it cannot deadlock). Benefit = `F_observed_before − F_observed_after`, both over the observed free-capacity denominator.
- `pkg/alfred/policy/defrag/placement.go` — storage-aware target ranking: consolidation order (fullest schedulable node first), source exclusion, per-workload spot avoidance, and the model filter that switches on storage backend (per-node readiness labels vs PVC CSI topology; `VolumePinned` and `ModelUnresolved` downgrade to advisory before placement runs).

## Notes

- Advisory candidates never enter arbitration and never consume migration budget — they exist for the Reporter.
- RawDeployment surge-vs-evict is simulated from snapshot ready-replica state; the controller re-branches at execution time against live state, per the OEP.
- The tenant boundary is enforced where it is mechanically checkable in this policy: the emergency boost only counts pending demand in the workload's own namespace or its explicit shared tenant group (unless the cluster admin vetoed cross-tenant moves).
- Also fixes a trailing-space gofmt nit that slipped into `scoring.go` with #768's final amend.

## Testing

`go test ./pkg/alfred/...` — defrag package at 87.9% statement coverage. Scenario tests pin: the canonical consolidation candidate end-to-end (benefit exactly the reclaimable 0.2175, hints = the hole to fill), the NoSurgeHeadroom downgrade, free-then-place shape for multi-replica components, enumeration filters (cooldown, override, in-flight), LWS / VolumePinned / OMENativeUnavailable advisories, the emergency boost with tenant scoping (a cross-namespace pending must not boost), maintenance-window dispatch gating on a real weekday, per-node model readiness constraining hints, and score/footprint rank ordering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added defragmentation policy evaluation to identify and rank workload migration opportunities.
  * Added placement simulation accounting for GPU capacity, storage constraints, execution availability, maintenance windows, and migration costs.
  * Added actionable recommendations and advisories for eligible, blocked, emergency, and unavailable-target scenarios.
  * Added deterministic candidate scoring and ordering for consistent results.

* **Bug Fixes**
  * Improved filtering for cooldowns, active migrations, model readiness, tenant settings, spot policies, and placement eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->