### PR TITLE
[Misc] Add alfred deploy manifests and make install-alfred

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ REGISTRY     ?= ghcr.io/moirai-internal
 TAG          ?= $(GIT_TAG)
 ARCH         ?= linux/amd64
 MANAGER_IMG  ?= $(REGISTRY)/ome-manager:$(TAG)
+ALFRED_IMG   ?= $(REGISTRY)/alfred:$(TAG)
 
 # Git version and commit information for build
 version_pkg = sigs.k8s.io/ome/pkg/version
@@ -400,6 +401,16 @@ ome-agent-image: fmt vet xet-build ## Build ome-agent image.
 		. -f dockerfiles/ome-agent.Dockerfile -t $(REGISTRY)/ome-agent:$(TAG)
 	@echo "✅ Image built"
 
+.PHONY: alfred-image
+alfred-image: fmt vet ## Build alfred image.
+	@echo "🎩 Building alfred image..."
+	$(DOCKER_BUILD_CMD) build --platform=$(ARCH) \
+		--build-arg VERSION=$(GIT_TAG) \
+		--build-arg GIT_TAG=$(GIT_TAG) \
+		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
+		. -f dockerfiles/alfred.Dockerfile -t $(ALFRED_IMG)
+	@echo "✅ Image built"
+
 .PHONY: docker-buildx-setup
 docker-buildx-setup: ## 🔧 Setup Docker buildx for multi-arch builds
 	@echo "🔧 Setting up Docker buildx..."
@@ -517,11 +528,29 @@ uninstall: kustomize ## 🧹 Uninstall controller from the configured Kubernetes
 	kubectl delete --ignore-not-found=$(ignore-not-found) -k config/clusterresources
 	@echo "✅ Controller uninstalled"
 
+.PHONY: install-alfred
+install-alfred: kustomize ## 🎩 Deploy alfred (GPU cluster caretaker) in the configured Kubernetes cluster for testing.
+	@echo "\n🎩 Deploying alfred in recommend-only mode: $(ALFRED_IMG)"
+	@echo "  • OME must already be installed — alfred reads its CRDs and runs in the ome namespace"
+	@cp config/alfred/kustomization.yaml config/alfred/kustomization.yaml.bak; \
+		trap 'mv config/alfred/kustomization.yaml.bak config/alfred/kustomization.yaml' EXIT; \
+		(cd config/alfred && $(KUSTOMIZE) edit set image ghcr.io/moirai-internal/alfred=$(ALFRED_IMG)) && \
+		$(KUSTOMIZE) build config/alfred | kubectl apply --server-side --force-conflicts -f -
+	@kubectl -n ome rollout status deployment/ome-alfred --timeout=180s
+	@echo "\n✅ Alfred deployed. Tune it with 'kubectl -n ome edit configmap alfred-config' (hot-reloaded),"
+	@echo "   and scrape its gauges with 'kubectl -n ome port-forward svc/ome-alfred-metrics 8080:8080'.\n"
+
+.PHONY: uninstall-alfred
+uninstall-alfred: kustomize ## 🧹 Remove alfred from the configured Kubernetes cluster.
+	kubectl delete --ignore-not-found=$(ignore-not-found) -k config/alfred
+	@echo "✅ Alfred uninstalled"
+
 .PHONY: kustomize-validate
 kustomize-validate: kustomize ## 🔍 Validate kustomize configuration without applying to cluster
 	@echo "\n🔍 Validating kustomize configuration..."
 	@cd config/default && $(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone . > /dev/null && echo "✅ Default configuration is valid" || (echo "❌ Error in default configuration" && exit 1)
 	@cd config/clusterresources && $(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone . > /dev/null && echo "✅ Cluster resources configuration is valid" || (echo "❌ Error in cluster resources configuration" && exit 1)
+	@cd config/alfred && $(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone . > /dev/null && echo "✅ Alfred configuration is valid" || (echo "❌ Error in alfred configuration" && exit 1)
 	@echo "\n✅ Kustomize validation completed successfully!\n"
 
 .PHONY: push-manager-image
@@ -540,6 +569,12 @@ push-model-agent-image: model-agent-image ## Push model-agent image to registry.
 push-ome-agent-image: ome-agent-image ## Push ome-agent image to registry.
 	@echo "🚀 Pushing ome-agent image to registry..."
 	$(DOCKER_BUILD_CMD) push $(REGISTRY)/ome-agent:$(TAG)
+	@echo "✅ Image pushed"
+
+.PHONY: push-alfred-image
+push-alfred-image: alfred-image ## Push alfred image to registry.
+	@echo "🚀 Pushing alfred image to registry..."
+	$(DOCKER_BUILD_CMD) push $(ALFRED_IMG)
 	@echo "✅ Image pushed"
 
 .PHONY: patch-manager-dev

--- a/Makefile
+++ b/Makefile
@@ -532,10 +532,11 @@ uninstall: kustomize ## 🧹 Uninstall controller from the configured Kubernetes
 install-alfred: kustomize ## 🎩 Deploy alfred (GPU cluster caretaker) in the configured Kubernetes cluster for testing.
 	@echo "\n🎩 Deploying alfred in recommend-only mode: $(ALFRED_IMG)"
 	@echo "  • OME must already be installed — alfred reads its CRDs and runs in the ome namespace"
-	@cp config/alfred/kustomization.yaml config/alfred/kustomization.yaml.bak; \
-		trap 'mv config/alfred/kustomization.yaml.bak config/alfred/kustomization.yaml' EXIT; \
-		(cd config/alfred && $(KUSTOMIZE) edit set image ghcr.io/moirai-internal/alfred=$(ALFRED_IMG)) && \
-		$(KUSTOMIZE) build config/alfred | kubectl apply --server-side --force-conflicts -f -
+	@tmpdir=$$(mktemp -d); \
+		trap 'rm -rf "$$tmpdir"' EXIT; \
+		cp -R config/alfred/. "$$tmpdir"; \
+		(cd "$$tmpdir" && $(KUSTOMIZE) edit set image ghcr.io/moirai-internal/alfred=$(ALFRED_IMG)) && \
+		$(KUSTOMIZE) build "$$tmpdir" | kubectl apply --server-side --force-conflicts -f -
 	@kubectl -n ome rollout status deployment/ome-alfred --timeout=180s
 	@echo "\n✅ Alfred deployed. Tune it with 'kubectl -n ome edit configmap alfred-config' (hot-reloaded),"
 	@echo "   and scrape its gauges with 'kubectl -n ome port-forward svc/ome-alfred-metrics 8080:8080'.\n"

--- a/config/alfred/clusterrole.yaml
+++ b/config/alfred/clusterrole.yaml
@@ -1,0 +1,64 @@
+# Alfred's permission surface is read-only plus four narrow writes
+# (OEP-0008 §RBAC): no node writes, no pod writes, no pods/eviction. Every
+# pod-level action is executed by the controller that owns the workload.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ome-alfred
+  labels:
+    app.kubernetes.io/component: "ome-alfred"
+rules:
+  # Nodes (read-only) — no cordon, no drain, no patch.
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "list", "watch" ]
+
+  # Pods (read-only) — candidate selection reads placement; eviction is the
+  # owning controller's job.
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ "get", "list", "watch" ]
+
+  # PVCs / PVs (read-only) — PVC-backed model topology in the snapshot.
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims", "persistentvolumes" ]
+    verbs: [ "get", "list", "watch" ]
+
+  # ConfigMaps: read for policy loading, write only to the two pre-created
+  # Alfred-owned ConfigMaps — Alfred never creates a ConfigMap at runtime.
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "update", "patch", "delete" ]
+    resourceNames:
+      - alfred-config
+      - alfred-recommendations
+
+  # Events — recommendations, migrations, evacuation and repair signals.
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "create", "patch" ]
+
+  # Leader election.
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources: [ "leases" ]
+    verbs: [ "create", "get", "update" ]
+
+  # OME CRDs (read).
+  - apiGroups: [ "ome.io" ]
+    resources:
+      - inferenceservices
+      - inferenceservices/status
+      - servingruntimes
+      - clusterservingruntimes
+      - basemodels
+      - clusterbasemodels
+    verbs: [ "get", "list", "watch" ]
+
+  # The single executable contract: migration-request annotations on
+  # InferenceServices, written only in execute mode.
+  - apiGroups: [ "ome.io" ]
+    resources: [ "inferenceservices" ]
+    verbs: [ "patch" ]

--- a/config/alfred/clusterrole.yaml
+++ b/config/alfred/clusterrole.yaml
@@ -1,6 +1,8 @@
-# Alfred's permission surface is read-only plus four narrow writes
+# Alfred's cluster-scoped permissions are read-only plus two narrow writes
 # (OEP-0008 §RBAC): no node writes, no pod writes, no pods/eviction. Every
 # pod-level action is executed by the controller that owns the workload.
+# Anything confined to Alfred's own namespace — its ConfigMaps, its
+# leader-election Lease — lives in role.yaml instead.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -24,27 +26,11 @@ rules:
     resources: [ "persistentvolumeclaims", "persistentvolumes" ]
     verbs: [ "get", "list", "watch" ]
 
-  # ConfigMaps: read for policy loading, write only to the two pre-created
-  # Alfred-owned ConfigMaps — Alfred never creates a ConfigMap at runtime.
-  - apiGroups: [ "" ]
-    resources: [ "configmaps" ]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: [ "" ]
-    resources: [ "configmaps" ]
-    verbs: [ "update", "patch", "delete" ]
-    resourceNames:
-      - alfred-config
-      - alfred-recommendations
-
-  # Events — recommendations, migrations, evacuation and repair signals.
+  # Events — recommendations, migrations, evacuation and repair signals, on
+  # workloads and nodes in any namespace.
   - apiGroups: [ "" ]
     resources: [ "events" ]
     verbs: [ "create", "patch" ]
-
-  # Leader election.
-  - apiGroups: [ "coordination.k8s.io" ]
-    resources: [ "leases" ]
-    verbs: [ "create", "get", "update" ]
 
   # OME CRDs (read).
   - apiGroups: [ "ome.io" ]

--- a/config/alfred/clusterrolebinding.yaml
+++ b/config/alfred/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ome-alfred
+  labels:
+    app.kubernetes.io/component: "ome-alfred"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ome-alfred
+subjects:
+- kind: ServiceAccount
+  name: ome-alfred
+  namespace: ome

--- a/config/alfred/configmap.yaml
+++ b/config/alfred/configmap.yaml
@@ -1,0 +1,96 @@
+# Alfred's policy configuration (OEP-0008 §Configuration). Alfred watches this
+# ConfigMap and hot-reloads it; a config that fails schema validation is
+# rejected and the last-known-good stays in force.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alfred-config
+  namespace: ome
+  labels:
+    app.kubernetes.io/component: "ome-alfred"
+data:
+  config.yaml: |
+    schemaVersion: 1
+
+    # recommend-only | execute. recommend-only never dispatches a migration:
+    # policies, arbitration and reporting all run, only the dispatcher is off.
+    mode: recommend-only
+
+    # Loop cadence.
+    decisionLoopInterval: 5m
+    observationLoopInterval: 30s
+    # Advances the next decision tick; never interrupts a pass ([] disables).
+    earlyTickOn: [NodeConditionChange]
+
+    policies:
+      defragmentation:
+        enabled: true
+        fragmentationThreshold: 0.25
+        aggressiveness: balanced      # conservative | balanced | aggressive
+        scoring:
+          sizeLadder: [1, 2, 4, 8]    # within-node demand sizes, ascending
+          demandBlendLambda: 0.3      # 0: pure observed demand; 1: pure prior
+          sizePrior:                  # static prior over demand sizes; sums to 1
+            "1": 0.1
+            "2": 0.1
+            "4": 0.2
+            "8": 0.6
+          pendingUrgencyTauMinutes: 30
+      nodeHealth:
+        enabled: true
+        aggressiveness: balanced
+        # Consumed from existing node conditions; Alfred never detects health.
+        triggerConditions: [GpuUnhealthy]
+        signalOnly: false
+        healthCooldownFloorMinutes: 5
+        nodeSuspicionWindowMinutes: 30
+
+    # Per-workload defaults; annotations on an InferenceService win over these.
+    defaultMovable: true
+    recentPlacementCooldownMinutes: 10
+    perWorkloadCooldownMinutes: 30
+    perNodeCooldownMinutes: 10
+
+    # Execution surfaces — all annotation-mediated; owning controllers execute.
+    rawDeploymentMigrationEnabled: true
+    omenativeMigrationEnabled: true
+    lwsRecommendationsEnabled: true
+
+    # Output.
+    recommendationsConfigMapEnabled: true
+    recommendationsConfigMapName: alfred-recommendations
+
+    # Global safety bounds, applied once by the arbiter across every policy.
+    maxInFlightMigrations: 3
+    maxMigrationsPerHour: 10
+    emergencyPendingAgeMinutes: 10
+
+    # Weekly UTC windows gating defrag dispatch; empty means no window applies.
+    # Node-health evacuation deliberately overrides them.
+    maintenanceWindows: []
+    # maintenanceWindows:
+    #   - days: [Sat, Sun]
+    #     start: "02:00"
+    #     end: "06:00"
+
+    spotPolicy:
+      avoidAsTarget: true
+      preferAsSource: true
+      preemptibleLabels:
+        - node.kubernetes.io/preemptible
+        - cloud.google.com/gke-preemptible
+
+    allowCrossTenantOptimization: true
+
+    logLevel: info
+    structuredLogging: true
+---
+# Pre-created because Alfred's RBAC lets it update but never create a
+# ConfigMap; the reporter writes its recommendations here.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alfred-recommendations
+  namespace: ome
+  labels:
+    app.kubernetes.io/component: "ome-alfred"

--- a/config/alfred/deployment.yaml
+++ b/config/alfred/deployment.yaml
@@ -1,0 +1,94 @@
+# Alfred, the GPU cluster caretaker (OEP-0008). Every replica runs the
+# read-only observation loop; only the leader decides and dispatches. Production
+# runs three replicas — one is enough for a test cluster, and leader election
+# stays on so the deployed shape matches production.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ome-alfred
+  namespace: ome
+  labels:
+    control-plane: ome-alfred
+    app.kubernetes.io/component: "ome-alfred"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: ome-alfred
+  template:
+    metadata:
+      labels:
+        control-plane: ome-alfred
+        app.kubernetes.io/component: "ome-alfred"
+      annotations:
+        kubectl.kubernetes.io/default-container: alfred
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: ome-alfred
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: alfred
+        image: ghcr.io/moirai-internal/alfred:latest
+        imagePullPolicy: Always
+        args:
+          - "--metrics-bind-address=:8080"
+          - "--health-probe-bind-address=:8081"
+          - "--leader-elect=true"
+          - "--config-name=alfred-config"
+          - "--config-key=config.yaml"
+        env:
+          # Alfred reads its namespace from the downward API: it holds the
+          # config ConfigMap and the leader-election Lease.
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # Labels alfred_leader_status so the leader is identifiable.
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        ports:
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
+        - name: health
+          containerPort: 8081
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 10
+        resources:
+          # The cluster-wide pod cache dominates Alfred's memory; raise the
+          # memory limit on clusters with many thousands of pods.
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: '1'
+            memory: 1Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+      terminationGracePeriodSeconds: 10

--- a/config/alfred/deployment.yaml
+++ b/config/alfred/deployment.yaml
@@ -33,6 +33,10 @@ spec:
           type: RuntimeDefault
       containers:
       - name: alfred
+        # Placeholder: CI publishes no alfred image yet, so there is no
+        # released tag or digest to pin. Build and push one with
+        # `make push-alfred-image`, or point ALFRED_IMG at your own; pin this
+        # to a digest once alfred joins the dev-images matrix.
         image: ghcr.io/moirai-internal/alfred:latest
         imagePullPolicy: Always
         args:

--- a/config/alfred/kustomization.yaml
+++ b/config/alfred/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
   - serviceaccount.yaml
   - clusterrole.yaml
   - clusterrolebinding.yaml
+  - role.yaml
+  - rolebinding.yaml
   - configmap.yaml
   - service.yaml
   - deployment.yaml

--- a/config/alfred/kustomization.yaml
+++ b/config/alfred/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Alfred is opt-in: it is deliberately not part of config/default, so a cluster
+# installs it with `make install-alfred` (or `kubectl apply -k config/alfred`)
+# once OME itself is running.
+namespace: ome
+
+resources:
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - configmap.yaml
+  - service.yaml
+  - deployment.yaml

--- a/config/alfred/role.yaml
+++ b/config/alfred/role.yaml
@@ -1,0 +1,29 @@
+# Everything Alfred touches only inside its own namespace. These rules are
+# deliberately not in the ClusterRole: a resourceNames restriction cannot
+# narrow a cluster-wide list/watch, so granting ConfigMap reads there would
+# expose every ConfigMap in the cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ome-alfred
+  namespace: ome
+  labels:
+    app.kubernetes.io/component: "ome-alfred"
+rules:
+  # ConfigMaps: read for policy loading — Alfred's informer cache is scoped to
+  # this namespace — and write only to the two pre-created Alfred-owned
+  # ConfigMaps, which it never creates at runtime.
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "update", "patch", "delete" ]
+    resourceNames:
+      - alfred-config
+      - alfred-recommendations
+
+  # Leader election — the alfred.ome.io Lease lives in Alfred's namespace.
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources: [ "leases" ]
+    verbs: [ "create", "get", "update" ]

--- a/config/alfred/rolebinding.yaml
+++ b/config/alfred/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ome-alfred
+  namespace: ome
+  labels:
+    app.kubernetes.io/component: "ome-alfred"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ome-alfred
+subjects:
+- kind: ServiceAccount
+  name: ome-alfred
+  namespace: ome

--- a/config/alfred/service.yaml
+++ b/config/alfred/service.yaml
@@ -1,0 +1,17 @@
+# Metrics endpoint: every replica observes, so scraping any pod works.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ome-alfred-metrics
+  namespace: ome
+  labels:
+    control-plane: ome-alfred
+    app.kubernetes.io/component: "ome-alfred"
+spec:
+  selector:
+    control-plane: ome-alfred
+  ports:
+  - name: metrics
+    port: 8080
+    targetPort: metrics
+    protocol: TCP

--- a/config/alfred/serviceaccount.yaml
+++ b/config/alfred/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ome-alfred
+  namespace: ome
+  labels:
+    app.kubernetes.io/component: "ome-alfred"

--- a/pkg/alfred/policy/defrag/scoring.go
+++ b/pkg/alfred/policy/defrag/scoring.go
@@ -27,7 +27,7 @@ type SizeFrag struct {
 }
 
 // PoolScore is the full scoring breakdown for one hardware pool
-// (Node.GPUPool). 
+// (Node.GPUPool).
 type PoolScore struct {
 	Pool string
 


### PR DESCRIPTION
## What this PR does

Adds the deployable form of the `alfred` binary from #767: a standalone
kustomize overlay under `config/alfred` plus the Make targets to build, push,
install, and remove it.

- **`config/alfred/`** — ServiceAccount, ClusterRole/Binding, the
  `alfred-config` ConfigMap (full schema, `mode: recommend-only`), a
  pre-created `alfred-recommendations` ConfigMap (Alfred's RBAC lets it update
  but never create a ConfigMap), a metrics Service, and a leader-elected
  Deployment — one replica for a test cluster, with leader election left on so
  the deployed shape matches production.
- **RBAC is OEP-0008 §RBAC verbatim** — read-only nodes and pods, no
  `pods/eviction`, named-ConfigMap writes only, events, leases, OME CRD reads,
  and the narrow `inferenceservices` patch — plus `persistentvolumeclaims` and
  `persistentvolumes` reads, which `pkg/alfred/snapshot/pvc.go` needs and the
  OEP's ClusterRole snippet omits.
- **Deployment** takes `POD_NAMESPACE` / `POD_NAME` off the downward API
  (Alfred reads its namespace from the former and labels
  `alfred_leader_status` with the latter), probes `/healthz` and `/readyz` on
  `:8081`, and exposes metrics on `:8080`.
- **Makefile** — `install-alfred` / `uninstall-alfred`, `alfred-image` /
  `push-alfred-image` (`dockerfiles/alfred.Dockerfile` had no build target),
  an `ALFRED_IMG` override, and alfred added to `kustomize-validate`.

The overlay is deliberately **not** part of `config/default`: Alfred is opt-in,
so `make install` is unchanged and Alfred installs on its own.

## Why we need it

#767 shipped the binary and its Dockerfile, but nothing that deploys either —
trying Alfred on a cluster meant hand-writing RBAC and a Deployment. This is
the install path for testing the observation loop and the fragmentation gauges
against a real GPU cluster, in `recommend-only` mode where Alfred writes
nothing.

## How to test

```bash
make push-alfred-image                       # no CI-built alfred image exists yet
make install-alfred                          # or: ALFRED_IMG=<image> make install-alfred
kubectl -n ome logs deploy/ome-alfred
kubectl -n ome port-forward svc/ome-alfred-metrics 8080:8080 &
curl -s localhost:8080/metrics | grep alfred_
kubectl -n ome edit configmap alfred-config  # hot-reloaded, last-known-good on a bad edit
make uninstall-alfred
```

Verified locally:

- `make kustomize-validate` is green on all three overlays.
- The generated `config.yaml` round-trips through Alfred's own strict
  `config.Load` — schemaVersion, `sizeLadder` / `sizePrior`, and the cooldown
  validators all accept it.
- Every rendered object strict-decodes against the Kubernetes API types.
- The Deployment's args match the flags in `cmd/alfred/main.go`.

## Notes

- `dev-images.yaml` builds manager/model-agent/ome-agent only, so
  `ghcr.io/moirai-internal/alfred` does not exist yet; `make push-alfred-image`
  covers testing until alfred joins that matrix.
- Helm packaging (`charts/ome-resources`) is untouched — this is the kustomize
  test path only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the opt-in Alfred GPU cluster caretaker deployment.
  - Supports node health monitoring, workload defragmentation, migration recommendations, maintenance windows, and spot-node handling.
  - Provides configurable safety limits, cooldowns, logging, and cross-tenant optimization.
  - Exposes Prometheus-compatible metrics and health checks.
  - Includes secure, least-privilege runtime configuration.

- **Chores**
  - Added commands to build, publish, install, uninstall, and validate Alfred.
  - Extended configuration validation to cover the Alfred deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->