### PR TITLE
[Core] Alfred arbiter and safety-bound ledger

### DIFF
--- a/pkg/alfred/engine/arbiter.go
+++ b/pkg/alfred/engine/arbiter.go
@@ -1,0 +1,407 @@
+package engine
+
+import (
+	"sort"
+	"time"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/policy"
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+)
+
+// Rejection reason codes. The Reporter emits them verbatim as the `reason`
+// label of alfred_recommendations_rejected_total and in Events.
+const (
+	RejectCircuitBreakerOpen = "CircuitBreakerOpen"
+	RejectInstanceGone       = "InstanceGone"
+	RejectNotMovable         = "NotMovable"
+	RejectMalformedRequest   = "MalformedRequestPending"
+	RejectTerminating        = "InstanceTerminating"
+	RejectWorkloadBusy       = "WorkloadBusy"
+	RejectAutoscalerActive   = "AutoscalerActive"
+	RejectCooldown           = "Cooldown"
+	RejectPlacementCooldown  = "PlacementCooldown"
+	RejectNodeCooldown       = "NodeCooldown"
+	RejectTargetUnderEvac    = "TargetUnderEvacuation"
+	RejectTargetNodeBusy     = "TargetNodeBusy"
+	RejectNoCapacity         = "NoCapacity"
+	RejectInFlightCap        = "InFlightCap"
+	RejectHourlyCap          = "HourlyCap"
+)
+
+// AutoscalerIntent is the OEP-0013 read-only signal.
+type AutoscalerIntent int
+
+const (
+	// IntentIdle: the autoscaler is not touching the workload.
+	IntentIdle AutoscalerIntent = iota
+	// IntentScaling: replicas are actively being added or removed.
+	IntentScaling
+	// IntentUnknown: the signal exists but could not be read — treated as
+	// busy, because acting on a workload that might be mid-scale is the
+	// costlier error.
+	IntentUnknown
+)
+
+// Decision is the Arbiter's verdict on one executable candidate.
+type Decision struct {
+	Candidate policy.Candidate
+	Admitted  bool
+	// Reason is the rejection code; empty when admitted.
+	Reason string
+	// Target is the claimed placement for an admitted candidate: the
+	// first feasible hint net of claims, or empty for an eviction
+	// expected to reuse its source.
+	Target string
+	// CooldownOverridden marks a health evacuation admitted under the
+	// health floor while the standard per-workload window was still
+	// running (audited as CooldownOverriddenForEvacuation).
+	CooldownOverridden bool
+}
+
+// Arbiter applies the global safety bounds to the merged candidate stream of
+// every policy — one budget for Alfred as a whole, enforced once, here.
+type Arbiter struct {
+	Ledger *Ledger
+
+	// AutoscalerIntent reports whether OEP-0013 is actively scaling a
+	// workload. Nil means no autoscaler integration is wired into this
+	// build (no CRDs are read yet), which is idle by construction — the
+	// treat-unavailable-as-busy default applies to a wired signal that
+	// fails, not to an integration that does not exist.
+	AutoscalerIntent func(snap *snapshot.ClusterSnapshot, workload string) AutoscalerIntent
+}
+
+// Admit arbitrates the executable candidates and returns one Decision per
+// candidate, in arbitration order (health before defrag, then score).
+// Advisory candidates are not arbitrated — the engine routes them straight
+// to the Reporter — and produce no Decision. Admit reconciles the Ledger
+// against the snapshot (expired records are pruned, completed migrations
+// stop claiming capacity) but records no new state: recording actual
+// dispatches is the caller's act, after actuation.
+func (a *Arbiter) Admit(snap *snapshot.ClusterSnapshot, cands []policy.Candidate, cfg *config.Config, now time.Time) []Decision {
+	ordered := make([]policy.Candidate, 0, len(cands))
+	for _, c := range cands {
+		if c.Executable {
+			ordered = append(ordered, c)
+		}
+	}
+	// Priority: health preempts defrag across the merged stream; within a
+	// class the policies' own ranking (score, then smaller footprint)
+	// carries over deterministically.
+	sort.SliceStable(ordered, func(i, j int) bool {
+		hi, hj := ordered[i].Reason == policy.ReasonNodeUnhealthy, ordered[j].Reason == policy.ReasonNodeUnhealthy
+		if hi != hj {
+			return hi
+		}
+		if ordered[i].Score != ordered[j].Score {
+			return ordered[i].Score > ordered[j].Score
+		}
+		return ordered[i].FootprintGPUs < ordered[j].FootprintGPUs
+	})
+
+	st := newAdmitState(a, snap, cfg, ordered, now)
+	decisions := make([]Decision, 0, len(ordered))
+	for _, c := range ordered {
+		decisions = append(decisions, st.decide(c))
+	}
+	return decisions
+}
+
+// admitState is the per-pass arbitration bookkeeping.
+type admitState struct {
+	arbiter *Arbiter
+	snap    *snapshot.ClusterSnapshot
+	cfg     *config.Config
+	now     time.Time
+
+	breakerOpen bool
+	// evacuating are the FromNodes of this cycle's health candidates —
+	// nodes no admitted move may land on.
+	evacuating map[string]bool
+	// claims is per-node replacement GPUs: prior in-flight dispatches
+	// (ledger) plus this cycle's admissions.
+	claims map[string]int64
+	// landed are nodes an admitted move already targets this cycle (at
+	// most one landing per node per cycle).
+	landed map[string]bool
+	// admittedWorkloads enforces one action per workload per cycle.
+	admittedWorkloads map[string]bool
+
+	inFlight int
+	hourly   int
+	admitted int
+}
+
+func newAdmitState(a *Arbiter, snap *snapshot.ClusterSnapshot, cfg *config.Config, ordered []policy.Candidate, now time.Time) *admitState {
+	st := &admitState{
+		arbiter:           a,
+		snap:              snap,
+		cfg:               cfg,
+		now:               now,
+		evacuating:        map[string]bool{},
+		claims:            map[string]int64{},
+		landed:            map[string]bool{},
+		admittedWorkloads: map[string]bool{},
+	}
+	if a.Ledger != nil {
+		a.Ledger.AbsorbSnapshot(snap, now)
+		st.breakerOpen = a.Ledger.BreakerOpen(now)
+		st.claims = a.Ledger.ActiveClaims()
+	}
+	for _, c := range ordered {
+		if c.Reason == policy.ReasonNodeUnhealthy && c.FromNode != "" {
+			st.evacuating[c.FromNode] = true
+		}
+	}
+	st.inFlight, st.hourly = migrationLoad(snap, a.Ledger, now)
+	return st
+}
+
+// migrationLoad derives current in-flight and rolling-hour usage. In-flight
+// is authoritative in the snapshot (one entry per live request UUID). The
+// hourly figure takes the max of the ledger's own dispatch count and the
+// snapshot-visible migration starts — max, not sum, so a dispatch is never
+// double-counted once its annotation lands, while a fresh ledger after
+// failover still sees the cluster's recent churn.
+func migrationLoad(snap *snapshot.ClusterSnapshot, ledger *Ledger, now time.Time) (inFlight, hourly int) {
+	snapshotHour := 0
+	for _, w := range snap.Workloads {
+		inFlight += len(w.ActiveMigrations)
+		for _, m := range w.ActiveMigrations {
+			if now.Sub(m.RequestedAt) <= time.Hour {
+				snapshotHour++
+			}
+		}
+		if w.LastMigration != nil && now.Sub(*w.LastMigration) <= time.Hour {
+			snapshotHour++
+		}
+	}
+	hourly = snapshotHour
+	if ledger != nil {
+		if n := ledger.DispatchesWithinHour(now); n > hourly {
+			hourly = n
+		}
+	}
+	return inFlight, hourly
+}
+
+// decide runs one candidate through the gates in order; the first failing
+// gate names the rejection.
+func (st *admitState) decide(c policy.Candidate) Decision {
+	if st.breakerOpen {
+		return Decision{Candidate: c, Reason: RejectCircuitBreakerOpen}
+	}
+
+	w := st.snap.Workloads[c.Workload]
+	inst := lookupInstance(w, c)
+	if w == nil || inst == nil {
+		return Decision{Candidate: c, Reason: RejectInstanceGone}
+	}
+
+	// Opt-in/eligibility is the Arbiter's gate too: policies pre-filter,
+	// but a pluggable policy must never be able to move an opted-out
+	// workload. A workload carrying an unresolved (malformed) request
+	// write is treated as busy until the executor ack-rejects it — the
+	// garbage might be a corrupted real intent.
+	if !w.Movable {
+		return Decision{Candidate: c, Reason: RejectNotMovable}
+	}
+	if len(w.MalformedRequests) > 0 {
+		return Decision{Candidate: c, Reason: RejectMalformedRequest}
+	}
+
+	// Terminating exclusion: action never while a pod is deleting.
+	for _, pod := range inst.Pods {
+		if pod.Terminating {
+			return Decision{Candidate: c, Reason: RejectTerminating}
+		}
+	}
+
+	// Mutual exclusion per workload: one in-flight action, whether it is
+	// already running (snapshot) or admitted earlier this cycle.
+	key := c.Workload.String()
+	if len(w.ActiveMigrations) > 0 || st.admittedWorkloads[key] {
+		return Decision{Candidate: c, Reason: RejectWorkloadBusy}
+	}
+
+	// OEP-0013 awareness: never race the autoscaler over the same pods.
+	if st.arbiter.AutoscalerIntent != nil {
+		if st.arbiter.AutoscalerIntent(st.snap, key) != IntentIdle {
+			return Decision{Candidate: c, Reason: RejectAutoscalerActive}
+		}
+	}
+
+	// Class-aware cooldowns: health evacuations wait only the floor.
+	health := c.Reason == policy.ReasonNodeUnhealthy
+	window := st.cfg.PerWorkloadCooldown()
+	if w.CooldownOverride != nil {
+		window = *w.CooldownOverride
+	}
+	floor := st.cfg.HealthCooldownFloor()
+	overridden := false
+	if w.LastMigration != nil {
+		age := st.now.Sub(*w.LastMigration)
+		if health {
+			if age < floor {
+				return Decision{Candidate: c, Reason: RejectCooldown}
+			}
+			overridden = age < window
+		} else if age < window {
+			return Decision{Candidate: c, Reason: RejectCooldown}
+		}
+	}
+	// Placement cooldown, authorship-blind: a freshly scheduled pod means
+	// someone just placed this instance — operator, scheduler, or Alfred.
+	placementWindow := st.cfg.RecentPlacementCooldown()
+	if health {
+		placementWindow = floor
+	}
+	for _, pod := range inst.Pods {
+		if pod.StartTime != nil && st.now.Sub(*pod.StartTime) < placementWindow {
+			return Decision{Candidate: c, Reason: RejectPlacementCooldown}
+		}
+	}
+	// Per-node cooldown, source side: a routine move may not pull from a
+	// node still cooling; a health evacuation may (draining is the point).
+	if st.arbiter.Ledger != nil && !health &&
+		st.arbiter.Ledger.NodeCooling(c.FromNode, st.cfg.PerNodeCooldown(), st.now) {
+		return Decision{Candidate: c, Reason: RejectNodeCooldown}
+	}
+
+	target, placement, reason := st.selectTarget(c, inst)
+	if reason != "" {
+		return Decision{Candidate: c, Reason: reason}
+	}
+
+	// Global caps, on the combined stream, after everything candidate-
+	// specific: budget is a property of Alfred as a whole.
+	if st.inFlight+st.admitted >= st.cfg.MaxInFlightMigrations {
+		return Decision{Candidate: c, Reason: RejectInFlightCap}
+	}
+	if st.hourly+st.admitted >= st.cfg.MaxMigrationsPerHour {
+		return Decision{Candidate: c, Reason: RejectHourlyCap}
+	}
+
+	st.admitted++
+	st.admittedWorkloads[key] = true
+	for node, gpus := range placement {
+		st.landed[node] = true
+		st.claims[node] += gpus
+	}
+	return Decision{Candidate: c, Admitted: true, Target: target, CooldownOverridden: overridden}
+}
+
+// selectTarget re-checks capacity mode-aware and net of claims, against the
+// candidate's own hints (already schedulable- and model-filtered by the
+// policy on this same snapshot). Surge shapes must fit while the source
+// still holds its GPUs; eviction needs no headroom and may reuse its source.
+// It returns the primary target, the per-node GPUs the admission will claim,
+// and — when nothing fits a surge — a reason distinguishing *why*: a hint
+// under evacuation, a hint already landed on this cycle, or plain capacity.
+func (st *admitState) selectTarget(c policy.Candidate, inst *snapshot.Instance) (string, map[string]int64, string) {
+	// The saw* flags feed the rejection reason (a metrics label and Event
+	// text), so they are reset per placement attempt: an early pod probing
+	// past a busy hint must not relabel a later pod's plain capacity
+	// failure.
+	var sawEvacuating, sawLanded, sawCooling bool
+	resetSaw := func() { sawEvacuating, sawLanded, sawCooling = false, false, false }
+	fits := func(node string, gpus int64) bool {
+		n := st.snap.Nodes[node]
+		if n == nil {
+			return false
+		}
+		if st.evacuating[node] {
+			sawEvacuating = true
+			return false
+		}
+		if st.landed[node] {
+			sawLanded = true
+			return false
+		}
+		// Target-side per-node cooldown: nothing lands on a node still
+		// cooling from a recent landing (or recent defrag outflow).
+		if st.arbiter.Ledger != nil &&
+			st.arbiter.Ledger.NodeCooling(node, st.cfg.PerNodeCooldown(), st.now) {
+			sawCooling = true
+			return false
+		}
+		return n.FreeGPUs-st.claims[node] >= gpus
+	}
+
+	if !c.SurgeShaped {
+		// Free-then-place cannot deadlock; a target is a preference,
+		// not a precondition. Claim the hint it will likely land on;
+		// none feasible means the replacement reuses the source.
+		for _, hint := range c.HintTargetNodes {
+			if fits(hint, c.FootprintGPUs) {
+				return hint, map[string]int64{hint: c.FootprintGPUs}, ""
+			}
+		}
+		return "", nil, ""
+	}
+
+	// Surge: every member pod's replacement must fit simultaneously.
+	// Greedy largest-first over the ranked hints mirrors the policy's own
+	// simulation; claims accumulate per hint as pods are placed.
+	pods := make([]int64, 0, len(inst.Pods))
+	for _, pod := range inst.Pods {
+		if pod.GPUs > 0 {
+			pods = append(pods, pod.GPUs)
+		}
+	}
+	sort.Slice(pods, func(i, j int) bool { return pods[i] > pods[j] })
+	if len(pods) == 0 && c.FootprintGPUs > 0 {
+		// Defensive: a pluggable policy may declare a footprint without
+		// per-pod detail; hold the declared footprint so the surge
+		// still passes the capacity gate and claims its block.
+		pods = append(pods, c.FootprintGPUs)
+	}
+	placement := map[string]int64{}
+	first := ""
+	for _, gpus := range pods {
+		placed := false
+		resetSaw()
+		for _, hint := range c.HintTargetNodes {
+			if !fits(hint, gpus+placement[hint]) {
+				continue
+			}
+			placement[hint] += gpus
+			if first == "" {
+				first = hint
+			}
+			placed = true
+			break
+		}
+		if !placed {
+			switch {
+			case sawEvacuating:
+				return "", nil, RejectTargetUnderEvac
+			case sawLanded:
+				return "", nil, RejectTargetNodeBusy
+			case sawCooling:
+				return "", nil, RejectNodeCooldown
+			default:
+				return "", nil, RejectNoCapacity
+			}
+		}
+	}
+	return first, placement, ""
+}
+
+// lookupInstance resolves the candidate's addressed instance by Index.
+func lookupInstance(w *snapshot.Workload, c policy.Candidate) *snapshot.Instance {
+	if w == nil {
+		return nil
+	}
+	comp := w.Components[c.Component]
+	if comp == nil {
+		return nil
+	}
+	for _, inst := range comp.Instances {
+		if inst.Index == c.Instance {
+			return inst
+		}
+	}
+	return nil
+}

--- a/pkg/alfred/engine/arbiter_test.go
+++ b/pkg/alfred/engine/arbiter_test.go
@@ -1,0 +1,505 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/policy"
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+	"sigs.k8s.io/ome/pkg/alfred/testutil"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+	"sigs.k8s.io/ome/pkg/constants"
+)
+
+var testNow = testutil.ReferenceTime
+
+// scenario: prod/a (2 GPUs) on node1, prod/b (2 GPUs) on node3, node2 empty.
+func scenario() *testutil.SnapshotBuilder {
+	return testutil.NewSnapshot().
+		WithNode("node1", "h100", 8).
+		WithNode("node2", "h100", 8).
+		WithNode("node3", "h100", 8).
+		WithInstance("prod/a", v1beta1.EngineComponent, constants.RawDeployment, "node1", 2).
+		WithInstance("prod/b", v1beta1.EngineComponent, constants.RawDeployment, "node3", 2)
+}
+
+// cand is an executable surge-shaped defrag candidate for a scenario
+// workload ("namespace/name"). Hints default to node2.
+func cand(workload, from string, hints ...string) policy.Candidate {
+	if len(hints) == 0 {
+		hints = []string{"node2"}
+	}
+	parts := strings.SplitN(workload, "/", 2)
+	if len(parts) != 2 {
+		panic("workload must be namespace/name: " + workload)
+	}
+	nn := types.NamespacedName{Namespace: parts[0], Name: parts[1]}
+	return policy.Candidate{
+		Policy:          "defragmentation",
+		Workload:        nn,
+		Component:       v1beta1.EngineComponent,
+		Instance:        0,
+		Mode:            constants.RawDeployment,
+		Reason:          policy.ReasonFragmentation,
+		FromNode:        from,
+		HintTargetNodes: hints,
+		Executable:      true,
+		SurgeShaped:     true,
+		FootprintGPUs:   2,
+		Score:           0.2,
+	}
+}
+
+func health(workload, from string, hints ...string) policy.Candidate {
+	c := cand(workload, from, hints...)
+	c.Policy = "nodehealth"
+	c.Reason = policy.ReasonNodeUnhealthy
+	c.Score = 0.1 // deliberately below the defrag scores in tests
+	return c
+}
+
+func admit(t *testing.T, a *Arbiter, snap *snapshot.ClusterSnapshot, cfg *config.Config, cands ...policy.Candidate) []Decision {
+	t.Helper()
+	if a.Ledger == nil {
+		a.Ledger = NewLedger()
+	}
+	return a.Admit(snap, cands, cfg, testNow)
+}
+
+func decisionFor(t *testing.T, decisions []Decision, workload string) Decision {
+	t.Helper()
+	for _, d := range decisions {
+		if d.Candidate.Workload.String() == workload {
+			return d
+		}
+	}
+	t.Fatalf("no decision for %s in %+v", workload, decisions)
+	return Decision{}
+}
+
+func TestAdmitHappyPathAndAdvisoryBypass(t *testing.T) {
+	advisory := cand("prod/b", "node3")
+	advisory.Executable = false
+	advisory.AdvisoryReason = policy.AdvisoryNoSurgeHeadroom
+
+	decisions := admit(t, &Arbiter{}, scenario().Build(), config.Default(),
+		cand("prod/a", "node1"), advisory)
+
+	if len(decisions) != 1 {
+		t.Fatalf("advisories must not be arbitrated: %+v", decisions)
+	}
+	d := decisions[0]
+	if !d.Admitted || d.Reason != "" || d.Target != "node2" || d.CooldownOverridden {
+		t.Fatalf("happy path decision: %+v", d)
+	}
+}
+
+func TestHealthPreemptsDefragOnSameWorkload(t *testing.T) {
+	defrag := cand("prod/a", "node1")
+	defrag.Score = 5.0 // even a much better defrag score must lose
+
+	decisions := admit(t, &Arbiter{}, scenario().Build(), config.Default(),
+		defrag, health("prod/a", "node1"))
+
+	if decisions[0].Candidate.Reason != policy.ReasonNodeUnhealthy || !decisions[0].Admitted {
+		t.Fatalf("health must be arbitrated first and admitted: %+v", decisions)
+	}
+	if decisions[1].Admitted || decisions[1].Reason != RejectWorkloadBusy {
+		t.Fatalf("defrag on the same workload must lose: %+v", decisions[1])
+	}
+}
+
+func TestDefragNeverLandsOnEvacuatingNode(t *testing.T) {
+	// prod/b is being evacuated off node3; defrag wants to move prod/a
+	// onto node3.
+	snap := scenario().Build()
+	cfg := config.Default()
+
+	blocked := admit(t, &Arbiter{}, snap, cfg,
+		health("prod/b", "node3"), cand("prod/a", "node1", "node3"))
+	d := decisionFor(t, blocked, "prod/a")
+	if d.Admitted || d.Reason != RejectTargetUnderEvac {
+		t.Fatalf("move toward an evacuating node must be rejected: %+v", d)
+	}
+
+	// With an alternative hint the move proceeds — around both the
+	// evacuation and the node the evacuation itself lands on (node2).
+	four := scenario().WithNode("node4", "h100", 8).Build()
+	rerouted := admit(t, &Arbiter{}, four, cfg,
+		health("prod/b", "node3"), cand("prod/a", "node1", "node3", "node2", "node4"))
+	if d := decisionFor(t, rerouted, "prod/b"); !d.Admitted || d.Target != "node2" {
+		t.Fatalf("evacuation must land on node2: %+v", d)
+	}
+	d = decisionFor(t, rerouted, "prod/a")
+	if !d.Admitted || d.Target != "node4" {
+		t.Fatalf("defrag must reroute around the evacuation and its landing: %+v", d)
+	}
+}
+
+func TestWorkloadMutualExclusion(t *testing.T) {
+	b := scenario().
+		WithInstance("prod/a", v1beta1.EngineComponent, constants.RawDeployment, "node1", 2)
+	second := cand("prod/a", "node1")
+	second.Instance = 1
+	second.Score = 0.1
+
+	decisions := admit(t, &Arbiter{}, b.Build(), config.Default(),
+		cand("prod/a", "node1"), second)
+	if !decisions[0].Admitted {
+		t.Fatalf("first candidate must be admitted: %+v", decisions[0])
+	}
+	if decisions[1].Admitted || decisions[1].Reason != RejectWorkloadBusy {
+		t.Fatalf("second candidate on one workload must lose the cycle: %+v", decisions[1])
+	}
+
+	inFlight := scenario().ConfigureWorkload("prod/a", func(w *snapshot.Workload) {
+		w.ActiveMigrations = []snapshot.InFlight{{UUID: "u1", Component: v1beta1.EngineComponent, RequestedAt: testNow.Add(-2 * time.Minute)}}
+	})
+	d := admit(t, &Arbiter{}, inFlight.Build(), config.Default(), cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectWorkloadBusy {
+		t.Fatalf("an in-flight migration must exclude the workload: %+v", d)
+	}
+}
+
+func TestTargetNodeExclusionPerCycle(t *testing.T) {
+	// node2 has room for both 2-GPU replacements; the per-target rule
+	// still allows only one landing per cycle.
+	decisions := admit(t, &Arbiter{}, scenario().Build(), config.Default(),
+		cand("prod/a", "node1"), cand("prod/b", "node3"))
+	if !decisions[0].Admitted || decisions[0].Target != "node2" {
+		t.Fatalf("first landing on node2 must be admitted: %+v", decisions[0])
+	}
+	if decisions[1].Admitted || decisions[1].Reason != RejectTargetNodeBusy {
+		t.Fatalf("second landing on node2 in one cycle must be rejected: %+v", decisions[1])
+	}
+}
+
+func TestTerminatingInstanceExcluded(t *testing.T) {
+	b := scenario().ConfigureWorkload("prod/a", func(w *snapshot.Workload) {
+		w.Components[v1beta1.EngineComponent].Instances[0].Pods[0].Terminating = true
+	})
+	d := admit(t, &Arbiter{}, b.Build(), config.Default(), cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectTerminating {
+		t.Fatalf("terminating instance must never be acted on: %+v", d)
+	}
+}
+
+func TestInstanceGone(t *testing.T) {
+	missing := cand("prod/a", "node1")
+	missing.Instance = 7
+	d := admit(t, &Arbiter{}, scenario().Build(), config.Default(), missing)[0]
+	if d.Admitted || d.Reason != RejectInstanceGone {
+		t.Fatalf("candidate for a vanished instance: %+v", d)
+	}
+}
+
+func TestClassAwareWorkloadCooldown(t *testing.T) {
+	cfg := config.Default()
+	migrated := func(age time.Duration) *snapshot.ClusterSnapshot {
+		at := testNow.Add(-age)
+		return scenario().ConfigureWorkload("prod/a", func(w *snapshot.Workload) {
+			w.LastMigration = &at
+		}).Build()
+	}
+
+	d := admit(t, &Arbiter{}, migrated(10*time.Minute), cfg, cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectCooldown {
+		t.Fatalf("defrag inside the 30m window must wait: %+v", d)
+	}
+
+	d = admit(t, &Arbiter{}, migrated(10*time.Minute), cfg, health("prod/a", "node1"))[0]
+	if !d.Admitted || !d.CooldownOverridden {
+		t.Fatalf("health past the 5m floor must be admitted with the override audited: %+v", d)
+	}
+
+	d = admit(t, &Arbiter{}, migrated(3*time.Minute), cfg, health("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectCooldown {
+		t.Fatalf("inside the floor even health waits: %+v", d)
+	}
+
+	d = admit(t, &Arbiter{}, migrated(31*time.Minute), cfg, cand("prod/a", "node1"))[0]
+	if !d.Admitted || d.CooldownOverridden {
+		t.Fatalf("defrag past the standard window is clean: %+v", d)
+	}
+}
+
+func TestPlacementCooldownAuthorshipBlind(t *testing.T) {
+	cfg := config.Default()
+	placed := func(age time.Duration) *snapshot.ClusterSnapshot {
+		at := testNow.Add(-age)
+		return scenario().ConfigureWorkload("prod/a", func(w *snapshot.Workload) {
+			w.Components[v1beta1.EngineComponent].Instances[0].Pods[0].StartTime = &at
+		}).Build()
+	}
+
+	d := admit(t, &Arbiter{}, placed(5*time.Minute), cfg, cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectPlacementCooldown {
+		t.Fatalf("a freshly placed instance must settle first: %+v", d)
+	}
+	d = admit(t, &Arbiter{}, placed(6*time.Minute), cfg, health("prod/a", "node1"))[0]
+	if !d.Admitted {
+		t.Fatalf("health waits only the floor on placement: %+v", d)
+	}
+	d = admit(t, &Arbiter{}, placed(2*time.Minute), cfg, health("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectPlacementCooldown {
+		t.Fatalf("inside the floor even health waits on placement: %+v", d)
+	}
+}
+
+func TestPerNodeCooldown(t *testing.T) {
+	cfg := config.Default()
+	snap := scenario().Build()
+
+	// node1 was a landing target 5 minutes ago.
+	ledger := NewLedger()
+	ledger.RecordDispatch(DispatchRecord{
+		Workload: types.NamespacedName{Namespace: "prod", Name: "x"},
+		FromNode: "node9", Target: "node1", GPUs: 2, At: testNow.Add(-5 * time.Minute),
+	})
+
+	// Source side: a routine move may not pull from the cooling node.
+	d := admit(t, &Arbiter{Ledger: ledger}, snap, cfg, cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectNodeCooldown {
+		t.Fatalf("defrag from a cooling node must wait: %+v", d)
+	}
+	// Health evacuation is exempt as a source — draining is the point.
+	d = admit(t, &Arbiter{Ledger: ledger}, snap, cfg, health("prod/a", "node1"))[0]
+	if !d.Admitted {
+		t.Fatalf("health evacuation must be exempt from source cooling: %+v", d)
+	}
+
+	// Target side: nothing lands on the cooling node.
+	d = admit(t, &Arbiter{Ledger: ledger}, snap, cfg, cand("prod/b", "node3", "node1"))[0]
+	if d.Admitted || d.Reason != RejectNodeCooldown {
+		t.Fatalf("landing on a cooling node must be rejected: %+v", d)
+	}
+}
+
+func TestGlobalCaps(t *testing.T) {
+	cfg := config.Default()
+
+	// In-flight cap: three running migrations saturate the default cap.
+	b := scenario().WithNode("node4", "h100", 8)
+	for i, w := range []string{"prod/m1", "prod/m2", "prod/m3"} {
+		b.WithInstance(w, v1beta1.EngineComponent, constants.RawDeployment, "node4", 1).
+			ConfigureWorkload(w, func(w *snapshot.Workload) {
+				w.ActiveMigrations = []snapshot.InFlight{{UUID: fmt.Sprintf("u%d", i), RequestedAt: testNow.Add(-5 * time.Minute)}}
+			})
+	}
+	d := admit(t, &Arbiter{}, b.Build(), cfg, cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectInFlightCap {
+		t.Fatalf("in-flight cap must bind: %+v", d)
+	}
+
+	// Hourly cap: ten ledger dispatches inside the hour saturate it; the
+	// same ten aged past the hour do not.
+	saturated, expired := NewLedger(), NewLedger()
+	for i := 0; i < 10; i++ {
+		rec := DispatchRecord{
+			Workload: types.NamespacedName{Namespace: "prod", Name: fmt.Sprintf("w%d", i)},
+			Target:   "node9", GPUs: 1,
+		}
+		rec.At = testNow.Add(-30 * time.Minute)
+		saturated.RecordDispatch(rec)
+		rec.At = testNow.Add(-61 * time.Minute)
+		expired.RecordDispatch(rec)
+	}
+	d = admit(t, &Arbiter{Ledger: saturated}, scenario().Build(), cfg, cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectHourlyCap {
+		t.Fatalf("hourly cap must bind: %+v", d)
+	}
+	d = admit(t, &Arbiter{Ledger: expired}, scenario().Build(), cfg, cand("prod/a", "node1"))[0]
+	if !d.Admitted {
+		t.Fatalf("dispatches older than an hour must not count: %+v", d)
+	}
+}
+
+func TestCircuitBreaker(t *testing.T) {
+	ledger := NewLedger()
+	for _, ok := range []bool{true, false, false, false} {
+		ledger.RecordOutcome(ok, testNow.Add(-time.Minute))
+	}
+	if !ledger.BreakerOpen(testNow) {
+		t.Fatal("3 failures in 4 outcomes must trip the breaker")
+	}
+	d := admit(t, &Arbiter{Ledger: ledger}, scenario().Build(), config.Default(), cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectCircuitBreakerOpen {
+		t.Fatalf("open breaker must pause all execution: %+v", d)
+	}
+	if ledger.BreakerOpen(testNow.Add(61 * time.Minute)) {
+		t.Fatal("breaker must release after the pause")
+	}
+
+	// The trip cleared the window: the first post-resume outcome must be
+	// judged fresh, not against the stale failures that tripped it.
+	resumed := testNow.Add(61 * time.Minute)
+	ledger.RecordOutcome(true, resumed)
+	if ledger.BreakerOpen(resumed.Add(time.Minute)) {
+		t.Fatal("stale failures must not re-trip the breaker after the pause")
+	}
+
+	fresh := NewLedger()
+	fresh.RecordOutcome(false, testNow)
+	fresh.RecordOutcome(false, testNow)
+	if fresh.BreakerOpen(testNow) {
+		t.Fatal("two early failures must not freeze execution for an hour")
+	}
+}
+
+func TestAutoscalerDefer(t *testing.T) {
+	snap := scenario().Build()
+	cfg := config.Default()
+	for _, intent := range []AutoscalerIntent{IntentScaling, IntentUnknown} {
+		a := &Arbiter{AutoscalerIntent: func(*snapshot.ClusterSnapshot, string) AutoscalerIntent {
+			return intent
+		}}
+		d := admit(t, a, snap, cfg, cand("prod/a", "node1"))[0]
+		if d.Admitted || d.Reason != RejectAutoscalerActive {
+			t.Fatalf("intent %v must defer the workload: %+v", intent, d)
+		}
+	}
+	idle := &Arbiter{AutoscalerIntent: func(*snapshot.ClusterSnapshot, string) AutoscalerIntent {
+		return IntentIdle
+	}}
+	if d := admit(t, idle, snap, cfg, cand("prod/a", "node1"))[0]; !d.Admitted {
+		t.Fatalf("idle autoscaler must not defer: %+v", d)
+	}
+}
+
+func TestCapacityNetOfInFlightClaims(t *testing.T) {
+	// prod/b's still-running migration claims 7 of node2's 8 free GPUs;
+	// the record is old enough to be outside the node cooldown but well
+	// inside the claim window, and the workload's migration is still
+	// visible in the snapshot so the claim is not absorbed.
+	b := scenario().ConfigureWorkload("prod/b", func(w *snapshot.Workload) {
+		w.ActiveMigrations = []snapshot.InFlight{{UUID: "u1", RequestedAt: testNow.Add(-30 * time.Minute)}}
+	})
+	ledger := NewLedger()
+	ledger.RecordDispatch(DispatchRecord{
+		Workload: types.NamespacedName{Namespace: "prod", Name: "b"},
+		Target:   "node2", GPUs: 7, At: testNow.Add(-30 * time.Minute),
+	})
+	d := admit(t, &Arbiter{Ledger: ledger}, b.Build(), config.Default(), cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectNoCapacity {
+		t.Fatalf("claimed capacity must count as allocated: %+v", d)
+	}
+}
+
+func TestArbiterEnforcesOptOutAndMalformedRequests(t *testing.T) {
+	cfg := config.Default()
+
+	optOut := scenario().ConfigureWorkload("prod/a", func(w *snapshot.Workload) {
+		w.Movable = false
+	})
+	d := admit(t, &Arbiter{}, optOut.Build(), cfg, cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectNotMovable {
+		t.Fatalf("an opted-out workload must be rejected regardless of policy: %+v", d)
+	}
+
+	malformed := scenario().ConfigureWorkload("prod/a", func(w *snapshot.Workload) {
+		w.MalformedRequests = map[string]string{"bad-1": "not json"}
+	})
+	d = admit(t, &Arbiter{}, malformed.Build(), cfg, cand("prod/a", "node1"))[0]
+	if d.Admitted || d.Reason != RejectMalformedRequest {
+		t.Fatalf("a pending malformed request must hold the workload: %+v", d)
+	}
+}
+
+// TestSurgeWithoutPodDetailStillClaims: a pluggable policy may declare a
+// footprint without per-pod GPU detail; the capacity gate must still run and
+// the admission must still claim its block.
+func TestSurgeWithoutPodDetailStillClaims(t *testing.T) {
+	b := scenario().
+		WithInstance("prod/z", v1beta1.EngineComponent, constants.RawDeployment, "node1", 0)
+	ghost := cand("prod/z", "node1")
+	ghost.FootprintGPUs = 2
+
+	decisions := admit(t, &Arbiter{}, b.Build(), config.Default(), ghost, cand("prod/b", "node3"))
+	if !decisions[0].Admitted || decisions[0].Target != "node2" {
+		t.Fatalf("declared footprint must pass the capacity gate and claim a target: %+v", decisions[0])
+	}
+	if decisions[1].Admitted || decisions[1].Reason != RejectTargetNodeBusy {
+		t.Fatalf("the claim must be visible to the next candidate: %+v", decisions[1])
+	}
+}
+
+func TestEvictionNeedsNoHeadroom(t *testing.T) {
+	b := scenario()
+	b.WithOtherOccupant("node2", 8) // every hint is full
+	evict := cand("prod/a", "node1")
+	evict.SurgeShaped = false
+	d := admit(t, &Arbiter{}, b.Build(), config.Default(), evict)[0]
+	if !d.Admitted || d.Target != "" {
+		t.Fatalf("free-then-place cannot deadlock and needs no claim: %+v", d)
+	}
+}
+
+func TestLedgerAbsorbAndClaims(t *testing.T) {
+	ledger := NewLedger()
+	ledger.RecordDispatch(DispatchRecord{
+		Workload: types.NamespacedName{Namespace: "prod", Name: "a"},
+		Target:   "node2", GPUs: 4, At: testNow.Add(-20 * time.Minute),
+	})
+	if got := ledger.ActiveClaims()["node2"]; got != 4 {
+		t.Fatalf("claim = %d, want 4", got)
+	}
+
+	// The workload's migration completed after the dispatch: the claim is
+	// absorbed into real occupancy, but the hourly ledger still counts it.
+	done := testNow.Add(-10 * time.Minute)
+	snap := scenario().ConfigureWorkload("prod/a", func(w *snapshot.Workload) {
+		w.LastMigration = &done
+	}).Build()
+	ledger.AbsorbSnapshot(snap, testNow)
+	if got := ledger.ActiveClaims()["node2"]; got != 0 {
+		t.Fatalf("absorbed claim must release: %d", got)
+	}
+	if got := ledger.DispatchesWithinHour(testNow); got != 1 {
+		t.Fatalf("absorbed dispatch must still count hourly: %d", got)
+	}
+
+	// Past retention the record disappears entirely.
+	ledger.AbsorbSnapshot(snap, testNow.Add(2*time.Hour))
+	if got := ledger.DispatchesWithinHour(testNow.Add(2 * time.Hour)); got != 0 {
+		t.Fatalf("expired record must drop: %d", got)
+	}
+}
+
+// TestLedgerReleasesClaimsOfDeletedWorkloads: a dispatch record whose
+// workload vanished from the cluster stops claiming capacity (the migration
+// is moot) but still counts toward the hourly ledger.
+func TestLedgerReleasesClaimsOfDeletedWorkloads(t *testing.T) {
+	ledger := NewLedger()
+	ledger.RecordDispatch(DispatchRecord{
+		Workload: types.NamespacedName{Namespace: "prod", Name: "ghost"},
+		Target:   "node2", GPUs: 4, At: testNow.Add(-20 * time.Minute),
+	})
+	ledger.AbsorbSnapshot(scenario().Build(), testNow)
+	if got := ledger.ActiveClaims()["node2"]; got != 0 {
+		t.Fatalf("deleted workload's claim must release: %d", got)
+	}
+	if got := ledger.DispatchesWithinHour(testNow); got != 1 {
+		t.Fatalf("the dispatch must still count hourly: %d", got)
+	}
+}
+
+// TestNodeCoolingIgnoresEmptyName: eviction records carry an empty Target;
+// querying an empty node name must not match them.
+func TestNodeCoolingIgnoresEmptyName(t *testing.T) {
+	ledger := NewLedger()
+	ledger.RecordDispatch(DispatchRecord{
+		Workload: types.NamespacedName{Namespace: "prod", Name: "a"},
+		FromNode: "node1", Target: "", At: testNow.Add(-time.Minute),
+	})
+	if ledger.NodeCooling("", 10*time.Minute, testNow) {
+		t.Fatal("an empty node name must never read as cooling")
+	}
+	if !ledger.NodeCooling("node1", 10*time.Minute, testNow) {
+		t.Fatal("the defrag source must still cool")
+	}
+}

--- a/pkg/alfred/engine/state.go
+++ b/pkg/alfred/engine/state.go
@@ -1,0 +1,197 @@
+// Package engine is Alfred's decision core: the Arbiter that admits or
+// rejects the merged candidate stream under the global safety bounds, and the
+// Ledger that carries the little cross-pass state arbitration needs
+// (OEP-0008 §The arbiter, §Safety bounds). Everything here is pure and
+// clock-injected: methods take `now`, hold no client, and re-derive whatever
+// they can from the snapshot so leader failover degrades safety margins,
+// never correctness.
+package engine
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+)
+
+// Breaker parameters (OEP-fixed): trip when more than half of the recent
+// outcomes failed, pause everything for an hour.
+const (
+	breakerWindow   = 10
+	breakerPause    = 60 * time.Minute
+	breakerMinTrips = 4 // outcomes required before the breaker may trip
+)
+
+// ledgerRetention bounds how long a dispatch record matters: the hourly cap
+// looks back one hour, the node cooldown far less, and the dispatcher's
+// abandon timeout for a stalled migration is also one hour.
+const ledgerRetention = time.Hour
+
+// DispatchRecord is one actuation the engine performed: who moved, from
+// where, toward which claimed target, and under which policy class.
+type DispatchRecord struct {
+	Workload types.NamespacedName
+	FromNode string
+	// Target is the claimed placement (first feasible hint at admission);
+	// empty for an eviction expected to reuse its source.
+	Target string
+	// GPUs is the replacement footprint the migration will occupy on
+	// Target while in flight.
+	GPUs int64
+	// Health marks a node-health evacuation (class-aware rules).
+	Health bool
+	At     time.Time
+
+	// absorbed is set once the snapshot reflects the migration's outcome;
+	// the record then stops claiming capacity but still counts toward the
+	// hourly ledger.
+	absorbed bool
+}
+
+// Ledger is the Arbiter's cross-pass memory. In-flight state is
+// authoritative in the snapshot (request annotations + non-terminal
+// MigrationHistory, rebuilt every pass); the ledger adds only what the
+// cluster cannot carry: dispatch claims not yet visible in the snapshot, the
+// rolling hourly window, the outcome ring, and the breaker clock. On leader
+// failover a fresh ledger under-counts toward safety (caps re-derive from
+// the snapshot via max) and never resumes stale claims.
+type Ledger struct {
+	// dispatches holds every actuation of the last hour (ledgerRetention),
+	// appended by RecordDispatch after the Dispatcher writes a request and
+	// reconciled by AbsorbSnapshot each pass. One list feeds three reads
+	// with different lifetimes: the rolling-hour cap counts every record,
+	// absorbed or not (DispatchesWithinHour); the per-node cooldown reads
+	// target landings and defrag-class sources inside its 10m window
+	// (NodeCooling); and the capacity arithmetic counts only records whose
+	// migration is still in flight — AbsorbSnapshot marks a record
+	// absorbed once its workload shows a newer terminal migration or has
+	// left the cluster, releasing the claim (ActiveClaims).
+	dispatches []DispatchRecord
+
+	// outcomes is the circuit breaker's evidence: one bool per terminal
+	// migration outcome (true = completed), newest last, capped at
+	// breakerWindow. RecordOutcome trips the breaker when at least
+	// breakerMinTrips outcomes are held and more than half are failures,
+	// then clears the slice so the post-pause window starts fresh instead
+	// of re-tripping on stale failures. Lost on failover by design: a new
+	// leader starts with an empty window, and the caps still bound churn
+	// while it refills.
+	outcomes []bool
+
+	// breakerTil is the instant execution resumes after a breaker trip
+	// (now + breakerPause at trip time); the zero value means the breaker
+	// has never tripped. BreakerOpen is simply now < breakerTil — nothing
+	// resets it early, and RecordOutcome may push it further out.
+	breakerTil time.Time
+}
+
+// NewLedger returns an empty ledger.
+func NewLedger() *Ledger { return &Ledger{} }
+
+// RecordDispatch appends one performed actuation.
+func (l *Ledger) RecordDispatch(rec DispatchRecord) {
+	l.dispatches = append(l.dispatches, rec)
+}
+
+// RecordOutcome appends one terminal migration outcome and trips the breaker
+// when the recent window is majority-failure. The minimum-sample floor keeps
+// one unlucky first move from freezing execution for an hour.
+func (l *Ledger) RecordOutcome(success bool, now time.Time) {
+	l.outcomes = append(l.outcomes, success)
+	if len(l.outcomes) > breakerWindow {
+		l.outcomes = l.outcomes[len(l.outcomes)-breakerWindow:]
+	}
+	failures := 0
+	for _, ok := range l.outcomes {
+		if !ok {
+			failures++
+		}
+	}
+	if len(l.outcomes) >= breakerMinTrips && failures*2 > len(l.outcomes) {
+		l.breakerTil = now.Add(breakerPause)
+		// A fresh window after the pause: stale failures must not
+		// re-trip the breaker off the first post-resume outcome.
+		l.outcomes = nil
+	}
+}
+
+// BreakerOpen reports whether the circuit breaker is holding execution.
+func (l *Ledger) BreakerOpen(now time.Time) bool { return now.Before(l.breakerTil) }
+
+// BreakerOpenUntil exposes the hold deadline for reporting.
+func (l *Ledger) BreakerOpenUntil() time.Time { return l.breakerTil }
+
+// AbsorbSnapshot reconciles the ledger against a fresh snapshot: records
+// older than the retention window drop out entirely, and a record stops
+// claiming capacity once its migration can no longer occupy the target —
+// the workload shows a terminal migration newer than the dispatch (the
+// replacement pod, if any, is now real occupancy), or the workload is gone
+// from the cluster altogether. Absorbed records still count toward the
+// hourly ledger.
+func (l *Ledger) AbsorbSnapshot(snap *snapshot.ClusterSnapshot, now time.Time) {
+	kept := l.dispatches[:0]
+	for _, rec := range l.dispatches {
+		if now.Sub(rec.At) > ledgerRetention {
+			continue
+		}
+		if !rec.absorbed {
+			if w, ok := snap.Workloads[rec.Workload]; !ok {
+				rec.absorbed = true
+			} else if w.LastMigration != nil && w.LastMigration.After(rec.At) {
+				rec.absorbed = true
+			}
+		}
+		kept = append(kept, rec)
+	}
+	l.dispatches = kept
+}
+
+// DispatchesWithinHour counts this ledger's actuations in the rolling hour.
+func (l *Ledger) DispatchesWithinHour(now time.Time) int {
+	count := 0
+	for _, rec := range l.dispatches {
+		if now.Sub(rec.At) <= time.Hour {
+			count++
+		}
+	}
+	return count
+}
+
+// NodeCooling reports the target-scoped per-node cooldown: a node an action
+// landed on as a target — or left as the source of a routine (defrag-class)
+// move — within the window. Health-evacuation sources are exempt: the point
+// of a drain is outflow, bounded by the in-flight cap instead.
+func (l *Ledger) NodeCooling(node string, window time.Duration, now time.Time) bool {
+	if node == "" {
+		// Eviction records carry an empty Target; an empty query must
+		// not match them.
+		return false
+	}
+	for _, rec := range l.dispatches {
+		if now.Sub(rec.At) >= window {
+			continue
+		}
+		if rec.Target == node {
+			return true
+		}
+		if rec.FromNode == node && !rec.Health {
+			return true
+		}
+	}
+	return false
+}
+
+// ActiveClaims sums the replacement GPUs of unabsorbed dispatches per target
+// node — capacity a still-running migration will occupy, which must count as
+// allocated so two admissions can never both "fit" into the same free block.
+func (l *Ledger) ActiveClaims() map[string]int64 {
+	claims := map[string]int64{}
+	for _, rec := range l.dispatches {
+		if rec.absorbed || rec.Target == "" {
+			continue
+		}
+		claims[rec.Target] += rec.GPUs
+	}
+	return claims
+}

--- a/pkg/alfred/policy/defrag/policy.go
+++ b/pkg/alfred/policy/defrag/policy.go
@@ -131,12 +131,14 @@ func (*Policy) Evaluate(snap *snapshot.ClusterSnapshot, cfg *config.Config) []po
 
 	// Maintenance windows gate defragmentation dispatch: outside every
 	// window, executable candidates are dropped; advisories carry no
-	// dispatch and survive. (Node-health evacuation deliberately ignores
-	// windows — that policy applies its own rules.)
+	// dispatch and survive, and an emergency — a pod starved past
+	// emergencyPendingAgeMinutes — overrides the window (a steady-state
+	// optimization can wait; a starving workload cannot). Node-health
+	// evacuation ignores windows entirely in its own policy.
 	if !maintenanceOpen(cfg, now) {
 		kept := out[:0]
 		for _, c := range out {
-			if !c.Executable {
+			if !c.Executable || c.Emergency {
 				kept = append(kept, c)
 			}
 		}

--- a/pkg/alfred/policy/defrag/policy_test.go
+++ b/pkg/alfred/policy/defrag/policy_test.go
@@ -406,6 +406,18 @@ func TestMaintenanceWindowGatesDispatch(t *testing.T) {
 	if open := evaluate(t, build(), cfg); len(executables(open)) != 1 {
 		t.Fatalf("inside the window the move must dispatch: %+v", open)
 	}
+
+	// An emergency — a pod starved past emergencyPendingAgeMinutes —
+	// overrides a closed window: a steady-state optimization can wait, a
+	// starving workload cannot. The age threshold is pinned explicitly so
+	// the assertion does not lean on the default.
+	cfg.MaintenanceWindows = []config.MaintenanceWindow{{Days: []string{"Mon"}, Start: "09:00", End: "17:00"}}
+	cfg.EmergencyPendingAgeMinutes = 15
+	starving := consolidationBuilder().WithPendingPodIn("prod", 8, 30*time.Minute, "h100")
+	emergency := executables(evaluate(t, starving.Build(), cfg))
+	if len(emergency) != 1 || !emergency[0].Emergency {
+		t.Fatalf("an emergency must override the closed window: %+v", emergency)
+	}
 }
 
 // TestModelReadinessFiltersTargets: per-node models restrict hints to nodes


### PR DESCRIPTION
## What

Implements OEP-0008's arbiter (arbitration-lite) and its cross-pass ledger (plan step A5): the stage between policy candidate-production and dispatch that applies the global safety bounds — one budget for Alfred as a whole, enforced once, on the merged stream of every policy. Pure and clock-injected: no client, methods take `now`, and everything re-derivable comes from the snapshot so leader failover degrades safety margins, never correctness.

Stacked on #774 (uses `policy.Candidate`).

- `pkg/alfred/engine/arbiter.go` — `Admit(snapshot, candidates, cfg, now) []Decision`, gates in order per the OEP's four rules + safety bounds:
  - **Advisory bypass**: advisories are not arbitrated (the engine routes them to the Reporter).
  - **Priority**: health preempts defrag across the merged stream, regardless of score.
  - **Mutual exclusion**: one action per workload per cycle (in-flight from the snapshot, or admitted earlier this cycle), and at most one admitted landing per *target* node per cycle — source outflow deliberately unlimited (a drain is bounded by the in-flight cap instead).
  - **Toward-evacuation rule**: no admitted move may land on a node any health candidate is evacuating this cycle — including the node the evacuation itself lands on.
  - **Terminating exclusion**, and a defensive `InstanceGone` for candidates whose instance vanished.
  - **Class-aware cooldowns**: per-workload 30m (annotation-overridable) with the 5m health floor — an admission under the floor but inside the standard window is flagged `CooldownOverridden` for the `CooldownOverriddenForEvacuation` audit; authorship-blind placement cooldown from pod `StartTime`; target-scoped per-node cooldown with the health source exemption.
  - **Autoscaler defer** (OEP-0013 awareness): a hook seam — `Scaling` and `Unknown` intent defer the workload; a nil hook means no integration is wired yet, which is idle by construction (the treat-unavailable-as-busy default applies to a wired signal that fails, not to an absent integration).
  - **Mode-aware capacity, net of in-flight claims**: surge shapes must fit every member pod on the candidate's hints while the source still holds its GPUs, minus GPUs claimed by still-running migrations and by this cycle's admissions (per-node claim maps, so two admissions can never both "fit" the same free block); free-then-place eviction needs no headroom. Rejection reasons distinguish *why* nothing fits: `TargetUnderEvacuation` / `TargetNodeBusy` / `NodeCooldown` / `NoCapacity`.
  - **Global caps**: in-flight (authoritative from the snapshot) and rolling-hour (max of ledger count and snapshot-visible starts — never double-counted, and a fresh ledger after failover still sees the cluster's churn).
  - **Circuit breaker**: majority failure over the last 10 outcomes (with a 4-sample floor so one unlucky first move cannot freeze execution) pauses everything for 60 minutes.
- `pkg/alfred/engine/state.go` — the `Ledger`: dispatch records (claimed target, footprint, class), the outcome ring and breaker clock, `AbsorbSnapshot` (a record whose migration turned terminal stops claiming capacity but still counts toward the hourly window; records expire at the 1h retention), `NodeCooling`, `ActiveClaims`.

## Also

Fixes an A4 gap the safety-bounds section calls out: `emergencyPendingAgeMinutes` overrides the maintenance window for defragmentation. The window filter now keeps emergency candidates; test added.

## Testing

`go test ./pkg/alfred/...` — engine at 95.1% statement coverage. Table/scenario tests cover every gate and reason code: happy path + advisory bypass, health-preempts-defrag on shared workloads, the toward-evacuation rule with rerouting around both the evacuated node and the evacuation's own landing, workload and target-node mutual exclusion, terminating exclusion, all three cooldown classes on both sides of their windows (including the audited health override and the health source exemption), autoscaler defer for Scaling/Unknown/nil, capacity net of prior claims, eviction admitted without headroom, both caps binding and the hourly window expiring, breaker trip/hold/release and the minimum-sample floor, and ledger absorb/claim/retention semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added centralized migration admission and target selection.
  - Added safeguards for workload conflicts, node health, capacity, cooldowns, autoscaler activity, and migration limits.
  - Added dispatch tracking, capacity-claim accounting, circuit-breaker protection, and detailed admission decisions.

- **Bug Fixes**
  - Emergency maintenance actions can proceed outside configured maintenance windows.
  - Improved handling of evacuations, missing or terminating instances, and in-flight migrations.
  - Improved protection against conflicting workload and node placements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->