### PR TITLE
[Bugfix] benchmark: derive --api-model-name

### DIFF
--- a/pkg/controller/v1beta1/benchmark/utils/utils.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils.go
@@ -3,6 +3,7 @@ package benchmarkutils
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -67,8 +68,11 @@ func BuildInferenceServiceArgs(ctx context.Context, c client.Client, endpointSpe
 		}
 
 		args := map[string]string{
-			"--api-key":         "sample-key", // TODO: Use actual service account key later
-			"--api-model-name":  "vllm-model",
+			// genai-bench requires a non-empty api-key for the openai backend but
+			// does not verify it; engines fronted by OME don't authenticate either.
+			// A real key would have to come from the spec or a Secret.
+			"--api-key":         "sample-key",
+			"--api-model-name":  resolveAPIModelName(inferenceService, baseModelName),
 			"--model-tokenizer": *baseModel.Storage.Path,
 		}
 
@@ -104,6 +108,54 @@ func BuildInferenceServiceArgs(ctx context.Context, c client.Client, endpointSpe
 	}
 
 	return nil, fmt.Errorf("invalid EndpointSpec: both Endpoint and InferenceService are nil")
+}
+
+// servedModelNameFlag is how vLLM and SGLang name the identifier a client must
+// put in the "model" field of an OpenAI request.
+const servedModelNameFlag = "--served-model-name"
+
+// resolveAPIModelName determines the value the benchmark client should send as
+// the OpenAI "model" field.
+//
+// Engines validate it against their --served-model-name and answer 404 on a
+// mismatch, so guessing here means every request in the run fails while the job
+// still reports Completed. Preference order:
+//
+//  1. the first --served-model-name value the InferenceService sets on its
+//     engine runner, when the user overrode the runtime's command;
+//  2. otherwise the BaseModel name, which is what OME uses elsewhere to
+//     identify a model.
+//
+// A runtime that sets --served-model-name to something unrelated to the model
+// name and is not overridden by the InferenceService is not covered; resolving
+// that would require fetching the ServingRuntime here.
+func resolveAPIModelName(isvc *v1beta1.InferenceService, baseModelName string) string {
+	if isvc != nil && isvc.Spec.Engine != nil && isvc.Spec.Engine.Runner != nil {
+		runner := isvc.Spec.Engine.Runner
+		if name := servedModelNameFrom(runner.Command); name != "" {
+			return name
+		}
+		if name := servedModelNameFrom(runner.Args); name != "" {
+			return name
+		}
+	}
+	return baseModelName
+}
+
+// servedModelNameFrom returns the first value after --served-model-name.
+// The flag is variadic in both engines, so only the first name is taken: it is
+// the canonical one, later entries are aliases.
+func servedModelNameFrom(tokens []string) string {
+	for i, tok := range tokens {
+		if tok != servedModelNameFlag {
+			continue
+		}
+		if i+1 < len(tokens) && !strings.HasPrefix(tokens[i+1], "-") {
+			return tokens[i+1]
+		}
+		return ""
+	}
+	return ""
 }
 
 // buildArgsFromEndpoint constructs the arguments map when an Endpoint is directly provided.

--- a/pkg/controller/v1beta1/benchmark/utils/utils_test.go
+++ b/pkg/controller/v1beta1/benchmark/utils/utils_test.go
@@ -523,3 +523,81 @@ func TestUpdateVolumeMounts(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveAPIModelName(t *testing.T) {
+	runnerWith := func(command, args []string) *v1beta1.InferenceService {
+		return &v1beta1.InferenceService{
+			Spec: v1beta1.InferenceServiceSpec{
+				Engine: &v1beta1.EngineSpec{
+					Runner: &v1beta1.RunnerSpec{
+						Container: v1.Container{
+							Command: command,
+							Args:    args,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		isvc          *v1beta1.InferenceService
+		baseModelName string
+		want          string
+	}{
+		{
+			// The regression this guards: the value used to be the literal
+			// "vllm-model", which 404s against any normally configured engine.
+			name:          "falls back to the base model name",
+			isvc:          &v1beta1.InferenceService{},
+			baseModelName: "qwen2-5-0-5b-instruct",
+			want:          "qwen2-5-0-5b-instruct",
+		},
+		{
+			name:          "nil inference service falls back too",
+			isvc:          nil,
+			baseModelName: "some-model",
+			want:          "some-model",
+		},
+		{
+			name:          "served model name from the runner command wins",
+			isvc:          runnerWith([]string{"python3", "-m", "srv", "--served-model-name", "from-command"}, nil),
+			baseModelName: "base",
+			want:          "from-command",
+		},
+		{
+			name:          "served model name from the runner args wins",
+			isvc:          runnerWith(nil, []string{"--served-model-name", "from-args"}),
+			baseModelName: "base",
+			want:          "from-args",
+		},
+		{
+			// The flag is variadic; later entries are aliases, the first is canonical.
+			name:          "only the first served model name is taken",
+			isvc:          runnerWith([]string{"--served-model-name", "canonical", "alias-one", "alias-two"}, nil),
+			baseModelName: "base",
+			want:          "canonical",
+		},
+		{
+			name:          "dangling flag falls back instead of consuming the next flag",
+			isvc:          runnerWith([]string{"--served-model-name", "--port", "8080"}, nil),
+			baseModelName: "base",
+			want:          "base",
+		},
+		{
+			name:          "flag at the very end falls back",
+			isvc:          runnerWith([]string{"python3", "--served-model-name"}, nil),
+			baseModelName: "base",
+			want:          "base",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveAPIModelName(tt.isvc, tt.baseModelName); got != tt.want {
+				t.Errorf("resolveAPIModelName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes the second problem reported in #778.

## What this fixes

`BuildInferenceServiceArgs` passed the literal string `"vllm-model"` as `--api-model-name`:

```go
args := map[string]string{
    "--api-key":         "sample-key", // TODO: Use actual service account key later
    "--api-model-name":  "vllm-model",
    "--model-tokenizer": *baseModel.Storage.Path,
}
```

That value becomes the `model` field of every OpenAI request genai-bench sends. vLLM and SGLang validate it against their `--served-model-name` and return 404 on a mismatch, so unless a runtime happens to serve under the literal name `vllm-model`, every request in the benchmark fails.

The failure is quiet, which is what makes it costly: the BenchmarkJob reports `Completed`, the pod exits 0, and a full set of result files and plots is written. Only `num_error_requests` inside the per-run JSON reveals that nothing succeeded.

Note the neighbouring `--api-key` line carries a `// TODO`; this one did not, so it read as an intentional constant rather than a placeholder.

## Approach

The correct value is already in scope — the function holds both the `InferenceService` and the `BaseModel`. Preference order:

1. the first `--served-model-name` value on the InferenceService's engine runner, when the user overrode the runtime's command there;
2. otherwise the `BaseModel` name, which is how OME identifies a model elsewhere.

The flag is variadic in both engines, so only the first value is taken — later entries are aliases. A dangling flag (nothing after it, or another flag) falls through to the BaseModel name rather than consuming an unrelated token.

Not covered: a runtime that sets `--served-model-name` to something unrelated to the model name and is not overridden by the InferenceService. Resolving that would mean fetching the ServingRuntime here; it seemed out of scope for a bug fix, but I'm happy to extend it if you'd prefer.

`--api-key` is left as `"sample-key"` with the `TODO` replaced by a note explaining why a placeholder is acceptable there (genai-bench requires the flag to be non-empty for the openai backend but does not verify it).

## Tests

`TestResolveAPIModelName` covers seven cases: fallback to the BaseModel name, nil InferenceService, resolution from the runner command, resolution from the runner args, only-the-first-name-of-a-variadic-flag, a dangling flag followed by another flag, and the flag at the very end of the token list.

The test fails without the fix — with the old constant in place, four of the seven cases report `resolveAPIModelName() = "vllm-model"`.

## Verified on a cluster

Kubernetes 1.30, OME v1.2.2-based build with this patch applied on top, vLLM 0.8.5.post1 on a V100, BaseModel `qwen2-5-0-5b-instruct`.

The runtime serves under its own name only — no `vllm-model` alias — which is exactly the case that used to 404:

```
$ curl .../v1/models
served: ['qwen2-5-0-5b-instruct']
```

The generated benchmark pod now carries the derived name:

```
--api-model-name qwen2-5-0-5b-instruct
```

and the run completes clean:

```
conc=1  done=17  err=0  rps=5.37  tput=868.9   ttft_p95=0.1361
conc=2  done=18  err=0  rps=8.98  tput=1457.7  ttft_p95=0.0626
```

Before the fix, the same setup required adding `vllm-model` as a second `--served-model-name` on the runtime to get any successful request at all.

## Scope

This PR deliberately covers only the `--api-model-name` problem. The PVC-related half of #778 (node selector and model volume) is a separate change and I'd rather send it once I can verify it on a cluster the same way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark compatibility with custom inference service configurations by using the configured served model name when available.
  * Added fallback behavior to use the base model name when no served model name is configured.
  * Ensured benchmark API requests include a valid API key value as required by the benchmarking tool.

* **Tests**
  * Added coverage for custom model names, fallback behavior, repeated flags, and invalid or missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->