### PR TITLE
[Core] Alfred reporter and decision loop

### DIFF
--- a/cmd/alfred/main.go
+++ b/cmd/alfred/main.go
@@ -16,9 +16,12 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,8 +31,10 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/engine"
 	"sigs.k8s.io/ome/pkg/alfred/metrics"
 	"sigs.k8s.io/ome/pkg/alfred/observer"
+	"sigs.k8s.io/ome/pkg/alfred/policy"
 	"sigs.k8s.io/ome/pkg/alfred/policy/defrag"
 	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
 	"sigs.k8s.io/ome/pkg/constants"
@@ -159,15 +164,83 @@ func main() {
 		os.Exit(1)
 	}
 
+	// OMENative availability: surface enabled AND the InferenceReplica CRD
+	// registered. No real executor ships yet, so this is the heuristic the
+	// OEP's degraded mode keys on. The probe runs on its own rest.Config
+	// copy with a finite timeout (a global timeout on the manager's config
+	// would kill long-lived informer watches) and is TTL-cached so an
+	// executor installed later is noticed without a restart.
+	discoveryConfig := rest.CopyConfig(mgr.GetConfig())
+	discoveryConfig.Timeout = 15 * time.Second
+	probeInferenceReplica := func(context.Context) (bool, error) {
+		dc, err := discovery.NewDiscoveryClientForConfig(discoveryConfig)
+		if err != nil {
+			return false, err
+		}
+		resources, err := dc.ServerResourcesForGroupVersion(constants.OMEAPIGroupName + "/" + v1beta1.APIVersion)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		for _, resource := range resources.APIResources {
+			if resource.Kind == "InferenceReplica" {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	discoverOMENative := engine.OMENativeDiscovery(store,
+		engine.CachedProbe(5*time.Minute, nil, probeInferenceReplica),
+		ctrl.Log.WithName("alfred-omenative"))
+
 	observationLoop := &observer.Loop{
-		Reader:  mgr.GetClient(),
-		Store:   store,
-		Metrics: alfredMetrics,
-		Log:     ctrl.Log.WithName("alfred-observer"),
-		Scorer:  defrag.PublishScores,
+		Reader:             mgr.GetClient(),
+		Store:              store,
+		Metrics:            alfredMetrics,
+		Log:                ctrl.Log.WithName("alfred-observer"),
+		Scorer:             defrag.PublishScores,
+		OMENativeAvailable: discoverOMENative,
 	}
 	if err := mgr.Add(observationLoop); err != nil {
 		setupLog.Error(err, "unable to add observation loop")
+		os.Exit(1)
+	}
+
+	// Decision side: leader-only loop over policies → arbiter → reporter.
+	// The dispatcher joins in the execute path; until then admitted
+	// candidates are withheld and reported as such.
+	earlyTicker := &engine.EarlyTicker{
+		Cache: mgr.GetCache(),
+		Store: store,
+		Log:   ctrl.Log.WithName("alfred-earlytick"),
+		C:     make(chan struct{}, 1),
+	}
+	if err := mgr.Add(earlyTicker); err != nil {
+		setupLog.Error(err, "unable to add early ticker")
+		os.Exit(1)
+	}
+	decisionLoop := &engine.DecisionLoop{
+		Snapshots: observationLoop,
+		Store:     store,
+		Policies:  []policy.Policy{&defrag.Policy{}},
+		Arbiter:   &engine.Arbiter{Ledger: engine.NewLedger()},
+		Reporter: &engine.Reporter{
+			Client:        mgr.GetClient(),
+			DirectReader:  mgr.GetAPIReader(),
+			Recorder:      mgr.GetEventRecorderFor("alfred"),
+			Metrics:       alfredMetrics,
+			Log:           ctrl.Log.WithName("alfred-reporter"),
+			Namespace:     opts.namespace,
+			ConfigMapName: opts.configMapName,
+		},
+		Metrics:   alfredMetrics,
+		Log:       ctrl.Log.WithName("alfred-decision"),
+		EarlyTick: earlyTicker.C,
+	}
+	if err := mgr.Add(decisionLoop); err != nil {
+		setupLog.Error(err, "unable to add decision loop")
 		os.Exit(1)
 	}
 

--- a/pkg/alfred/engine/earlytick.go
+++ b/pkg/alfred/engine/earlytick.go
@@ -1,0 +1,108 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+)
+
+// EarlyTicker turns node-condition changes into decision-loop tick
+// advancements (earlyTickOn: [NodeConditionChange]): health evacuation
+// starts within seconds while defragmentation stays lazily periodic. The
+// signal advances the timer feeding a non-reentrant loop, so it can shorten
+// waiting but never introduce concurrency. It runs on every replica — the
+// channel is only consumed by the leader's decision loop, and a non-leader's
+// signals are cheap.
+type EarlyTicker struct {
+	Cache ctrlcache.Cache
+	Store *config.Store
+	Log   logr.Logger
+
+	// C carries the tick signal; buffered with capacity 1 so a signal
+	// landing mid-pass waits there instead of being lost, and a storm of
+	// changes collapses into one advancement.
+	C chan struct{}
+}
+
+var _ manager.Runnable = &EarlyTicker{}
+var _ manager.LeaderElectionRunnable = &EarlyTicker{}
+
+// NeedLeaderElection returns false — see the type comment.
+func (e *EarlyTicker) NeedLeaderElection() bool { return false }
+
+// Start registers the node handler and blocks until the context ends.
+func (e *EarlyTicker) Start(ctx context.Context) error {
+	informer, err := e.Cache.GetInformer(ctx, &corev1.Node{})
+	if err != nil {
+		return fmt.Errorf("get node informer: %w", err)
+	}
+	registration, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) { e.observe(oldObj, newObj) },
+	})
+	if err != nil {
+		return fmt.Errorf("register node handler: %w", err)
+	}
+	defer func() {
+		_ = informer.RemoveEventHandler(registration)
+	}()
+	<-ctx.Done()
+	return nil
+}
+
+// observe signals when a node's conditions changed and the trigger is
+// enabled. Enablement is checked at signal time against the live config, so
+// a reload takes effect without re-registering the handler.
+func (e *EarlyTicker) observe(oldObj, newObj interface{}) {
+	oldNode, okOld := oldObj.(*corev1.Node)
+	newNode, okNew := newObj.(*corev1.Node)
+	if !okOld || !okNew {
+		return
+	}
+	if !earlyTickEnabled(e.Store.Get()) {
+		return
+	}
+	if !nodeConditionsChanged(oldNode, newNode) {
+		return
+	}
+	select {
+	case e.C <- struct{}{}:
+		e.Log.V(1).Info("node condition change; advancing decision tick", "node", newNode.Name)
+	default:
+		// A signal is already pending; the next pass covers this change.
+	}
+}
+
+func earlyTickEnabled(cfg *config.Config) bool {
+	for _, trigger := range cfg.EarlyTickOn {
+		if trigger == config.EarlyTickNodeConditionChange {
+			return true
+		}
+	}
+	return false
+}
+
+// nodeConditionsChanged compares condition statuses by type: a status flip
+// (or a condition appearing/disappearing) is a change; heartbeat-only
+// updates are not.
+func nodeConditionsChanged(oldNode, newNode *corev1.Node) bool {
+	if len(oldNode.Status.Conditions) != len(newNode.Status.Conditions) {
+		return true
+	}
+	previous := make(map[corev1.NodeConditionType]corev1.ConditionStatus, len(oldNode.Status.Conditions))
+	for _, cond := range oldNode.Status.Conditions {
+		previous[cond.Type] = cond.Status
+	}
+	for _, cond := range newNode.Status.Conditions {
+		if status, ok := previous[cond.Type]; !ok || status != cond.Status {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/alfred/engine/loop.go
+++ b/pkg/alfred/engine/loop.go
@@ -1,0 +1,108 @@
+package engine
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/metrics"
+	"sigs.k8s.io/ome/pkg/alfred/policy"
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+)
+
+// SnapshotSource yields the freshest observation-loop snapshot; nil before
+// the first pass. observer.Loop implements it.
+type SnapshotSource interface {
+	Latest() *snapshot.ClusterSnapshot
+}
+
+// DecisionLoop is the leader-only decision Runnable: policies → arbiter →
+// reporter (→ dispatcher, in the execute path) on the configured cadence.
+// One pass at a time by construction — a single goroutine runs RunOnce, so
+// an overrunning pass delays the next tick and never overlaps it: every
+// safety bound assumes admissions are totally ordered.
+type DecisionLoop struct {
+	Snapshots SnapshotSource
+	Store     *config.Store
+	Policies  []policy.Policy
+	Arbiter   *Arbiter
+	Reporter  *Reporter
+	Metrics   *metrics.Metrics
+	Log       logr.Logger
+
+	// EarlyTick advances the next tick when a subscribed event (a node
+	// condition change) arrives; it never interrupts a running pass. The
+	// channel must be buffered (capacity 1): a signal landing mid-pass
+	// waits there and fires the next select immediately.
+	EarlyTick <-chan struct{}
+
+	// Now overrides the clock in tests.
+	Now func() time.Time
+}
+
+var _ manager.Runnable = &DecisionLoop{}
+var _ manager.LeaderElectionRunnable = &DecisionLoop{}
+
+// NeedLeaderElection returns true: exactly one replica decides and acts.
+func (l *DecisionLoop) NeedLeaderElection() bool { return true }
+
+// Start runs an immediate first pass, then ticks at decisionLoopInterval,
+// re-reading the interval every pass so a config reload takes effect without
+// a restart.
+func (l *DecisionLoop) Start(ctx context.Context) error {
+	l.RunOnce(ctx)
+	for {
+		timer := time.NewTimer(l.Store.Get().DecisionLoopInterval.Duration)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+		case <-timer.C:
+		case <-l.EarlyTick:
+			timer.Stop()
+		}
+		l.RunOnce(ctx)
+	}
+}
+
+// RunOnce executes one decision pass against the latest snapshot. Exported
+// for tests; Start is its only production caller.
+func (l *DecisionLoop) RunOnce(ctx context.Context) {
+	started := l.now()
+	snap := l.Snapshots.Latest()
+	if snap == nil {
+		l.Log.V(1).Info("no snapshot yet; skipping decision pass")
+		return
+	}
+	cfg := l.Store.Get()
+
+	l.Reporter.ReportOMENativeState(snap.OMENativeAvailable)
+
+	var candidates []policy.Candidate
+	for _, p := range l.Policies {
+		candidates = append(candidates, p.Evaluate(snap, cfg)...)
+	}
+	decisions := l.Arbiter.Admit(snap, candidates, cfg, l.now())
+
+	if l.Arbiter.Ledger != nil && l.Arbiter.Ledger.BreakerOpen(l.now()) {
+		l.Metrics.CircuitBreakerState.Set(1)
+	} else {
+		l.Metrics.CircuitBreakerState.Set(0)
+	}
+
+	// The Dispatcher joins in the execute path (with the VAP guard); until
+	// then every admitted candidate is withheld and the Reporter says so.
+	l.Reporter.ReportCycle(ctx, candidates, decisions, cfg, l.now())
+
+	l.Metrics.DecisionLoopDuration.Observe(l.now().Sub(started).Seconds())
+}
+
+func (l *DecisionLoop) now() time.Time {
+	if l.Now == nil {
+		return time.Now()
+	}
+	return l.Now()
+}

--- a/pkg/alfred/engine/loop_test.go
+++ b/pkg/alfred/engine/loop_test.go
@@ -1,0 +1,256 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/policy"
+	"sigs.k8s.io/ome/pkg/alfred/snapshot"
+)
+
+type stubSource struct{ snap *snapshot.ClusterSnapshot }
+
+func (s *stubSource) Latest() *snapshot.ClusterSnapshot { return s.snap }
+
+type stubPolicy struct {
+	calls int64
+	out   []policy.Candidate
+}
+
+func (p *stubPolicy) Name() string { return "stub" }
+func (p *stubPolicy) Evaluate(*snapshot.ClusterSnapshot, *config.Config) []policy.Candidate {
+	atomic.AddInt64(&p.calls, 1)
+	return p.out
+}
+
+func newTestLoop(t *testing.T, snap *snapshot.ClusterSnapshot, p policy.Policy) (*DecisionLoop, *Reporter, chan struct{}) {
+	t.Helper()
+	reporter, m, _, _ := newTestReporter(t, recommendationsCM(nil))
+	early := make(chan struct{}, 1)
+	loop := &DecisionLoop{
+		Snapshots: &stubSource{snap: snap},
+		Store:     config.NewStore(),
+		Policies:  []policy.Policy{p},
+		Arbiter:   &Arbiter{Ledger: NewLedger()},
+		Reporter:  reporter,
+		Metrics:   m,
+		Log:       logr.Discard(),
+		EarlyTick: early,
+		Now:       func() time.Time { return testNow },
+	}
+	return loop, reporter, early
+}
+
+func TestDecisionLoopIsLeaderOnly(t *testing.T) {
+	loop, _, _ := newTestLoop(t, nil, &stubPolicy{})
+	if !loop.NeedLeaderElection() {
+		t.Fatal("exactly one replica may decide and act")
+	}
+}
+
+func TestRunOncePipeline(t *testing.T) {
+	snap := scenario().Build()
+	executable := cand("prod/a", "node1")
+	advisory := cand("prod/b", "node3")
+	advisory.Executable = false
+	advisory.AdvisoryReason = policy.AdvisoryNoSurgeHeadroom
+	p := &stubPolicy{out: []policy.Candidate{executable, advisory}}
+	loop, reporter, _ := newTestLoop(t, snap, p)
+
+	loop.RunOnce(context.Background())
+
+	if got := atomic.LoadInt64(&p.calls); got != 1 {
+		t.Fatalf("policy evaluated %d times, want 1", got)
+	}
+	m := reporter.Metrics
+	if got := promtestutil.ToFloat64(m.RecommendationsAccepted.WithLabelValues("defragmentation", "prod/a", "engine")); got != 1 {
+		t.Fatalf("admitted candidate not reported: %v", got)
+	}
+	if got := promtestutil.ToFloat64(m.RecommendationsProduced.WithLabelValues("defragmentation", "prod/b", "engine", policy.ReasonFragmentation, "false")); got != 1 {
+		t.Fatalf("advisory bypass not reported: %v", got)
+	}
+	if got := promtestutil.ToFloat64(m.CircuitBreakerState); got != 0 {
+		t.Fatalf("breaker gauge = %v, want 0", got)
+	}
+	if got := promtestutil.CollectAndCount(m.DecisionLoopDuration); got != 1 {
+		t.Fatalf("decision duration histogram families = %d", got)
+	}
+}
+
+func TestRunOnceWithoutSnapshotSkips(t *testing.T) {
+	p := &stubPolicy{}
+	loop, _, _ := newTestLoop(t, nil, p)
+	loop.RunOnce(context.Background())
+	if atomic.LoadInt64(&p.calls) != 0 {
+		t.Fatal("no snapshot means no evaluation")
+	}
+}
+
+func TestBreakerGaugeFollowsLedger(t *testing.T) {
+	snap := scenario().Build()
+	loop, reporter, _ := newTestLoop(t, snap, &stubPolicy{})
+	for i := 0; i < 4; i++ {
+		loop.Arbiter.Ledger.RecordOutcome(false, testNow.Add(-time.Minute))
+	}
+	loop.RunOnce(context.Background())
+	if got := promtestutil.ToFloat64(reporter.Metrics.CircuitBreakerState); got != 1 {
+		t.Fatalf("breaker gauge = %v, want 1 while open", got)
+	}
+}
+
+// TestStartEarlyTickAdvances: with a 5-minute interval, only the early-tick
+// signal can trigger the second pass inside the test timeout.
+func TestStartEarlyTickAdvances(t *testing.T) {
+	p := &stubPolicy{}
+	loop, _, early := newTestLoop(t, scenario().Build(), p)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- loop.Start(ctx) }()
+
+	waitFor := func(passes int64) {
+		t.Helper()
+		deadline := time.After(5 * time.Second)
+		for atomic.LoadInt64(&p.calls) < passes {
+			select {
+			case <-deadline:
+				t.Fatalf("loop stuck at %d passes, want %d", atomic.LoadInt64(&p.calls), passes)
+			default:
+				time.Sleep(5 * time.Millisecond)
+			}
+		}
+	}
+	waitFor(1) // immediate first pass
+	early <- struct{}{}
+	waitFor(2) // advanced by the early tick, not the 5m timer
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Start returned error on shutdown: %v", err)
+	}
+}
+
+func TestOMENativeDiscoveryGating(t *testing.T) {
+	store := config.NewStore()
+	calls := 0
+	check := func(context.Context) (bool, error) { calls++; return true, nil }
+	discover := OMENativeDiscovery(store, check, logr.Discard())
+	if !discover(context.Background()) {
+		t.Fatal("enabled config with a registered CRD must read available")
+	}
+
+	if _, err := store.Update([]byte("schemaVersion: 1\nomenativeMigrationEnabled: false")); err != nil {
+		t.Fatal(err)
+	}
+	before := calls
+	if discover(context.Background()) {
+		t.Fatal("disabled surface must read unavailable")
+	}
+	if calls != before {
+		t.Fatal("disabled surface must not probe discovery")
+	}
+
+	if _, err := store.Update([]byte("schemaVersion: 1")); err != nil {
+		t.Fatal(err)
+	}
+	failing := OMENativeDiscovery(store, func(context.Context) (bool, error) {
+		return true, errors.New("discovery down")
+	}, logr.Discard())
+	if failing(context.Background()) {
+		t.Fatal("a discovery error must degrade, not enable")
+	}
+}
+
+// TestCachedProbe: successes are held for the TTL, a flip is noticed after
+// it expires, and errors are never cached.
+func TestCachedProbe(t *testing.T) {
+	calls := 0
+	result := false
+	var probeErr error
+	clock := testNow
+	probe := CachedProbe(5*time.Minute, func() time.Time { return clock },
+		func(context.Context) (bool, error) { calls++; return result, probeErr })
+
+	if ok, _ := probe(context.Background()); ok || calls != 1 {
+		t.Fatalf("first probe: ok=%v calls=%d", ok, calls)
+	}
+	if _, _ = probe(context.Background()); calls != 1 {
+		t.Fatalf("inside the TTL the probe must not re-run: %d", calls)
+	}
+
+	result = true
+	clock = clock.Add(6 * time.Minute)
+	if ok, _ := probe(context.Background()); !ok || calls != 2 {
+		t.Fatalf("after the TTL a flip must be noticed: ok=%v calls=%d", ok, calls)
+	}
+
+	probeErr = errors.New("discovery down")
+	clock = clock.Add(6 * time.Minute)
+	if _, err := probe(context.Background()); err == nil {
+		t.Fatal("errors must propagate")
+	}
+	probeErr = nil
+	if _, err := probe(context.Background()); err != nil || calls != 4 {
+		t.Fatalf("errors must not be cached: err=%v calls=%d", err, calls)
+	}
+}
+
+func TestEarlyTickerObserve(t *testing.T) {
+	node := func(ready corev1.ConditionStatus, extra ...corev1.NodeCondition) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+			Status: corev1.NodeStatus{Conditions: append([]corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: ready},
+			}, extra...)},
+		}
+	}
+	ticker := &EarlyTicker{
+		Store: config.NewStore(), // default earlyTickOn: [NodeConditionChange]
+		Log:   logr.Discard(),
+		C:     make(chan struct{}, 1),
+	}
+
+	// A status flip signals.
+	ticker.observe(node(corev1.ConditionTrue), node(corev1.ConditionFalse))
+	select {
+	case <-ticker.C:
+	default:
+		t.Fatal("a condition flip must advance the tick")
+	}
+
+	// A heartbeat-only update does not.
+	ticker.observe(node(corev1.ConditionTrue), node(corev1.ConditionTrue))
+	select {
+	case <-ticker.C:
+		t.Fatal("heartbeat updates must not advance the tick")
+	default:
+	}
+
+	// A new condition appearing signals; a full channel never blocks.
+	bad := corev1.NodeCondition{Type: "GpuUnhealthy", Status: corev1.ConditionTrue}
+	ticker.observe(node(corev1.ConditionTrue), node(corev1.ConditionTrue, bad))
+	ticker.observe(node(corev1.ConditionTrue), node(corev1.ConditionTrue, bad, corev1.NodeCondition{Type: "X", Status: corev1.ConditionTrue}))
+	if len(ticker.C) != 1 {
+		t.Fatalf("signals must collapse into the buffered slot, got %d", len(ticker.C))
+	}
+	<-ticker.C
+
+	// Disabled trigger stays silent.
+	if _, err := ticker.Store.Update([]byte("schemaVersion: 1\nearlyTickOn: []")); err != nil {
+		t.Fatal(err)
+	}
+	ticker.observe(node(corev1.ConditionTrue), node(corev1.ConditionFalse))
+	select {
+	case <-ticker.C:
+		t.Fatal("a disabled trigger must not signal")
+	default:
+	}
+}

--- a/pkg/alfred/engine/omenative.go
+++ b/pkg/alfred/engine/omenative.go
@@ -1,0 +1,59 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+)
+
+// OMENativeDiscovery builds the observation loop's executor-availability
+// hook. No OMENative controller ships yet, so availability is a heuristic:
+// the operator has the surface enabled AND the InferenceReplica CRD is
+// registered (the strategy's footprint on the cluster). check is injected —
+// cmd/alfred passes a discovery-client probe — so the gating logic stays
+// unit-testable. Errors read as unavailable: degrading to recommend-only on
+// a flaky discovery beats dispatching a migration verb nobody consumes.
+func OMENativeDiscovery(store *config.Store, check func(ctx context.Context) (bool, error), log logr.Logger) func(ctx context.Context) bool {
+	return func(ctx context.Context) bool {
+		if !*store.Get().OMENativeMigrationEnabled {
+			return false
+		}
+		available, err := check(ctx)
+		if err != nil {
+			log.Error(err, "OMENative discovery failed; treating executor as unavailable")
+			return false
+		}
+		return available
+	}
+}
+
+// CachedProbe rate-limits a discovery probe: successful results are held for
+// ttl, so the API server is not asked on every observation pass yet an
+// executor installed later is noticed without a restart. Errors are never
+// cached — the next call re-probes. now is injectable for tests; nil uses
+// the wall clock.
+func CachedProbe(ttl time.Duration, now func() time.Time, probe func(ctx context.Context) (bool, error)) func(ctx context.Context) (bool, error) {
+	if now == nil {
+		now = time.Now
+	}
+	var mu sync.Mutex
+	var last time.Time
+	var cached, seeded bool
+	return func(ctx context.Context) (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if seeded && now().Sub(last) < ttl {
+			return cached, nil
+		}
+		result, err := probe(ctx)
+		if err != nil {
+			return false, err
+		}
+		cached, last, seeded = result, now(), true
+		return result, nil
+	}
+}

--- a/pkg/alfred/engine/reporter.go
+++ b/pkg/alfred/engine/reporter.go
@@ -1,0 +1,366 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/metrics"
+	"sigs.k8s.io/ome/pkg/alfred/policy"
+	"sigs.k8s.io/ome/pkg/apis/ome/v1beta1"
+)
+
+// Candidate outcomes as recorded in the alfred-recommendations ConfigMap.
+const (
+	OutcomeAdvisory = "advisory"
+	OutcomeAdmitted = "admitted"
+	// OutcomeWithheld is an admitted candidate in recommend-only mode: the
+	// Arbiter would act, the Dispatcher never fires.
+	OutcomeWithheld = "withheld"
+	OutcomeRejected = "rejected"
+)
+
+// recommendationsKey is the ConfigMap key holding the latest cycle record;
+// node remediation records (Policy #2) live beside it under node.<name> keys.
+const recommendationsKey = "last-cycle.json"
+
+// Reporter is the engine's single observability emitter: every Event, every
+// decision metric, and every alfred-recommendations ConfigMap entry comes
+// from here, so emission is tested and deduplicated once, not per policy.
+type Reporter struct {
+	// Client updates the recommendations ConfigMap. Update-only: the chart
+	// pre-creates it, and a missing ConfigMap disables the record with a
+	// log line rather than a create (the write contract is narrow).
+	Client client.Client
+	// DirectReader reads the ConfigMap uncached for the read-modify-write
+	// cycle (the manager's API reader): retrying a conflict against the
+	// informer cache would just re-read the same stale object. Nil falls
+	// back to Client.
+	DirectReader client.Reader
+	Recorder     record.EventRecorder
+	Metrics      *metrics.Metrics
+	Log          logr.Logger
+	// Namespace is Alfred's own namespace — the recommendations ConfigMap
+	// and the engine-level transition events live there.
+	Namespace string
+	// ConfigMapName is the alfred-config ConfigMap's configured name (the
+	// --config-name flag): the anchor object for engine-level events.
+	ConfigMapName string
+
+	// Transition dedup: the OMENativeUnavailable event fires on the way
+	// into degraded mode, never per pass.
+	omenativeSeeded   bool
+	omenativeDegraded bool
+
+	// cmMissingLogged dedups the missing-ConfigMap log.
+	cmMissingLogged bool
+
+	// nodeSignals dedups node remediation signals across decision loops (a
+	// flapping condition must not spam fresh signals): node name → the
+	// condition fingerprint last signaled. Policy #2 drives this.
+	nodeSignals map[string]string
+}
+
+// cycleRecord is the JSON document written to the recommendations ConfigMap.
+type cycleRecord struct {
+	Timestamp       time.Time            `json:"timestamp"`
+	Mode            string               `json:"mode"`
+	Recommendations []recommendationView `json:"recommendations"`
+}
+
+type recommendationView struct {
+	Workload       string   `json:"workload"`
+	Component      string   `json:"component"`
+	Instance       int32    `json:"instance"`
+	Policy         string   `json:"policy"`
+	Reason         string   `json:"reason"`
+	Outcome        string   `json:"outcome"`
+	AdvisoryReason string   `json:"advisoryReason,omitempty"`
+	RejectReason   string   `json:"rejectReason,omitempty"`
+	FromNode       string   `json:"fromNode,omitempty"`
+	Target         string   `json:"target,omitempty"`
+	HintTargets    []string `json:"hintTargets,omitempty"`
+	Score          float64  `json:"score"`
+	Emergency      bool     `json:"emergency,omitempty"`
+	CooldownOver   bool     `json:"cooldownOverridden,omitempty"`
+}
+
+// ReportCycle publishes one decision pass: produced/accepted/rejected
+// counters, Events on the target InferenceServices, and (when enabled) the
+// recommendations ConfigMap record. decisions covers the executable
+// candidates; advisories appear only in candidates.
+func (r *Reporter) ReportCycle(ctx context.Context, candidates []policy.Candidate, decisions []Decision, cfg *config.Config, now time.Time) {
+	record := cycleRecord{Timestamp: now, Mode: cfg.Mode}
+
+	decided := map[string]Decision{}
+	for _, d := range decisions {
+		decided[candidateKey(d.Candidate)] = d
+	}
+
+	for _, c := range candidates {
+		executable := "false"
+		if c.Executable {
+			executable = "true"
+		}
+		r.Metrics.RecommendationsProduced.WithLabelValues(
+			c.Policy, c.Workload.String(), string(c.Component), c.Reason, executable).Inc()
+
+		view := recommendationView{
+			Workload:       c.Workload.String(),
+			Component:      string(c.Component),
+			Instance:       c.Instance,
+			Policy:         c.Policy,
+			Reason:         c.Reason,
+			AdvisoryReason: c.AdvisoryReason,
+			FromNode:       c.FromNode,
+			HintTargets:    c.HintTargetNodes,
+			Score:          c.Score,
+			Emergency:      c.Emergency,
+		}
+
+		if !c.Executable {
+			view.Outcome = OutcomeAdvisory
+			r.reportAdvisory(c)
+			record.Recommendations = append(record.Recommendations, view)
+			continue
+		}
+
+		d, ok := decided[candidateKey(c)]
+		if !ok {
+			// An executable candidate without a decision (the arbiter
+			// never saw it) is a wiring bug worth surfacing loudly.
+			r.Log.Error(nil, "executable candidate has no arbitration decision",
+				"workload", c.Workload.String(), "component", c.Component)
+			continue
+		}
+		if d.Admitted {
+			view.Outcome = OutcomeAdmitted
+			if cfg.Mode == config.ModeRecommendOnly {
+				view.Outcome = OutcomeWithheld
+			}
+			view.Target = d.Target
+			view.CooldownOver = d.CooldownOverridden
+			r.reportAdmitted(c, d, cfg)
+		} else {
+			view.Outcome = OutcomeRejected
+			view.RejectReason = d.Reason
+			r.Metrics.RecommendationsRejected.WithLabelValues(
+				c.Policy, c.Workload.String(), string(c.Component), d.Reason).Inc()
+			r.event(c, corev1.EventTypeNormal, "RecommendationRejected",
+				"%s recommendation for %s/%s rejected: %s",
+				c.Policy, c.Workload.String(), c.Component, d.Reason)
+		}
+		record.Recommendations = append(record.Recommendations, view)
+	}
+
+	if *cfg.RecommendationsConfigMapEnabled {
+		r.writeRecord(ctx, cfg.RecommendationsConfigMapName, record)
+	}
+}
+
+func (r *Reporter) reportAdvisory(c policy.Candidate) {
+	r.event(c, corev1.EventTypeNormal, producedEventReason(c),
+		"%s advisory for %s/%s: %s (from %s, footprint %d GPUs)",
+		c.Policy, c.Workload.String(), c.Component, c.AdvisoryReason, c.FromNode, c.FootprintGPUs)
+	if c.AdvisoryReason == policy.AdvisoryLWSMigrationUnsupported {
+		r.Metrics.LWSRecommendations.WithLabelValues(c.Workload.String(), "MigrateToOMENative").Inc()
+	}
+}
+
+func (r *Reporter) reportAdmitted(c policy.Candidate, d Decision, cfg *config.Config) {
+	r.Metrics.RecommendationsAccepted.WithLabelValues(
+		c.Policy, c.Workload.String(), string(c.Component)).Inc()
+
+	reason, note := "RecommendationAdmitted", "will dispatch"
+	if cfg.Mode == config.ModeRecommendOnly {
+		reason, note = "RecommendationWithheld", "recommend-only: not dispatched"
+	}
+	target := d.Target
+	if target == "" {
+		target = "scheduler's choice"
+	}
+	r.event(c, corev1.EventTypeNormal, reason,
+		"%s recommends migrating %s/%s instance %d off %s (target %s, score %.3f) — %s",
+		c.Policy, c.Workload.String(), c.Component, c.Instance, c.FromNode, target, c.Score, note)
+
+	if d.CooldownOverridden {
+		r.Metrics.CooldownOverrides.WithLabelValues(c.Policy).Inc()
+		r.event(c, corev1.EventTypeNormal, "CooldownOverriddenForEvacuation",
+			"health evacuation of %s/%s admitted under the cooldown floor while the standard window was still running",
+			c.Workload.String(), c.Component)
+	}
+}
+
+// ReportOMENativeState emits the degraded-mode transition event: once on the
+// way in, never per pass (the alfred_omenative_unavailable gauge — published
+// by the observation loop every pass — is the per-pass signal; the event
+// stream must not become noise).
+func (r *Reporter) ReportOMENativeState(available bool) {
+	degraded := !available
+	enteringDegraded := degraded && (!r.omenativeSeeded || !r.omenativeDegraded)
+	if enteringDegraded {
+		r.Recorder.Eventf(r.namespaceRef(), corev1.EventTypeWarning, "OMENativeUnavailable",
+			"no OMENative executor is available; multi-pod candidates degrade to advisory")
+	}
+	if r.omenativeSeeded && r.omenativeDegraded && available {
+		r.Log.Info("OMENative executor available again; degraded mode cleared")
+	}
+	r.omenativeSeeded, r.omenativeDegraded = true, degraded
+}
+
+// NodeSignal emits a node remediation signal, deduplicated across decision
+// loops: a Warning Event on the Node (what remediation controllers watch), a
+// node.<name> entry in the recommendations ConfigMap (the durable record
+// Alfred owns), and the signal counter. A repeat with the same condition
+// fingerprint is suppressed until ClearNodeSignal. Policy #2 drives this.
+func (r *Reporter) NodeSignal(ctx context.Context, node, condition string, workloads []string, cfg *config.Config, now time.Time) {
+	if r.nodeSignals == nil {
+		r.nodeSignals = map[string]string{}
+	}
+	if r.nodeSignals[node] == condition {
+		return
+	}
+	r.nodeSignals[node] = condition
+
+	r.Metrics.NodeHealthSignals.WithLabelValues(node, condition).Inc()
+	r.Recorder.Eventf(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: node}},
+		corev1.EventTypeWarning, "GpuUnhealthyEvacuating",
+		"node %s is unhealthy (%s); Alfred is evacuating %d workload(s) and signaling for repair",
+		node, condition, len(workloads))
+
+	if !*cfg.RecommendationsConfigMapEnabled {
+		return
+	}
+	entry, err := json.Marshal(map[string]interface{}{
+		"condition": condition,
+		"workloads": workloads,
+		"signaled":  now,
+	})
+	if err != nil {
+		return
+	}
+	writeErr := r.updateConfigMap(ctx, cfg.RecommendationsConfigMapName, func(cm *corev1.ConfigMap) {
+		cm.Data["node."+node] = string(entry)
+	})
+	if writeErr != nil && !apierrors.IsNotFound(writeErr) {
+		// The durable record is missing while the fingerprint says
+		// "signaled" — drop it so the next pass retries the write. A
+		// NotFound keeps the dedup: the record surface is absent by
+		// operator choice, and the event and metric already fired.
+		delete(r.nodeSignals, node)
+	}
+}
+
+// ClearNodeSignal forgets a node's dedup record so a fresh incident signals
+// again after the condition genuinely cleared.
+func (r *Reporter) ClearNodeSignal(node string) {
+	delete(r.nodeSignals, node)
+}
+
+func (r *Reporter) writeRecord(ctx context.Context, name string, rec cycleRecord) {
+	raw, err := json.Marshal(rec)
+	if err != nil {
+		r.Log.Error(err, "marshal recommendations record")
+		return
+	}
+	// A failed cycle record needs no unwinding: the next pass rewrites it.
+	_ = r.updateConfigMap(ctx, name, func(cm *corev1.ConfigMap) {
+		cm.Data[recommendationsKey] = string(raw)
+	})
+}
+
+// updateConfigMap applies a mutation to the recommendations ConfigMap,
+// update-only: other keys (node records) are preserved, and a missing
+// ConfigMap logs once instead of being created. The read-modify-write cycle
+// retries on conflict with an uncached read — a lost node-signal write would
+// otherwise be deduped away and never rewritten. The error is returned
+// (already logged) so callers holding dedup state can undo it on failure.
+func (r *Reporter) updateConfigMap(ctx context.Context, name string, mutate func(*corev1.ConfigMap)) error {
+	key := types.NamespacedName{Namespace: r.Namespace, Name: name}
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var cm corev1.ConfigMap
+		if err := r.reader().Get(ctx, key, &cm); err != nil {
+			return err
+		}
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		mutate(&cm)
+		return r.Client.Update(ctx, &cm)
+	})
+	switch {
+	case err == nil:
+		r.cmMissingLogged = false
+	case apierrors.IsNotFound(err):
+		if !r.cmMissingLogged {
+			r.cmMissingLogged = true
+			r.Log.Info("recommendations ConfigMap missing; record disabled (the chart pre-creates it)",
+				"configmap", key.String())
+		}
+	default:
+		r.Log.Error(err, "update recommendations ConfigMap", "configmap", key.String())
+	}
+	return err
+}
+
+func (r *Reporter) reader() client.Reader {
+	if r.DirectReader != nil {
+		return r.DirectReader
+	}
+	return r.Client
+}
+
+// event emits a candidate-scoped Event on its InferenceService. A minimal
+// object reference is enough for the recorder, and candidates without a
+// workload (node-scoped signals) skip the ISVC event.
+func (r *Reporter) event(c policy.Candidate, eventType, reason, format string, args ...interface{}) {
+	if c.Workload.Name == "" {
+		return
+	}
+	ref := &v1beta1.InferenceService{ObjectMeta: metav1.ObjectMeta{
+		Namespace: c.Workload.Namespace,
+		Name:      c.Workload.Name,
+	}}
+	r.Recorder.Eventf(ref, eventType, reason, format, args...)
+}
+
+func (r *Reporter) namespaceRef() *corev1.ConfigMap {
+	name := r.ConfigMapName
+	if name == "" {
+		name = "alfred-config"
+	}
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Namespace: r.Namespace,
+		Name:      name,
+	}}
+}
+
+func producedEventReason(c policy.Candidate) string {
+	switch c.Reason {
+	case policy.ReasonNodeUnhealthy:
+		return "EvacuationRecommendationProduced"
+	case policy.ReasonRemediationSignal:
+		return "RemediationSignalProduced"
+	default:
+		return "FragmentationRecommendationProduced"
+	}
+}
+
+// candidateKey identifies one candidate within a cycle. The policy is part
+// of the key: node-health evacuation and defragmentation can both target the
+// same instance in one pass, and their decisions must not overwrite each
+// other in the report.
+func candidateKey(c policy.Candidate) string {
+	return fmt.Sprintf("%s|%s|%s|%d", c.Policy, c.Workload.String(), c.Component, c.Instance)
+}

--- a/pkg/alfred/engine/reporter_test.go
+++ b/pkg/alfred/engine/reporter_test.go
@@ -1,0 +1,375 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"sigs.k8s.io/ome/pkg/alfred/config"
+	"sigs.k8s.io/ome/pkg/alfred/metrics"
+	"sigs.k8s.io/ome/pkg/alfred/policy"
+)
+
+func newTestReporter(t *testing.T, objs ...client.Object) (*Reporter, *metrics.Metrics, *record.FakeRecorder, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	m := metrics.New(prometheus.NewRegistry())
+	recorder := record.NewFakeRecorder(50)
+	return &Reporter{
+		Client:    fakeClient,
+		Recorder:  recorder,
+		Metrics:   m,
+		Log:       logr.Discard(),
+		Namespace: "ome",
+	}, m, recorder, fakeClient
+}
+
+func recommendationsCM(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ome", Name: "alfred-recommendations"},
+		Data:       data,
+	}
+}
+
+func drainEvents(recorder *record.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-recorder.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+func hasEvent(events []string, substr string) bool {
+	for _, e := range events {
+		if strings.Contains(e, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestReportCycleOutcomes(t *testing.T) {
+	r, m, recorder, cl := newTestReporter(t, recommendationsCM(map[string]string{"node.old": "kept"}))
+	cfg := config.Default() // recommend-only
+
+	admitted := cand("prod/a", "node1")
+	rejected := cand("prod/b", "node3")
+	lws := cand("prod/lws", "node1")
+	lws.Executable = false
+	lws.AdvisoryReason = policy.AdvisoryLWSMigrationUnsupported
+
+	decisions := []Decision{
+		{Candidate: admitted, Admitted: true, Target: "node2"},
+		{Candidate: rejected, Reason: RejectCooldown},
+	}
+	r.ReportCycle(context.Background(), []policy.Candidate{admitted, rejected, lws}, decisions, cfg, testNow)
+
+	get := func(vec *prometheus.CounterVec, labels ...string) float64 {
+		return promtestutil.ToFloat64(vec.WithLabelValues(labels...))
+	}
+	if got := get(m.RecommendationsProduced, "defragmentation", "prod/a", "engine", policy.ReasonFragmentation, "true"); got != 1 {
+		t.Fatalf("produced{prod/a} = %v", got)
+	}
+	if got := get(m.RecommendationsProduced, "defragmentation", "prod/lws", "engine", policy.ReasonFragmentation, "false"); got != 1 {
+		t.Fatalf("produced{advisory} = %v", got)
+	}
+	if got := get(m.RecommendationsAccepted, "defragmentation", "prod/a", "engine"); got != 1 {
+		t.Fatalf("accepted = %v", got)
+	}
+	if got := get(m.RecommendationsRejected, "defragmentation", "prod/b", "engine", RejectCooldown); got != 1 {
+		t.Fatalf("rejected = %v", got)
+	}
+	if got := get(m.LWSRecommendations, "prod/lws", "MigrateToOMENative"); got != 1 {
+		t.Fatalf("lws counter = %v", got)
+	}
+
+	events := drainEvents(recorder)
+	for _, want := range []string{
+		"RecommendationWithheld", "recommend-only: not dispatched",
+		"RecommendationRejected", RejectCooldown,
+		"FragmentationRecommendationProduced", policy.AdvisoryLWSMigrationUnsupported,
+	} {
+		if !hasEvent(events, want) {
+			t.Fatalf("events missing %q: %v", want, events)
+		}
+	}
+
+	var cm corev1.ConfigMap
+	if err := cl.Get(context.Background(), types.NamespacedName{Namespace: "ome", Name: "alfred-recommendations"}, &cm); err != nil {
+		t.Fatal(err)
+	}
+	doc := cm.Data[recommendationsKey]
+	for _, want := range []string{
+		`"outcome":"` + OutcomeWithheld + `"`,
+		`"outcome":"` + OutcomeRejected + `"`,
+		`"outcome":"` + OutcomeAdvisory + `"`,
+		`"rejectReason":"` + RejectCooldown + `"`,
+		`"mode":"recommend-only"`,
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("record missing %s: %s", want, doc)
+		}
+	}
+	if cm.Data["node.old"] != "kept" {
+		t.Fatal("sibling ConfigMap keys must be preserved")
+	}
+}
+
+// TestCrossPolicyDecisionsKeyedSeparately: node-health and defrag can both
+// target the same instance in one pass; each candidate must be reported with
+// its own decision, not the other policy's.
+func TestCrossPolicyDecisionsKeyedSeparately(t *testing.T) {
+	r, m, _, cl := newTestReporter(t, recommendationsCM(nil))
+	cfg := config.Default()
+
+	defragCand := cand("prod/a", "node1")
+	healthCand := health("prod/a", "node1")
+	decisions := []Decision{
+		{Candidate: healthCand, Admitted: true, Target: "node2"},
+		{Candidate: defragCand, Reason: RejectWorkloadBusy},
+	}
+	r.ReportCycle(context.Background(), []policy.Candidate{defragCand, healthCand}, decisions, cfg, testNow)
+
+	if got := promtestutil.ToFloat64(m.RecommendationsAccepted.WithLabelValues("nodehealth", "prod/a", "engine")); got != 1 {
+		t.Fatalf("health admission miscounted: %v", got)
+	}
+	if got := promtestutil.ToFloat64(m.RecommendationsRejected.WithLabelValues("defragmentation", "prod/a", "engine", RejectWorkloadBusy)); got != 1 {
+		t.Fatalf("defrag rejection miscounted: %v", got)
+	}
+	var cm corev1.ConfigMap
+	if err := cl.Get(context.Background(), types.NamespacedName{Namespace: "ome", Name: "alfred-recommendations"}, &cm); err != nil {
+		t.Fatal(err)
+	}
+	doc := cm.Data[recommendationsKey]
+	for _, want := range []string{
+		`"policy":"nodehealth","reason":"NodeUnhealthy","outcome":"withheld"`,
+		`"policy":"defragmentation","reason":"Fragmentation","outcome":"rejected"`,
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("record missing %s: %s", want, doc)
+		}
+	}
+}
+
+func TestReportCycleExecuteModeAdmits(t *testing.T) {
+	r, _, recorder, cl := newTestReporter(t, recommendationsCM(nil))
+	cfg := config.Default()
+	cfg.Mode = config.ModeExecute
+
+	c := cand("prod/a", "node1")
+	r.ReportCycle(context.Background(), []policy.Candidate{c},
+		[]Decision{{Candidate: c, Admitted: true, Target: "node2"}}, cfg, testNow)
+
+	if events := drainEvents(recorder); !hasEvent(events, "RecommendationAdmitted") {
+		t.Fatalf("execute-mode admission must not read as withheld: %v", events)
+	}
+	var cm corev1.ConfigMap
+	if err := cl.Get(context.Background(), types.NamespacedName{Namespace: "ome", Name: "alfred-recommendations"}, &cm); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(cm.Data[recommendationsKey], `"outcome":"`+OutcomeAdmitted+`"`) {
+		t.Fatalf("record outcome: %s", cm.Data[recommendationsKey])
+	}
+}
+
+func TestCooldownOverrideAudited(t *testing.T) {
+	r, m, recorder, _ := newTestReporter(t, recommendationsCM(nil))
+	c := health("prod/a", "node1")
+	r.ReportCycle(context.Background(), []policy.Candidate{c},
+		[]Decision{{Candidate: c, Admitted: true, Target: "node2", CooldownOverridden: true}},
+		config.Default(), testNow)
+
+	if got := promtestutil.ToFloat64(m.CooldownOverrides.WithLabelValues("nodehealth")); got != 1 {
+		t.Fatalf("override counter = %v", got)
+	}
+	if events := drainEvents(recorder); !hasEvent(events, "CooldownOverriddenForEvacuation") {
+		t.Fatalf("override event missing: %v", events)
+	}
+}
+
+func TestConfigMapIsUpdateOnly(t *testing.T) {
+	r, _, _, cl := newTestReporter(t) // no pre-created ConfigMap
+	c := cand("prod/a", "node1")
+	r.ReportCycle(context.Background(), []policy.Candidate{c},
+		[]Decision{{Candidate: c, Admitted: true, Target: "node2"}}, config.Default(), testNow)
+
+	var cm corev1.ConfigMap
+	err := cl.Get(context.Background(), types.NamespacedName{Namespace: "ome", Name: "alfred-recommendations"}, &cm)
+	if err == nil {
+		t.Fatal("the reporter must never create the ConfigMap (the chart pre-creates it)")
+	}
+}
+
+// TestConfigMapConflictRetried: a stale read must not drop the record — a
+// lost node-signal write would be deduped away and never rewritten.
+func TestConfigMapConflictRetried(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	conflicts := 1
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(recommendationsCM(nil)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if conflicts > 0 {
+					conflicts--
+					return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, obj.GetName(), errors.New("stale"))
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := &Reporter{
+		Client:    cl,
+		Recorder:  record.NewFakeRecorder(10),
+		Metrics:   metrics.New(prometheus.NewRegistry()),
+		Log:       logr.Discard(),
+		Namespace: "ome",
+	}
+
+	c := cand("prod/a", "node1")
+	r.ReportCycle(context.Background(), []policy.Candidate{c},
+		[]Decision{{Candidate: c, Admitted: true, Target: "node2"}}, config.Default(), testNow)
+
+	var cm corev1.ConfigMap
+	if err := cl.Get(context.Background(), types.NamespacedName{Namespace: "ome", Name: "alfred-recommendations"}, &cm); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(cm.Data[recommendationsKey], `"outcome":"`+OutcomeWithheld+`"`) {
+		t.Fatalf("record lost to the conflict: %v", cm.Data)
+	}
+	if conflicts != 0 {
+		t.Fatal("the interceptor conflict was never exercised")
+	}
+}
+
+// TestNodeSignalRetriesAfterFailedWrite: a failed durable write must clear
+// the dedup fingerprint so the next pass retries — otherwise the event and
+// metric fire once and the node.<name> record is suppressed forever.
+func TestNodeSignalRetriesAfterFailedWrite(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	failing := true
+	updates := 0
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(recommendationsCM(nil)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				updates++
+				if failing {
+					return apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, obj.GetName(), errors.New("rbac denied"))
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := &Reporter{
+		Client:    cl,
+		Recorder:  record.NewFakeRecorder(10),
+		Metrics:   metrics.New(prometheus.NewRegistry()),
+		Log:       logr.Discard(),
+		Namespace: "ome",
+	}
+	cfg := config.Default()
+
+	r.NodeSignal(context.Background(), "node7", "GpuUnhealthy", []string{"prod/a"}, cfg, testNow)
+	afterFirst := updates
+	if afterFirst == 0 {
+		t.Fatal("the first signal must attempt the durable write")
+	}
+
+	r.NodeSignal(context.Background(), "node7", "GpuUnhealthy", []string{"prod/a"}, cfg, testNow.Add(time.Minute))
+	if updates <= afterFirst {
+		t.Fatal("a failed durable write must be retried on the next signal, not deduped away")
+	}
+
+	failing = false
+	r.NodeSignal(context.Background(), "node7", "GpuUnhealthy", []string{"prod/a"}, cfg, testNow.Add(2*time.Minute))
+	var cm corev1.ConfigMap
+	if err := cl.Get(context.Background(), types.NamespacedName{Namespace: "ome", Name: "alfred-recommendations"}, &cm); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(cm.Data["node.node7"], "GpuUnhealthy") {
+		t.Fatalf("durable record still missing after recovery: %v", cm.Data)
+	}
+
+	settled := updates
+	r.NodeSignal(context.Background(), "node7", "GpuUnhealthy", []string{"prod/a"}, cfg, testNow.Add(3*time.Minute))
+	if updates != settled {
+		t.Fatal("once the write landed the signal must dedup again")
+	}
+}
+
+func TestOMENativeTransitionEventOnce(t *testing.T) {
+	r, _, recorder, _ := newTestReporter(t)
+
+	r.ReportOMENativeState(false)
+	r.ReportOMENativeState(false)
+	if events := drainEvents(recorder); len(events) != 1 || !hasEvent(events, "OMENativeUnavailable") {
+		t.Fatalf("transition into degraded must emit exactly once: %v", events)
+	}
+
+	r.ReportOMENativeState(true)
+	if events := drainEvents(recorder); len(events) != 0 {
+		t.Fatalf("recovery is a log line, not an event: %v", events)
+	}
+
+	r.ReportOMENativeState(false)
+	if events := drainEvents(recorder); len(events) != 1 {
+		t.Fatalf("a fresh degradation must emit again: %v", events)
+	}
+}
+
+func TestNodeSignalDedup(t *testing.T) {
+	r, m, recorder, cl := newTestReporter(t, recommendationsCM(nil))
+	cfg := config.Default()
+
+	r.NodeSignal(context.Background(), "node7", "GpuUnhealthy", []string{"prod/a"}, cfg, testNow)
+	r.NodeSignal(context.Background(), "node7", "GpuUnhealthy", []string{"prod/a"}, cfg, testNow.Add(5*time.Minute))
+	if got := promtestutil.ToFloat64(m.NodeHealthSignals.WithLabelValues("node7", "GpuUnhealthy")); got != 1 {
+		t.Fatalf("flapping condition must not spam signals: %v", got)
+	}
+	if events := drainEvents(recorder); len(events) != 1 || !hasEvent(events, "GpuUnhealthyEvacuating") {
+		t.Fatalf("node signal events: %v", events)
+	}
+
+	var cm corev1.ConfigMap
+	if err := cl.Get(context.Background(), types.NamespacedName{Namespace: "ome", Name: "alfred-recommendations"}, &cm); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(cm.Data["node.node7"], "GpuUnhealthy") {
+		t.Fatalf("durable node record missing: %v", cm.Data)
+	}
+
+	r.ClearNodeSignal("node7")
+	r.NodeSignal(context.Background(), "node7", "GpuUnhealthy", []string{"prod/a"}, cfg, testNow.Add(time.Hour))
+	if got := promtestutil.ToFloat64(m.NodeHealthSignals.WithLabelValues("node7", "GpuUnhealthy")); got != 2 {
+		t.Fatalf("a fresh incident after clearing must signal again: %v", got)
+	}
+}


### PR DESCRIPTION
## What

Implements OEP-0008's Reporter and the leader-only decision loop (plan step A6) and wires them into `cmd/alfred` — Alfred is now recommend-only end-to-end: snapshot → policies → arbiter → reporter, emitting Events, decision metrics, and the `alfred-recommendations` ConfigMap, with **zero writes to InferenceServices** (the Dispatcher joins in the execute path).

- `pkg/alfred/engine/reporter.go` — the single observability emitter. Per cycle: `alfred_recommendations_{produced,accepted,rejected}_total` (rejections labeled with the arbiter's reason code), `alfred_lws_recommendations_total`, `alfred_cooldown_overrides_total` + the `CooldownOverriddenForEvacuation` audit event, and Events on the target InferenceServices (`FragmentationRecommendationProduced` for advisories, `RecommendationWithheld` in recommend-only vs `RecommendationAdmitted` in execute, `RecommendationRejected` with the drop reason). The recommendations ConfigMap record is **update-only** (the chart pre-creates it; a missing ConfigMap logs once, never a create): a `last-cycle.json` document with every candidate's outcome — `advisory` / `withheld` / `admitted` / `rejected` — preserving sibling keys. Also carries the node-signal dedup ledger for Policy #2 (`GpuUnhealthyEvacuating` Warning Event on the Node + durable `node.<name>` record, deduped across loops until the condition genuinely clears) and the `OMENativeUnavailable` transition event (on the way into degraded mode, never per pass — the gauge is the per-pass signal).
- `pkg/alfred/engine/loop.go` — the leader-only decision Runnable (`NeedLeaderElection() = true`): non-reentrant single goroutine, so an overrunning pass delays the next tick and never overlaps it; interval re-read from the hot-reloaded config every pass; skips cleanly while the observation loop has no snapshot yet; publishes `alfred_decision_loop_duration_seconds` and mirrors the breaker state into `alfred_circuit_breaker_state`.
- `pkg/alfred/engine/earlytick.go` — `earlyTickOn: [NodeConditionChange]`: a node-informer handler that advances the next tick through a 1-buffered channel (a signal landing mid-pass waits; a storm collapses into one advancement; it can shorten waiting, never introduce concurrency). Condition comparison ignores heartbeat-only updates; enablement is checked at signal time so a config reload needs no re-registration.
- `pkg/alfred/engine/omenative.go` — the degraded-mode heuristic: available iff `omenativeMigrationEnabled` AND the `InferenceReplica` CRD is registered, with the discovery probe injected so the gating stays unit-testable; discovery errors read as unavailable.
- `cmd/alfred/main.go` — wires the discovery hook into the observation loop and adds the early ticker + decision loop (recorder `alfred`, defrag as the first registered policy).

## Testing

`go test ./pkg/alfred/... ./cmd/alfred/` — engine package at 90.5% statement coverage. Covered: the full cycle report (counters, events, ConfigMap outcomes, sibling-key preservation), execute-mode vs recommend-only outcome labeling, the cooldown-override audit, update-only ConfigMap semantics (no create), the OMENative transition event firing exactly once per degradation, node-signal dedup with clear-and-resignal, the decision pipeline end-to-end over a synthetic snapshot, the nil-snapshot skip, the breaker gauge following the ledger, early-tick advancement against a 5-minute interval (only the signal can fire the second pass inside the test timeout), condition-change vs heartbeat discrimination, signal collapsing, the disabled-trigger path, and the discovery gating (disabled surface never probes; probe errors degrade).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated decision cycles with configurable scheduling and immediate evaluation at startup.
  * Added leader-only processing and faster reactions to meaningful node condition changes.
  * Added availability-aware handling for OMENative execution with cached checks.
  * Added reporting for recommendations, decisions, degraded states, and node remediation signals through metrics and platform events.
  * Added durable decision-cycle and remediation records with duplicate suppression.

* **Bug Fixes**
  * Prevented processing when no current cluster snapshot is available.
  * Ensured startup failures stop the service cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->